### PR TITLE
Remove convert-model container after run

### DIFF
--- a/tests/functional/utils/model_management.py
+++ b/tests/functional/utils/model_management.py
@@ -96,5 +96,6 @@ def convert_model(client,
                           name='convert-model-{}'.format(get_tests_suffix()),
                           volumes=volumes,
                           user=user_id,
-                          command=command)
+                          command=command,
+                          remove=True)
     return files


### PR DESCRIPTION
Remove container after run as it is used multiple times during test execution.