### PR TITLE
[AMS] Detection type results handling

### DIFF
--- a/extras/ams_wrapper/src/api/models/example_model.py
+++ b/extras/ams_wrapper/src/api/models/example_model.py
@@ -21,7 +21,7 @@ class ExampleModel(Model):
        """
         Examplary flow:
 
-        from api.types import Tag, Box, SingleEntity, Entity
+        from api.types import Tag, Rectangle, SingleEntity, Entity
 
         result_array = inference_output[output_name]
 
@@ -39,8 +39,9 @@ class ExampleModel(Model):
             x_max = detection[5]
             y_max = detection[6]
 
-            tag = Tag(value=self.labels[label], confidence=conf)
-            box = Box(x_min, y_min, x_max, y_max)
+            tag = Tag(self.labels[label], conf)
+
+            box = Rectangle(x_min, y_min, abs(x_max-x_min), abs(y_max-y_min))
 
             detection = SingleEntity(tag, box)
             detections.append(detection)

--- a/extras/ams_wrapper/src/api/models/example_model.py
+++ b/extras/ams_wrapper/src/api/models/example_model.py
@@ -18,5 +18,37 @@ from api.models.model import Model
 
 class ExampleModel(Model):
    def postprocess_inference_output(self, inference_output: dict) -> str:
-       #TODO: Implement postprocessing for example model
+       """
+        Examplary flow:
+
+        from api.types import Tag, Box, SingleEntity, Entity
+
+        result_array = inference_output[output_name]
+
+        # assuming detection model with output shape (1,1,N,7) 
+        # with last dimension containg detection details
+        # TODO: add handling of empty rows
+
+        detections = []
+        for detection in result_array[0][0]:
+            image_id = detection[0]
+            label = detection[1]
+            conf = detection[2]
+            x_min = detection[3]
+            y_min = detection[4]
+            x_max = detection[5]
+            y_max = detection[6]
+
+            tag = Tag(value=self.labels[label], confidence=conf)
+            box = Box(x_min, y_min, x_max, y_max)
+
+            detection = SingleEntity(tag, box)
+            detections.append(detection)
+        
+        entity = Entity(subtype_name=self.model_name, entities=detections)
+        response_dict = []
+        response_dict[inferences] = [entity.as_dict()]
+        response = json.dumps(response_dict)
+        return response
+       """
        return

--- a/extras/ams_wrapper/src/api/models/model.py
+++ b/extras/ams_wrapper/src/api/models/model.py
@@ -35,10 +35,10 @@ class Model(ABC):
 
     def load_labels(labels_path: str) -> str:
         try:
-        with open(labels_path, 'r') as labels_file:
-            data = json.load(labels_file)
+            with open(labels_path, 'r') as labels_file:
+                data = json.load(labels_file)
         except Exception as e:
-            logger.error("Error occurred while opening labels file: {}".format(e))
+            logger.exception("Error occurred while opening labels file: {}".format(e))
             sys.exit(1)
         return data
 

--- a/extras/ams_wrapper/src/api/models/model.py
+++ b/extras/ams_wrapper/src/api/models/model.py
@@ -15,6 +15,7 @@
 #
 
 import datetime
+import json
 import falcon
 import tensorflow as tf
 import numpy as np
@@ -28,6 +29,18 @@ class Model(ABC):
 
     def __init__(self, ovms_connector):
         self.ovms_connector = ovms_connector
+        self.model_name = None # subtype / model name in AMS
+        self.result_type = None # type class
+        self.labels = None # load_labels
+
+    def load_labels(labels_path: str) -> str:
+        try:
+        with open(labels_path, 'r') as labels_file:
+            data = json.load(labels_file)
+        except Exception as e:
+            logger.error("Error occurred while opening labels file: {}".format(e))
+            sys.exit(1)
+        return data
 
     def preprocess_binary_image(self, binary_image: bytes) -> np.ndarray:
         # By default the only performed preprocessing is converting image 

--- a/extras/ams_wrapper/src/api/types.py
+++ b/extras/ams_wrapper/src/api/types.py
@@ -1,0 +1,112 @@
+from typing import List
+from abc import ABC
+
+class Tag:
+    def __init__(self, value: str, confidence: float):
+        self.value = value
+        self.confidence = confidence
+
+    def as_dict(self):
+        result_dict = {
+            "value": self.value,
+            "confidence": self.confidence
+        }
+        return result_dict
+
+class Attribute:
+    def __init__(self, name: str, value: str, confidence: float):
+        self.name = name
+        self.value = value
+        self.confidence = confidence
+
+    def as_dict(self):
+        result_dict = {
+            "name": self.name
+            "value": self.value,
+            "confidence": self.confidence
+        }
+        return result_dict
+
+class Rectangle:
+    def __init__ (self, l: float, t: float, r: float, b: float):
+        self.l = l
+        self.t = t
+        self.r = r
+        self.b = b
+
+    def as_dict(self):
+        result_dict = {
+            "l": self.l,
+            "t": self.t,
+            "r": self.r,
+            "b": self.b
+        }
+        return result_dict
+
+class ResultType(ABC):
+    pass
+
+class Motion(ResultType):
+    def __init__(self, box: Rectangle):
+        self.box = box
+        self.type_name = "motion"
+
+    def as_dict(self):
+        result_dict = {
+            "box": self.box.as_dict()
+        }
+
+class Classification(ResultType):
+    def __init__(self, tag: Tag, attributes: List[Attribute]):
+        self.tag = tag
+        self.attributes = attributes
+        self.type_name = "classification"
+
+    def as_dict(self):
+        result_dict = {
+            "tag": self.tag.as_dict(),
+            "attributes": [attribute.as_dict() for attribute in self.attributes]
+        }
+
+class SingleEntity:
+    def __init__(self, tag: Tag, box: Rectangle, attributes: List[Attribute] = None):
+        self.tag = tag
+        self.box = box
+        self.attributes = attributes
+
+    def as_dict(self):
+        result_dict = {
+            "tag": self.tag.as_dict(),
+            "box": self.box.as_dict()
+        }
+        if self.attributes is not None:
+            result_dict[attributes] = [attribute.as_dict() for attribute in self.attributes]
+        return result_dict
+
+class Entity(ResultType):
+
+    def __init__(self, subtype_name: str, entities: List[SingleEntity]):
+        self.type_name = "entity"
+        self.subtype_name = subtype_name
+        self.entities = entities
+
+    def as_dict(self):
+        result_dict = {
+            "type": self.type_name,
+            "subtype": self.subtype_name,
+            "entities": [entity.as_dict() for entity in self.entities]
+        }
+        return result_dict
+
+class Text(ResultType):
+    # TODO: add support
+    pass
+
+class InferenceExtension:
+    # TODO: add support
+    pass
+
+class Inference:
+    def __init__(self, value: ResultType, extensions: List[InferenceExtension] = None):
+        self.value = value
+        self.extensions = extensions

--- a/extras/ams_wrapper/src/api/types.py
+++ b/extras/ams_wrapper/src/api/types.py
@@ -1,3 +1,20 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 from typing import List
 from abc import ABC
 
@@ -21,25 +38,25 @@ class Attribute:
 
     def as_dict(self):
         result_dict = {
-            "name": self.name
+            "name": self.name,
             "value": self.value,
             "confidence": self.confidence
         }
         return result_dict
 
 class Rectangle:
-    def __init__ (self, l: float, t: float, r: float, b: float):
+    def __init__ (self, l: float, t: float, w: float, h: float):
         self.l = l
         self.t = t
-        self.r = r
-        self.b = b
+        self.w = w
+        self.h = h
 
     def as_dict(self):
         result_dict = {
             "l": self.l,
             "t": self.t,
-            "r": self.r,
-            "b": self.b
+            "w": self.w,
+            "h": self.h
         }
         return result_dict
 

--- a/extras/ams_wrapper/tests/test_entity_type.py
+++ b/extras/ams_wrapper/tests/test_entity_type.py
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from src.api.types import Tag, Rectangle, SingleEntity, Entity
+
+def test_single_entity():
+    expected_dict = {
+        "tag": {
+            "value": "car",
+            "confidence": 0.97
+        },
+        "box": { "l": 1.0, "t": 2.0, "w": 3.0, "h": 4.0 }
+    }
+
+    tag = Tag("car", 0.97)
+    box = Rectangle(1.0, 2.0, 3.0, 4.0)
+    single_entity = SingleEntity(tag, box)
+    assert expected_dict == single_entity.as_dict()
+
+def test_entity():
+    expected_dict = {
+        "type": "entity",
+        "subtype": "vehicleDetection",
+        "entities": [
+        {
+        "tag": {
+            "value": "car",
+            "confidence": 0.97
+            },
+        "box": { "l": 1.0, "t": 2.0, "w": 3.0, "h": 4.0 }
+        },
+                {
+        "tag": {
+            "value": "bike",
+            "confidence": 0.94
+            },
+        "box": { "l": 0.0, "t": 0.0, "w": 0.0, "h": 0.0 }
+        },
+        ]
+    }
+
+    entities = [
+        SingleEntity(Tag("car", 0.97), Rectangle(1.0, 2.0, 3.0, 4.0)),
+        SingleEntity(Tag("bike", 0.94), Rectangle(0.0, 0.0, 0.0, 0.0)),
+    ]
+    entity = Entity("vehicleDetection", entities)
+    assert expected_dict == entity.as_dict()


### PR DESCRIPTION
Changes made:

- added types.py file containing types used in post-processing of inference output in AMS service
- added load_labels method for loading json file with mapping of class ids to class names (might be changed in the future to load more info about the model)
- provided examplary code (commented in `postprocess_inference_output` of `ExampleModel`) doing inference output conversion to json response based on loaded labels and `Entity` types (not tested, just an example of the flow)