### PR TITLE
Parse model's input configuration

### DIFF
--- a/extras/ams_wrapper/src/api/dispatcher.py
+++ b/extras/ams_wrapper/src/api/dispatcher.py
@@ -15,7 +15,8 @@
 #
 
 import falcon
-from api.ovms_connector import OvmsConnector
+
+from src.api.ovms_connector import OvmsConnector
 
 def create_dispatcher(available_models: list, ovms_port: int):
     dispatch_map = {}

--- a/extras/ams_wrapper/src/api/models/__init__.py
+++ b/extras/ams_wrapper/src/api/models/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .model import *

--- a/extras/ams_wrapper/src/api/models/__init__.py
+++ b/extras/ams_wrapper/src/api/models/__init__.py
@@ -14,4 +14,3 @@
 # limitations under the License.
 #
 
-from .model import *

--- a/extras/ams_wrapper/src/api/models/example_model.py
+++ b/extras/ams_wrapper/src/api/models/example_model.py
@@ -14,9 +14,17 @@
 # limitations under the License.
 #
 
+import numpy as np
+
+import preprocessing
 from api.models.model import Model
 
 class ExampleModel(Model):
+
+    def preprocess_binary_image(self, binary_image: bytes) -> np.ndarray:
+        return preprocessing.preprocess_binary_image(image=binary_image)
+
+
    def postprocess_inference_output(self, inference_output: dict) -> str:
        """
         Examplary flow:

--- a/extras/ams_wrapper/src/api/models/example_model.py
+++ b/extras/ams_wrapper/src/api/models/example_model.py
@@ -21,10 +21,12 @@ from api.models.model import Model
 
 class ExampleModel(Model):
 
-    def preprocess_binary_image(self, binary_image: bytes) -> np.ndarray:
-        return preprocessing.preprocess_binary_image(image=binary_image)
+    # TODO: think how to handle multiple different inputs
+    def preprocess_binary_image(self, binary_image: bytes, input_name: str) -> np.ndarray:
+        preprocessing_config = self.input_configs[input_name]
+        return preprocessing.preprocess_binary_image(image=binary_image, **preprocessing_config)
 
-   def postprocess_inference_output(self, inference_output: dict) -> str:
+    def postprocess_inference_output(self, inference_output: dict) -> str:
        """
         Examplary flow:
 

--- a/extras/ams_wrapper/src/api/models/example_model.py
+++ b/extras/ams_wrapper/src/api/models/example_model.py
@@ -24,7 +24,6 @@ class ExampleModel(Model):
     def preprocess_binary_image(self, binary_image: bytes) -> np.ndarray:
         return preprocessing.preprocess_binary_image(image=binary_image)
 
-
    def postprocess_inference_output(self, inference_output: dict) -> str:
        """
         Examplary flow:

--- a/extras/ams_wrapper/src/api/models/example_model.py
+++ b/extras/ams_wrapper/src/api/models/example_model.py
@@ -16,15 +16,15 @@
 
 import numpy as np
 
-import preprocessing
-from api.models.model import Model
+from src.preprocessing import preprocess_binary_image
+from src.api.models.model import Model
 
 class ExampleModel(Model):
 
     # TODO: think how to handle multiple different inputs
     def preprocess_binary_image(self, binary_image: bytes, input_name: str) -> np.ndarray:
         preprocessing_config = self.input_configs[input_name]
-        return preprocessing.preprocess_binary_image(image=binary_image, **preprocessing_config)
+        return preprocess_binary_image(image=binary_image, **preprocessing_config)
 
     def postprocess_inference_output(self, inference_output: dict) -> str:
        """

--- a/extras/ams_wrapper/src/api/models/input_config.py
+++ b/extras/ams_wrapper/src/api/models/input_config.py
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from marshmallow import Schema, fields, validates_schema, ValidationError, post_load, validate
+
+
+class ModelInputConfiguration:
+    def __init__(self, input_name: str, channels: int = None,
+                 target_height: int = None, target_width: int = None,
+                 color_format: str = 'RGB', scale: float = None,
+                 standardization: bool = False, input_format: str = 'NCHW'):
+                 self.input_name = input_name
+                 self.channels = channels
+                 self.target_height = target_height
+                 self.target_width = target_width
+                 self.color_format = color_format
+                 self.scale = scale
+                 self.standardization = standardization
+                 self.input_format = input_format
+
+
+class ModelInputConfigurationSchema(Schema):
+    input_name = fields.String(required=True)
+    channels = fields.Integer(required=False)
+    target_height = fields.Integer(required=False)
+    target_width = fields.Integer(required=False)
+    color_format = fields.String(required=False, validate=validate.OneOf({'BGR', 'RGB'}))
+    scale = fields.Float(required=False,
+                         validate=validate.Range(min=0, min_inclusive=False))
+    standardization = fields.Bool(required=False)
+    input_format = fields.String(required=False, validate=validate.OneOf({'NCHW', 'NHWC'}))
+
+    @post_load
+    def make_model_input_configuration(self, data, **kwargs):
+        return ModelInputConfiguration(**data)
+
+    @validates_schema
+    def validate_type(self, data, **kwargs):
+        if data.get('target_width') and not data.get('target_height'):
+            raise ValidationError('target_height must defined if target_width was set. '
+                                  'Invalid config: {}'.format(data))
+        if data.get('target_height') and not data.get('target_width'):
+            raise ValidationError('target_width must defined if target_height was set. '
+                                  'Invalid config: {}'.format(data))

--- a/extras/ams_wrapper/src/api/models/input_config.py
+++ b/extras/ams_wrapper/src/api/models/input_config.py
@@ -26,10 +26,13 @@ class ModelInputConfiguration:
                  self.channels = channels
                  self.target_height = target_height
                  self.target_width = target_width
-                 self.color_format = color_format
+                 self.reverse_input_channels = True if color_format == 'BGR' else False
                  self.scale = scale
                  self.standardization = standardization
-                 self.input_format = input_format
+                 self.channels_first = False if input_format == 'NHWC' else True
+    
+    def as_dict(self) -> dict:
+        return vars(self)
 
 
 class ModelInputConfigurationSchema(Schema):

--- a/extras/ams_wrapper/src/api/models/input_config.py
+++ b/extras/ams_wrapper/src/api/models/input_config.py
@@ -20,7 +20,7 @@ from marshmallow import Schema, fields, validates_schema, ValidationError, post_
 class ModelInputConfiguration:
     def __init__(self, input_name: str, channels: int = None,
                  target_height: int = None, target_width: int = None,
-                 color_format: str = 'RGB', scale: float = None,
+                 color_format: str = 'BGR', scale: float = None,
                  standardization: bool = False, input_format: str = 'NCHW'):
                  self.input_name = input_name
                  self.channels = channels

--- a/extras/ams_wrapper/src/api/models/model.py
+++ b/extras/ams_wrapper/src/api/models/model.py
@@ -28,7 +28,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 from logger import get_logger
 from preprocessing.preprocess_image import preprocess_binary_image as default_preprocessing
-from api.ovms_connector import OvmsUnavailableError, ModelNotFoundError
+from api.ovms_connector import OvmsUnavailableError, ModelNotFoundError, OvmsConnector
 from .input_config import ModelInputConfiguration, \
     ModelInputConfigurationSchema, ValidationError
 
@@ -36,7 +36,8 @@ logger = get_logger(__name__)
 
 
 class Model(ABC):
-    def __init__(self, ovms_connector, labels_path, config_file_path: str = None):
+    def __init__(self, model_name: str, ovms_connector: OvmsConnector,
+                 labels_path: str, config_file_path: str = None):
         self.ovms_connector = ovms_connector
         self.model_name = None # subtype / model name in AMS
         self.result_type = None # type class
@@ -153,8 +154,6 @@ class Model(ABC):
         resp.body = results
         return
 
-<<<<<<< HEAD
-=======
     @staticmethod
     def load_input_configs(config_file_path: str) -> Dict[str, ModelInputConfiguration]:
         """
@@ -189,4 +188,3 @@ class Model(ABC):
         return model_input_configs
 
         
->>>>>>> 9b2a38e... Parse model input configuration

--- a/extras/ams_wrapper/src/api/models/model.py
+++ b/extras/ams_wrapper/src/api/models/model.py
@@ -14,29 +14,40 @@
 # limitations under the License.
 #
 
+from abc import ABC, abstractmethod
 import datetime
 import json
+import sys
+from typing import Dict
+
 import falcon
 import tensorflow as tf
 import sys
 import numpy as np
+
 from abc import ABC, abstractmethod
 from logger import get_logger
 from preprocessing.preprocess_image import preprocess_binary_image as default_preprocessing
 from api.ovms_connector import OvmsUnavailableError, ModelNotFoundError
+from .input_config import ModelInputConfiguration, \
+    ModelInputConfigurationSchema, ValidationError
 
 logger = get_logger(__name__)
 
-class Model(ABC):
 
-    def __init__(self, model_name, ovms_connector, labels_path):
+class Model(ABC):
+    def __init__(self, ovms_connector, labels_path, config_file_path: str = None):
         self.ovms_connector = ovms_connector
-        self.model_name = model_name
+        self.model_name = None # subtype / model name in AMS
+        self.result_type = None # type class
         self.labels = self.load_labels(labels_path)
+        self.input_configs: Dict[str, ModelInputConfiguration] = None # load input configuration
+        if config_file_path:
+            self.input_configs = self.load_input_configs(config_file_path)
 
     def load_labels(self, labels_path):
         try:                                                                          
-            with open(labels_path, 'r') as labels_file:                               
+            with open(labels_path, 'r') as labels_file:
                 data = json.load(labels_file)
                 labels = dict()
                 for output in data['outputs']: 
@@ -142,3 +153,40 @@ class Model(ABC):
         resp.body = results
         return
 
+<<<<<<< HEAD
+=======
+    @staticmethod
+    def load_input_configs(config_file_path: str) -> Dict[str, ModelInputConfiguration]:
+        """
+        :raises ValueError: when loading of configuration file fails
+        :raises marshmallow.ValidationError: if input configuration has invalid schema
+        :returns: a dictionary where key is the input name and value
+                 is ModelInputConfiguration for given input
+        """
+        try:
+            with open(config_file_path, mode='r') as config_file:
+                config = json.load(config_file)
+        except FileNotFoundError as e:
+            # TODO: think what exactly should we do in this case
+            logger.exception('Model\'s configuration file {} was not found.'.format(config_file_path))
+            raise ValueError from e
+        except Exception as e:
+            logger.exception('Failed to load Model\'s configuration file {}.'.format(config_file_path))
+            raise ValueError from e
+        
+        model_input_configs = {}
+        input_config_schema = ModelInputConfigurationSchema()
+        
+        for input_config_dict in config.get('inputs'):
+            try:
+                input_config = input_config_schema.load(input_config_dict)
+            except ValidationError:
+                logger.exception('Model input configuration is invalid: {}'.format(input_config_dict))
+                raise
+
+            model_input_configs[input_config.input_name] = input_config
+        
+        return model_input_configs
+
+        
+>>>>>>> 9b2a38e... Parse model input configuration

--- a/extras/ams_wrapper/src/api/models/model.py
+++ b/extras/ams_wrapper/src/api/models/model.py
@@ -25,11 +25,10 @@ import tensorflow as tf
 import sys
 import numpy as np
 
-from abc import ABC, abstractmethod
-from logger import get_logger
-from preprocessing.preprocess_image import preprocess_binary_image as default_preprocessing
-from api.ovms_connector import OvmsUnavailableError, ModelNotFoundError, OvmsConnector
-from .input_config import ModelInputConfiguration, \
+from src.logger import get_logger
+from src.preprocessing.preprocess_image import preprocess_binary_image as default_preprocessing
+from src.api.ovms_connector import OvmsUnavailableError, ModelNotFoundError, OvmsConnector
+from src.api.models.input_config import ModelInputConfiguration, \
     ModelInputConfigurationSchema, ValidationError
 
 logger = get_logger(__name__)

--- a/extras/ams_wrapper/src/api/models/model.py
+++ b/extras/ams_wrapper/src/api/models/model.py
@@ -38,8 +38,7 @@ class Model(ABC):
     def __init__(self, model_name: str, ovms_connector: OvmsConnector,
                  labels_path: str, config_file_path: str = None):
         self.ovms_connector = ovms_connector
-        self.model_name = None # subtype / model name in AMS
-        self.result_type = None # type class
+        self.model_name = model_name
         self.labels = self.load_labels(labels_path)
         self.input_configs: Dict[str, ModelInputConfiguration] = None # load input configuration
         if config_file_path:

--- a/extras/ams_wrapper/src/api/models/vehicle_attributes_model.py
+++ b/extras/ams_wrapper/src/api/models/vehicle_attributes_model.py
@@ -16,9 +16,10 @@
 import os
 import sys
 import json
-from logger import get_logger
-from api.models.model import Model
-from api.types import Tag, Attribute, SingleClassification, Classification
+
+from src.logger import get_logger
+from src.api.models.model import Model
+from src.api.types import Tag, Attribute, SingleClassification, Classification
 
 logger = get_logger(__name__)
 

--- a/extras/ams_wrapper/src/api/models/vehicle_detection_adas_model.py
+++ b/extras/ams_wrapper/src/api/models/vehicle_detection_adas_model.py
@@ -16,10 +16,11 @@
 import os
 import json
 import numpy as np
-from logger import get_logger
-from api.models.model import Model
-from api.types import Tag, Rectangle, SingleEntity, Entity
-from preprocessing.preprocess_image import preprocess_binary_image as default_preprocessing
+
+from src.logger import get_logger
+from src.api.models.model import Model
+from src.api.types import Tag, Rectangle, SingleEntity, Entity
+from src.preprocessing.preprocess_image import preprocess_binary_image as default_preprocessing
 
 logger = get_logger(__name__)
 

--- a/extras/ams_wrapper/src/config.py
+++ b/extras/ams_wrapper/src/config.py
@@ -15,8 +15,9 @@
 #
 
 import os
-from api.models.vehicle_detection_adas_model import VehicleDetectionAdas
-from api.ovms_connector import OvmsConnector
+
+from src.api.models.vehicle_detection_adas_model import VehicleDetectionAdas
+from src.api.ovms_connector import OvmsConnector
 
 # Default version for a model is the latest one
 DEFAULT_VERSION = 0 

--- a/extras/ams_wrapper/src/preprocessing/preprocess_image.py
+++ b/extras/ams_wrapper/src/preprocessing/preprocess_image.py
@@ -20,7 +20,7 @@ from typing import Tuple
 import tensorflow as tf
 import numpy as np
 
-from logger import get_logger
+from src.logger import get_logger
 
 
 log = get_logger(__name__)

--- a/extras/ams_wrapper/src/wrapper.py
+++ b/extras/ams_wrapper/src/wrapper.py
@@ -16,9 +16,9 @@
 
 import argparse
 from cheroot.wsgi import Server as WSGIServer, PathInfoDispatcher
-from api.dispatcher import create_dispatcher
-from config import AVAILABLE_MODELS
-from logger import get_logger
+from src.api.dispatcher import create_dispatcher
+from src.config import AVAILABLE_MODELS
+from src.logger import get_logger
 
 logger = get_logger(__name__)
 
@@ -42,4 +42,5 @@ def main():
                           required=False, default=9000)
     args = parser.parse_args()
     start_rest_service(args.port, args.workers, args.ovms_port)
+
 main()

--- a/extras/ams_wrapper/start_ams.sh
+++ b/extras/ams_wrapper/start_ams.sh
@@ -52,4 +52,4 @@ done
 
 . /ie-serving-py/.venv/bin/activate
 /ie-serving-py/start_server.sh ie_serving model --model_path /opt/models/vehicle_detection_adas --model_name vehicle_detection_adas --port $OVMS_PORT & 
-python /ams_wrapper/src/wrapper.py --port $AMS_PORT
+cd /ams_wrapper && python -m src.wrapper --port $AMS_PORT

--- a/extras/ams_wrapper/tests/test_model.py
+++ b/extras/ams_wrapper/tests/test_model.py
@@ -23,7 +23,7 @@ from src.api.models.input_config import ValidationError
 
 
 @pytest.fixture()
-def test_model_config(tmpdir):
+def test_model_config():
     config_file_content = {
         "model_name": "age-gender-recognition-retail-0013",
         "outputs": [

--- a/extras/ams_wrapper/tests/test_model.py
+++ b/extras/ams_wrapper/tests/test_model.py
@@ -18,7 +18,7 @@ import json
 
 import pytest
 
-from src.api.models import Model
+from src.api.models.model import Model
 from src.api.models.input_config import ValidationError
 
 

--- a/extras/ams_wrapper/tests/test_model.py
+++ b/extras/ams_wrapper/tests/test_model.py
@@ -1,0 +1,110 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+
+import pytest
+
+from src.api.models import Model
+from src.api.models.input_config import ValidationError
+
+
+@pytest.fixture()
+def test_model_config(tmpdir):
+    config_file_content = {
+        "model_name": "age-gender-recognition-retail-0013",
+        "outputs": [
+            {
+                "output_name": "prob",
+                "classes": {
+                    "0.0": "female",
+                    "1.0": "male"
+                    }
+            },
+            {
+                "output_name": "age_conv3"
+            }
+        ],
+        "inputs": [
+            {
+                "input_name": "result",
+            }
+        ]
+    }
+    return config_file_content
+
+
+@pytest.mark.parametrize("input_name", ["result"])
+@pytest.mark.parametrize("channels", [None, 3])
+@pytest.mark.parametrize("target_size", [(None, None), (256, 256)])
+@pytest.mark.parametrize("input_format", [None, 'NCHW', 'NHWC'])
+@pytest.mark.parametrize("scale", [None, 1/255])
+@pytest.mark.parametrize("standardization", [None, True, False])
+@pytest.mark.parametrize("color_format", [None, 'RGB', 'BGR'])
+def test_model_load_valid_input_config(tmpdir, test_model_config,
+                                       input_name, channels, target_size,
+                                       color_format, scale, standardization,
+                                       input_format):
+    for input_param, input_param_value in [('channels', channels),
+                                           ('target_height', target_size[0]),
+                                           ('target_width', target_size[1]),
+                                           ('input_format', input_format),
+                                           ('scale', scale),
+                                           ('standardization', standardization),
+                                           ('color_format', color_format)]:
+        if input_param_value is not None:
+            test_model_config['inputs'][0][input_param] = input_param_value
+
+    config_file_path = tmpdir.join("model_config.json")
+    with open(config_file_path, mode='w') as config_file:
+        json.dump(test_model_config, config_file)
+
+    Model.load_input_configs(config_file_path)
+
+
+@pytest.mark.parametrize("input_name", ["result"])
+@pytest.mark.parametrize("channels", [None, 'two'])
+@pytest.mark.parametrize("target_size", [(None, 256), (256, None)])
+@pytest.mark.parametrize("input_format", ['CHWN'])
+@pytest.mark.parametrize("scale", [0, 'zero'])
+@pytest.mark.parametrize("standardization", ['no'])
+@pytest.mark.parametrize("color_format", ['RGR'])
+def test_model_load_invalid_input_config(tmpdir, test_model_config,
+                                         input_name, channels, target_size,
+                                         input_format, scale, standardization,
+                                         color_format):
+    for input_param, input_param_value in [('channels', channels),
+                                           ('target_height', target_size[0]),
+                                           ('target_width', target_size[1]),
+                                           ('input_format', input_format),
+                                           ('scale', scale),
+                                           ('standardization', standardization),
+                                           ('color_format', color_format)]:
+        if input_param_value is not None:
+            test_model_config['inputs'][0][input_param] = input_param_value
+
+    config_file_path = tmpdir.join("model_config.json")
+    with open(config_file_path, mode='w') as config_file:
+        json.dump(test_model_config, config_file)
+
+    with pytest.raises(ValidationError):
+        Model.load_input_configs(config_file_path)
+
+
+def test_model_load_non_existing_input_config():
+    with pytest.raises(ValueError):
+        Model.load_input_configs('/not-existing-path')
+

--- a/extras/ams_wrapper/tests/test_preprocess_binary_images.py
+++ b/extras/ams_wrapper/tests/test_preprocess_binary_images.py
@@ -21,10 +21,7 @@ import pytest
 import sys
 import pathlib
 
-ams_root_path = pathlib.Path(__file__).parent.parent.absolute()
-sys.path.append(os.path.join(ams_root_path, "src"))
-
-from preprocessing import preprocess_binary_image, ImageResizeError, ImageDecodeError
+from src.preprocessing import preprocess_binary_image, ImageResizeError, ImageDecodeError
 
 
 IMAGES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_images')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ grpcio-testing==1.22.0
 docker==3.7.0
 protobuf==3.6.1
 opencv-python==4.1.2.30
-marshmallow==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ boto3==1.10.2
 jsonschema==3.1.1
 falcon==2.0.0
 cheroot==8.2.1
+marshmallow==3.5.1

--- a/tests/functional/test_single_model_vehicle.py
+++ b/tests/functional/test_single_model_vehicle.py
@@ -176,13 +176,10 @@ class TestVehicleDetection():
         print("output shape", output[out_name].shape)
         assert output[out_name].shape == (1, 1, 200, 7), ERROR_SHAPE
         
-        os.chdir("extras/ams_wrapper/src/")
+        sys.path.append(os.path.abspath('../../extras/ams_wrapper'))
+        from src.api.models.vehicle_detection_adas_model import VehicleDetectionAdas
 
-        from api.models.vehicle_detection_adas_model import VehicleDetectionAdas
-
-        model_adas = VehicleDetectionAdas("vehicle-detection","ovms_connector","../../ams_models/vehicle_detection_adas_model.json" )
-
-        os.chdir("../../../")
+        model_adas = VehicleDetectionAdas("vehicle-detection","ovms_connector","../../extras/ams_models/vehicle_detection_adas_model.json" )
 
         json_response = model_adas.postprocess_inference_output(output)
         print("json_response=  " + str(json_response))

--- a/tests/functional/test_single_model_vehicle.py
+++ b/tests/functional/test_single_model_vehicle.py
@@ -25,11 +25,6 @@ from utils.grpc import infer, get_model_metadata, model_metadata_response, \
 from utils.rest import infer_rest, get_model_metadata_response_rest, \
     get_model_status_response_rest
 
-sys.path.append(".")
-
-from ie_serving.models.models_utils import ModelVersionState, ErrorCode, \
-    _ERROR_MESSAGE  # noqa
-
 
 class TestVehicleDetection():
 
@@ -176,10 +171,11 @@ class TestVehicleDetection():
         print("output shape", output[out_name].shape)
         assert output[out_name].shape == (1, 1, 200, 7), ERROR_SHAPE
         
-        sys.path.append(os.path.abspath('../../extras/ams_wrapper'))
+        sys.path.append(os.path.abspath(os.path.join(os.path.realpath(__file__), '../../../extras/ams_wrapper/')))
         from src.api.models.vehicle_detection_adas_model import VehicleDetectionAdas
 
-        model_adas = VehicleDetectionAdas("vehicle-detection","ovms_connector","../../extras/ams_models/vehicle_detection_adas_model.json" )
+        config_path = os.path.abspath(os.path.join(os.path.realpath(__file__), '../../../extras/ams_models/vehicle_detection_adas_model.json'))
+        model_adas = VehicleDetectionAdas("vehicle-detection","ovms_connector", config_path)
 
         json_response = model_adas.postprocess_inference_output(output)
         print("json_response=  " + str(json_response))

--- a/tests/functional/test_single_model_vehicle_attributes.py
+++ b/tests/functional/test_single_model_vehicle_attributes.py
@@ -24,11 +24,6 @@ from utils.grpc import infer, get_model_metadata, model_metadata_response, \
 from utils.rest import infer_rest, get_model_metadata_response_rest, \
     get_model_status_response_rest
 
-sys.path.append(".")
-
-from ie_serving.models.models_utils import ModelVersionState, ErrorCode, \
-    _ERROR_MESSAGE  # noqa
-
 
 class TestVehicleAttributes():
 
@@ -221,13 +216,10 @@ class TestVehicleAttributes():
                        model_spec_version=None,
                        output_tensors=[out_color, out_type])
         
-        os.chdir("extras/ams_wrapper/src/")
+        sys.path.append(os.path.abspath('../../extras/ams_wrapper'))
+        from src.api.models.vehicle_attributes_model import VehicleAttributes
 
-        from api.models.vehicle_attributes_model import VehicleAttributes
-
-        model_attrib = VehicleAttributes("vehicle-attributes","ovms_connector","../../ams_models/vehicle_attributes_model.json")
-
-        os.chdir("../../../")
+        model_attrib = VehicleAttributes("vehicle-attributes","ovms_connector","../../extras/ams_models/vehicle_attributes_model.json")
 
         json_response = model_attrib.postprocess_inference_output(output)
         print("json_response=  " + str(json_response))

--- a/tests/functional/test_single_model_vehicle_attributes.py
+++ b/tests/functional/test_single_model_vehicle_attributes.py
@@ -216,10 +216,11 @@ class TestVehicleAttributes():
                        model_spec_version=None,
                        output_tensors=[out_color, out_type])
         
-        sys.path.append(os.path.abspath('../../extras/ams_wrapper'))
+        sys.path.append(os.path.abspath(os.path.join(os.path.realpath(__file__), '../../../extras/ams_wrapper/')))
         from src.api.models.vehicle_attributes_model import VehicleAttributes
 
-        model_attrib = VehicleAttributes("vehicle-attributes","ovms_connector","../../extras/ams_models/vehicle_attributes_model.json")
+        config_path = os.path.abspath(os.path.join(os.path.realpath(__file__), '../../../extras/ams_models/vehicle_attributes_model.json'))
+        model_attrib = VehicleAttributes("vehicle-attributes","ovms_connector", config_path)
 
         json_response = model_attrib.postprocess_inference_output(output)
         print("json_response=  " + str(json_response))


### PR DESCRIPTION
* Assuming that there will be one configuration file for each model
* Configuration will accept all currently supported preprocessing options
* `input_name` is the only required field in input configuration, rest is optional