### PR TITLE
Assign image dtype cast result

### DIFF
--- a/extras/ams_wrapper/src/preprocessing/preprocess_image.py
+++ b/extras/ams_wrapper/src/preprocessing/preprocess_image.py
@@ -89,7 +89,7 @@ def preprocess_binary_image(image: bytes, channels: int = None,
 
     try:
         decoded_image = tf.io.decode_image(image, channels=channels)
-        tf.dtypes.cast(decoded_image, dtype)
+        decoded_image = tf.dtypes.cast(decoded_image, dtype)
     except Exception as e:
         raise ImageDecodeError('Provided image is invalid, unable to decode.') from e
 


### PR DESCRIPTION
TF documentation example was a little bit misleading: https://www.tensorflow.org/api_docs/python/tf/cast#for_example - casting is not done in place in our case for some reason.