### PR TITLE
Small fixes to enable CI for OVMS early checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,7 @@ HTTP_PROXY := "$(http_proxy)"
 HTTPS_PROXY := "$(https_proxy)"
 OVMS_VERSION := "2020.3"
 DLDT_PACKAGE_URL := "$(dldt_package_url)"
-
-ifdef ov_source_branch
-OV_SOURCE_BRANCH = "$(ov_source_branch)"
-else
-OV_SOURCE_BRANCH = "2020.3.0"
-endif
+OV_SOURCE_BRANCH ?= "2020.3.0"
 
 TEST_MODELS_DIR = /tmp/ovms_models
 DOCKER_OVMS_TAG ?= ie-serving-py:latest

--- a/tests/scripts/prepare-virtualenv.sh
+++ b/tests/scripts/prepare-virtualenv.sh
@@ -4,7 +4,7 @@ set -ex
 # Check if pip is installed
 python3 -m pip --version || bash -c "echo pip3 is not installed; exit 1"
 
-python3 -m pip install --user -U virtualenv
+python3 -m pip install --user -U virtualenv==20.0.20
 python3 -m virtualenv .venv-jenkins
 
 . .venv-jenkins/bin/activate

--- a/tests/scripts/unit-tests.sh
+++ b/tests/scripts/unit-tests.sh
@@ -8,26 +8,28 @@ LD_LIBRARY_PATH+=:/opt/intel/openvino/deployment_tools/inference_engine/lib/inte
 LD_LIBRARY_PATH+=:/opt/intel/openvino/deployment_tools/ngraph/lib
 
 OPEN_VINO_DOCKER_IMAGE=openvino/ubuntu18_dev:2020.1
-OVMS_TESTS_IMAGE=${OPEN_VINO_DOCKER_IMAGE}-ovms-tests
+OVMS_TESTS_IMAGE="${OPEN_VINO_DOCKER_IMAGE}-ovms-tests"
 
 docker build \
-    -t ${OVMS_TESTS_IMAGE} \
-    -f `dirname $0`/Dockerfile.openvino \
-    --build-arg OPEN_VINO_DOCKER_IMAGE=${OPEN_VINO_DOCKER_IMAGE} \
-    `mktemp -d`
+    -t "${OVMS_TESTS_IMAGE}" \
+    -f "$(dirname "${0}")/Dockerfile.openvino" \
+    --build-arg OPEN_VINO_DOCKER_IMAGE="${OPEN_VINO_DOCKER_IMAGE}" \
+    "$(mktemp -d)"
 
 # Check python version in OV Docker Image
-PYTHON_VERSION=`docker run --rm $OVMS_TESTS_IMAGE \
-    /usr/bin/env python3 --version | awk -F"[ .]" '{ print $2"."$3 }'`
+PYTHON_VERSION="$(docker run --rm $OVMS_TESTS_IMAGE \
+    /usr/bin/env python3 --version | awk -F"[ .]" '{ print $2"."$3 }')"
+# PYTHON_VERSION=`docker run --rm $OVMS_TESTS_IMAGE \
+#     /usr/bin/env python3 --version | awk -F"[ .]" '{ print $2"."$3 }'`
 
 PYTHONPATH=/opt/intel/openvino/python/python${PYTHON_VERSION}
 
 docker run -t --rm \
-    -v $PWD:/mnt/ovms \
+    -v "${PWD}":/mnt/ovms \
     -w /mnt/ovms \
-    -e LD_LIBRARY_PATH=${LD_LIBRARY_PATH} \
-    -e PYTHONPATH=${PYTHONPATH} \
-    $OVMS_TESTS_IMAGE \
+    -e LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+    -e PYTHONPATH="${PYTHONPATH}" \
+    "${OVMS_TESTS_IMAGE}" \
     bash -c "
     set -ex;
     source /opt/intel/openvino/bin/setupvars.sh


### PR DESCRIPTION
Newest version of virtualenv was causing errors, fixing to version 20.0.20 fixed it.
Also because of some spaces in projects directory it was required to change string interpolation.
Also changed the ov_source_branch to OV_SOURCE_BRANCH. It now takes the variable also from shell environment.