### PR TITLE
Update person_vehicle_bike_detection_model.json

### DIFF
--- a/extras/ams_models/person_vehicle_bike_detection_model.json
+++ b/extras/ams_models/person_vehicle_bike_detection_model.json
@@ -14,7 +14,7 @@
     "outputs": [
         {
             "output_name": "detection_out",
-            "confidence_threshold": 0.5,
+            "confidence_threshold": 0.1,
             "classes": {
                 "background": 0.0,
                 "pedestrian": 1.0,


### PR DESCRIPTION
Updating the default confidence threshold value to 0.1 since 'bike' is not getting detected for person-vehicle-bike detection model with the below video file:
https://lvamedia.blob.core.windows.net/public/homes_00425.mkv 