### PR TITLE
CVS-41739 Lock model instance from reloading during GetModelMetadata request

### DIFF
--- a/src/get_model_metadata_impl.cpp
+++ b/src/get_model_metadata_impl.cpp
@@ -58,10 +58,6 @@ Status GetModelMetadataImpl::getModelStatus(
         }
     }
 
-    if (ModelVersionState::AVAILABLE != instance->getStatus().getState()) {
-        return StatusCode::MODEL_MISSING;
-    }
-
     return buildResponse(instance, response);
 }
 
@@ -107,8 +103,10 @@ Status GetModelMetadataImpl::buildResponse(
     std::shared_ptr<ModelInstance> instance,
     tensorflow::serving::GetModelMetadataResponse* response) {
 
+    const uint WAIT_FOR_LOADED_TIMEOUT_MILLISECONDS = 1;
+
     std::unique_ptr<ModelInstanceUnloadGuard> unloadGuard;
-    auto status = instance->waitForLoaded(1, unloadGuard);
+    auto status = instance->waitForLoaded(WAIT_FOR_LOADED_TIMEOUT_MILLISECONDS, unloadGuard);
     if (!status.ok()) {
         return status;
     }

--- a/src/get_model_metadata_impl.cpp
+++ b/src/get_model_metadata_impl.cpp
@@ -103,7 +103,7 @@ Status GetModelMetadataImpl::buildResponse(
     std::shared_ptr<ModelInstance> instance,
     tensorflow::serving::GetModelMetadataResponse* response) {
 
-    const uint WAIT_FOR_LOADED_TIMEOUT_MILLISECONDS = 1;
+    const uint WAIT_FOR_LOADED_TIMEOUT_MILLISECONDS = 0;
 
     std::unique_ptr<ModelInstanceUnloadGuard> unloadGuard;
     auto status = instance->waitForLoaded(WAIT_FOR_LOADED_TIMEOUT_MILLISECONDS, unloadGuard);

--- a/src/get_model_metadata_impl.cpp
+++ b/src/get_model_metadata_impl.cpp
@@ -103,10 +103,10 @@ Status GetModelMetadataImpl::buildResponse(
     std::shared_ptr<ModelInstance> instance,
     tensorflow::serving::GetModelMetadataResponse* response) {
 
-    const uint WAIT_FOR_LOADED_TIMEOUT_MILLISECONDS = 0;
-
     std::unique_ptr<ModelInstanceUnloadGuard> unloadGuard;
-    auto status = instance->waitForLoaded(WAIT_FOR_LOADED_TIMEOUT_MILLISECONDS, unloadGuard);
+
+    // 0 meaning immediately return unload guard if possible, otherwise do not wait for available state
+    auto status = instance->waitForLoaded(0, unloadGuard);
     if (!status.ok()) {
         return status;
     }

--- a/src/get_model_metadata_impl.hpp
+++ b/src/get_model_metadata_impl.hpp
@@ -40,7 +40,7 @@ public:
         const tensor_map_t& from,
         proto_signature_map_t* to);
 
-    static void buildResponse(
+    static Status buildResponse(
         std::shared_ptr<ModelInstance> instance,
         tensorflow::serving::GetModelMetadataResponse* response);
 

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -425,7 +425,7 @@ Status ModelInstance::reloadModel(const ModelConfig& config, const DynamicModelP
     std::lock_guard<std::recursive_mutex> loadingLock(loadingMutex);
     this->status.setLoading();
     while (!canUnloadInstance()) {
-        SPDLOG_INFO("Waiting to reload model: {} version: {}. Blocked by: {} inferences in progress.",
+        SPDLOG_INFO("Waiting to reload model: {} version: {}. Blocked by: {} requests in progress.",
             getName(), getVersion(), predictRequestsHandlesCount);
         std::this_thread::sleep_for(std::chrono::milliseconds(UNLOAD_AVAILABILITY_CHECKING_INTERVAL_MILLISECONDS));
     }
@@ -532,7 +532,7 @@ void ModelInstance::unloadModel() {
     std::lock_guard<std::recursive_mutex> loadingLock(loadingMutex);
     this->status.setUnloading();
     while (!canUnloadInstance()) {
-        SPDLOG_INFO("Waiting to unload model:{} version:{}. Blocked by:{} inferences in progres.",
+        SPDLOG_INFO("Waiting to unload model:{} version:{}. Blocked by:{} requests in progres.",
             getName(), getVersion(), predictRequestsHandlesCount);
         std::this_thread::sleep_for(std::chrono::milliseconds(UNLOAD_AVAILABILITY_CHECKING_INTERVAL_MILLISECONDS));
     }

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -458,7 +458,5 @@ public:
         std::unique_ptr<ModelInstanceUnloadGuard>& modelInstanceUnloadGuard);
 
     const Status validate(const tensorflow::serving::PredictRequest* request);
-
-    static const int WAIT_FOR_MODEL_LOADED_TIMEOUT_MILLISECONDS = 100;
 };
 }  // namespace ovms

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -337,7 +337,7 @@ public:
          *
          * @return status
          */
-    const ModelVersionStatus& getStatus() const {
+    virtual const ModelVersionStatus& getStatus() const {
         return status;
     }
 

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -337,7 +337,7 @@ public:
          *
          * @return status
          */
-    virtual const ModelVersionStatus& getStatus() const {
+    const ModelVersionStatus& getStatus() const {
         return status;
     }
 

--- a/src/test/get_model_metadata_response_test.cpp
+++ b/src/test/get_model_metadata_response_test.cpp
@@ -41,6 +41,7 @@ class GetModelMetadataResponse : public ::testing::Test {
         MOCK_METHOD(const ovms::tensor_map_t&, getOutputsInfo, (), (const, override));
         MOCK_METHOD(const std::string&, getName, (), (const, override));
         MOCK_METHOD(ovms::model_version_t, getVersion, (), (const, override));
+        MOCK_METHOD(const ovms::ModelVersionStatus&, getStatus, (), (const, override));
     };
 
     tensor_desc_map_t inputTensors;
@@ -48,10 +49,11 @@ class GetModelMetadataResponse : public ::testing::Test {
     ovms::tensor_map_t networkInputs;
     ovms::tensor_map_t networkOutputs;
 
+protected:
     std::string modelName = "resnet";
     ovms::model_version_t modelVersion = 23;
+    ovms::ModelVersionStatus modelStatus{modelName, modelVersion, ovms::ModelVersionState::AVAILABLE};
 
-protected:
     std::shared_ptr<NiceMock<MockModelInstance>> instance;
     tensorflow::serving::GetModelMetadataResponse response;
 
@@ -101,6 +103,8 @@ protected:
             .WillByDefault(ReturnRef(modelName));
         ON_CALL(*instance, getVersion())
             .WillByDefault(Return(modelVersion));
+        ON_CALL(*instance, getStatus())
+            .WillByDefault(ReturnRef(modelStatus));
     }
 };
 
@@ -235,6 +239,16 @@ TEST_F(GetModelMetadataResponse, HasCorrectShape) {
     EXPECT_TRUE(isShape(
         outputs.at("Output_FP32_2_20_3").tensor_shape(),
         {2, 20, 3}));
+}
+
+TEST_F(GetModelMetadataResponse, ModelVersionNotLoadedAnymore) {
+    modelStatus.setEnd();
+    EXPECT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
+}
+
+TEST_F(GetModelMetadataResponse, ModelVersionNotLoadedYet) {
+    modelStatus.setLoading();
+    EXPECT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_YET);
 }
 
 TEST_F(GetModelMetadataResponse, serialize2Json) {

--- a/src/test/get_model_metadata_response_test.cpp
+++ b/src/test/get_model_metadata_response_test.cpp
@@ -21,8 +21,8 @@
 #include "../get_model_metadata_impl.hpp"
 #include "../modelmanager.hpp"
 #include "../status.hpp"
-#include "test_utils.hpp"
 #include "mockmodelinstancechangingstates.hpp"
+#include "test_utils.hpp"
 
 using ::testing::NiceMock;
 using ::testing::Return;

--- a/src/test/get_model_metadata_response_test.cpp
+++ b/src/test/get_model_metadata_response_test.cpp
@@ -109,34 +109,34 @@ protected:
 };
 
 TEST_F(GetModelMetadataResponse, HasModelSpec) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
     EXPECT_TRUE(response.has_model_spec());
 }
 
 TEST_F(GetModelMetadataResponse, HasVersion) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
     EXPECT_TRUE(response.model_spec().has_version());
 }
 
 TEST_F(GetModelMetadataResponse, HasCorrectVersion) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
     EXPECT_EQ(response.model_spec().version().value(), 23);
 }
 
 TEST_F(GetModelMetadataResponse, HasOneMetadataInfo) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
     EXPECT_EQ(response.metadata_size(), 1);
 }
 
 TEST_F(GetModelMetadataResponse, HasCorrectMetadataSignatureName) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
     EXPECT_NE(
         response.metadata().find("signature_def"),
         response.metadata().end());
 }
 
 TEST_F(GetModelMetadataResponse, HasOneSignatureDef) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
 
     tensorflow::serving::SignatureDefMap def;
     response.metadata().at("signature_def").UnpackTo(&def);
@@ -145,7 +145,7 @@ TEST_F(GetModelMetadataResponse, HasOneSignatureDef) {
 }
 
 TEST_F(GetModelMetadataResponse, HasCorrectSignatureDefName) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
 
     tensorflow::serving::SignatureDefMap def;
     response.metadata().at("signature_def").UnpackTo(&def);
@@ -156,7 +156,7 @@ TEST_F(GetModelMetadataResponse, HasCorrectSignatureDefName) {
 }
 
 TEST_F(GetModelMetadataResponse, HasCorrectTensorNames) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
 
     tensorflow::serving::SignatureDefMap def;
     response.metadata().at("signature_def").UnpackTo(&def);
@@ -182,7 +182,7 @@ TEST_F(GetModelMetadataResponse, HasCorrectTensorNames) {
 }
 
 TEST_F(GetModelMetadataResponse, HasCorrectPrecision) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
 
     tensorflow::serving::SignatureDefMap def;
     response.metadata().at("signature_def").UnpackTo(&def);
@@ -205,7 +205,7 @@ TEST_F(GetModelMetadataResponse, HasCorrectPrecision) {
 }
 
 TEST_F(GetModelMetadataResponse, HasCorrectShape) {
-    ovms::GetModelMetadataImpl::buildResponse(instance, &response);
+    ASSERT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
 
     tensorflow::serving::SignatureDefMap def;
     response.metadata().at("signature_def").UnpackTo(&def);

--- a/src/test/modelinstance_test.cpp
+++ b/src/test/modelinstance_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 #include <stdlib.h>
 
+#include "../get_model_metadata_impl.hpp"
 #include "../modelinstance.hpp"
 #include "test_utils.hpp"
 
@@ -78,6 +79,39 @@ TEST_F(TestUnloadModel, CanUnloadModelNotHoldingModelInstanceAtPredictPath) {
     modelInstance.increasePredictRequestsHandlesCount();
     modelInstance.decreasePredictRequestsHandlesCount();
     EXPECT_TRUE(modelInstance.canUnloadInstance());
+}
+
+TEST_F(TestUnloadModel, UnloadWaitsUntilMetadataResponseIsBuilt) {
+    static std::thread thread;
+    static std::shared_ptr<ovms::ModelInstance> instance;
+
+    class MockModelInstanceTriggeringUnload : public ovms::ModelInstance {
+    public:
+        const ovms::tensor_map_t& getInputsInfo() const override {
+            thread = std::thread([]() {
+                instance->unloadModel();
+            });
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            return ovms::ModelInstance::getInputsInfo();
+        }
+    };
+    instance = std::make_shared<MockModelInstanceTriggeringUnload>();
+    ovms::Status status = instance->loadModel(DUMMY_MODEL_CONFIG);
+    ASSERT_EQ(status, ovms::StatusCode::OK);
+    ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, instance->getStatus().getState());
+    tensorflow::serving::GetModelMetadataResponse response;
+    EXPECT_EQ(ovms::GetModelMetadataImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
+    thread.join();
+    EXPECT_EQ(ovms::ModelVersionState::END, instance->getStatus().getState());
+
+    tensorflow::serving::SignatureDefMap def;
+    response.metadata().at("signature_def").UnpackTo(&def);
+    const auto& inputs = ((*def.mutable_signature_def())["serving_default"]).inputs();
+    const auto& outputs = ((*def.mutable_signature_def())["serving_default"]).outputs();
+    EXPECT_EQ(inputs.size(), 1);
+    EXPECT_EQ(outputs.size(), 1);
+    EXPECT_EQ(inputs.begin()->second.name(), DUMMY_MODEL_INPUT_NAME);
+    EXPECT_EQ(outputs.begin()->second.name(), DUMMY_MODEL_OUTPUT_NAME);
 }
 
 TEST_F(TestUnloadModel, CheckIfCanUnload) {

--- a/src/test/prediction_service_utils_test.cpp
+++ b/src/test/prediction_service_utils_test.cpp
@@ -191,7 +191,7 @@ TEST_F(ModelInstanceModelLoadedNotify, WhenChangedStateFromLoadingToAvailableInN
     ModelManagerWithModelInstanceLoadedWaitInLoadingState manager;
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     modelWithModelInstanceLoadedWaitInLoadingState = std::make_shared<ModelWithModelInstanceLoadedWaitInLoadingState>(
-        config.getName(), ovms::ModelInstance::WAIT_FOR_MODEL_LOADED_TIMEOUT_MILLISECONDS / 4);
+        config.getName(), ovms::WAIT_FOR_MODEL_LOADED_TIMEOUT_MS / 4);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK);
     std::shared_ptr<ovms::ModelInstance> modelInstance;
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> modelInstanceUnloadGuardPtr;


### PR DESCRIPTION
Task: https://jira.devtools.intel.com/browse/CVS-41739
Bug: https://jira.devtools.intel.com/browse/CVS-41248