### PR TITLE
CVS-41786 Dynamic parameter blockade for models refered in pipeline

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -32,6 +32,18 @@ void Model::unsubscribe(PipelineDefinition& pd) {
     subscriptionManager.unsubscribe(pd);
 }
 
+bool Model::isAnyVersionSubscribed() const {
+    if (subscriptionManager.isSubscribed()) {
+        return true;
+    }
+    for (const auto& [name, instance] : modelVersions) {
+        if (instance->getSubscribtionManager().isSubscribed()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 const std::map<model_version_t, const ModelInstance&> Model::getModelVersionsMapCopy() const {
     std::shared_lock lock(modelVersionsMtx);
     std::map<model_version_t, const ModelInstance&> modelInstancesMapCopy;

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -190,6 +190,9 @@ public:
          * @param custom loader name
          *
          */
+
+    bool isAnyVersionSubscribed() const;
+
     void setCustomLoaderName(const std::string name) {
         customLoaderName = name;
     }

--- a/src/modelchangesubscription.hpp
+++ b/src/modelchangesubscription.hpp
@@ -36,5 +36,7 @@ public:
     void unsubscribe(PipelineDefinition& pd);
 
     void notifySubscribers();
+
+    bool isSubscribed() const { return subscriptions.size() > 0; }
 };
 }  // namespace ovms

--- a/src/modelconfig.hpp
+++ b/src/modelconfig.hpp
@@ -320,6 +320,10 @@ public:
         return this->batchingMode;
     }
 
+    bool isDynamicParameterEnabled() const {
+        return this->getBatchingMode() == Mode::AUTO || this->anyShapeSetToAuto();
+    }
+
     /**
          * @brief Get the batch size 
          * 

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -478,6 +478,8 @@ public:
 
     void unsubscribe(PipelineDefinition& pd);
 
+    const ModelChangeSubscription& getSubscribtionManager() const { return subscriptionManager; }
+
     const Status validate(const tensorflow::serving::PredictRequest* request);
 };
 }  // namespace ovms

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -340,7 +340,7 @@ Status ModelManager::loadModelsConfig(rapidjson::Document& configJson, std::vect
             continue;
         }
         status = reloadModelWithVersions(modelConfig);
-        modelsInConfigFile.emplace(modelConfig.getName());
+        modelsInConfigFile.emplace(modelName);
 
         if (status.ok()) {
             newModelConfigs.emplace(modelName, std::move(modelConfig));
@@ -354,7 +354,7 @@ Status ModelManager::loadModelsConfig(rapidjson::Document& configJson, std::vect
             newModelConfigs.emplace(modelName, std::move(it->second));
             this->servedModelConfigs.erase(modelName);
         } else {
-            SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Cannot reload model with versions: {}", status.string());
+            SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Cannot reload model: {} with versions due to error: {}", modelName, status.string());
         }
     }
     this->servedModelConfigs = std::move(newModelConfigs);
@@ -678,7 +678,7 @@ Status ModelManager::reloadModelVersions(std::shared_ptr<ovms::Model>& model, st
 Status ModelManager::reloadModelWithVersions(ModelConfig& config) {
     auto model = getModelIfExistCreateElse(config.getName());
     if (model->isAnyVersionSubscribed() && config.isDynamicParameterEnabled()) {
-        SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Requested setting dynamic parameters for model {} but it is used in pipeline", config.getName());
+        SPDLOG_LOGGER_ERROR(modelmanager_logger, "Requested setting dynamic parameters for model {} but it is used in pipeline. Cannot reload model configuration.", config.getName());
         return StatusCode::REQUESTED_DYNAMIC_PARAMETERS_ON_SUBSCRIBED_MODEL;
     }
 

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -22,6 +22,7 @@
 #include <shared_mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include <rapidjson/document.h>
@@ -72,6 +73,7 @@ private:
     Status reloadModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToReload);
     Status addModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToStart);
     Status loadModelsConfig(rapidjson::Document& configJson);
+    Status tryReloadGatedModelConfigs();
     Status loadPipelinesConfig(rapidjson::Document& configJson);
     Status loadCustomLoadersConfig(rapidjson::Document& configJson);
 
@@ -103,7 +105,14 @@ private:
      * @brief A current configurations of models
      * 
      */
-    std::vector<ModelConfig> servedModelConfigs;
+    std::unordered_map<std::string, ModelConfig> servedModelConfigs;
+
+    /**
+     * @brief
+     * Configurations gated to be reloaded due to reference in pipeline.
+     * Such model configs are reloaded again after pipeline re-validation.
+     */
+    std::vector<ModelConfig> gatedModelConfigs;
 
     /**
      * @brief Retires models non existing in config file

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -72,8 +72,8 @@ private:
     Status cleanupModelTmpFiles(ModelConfig& config);
     Status reloadModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToReload);
     Status addModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToStart);
-    Status loadModelsConfig(rapidjson::Document& configJson);
-    Status tryReloadGatedModelConfigs();
+    Status loadModelsConfig(rapidjson::Document& configJson, std::vector<ModelConfig>& gatedModelConfigs);
+    Status tryReloadGatedModelConfigs(std::vector<ModelConfig>& gatedModelConfigs);
     Status loadPipelinesConfig(rapidjson::Document& configJson);
     Status loadCustomLoadersConfig(rapidjson::Document& configJson);
 
@@ -106,13 +106,6 @@ private:
      * 
      */
     std::unordered_map<std::string, ModelConfig> servedModelConfigs;
-
-    /**
-     * @brief
-     * Configurations gated to be reloaded due to reference in pipeline.
-     * Such model configs are reloaded again after pipeline re-validation.
-     */
-    std::vector<ModelConfig> gatedModelConfigs;
 
     /**
      * @brief Retires models non existing in config file

--- a/src/pipeline_factory.hpp
+++ b/src/pipeline_factory.hpp
@@ -82,7 +82,7 @@ public:
         std::for_each(definitions.begin(),
             definitions.end(),
             [&pipelinesInConfigFile, &manager](auto& nameDefinitionPair) {
-                if (pipelinesInConfigFile.find(nameDefinitionPair.second->getName()) == pipelinesInConfigFile.end()) {
+                if (pipelinesInConfigFile.find(nameDefinitionPair.second->getName()) == pipelinesInConfigFile.end() && nameDefinitionPair.second->getStateCode() != PipelineDefinitionStateCode::RETIRED) {
                     nameDefinitionPair.second->retire(manager);
                 }
             });

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -46,6 +46,7 @@ const std::map<const StatusCode, const std::string> Status::statusMessageMap = {
     {StatusCode::INVALID_SIGNATURE_DEF, "Invalid signature name"},
     {StatusCode::CONFIG_SHAPE_IS_NOT_IN_NETWORK, "Shape from config not found in network"},
     {StatusCode::INVALID_NIREQ, "Nireq parameter too high"},
+    {StatusCode::REQUESTED_DYNAMIC_PARAMETERS_ON_SUBSCRIBED_MODEL, "Requested dynamic parameters but model subscribed to pipeline"},
 
     // Predict request validation
     {StatusCode::INVALID_NO_OF_INPUTS, "Invalid number of inputs"},

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -46,7 +46,7 @@ const std::map<const StatusCode, const std::string> Status::statusMessageMap = {
     {StatusCode::INVALID_SIGNATURE_DEF, "Invalid signature name"},
     {StatusCode::CONFIG_SHAPE_IS_NOT_IN_NETWORK, "Shape from config not found in network"},
     {StatusCode::INVALID_NIREQ, "Nireq parameter too high"},
-    {StatusCode::REQUESTED_DYNAMIC_PARAMETERS_ON_SUBSCRIBED_MODEL, "Requested dynamic parameters but model subscribed to pipeline"},
+    {StatusCode::REQUESTED_DYNAMIC_PARAMETERS_ON_SUBSCRIBED_MODEL, "Requested dynamic parameters but model is subscribed to pipeline"},
 
     // Predict request validation
     {StatusCode::INVALID_NO_OF_INPUTS, "Invalid number of inputs"},

--- a/src/status.hpp
+++ b/src/status.hpp
@@ -53,6 +53,7 @@ enum class StatusCode {
     ANONYMOUS_FIXED_SHAPE_NOT_ALLOWED,      /*!< Anonymous fixed shape is invalid for models with multiple inputs */
     CONFIG_SHAPE_IS_NOT_IN_NETWORK,         /*!< Invalid shape dimension number or dimension value */
     CANNOT_LOAD_NETWORK_INTO_TARGET_DEVICE, /*!< Cannot load network into target device */
+    REQUESTED_DYNAMIC_PARAMETERS_ON_SUBSCRIBED_MODEL,
 
     // Model management
     MODEL_MISSING,                    /*!< Model with such name and/or version does not exist */

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -760,7 +760,7 @@ TEST_F(TestCustomLoader, CustomLoaderWithMissingModelFiles) {
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
     tensorflow::serving::PredictResponse response;
-    ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::MODEL_NAME_MISSING);
+    ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::MODEL_VERSION_MISSING);
 }
 
 TEST_F(TestCustomLoader, CustomLoaderGetStatusDeleteModelGetStatus) {

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -1503,48 +1503,6 @@ static const char* pipelineOneDummyConfig = R"(
     ]
 })";
 
-static const char* pipelineOneDynamicParamDummyConfig = R"(
-{
-    "model_config_list": [
-        {
-            "config": {
-                "name": "dummy",
-                "base_path": "/ovms/src/test/dummy",
-                "target_device": "CPU",
-                "model_version_policy": {"all": {}},
-                "nireq": 1,
-                "shape": "auto"
-            }
-        }
-    ],
-    "pipeline_config_list": [
-        {
-            "name": "pipeline1Dummy",
-            "inputs": ["custom_dummy_input"],
-            "nodes": [
-                {
-                    "name": "dummyNode",
-                    "model_name": "dummy",
-                    "type": "DL model",
-                    "inputs": [
-                        {"b": {"node_name": "request",
-                               "data_item": "custom_dummy_input"}}
-                    ],
-                    "outputs": [
-                        {"data_item": "a",
-                         "alias": "new_dummy_output"}
-                    ]
-                }
-            ],
-            "outputs": [
-                {"custom_dummy_output": {"node_name": "dummyNode",
-                                         "data_item": "new_dummy_output"}
-                }
-            ]
-        }
-    ]
-})";
-
 TEST_F(EnsembleFlowTest, PipelineFactoryCreationWithInputOutputsMappings) {
     std::string fileToReload = directoryPath + "/ovms_config_file.json";
     createConfigFileWithContent(pipelineOneDummyConfig, fileToReload);
@@ -2558,6 +2516,48 @@ TEST_F(EnsembleFlowTest, RetireReloadAddPipelineAtTheSameTime) {
     EXPECT_EQ(inputsInfoAfter.count(NEW_INPUT_NAME), 1);
 }
 
+static const char* pipelineOneDynamicParamDummyConfig = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "nireq": 1,
+                "shape": "auto"
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+
 TEST_F(EnsembleFlowTest, EnablingDynamicParametersForModelUsedInPipeline) {
     /*
         This test modifies config.json to enable dynamic parameters for model used in pipeline.
@@ -2584,6 +2584,7 @@ TEST_F(EnsembleFlowTest, EnablingDynamicParametersForModelUsedInPipeline) {
     auto instance = manager.findModelInstance("dummy");
     ASSERT_NE(instance, nullptr);
     ASSERT_FALSE(instance->getModelConfig().isDynamicParameterEnabled());
+    ASSERT_EQ(instance->getStatus().getState(), ModelVersionState::AVAILABLE);
 }
 
 static const char* dummyWithDynamicParamConfig = R"(
@@ -2629,4 +2630,5 @@ TEST_F(EnsembleFlowTest, EnablingDynamicParametersAndRemovingPipeline) {
     auto instance = manager.findModelInstance("dummy");
     ASSERT_NE(instance, nullptr);
     ASSERT_TRUE(instance->getModelConfig().isDynamicParameterEnabled());
+    ASSERT_EQ(instance->getStatus().getState(), ModelVersionState::AVAILABLE);
 }

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -153,10 +153,10 @@ public:
     ConstructorEnabledModelManager() :
         ovms::ModelManager() {}
     ~ConstructorEnabledModelManager() {
-        spdlog::info("Destructor of modelmanager(Enabled one). Models #: {}", models.size());
-        models.clear();
-        spdlog::info("Destructor of modelmanager(Enabled one). Models #: {}", models.size());
         join();
+        spdlog::info("Destructor of modelmanager(Enabled one). Models #:{}", models.size());
+        models.clear();
+        spdlog::info("Destructor of modelmanager(Enabled one). Models #:{}", models.size());
     }
 };
 class TestWithTempDir : public ::testing::Test {


### PR DESCRIPTION
- block models from loading if dynamic parameter (batch or shape equal to auto) is set and model is subscribed to atleast one pipeline
- add model load retry to make sure such blocked models are loaded if unsubscribed from pipeline