### PR TITLE
Fix data race in pipeline reload

### DIFF
--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -50,6 +50,8 @@ Status PipelineDefinition::validate(ModelManager& manager) {
 }
 
 Status PipelineDefinition::reload(ModelManager& manager, const std::vector<NodeInfo>&& nodeInfos, const pipeline_connections_t&& connections) {
+    // block creating new unloadGuards
+    this->status.handle(ReloadEvent());
     resetSubscriptions(manager);
     while (requestsHandlesCounter > 0) {
         std::this_thread::sleep_for(std::chrono::microseconds(1));
@@ -637,7 +639,6 @@ Status PipelineDefinition::getInputsInfo(tensor_map_t& inputsInfo, const ModelMa
             return nodeInfo.nodeName == name;
         };
     };
-
     for (const auto& [dependantNodeName, allMappings] : connections) {
         const auto& dependantNodeInfo = std::find_if(std::begin(nodeInfos), std::end(nodeInfos), byName(dependantNodeName));
         for (const auto& [dependencyNodeName, specificDependencyMapping] : allMappings) {
@@ -679,7 +680,6 @@ Status PipelineDefinition::getInputsInfo(tensor_map_t& inputsInfo, const ModelMa
             }
         }
     }
-
     return StatusCode::OK;
 }
 
@@ -692,7 +692,6 @@ Status PipelineDefinition::getOutputsInfo(tensor_map_t& outputsInfo, const Model
             return nodeInfo.nodeName == name;
         };
     };
-
     for (const auto& [dependantNodeName, allMappings] : connections) {
         const auto& dependantNodeInfo = std::find_if(std::begin(nodeInfos), std::end(nodeInfos), byName(dependantNodeName));
         if (dependantNodeInfo->kind != NodeKind::EXIT) {
@@ -736,7 +735,6 @@ Status PipelineDefinition::getOutputsInfo(tensor_map_t& outputsInfo, const Model
             }
         }
     }
-
     return StatusCode::OK;
 }
 

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -2006,6 +2006,7 @@ TEST_F(EnsembleFlowTest, ReloadPipelineDefinitionWithNewModelNameShouldPass) {
     status = pd.reload(managerWithDummyModel, std::move(infoNew), std::move(connections));
     EXPECT_TRUE(status.ok()) << status.string();
 }
+const std::string notifierDetails{"UnusedNotifierDetails"};
 
 TEST_F(EnsembleFlowTest, ReloadPipelineDefinitionWithNewNonExistingModelNameShouldFail) {
     ConstructorEnabledModelManager managerWithDummyModel;
@@ -2076,6 +2077,7 @@ TEST_F(EnsembleFlowTest, RevalidatePipelineDefinitionWhen1ModelVersionBecomesAva
     connections[EXIT_NODE_NAME] = {
         {"dummy_node", {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}}}};
     PipelineDefinition pd(pipelineName, info, connections);
+    pd.makeSubscriptions(managerWithDummyModel);
     auto status = pd.validate(managerWithDummyModel);
     ASSERT_TRUE(status.ok()) << status.string();
     managerWithDummyModel.findModelByName("dummy")->retireAllVersions();
@@ -2167,6 +2169,7 @@ TEST_F(EnsembleFlowTest, WaitForLoadingPipelineDefinitionFromBeginStatus) {
     connections[EXIT_NODE_NAME] = {
         {"dummy_node", {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}}}};
     MockedPipelineDefinitionWithHandlingStatus pd(pipelineName, info, connections);
+    pd.makeSubscriptions(managerWithDummyModel);
     std::unique_ptr<Pipeline> pipelineBeforeRetire;
     std::thread t([&managerWithDummyModel, &pd]() {
         std::this_thread::sleep_for(std::chrono::microseconds(PipelineDefinition::WAIT_FOR_LOADED_DEFAULT_TIMEOUT_MICROSECONDS / 4));
@@ -2176,10 +2179,12 @@ TEST_F(EnsembleFlowTest, WaitForLoadingPipelineDefinitionFromBeginStatus) {
     });
     auto status = pd.create(pipelineBeforeRetire, &request, &response, managerWithDummyModel);
     ASSERT_TRUE(status.ok());
+    pd.getControlableStatus().handle(UsedModelChangedEvent(notifierDetails));
     pd.getControlableStatus().handle(ValidationFailedEvent());
     status = pd.create(pipelineBeforeRetire, &request, &response, managerWithDummyModel);
     ASSERT_EQ(status, ovms::StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET);
     pd.getControlableStatus().handle(UsedModelChangedEvent());
+    pd.getControlableStatus().handle(UsedModelChangedEvent(notifierDetails));
     status = pd.create(pipelineBeforeRetire, &request, &response, managerWithDummyModel);
     ASSERT_EQ(status, ovms::StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET);
     std::thread t2([&managerWithDummyModel, &pd]() {

--- a/src/test/get_pipeline_metadata_response_test.cpp
+++ b/src/test/get_pipeline_metadata_response_test.cpp
@@ -252,6 +252,7 @@ TEST_F(GetPipelineMetadataResponse, PipelineNotLoadedAnymore) {
 }
 
 TEST_F(GetPipelineMetadataResponse, PipelineNotLoadedYet) {
+    this->pipelineDefinition.getPipelineDefinitionStatus().handle(UsedModelChangedEvent());
     this->pipelineDefinition.getPipelineDefinitionStatus().handle(ValidationFailedEvent());
     auto status = ovms::GetModelMetadataImpl::buildResponse(pipelineDefinition, &response, manager);
     ASSERT_EQ(status, ovms::StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET) << status.string();


### PR DESCRIPTION
Root cause was not blocking new requests from creation. There was no
transient state that would block requests so when pipeline reload
happened it checked once if there is no ongoing request but after that
new request could still be created.

JIRA:CVS-45093