### PR TITLE
CVS-45311Add class to hold additional information necessary during request processing

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -80,6 +80,7 @@ cc_library(
         "prediction_service.hpp",
         "prediction_service_utils.hpp",
         "prediction_service_utils.cpp",
+        "processing_spec.hpp",
         "rest_parser.cpp",
         "rest_parser.hpp",
         "rest_utils.cpp",

--- a/src/processing_spec.hpp
+++ b/src/processing_spec.hpp
@@ -32,7 +32,7 @@ private:
     std::shared_ptr<SequenceProcessingSpec> sequenceProcessingSpecPtr;
 
 public:
-    SequenceProcessingSpec& getSequenceProcessingSpec() { return *sequenceProcessingSpecPtr; }
+    std::shared_ptr<SequenceProcessingSpec> getSequenceProcessingSpecPtr() { return sequenceProcessingSpecPtr; }
 
     void setSequenceProcessingSpec(uint32_t sequenceControlInput, uint64_t sequenceId) {
         sequenceProcessingSpecPtr = std::make_shared<SequenceProcessingSpec>(sequenceControlInput, sequenceId);

--- a/src/processing_spec.hpp
+++ b/src/processing_spec.hpp
@@ -1,0 +1,41 @@
+//*****************************************************************************
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+
+#include <memory>
+
+namespace ovms {
+
+struct SequenceProcessingSpec {
+    uint32_t sequenceControlInput;
+    uint64_t sequenceId;
+    SequenceProcessingSpec(uint32_t sequenceControlInput, uint64_t sequenceId) :
+        sequenceControlInput(sequenceControlInput),
+        sequenceId(sequenceId) {}
+};
+
+class ProcessingSpec {
+private:
+    std::shared_ptr<SequenceProcessingSpec> sequenceProcessingSpecPtr;
+
+public:
+    SequenceProcessingSpec& getSequenceProcessingSpec() { return *sequenceProcessingSpecPtr; }
+
+    void setSequenceProcessingSpec(uint32_t sequenceControlInput, uint64_t sequenceId) {
+        sequenceProcessingSpecPtr = std::make_shared<SequenceProcessingSpec>(sequenceControlInput, sequenceId);
+    }
+};
+}  // namespace ovms

--- a/src/processing_spec.hpp
+++ b/src/processing_spec.hpp
@@ -29,13 +29,13 @@ struct SequenceProcessingSpec {
 
 class ProcessingSpec {
 private:
-    std::shared_ptr<SequenceProcessingSpec> sequenceProcessingSpecPtr;
+    std::shared_ptr<SequenceProcessingSpec> sequenceProcessingSpec;
 
 public:
-    std::shared_ptr<SequenceProcessingSpec> getSequenceProcessingSpecPtr() { return sequenceProcessingSpecPtr; }
+    std::shared_ptr<SequenceProcessingSpec> getSequenceProcessingSpecPtr() { return sequenceProcessingSpec; }
 
     void setSequenceProcessingSpec(uint32_t sequenceControlInput, uint64_t sequenceId) {
-        sequenceProcessingSpecPtr = std::make_shared<SequenceProcessingSpec>(sequenceControlInput, sequenceId);
+        sequenceProcessingSpec = std::make_shared<SequenceProcessingSpec>(sequenceControlInput, sequenceId);
     }
 };
 }  // namespace ovms


### PR DESCRIPTION
Introducing new classes to wrap data that needs to be passed back and forth between methods during request handling. 
Added ProcessingSpec that for now will hold only SequenceProcessingSpec, but might be used to keep other types of data that we may need to maintain throughout request processing. 
It contains pointer to SequenceProcessingSpec type that might point to valid object if request is processed by stateful model or nullptr if request is processed by stateless model. 