### PR TITLE
CVS-41787 Add pipeline Metadata stress tests (#407)

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -177,6 +177,7 @@ cc_test(
         "test/ensemble_tests.cpp",
         "test/ensemble_mapping_config_tests.cpp",
         "test/ensemble_metadata_test.cpp",
+        "test/ensemble_config_change_stress.cpp",
         "test/get_model_metadata_response_test.cpp",
         "test/get_pipeline_metadata_response_test.cpp",
         "test/get_model_metadata_signature_test.cpp",

--- a/src/dl_node.cpp
+++ b/src/dl_node.cpp
@@ -89,7 +89,7 @@ Status DLNode::setInputsForInference(InferenceEngine::InferRequest& infer_reques
         for (const auto& kv : this->inputBlobs) {
             std::string realModelInputName;
             if (!getRealInputName(kv.first, &realModelInputName).ok()) {
-                SPDLOG_WARN("DLNode::fetchResults (Node name {}); cannot find real model input name for ali{}", getName(), kv.first);
+                SPDLOG_WARN("DLNode::{} [Node name: {}]; cannot find real model input name for alias: {}", __FUNCTION__, getName(), kv.first);
                 return StatusCode::INTERNAL_ERROR;
             }
             infer_request.SetBlob(realModelInputName, kv.second);

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -89,7 +89,6 @@ Status EntryNode::deserialize(const tensorflow::TensorProto& proto, InferenceEng
     }
 
     // description.setLayout();  // Layout info is stored in model instance. If we find out it is required, then need to be set right before inference.
-
     try {
         switch (proto.dtype()) {
         case tensorflow::DataType::DT_FLOAT:

--- a/src/get_model_metadata_impl.cpp
+++ b/src/get_model_metadata_impl.cpp
@@ -21,7 +21,6 @@ using google::protobuf::util::JsonPrintOptions;
 using google::protobuf::util::MessageToJsonString;
 
 namespace ovms {
-
 Status GetModelMetadataImpl::getModelStatus(
     const tensorflow::serving::GetModelMetadataRequest* request,
     tensorflow::serving::GetModelMetadataResponse* response) {
@@ -29,10 +28,15 @@ Status GetModelMetadataImpl::getModelStatus(
     if (!status.ok()) {
         return status;
     }
+    return getModelStatus(request, response, ModelManager::getInstance());
+}
 
+Status GetModelMetadataImpl::getModelStatus(
+    const tensorflow::serving::GetModelMetadataRequest* request,
+    tensorflow::serving::GetModelMetadataResponse* response,
+    ModelManager& manager) {
     const auto& name = request->model_spec().name();
     model_version_t version = request->model_spec().has_version() ? request->model_spec().version().value() : 0;
-    auto& manager = ovms::ModelManager::getInstance();
 
     auto model = manager.findModelByName(name);
     if (model == nullptr) {

--- a/src/get_model_metadata_impl.hpp
+++ b/src/get_model_metadata_impl.hpp
@@ -51,6 +51,10 @@ public:
     static Status getModelStatus(
         const tensorflow::serving::GetModelMetadataRequest* request,
         tensorflow::serving::GetModelMetadataResponse* response);
+    static Status getModelStatus(
+        const tensorflow::serving::GetModelMetadataRequest* request,
+        tensorflow::serving::GetModelMetadataResponse* response,
+        ModelManager& manager);
     static Status createGrpcRequest(std::string model_name, std::optional<int64_t> model_version, tensorflow::serving::GetModelMetadataRequest* request);
     static Status serializeResponse2Json(const tensorflow::serving::GetModelMetadataResponse* response, std::string* output);
 };

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -25,7 +25,7 @@ std::shared_ptr<spdlog::logger> s3_logger = std::make_shared<spdlog::logger>("s3
 std::shared_ptr<spdlog::logger> modelmanager_logger = std::make_shared<spdlog::logger>("modelmanager");
 std::shared_ptr<spdlog::logger> dag_executor_logger = std::make_shared<spdlog::logger>("dag_executor");
 
-const std::string default_pattern = "[%Y-%m-%d %T.%e][%n][%l][%s:%#] %v";
+const std::string default_pattern = "[%Y-%m-%d %T.%e][%t][%n][%l][%s:%#] %v";
 
 void set_log_level(const std::string log_level, std::shared_ptr<spdlog::logger> logger) {
     logger->set_level(spdlog::level::info);

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -446,6 +446,14 @@ void ModelManager::retireModelsRemovedFromConfigFile(const std::set<std::string>
     }
 }
 
+void ModelManager::updateConfigurationWithoutConfigFile() {
+    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Checking if something changed with model versions");
+    for (auto& [name, config] : servedModelConfigs) {
+        reloadModelWithVersions(config);
+    }
+    pipelineFactory.revalidatePipelines(*this);
+}
+
 void ModelManager::watcher(std::future<void> exit) {
     SPDLOG_LOGGER_INFO(modelmanager_logger, "Started config watcher thread");
     int64_t lastTime;
@@ -460,10 +468,7 @@ void ModelManager::watcher(std::future<void> exit) {
             lastTime = statTime.st_ctime;
             loadConfig(configFilename);
         }
-        for (auto& [name, config] : servedModelConfigs) {
-            reloadModelWithVersions(config);
-        }
-        pipelineFactory.revalidatePipelines(*this);
+        updateConfigurationWithoutConfigFile();
         SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Watcher thread check cycle end");
     }
     SPDLOG_LOGGER_ERROR(modelmanager_logger, "Exited config watcher thread");
@@ -488,9 +493,9 @@ void ModelManager::getVersionsToChange(
     std::shared_ptr<model_versions_t>& versionsToRetireIn) {
     std::sort(requestedVersions.begin(), requestedVersions.end());
     model_versions_t registeredModelVersions;
-    SPDLOG_DEBUG("Currently registered versions count: {}", modelVersionsInstances.size());
+    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Currently registered model: {} versions count: {}", newModelConfig.getName(), modelVersionsInstances.size());
     for (const auto& [version, versionInstance] : modelVersionsInstances) {
-        SPDLOG_DEBUG("version: {} state: {}", version, ovms::ModelVersionStateToString(versionInstance->getStatus().getState()));
+        SPDLOG_LOGGER_DEBUG(modelmanager_logger, "model: {} version: {} state: {}", newModelConfig.getName(), version, ovms::ModelVersionStateToString(versionInstance->getStatus().getState()));
         registeredModelVersions.push_back(version);
     }
 
@@ -652,6 +657,7 @@ Status ModelManager::reloadModelVersions(std::shared_ptr<ovms::Model>& model, st
 }
 
 Status ModelManager::reloadModelWithVersions(ModelConfig& config) {
+    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Started applying config changes to model: {}", config.getName());
     auto model = getModelIfExistCreateElse(config.getName());
     if (model->isAnyVersionSubscribed() && config.isDynamicParameterEnabled()) {
         SPDLOG_LOGGER_ERROR(modelmanager_logger, "Requested setting dynamic parameters for model {} but it is used in pipeline. Cannot reload model configuration.", config.getName());
@@ -665,11 +671,9 @@ Status ModelManager::reloadModelWithVersions(ModelConfig& config) {
         return blocking_status;
     }
     requestedVersions = config.getModelVersionPolicy()->filter(requestedVersions);
-
     std::shared_ptr<model_versions_t> versionsToStart;
     std::shared_ptr<model_versions_t> versionsToReload;
     std::shared_ptr<model_versions_t> versionsToRetire;
-
     // first reset custom loader name to empty string so that any changes to name can be captured
     model->resetCustomLoaderName();
 

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -62,13 +62,7 @@ private:
      */
     ModelManager(const ModelManager&) = delete;
 
-    /**
-     * @brief Reads models from configuration file
-     * 
-     * @param jsonFilename configuration file
-     * @return Status 
-     */
-    Status loadConfig(const std::string& jsonFilename);
+    Status cleanupModelTmpFiles(ModelConfig& config);
     Status reloadModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToReload);
     Status addModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToStart);
     Status loadModelsConfig(rapidjson::Document& configJson, std::vector<ModelConfig>& gatedModelConfigs);
@@ -297,6 +291,20 @@ public:
         std::shared_ptr<model_versions_t>& versionsToStartIn);
 
     static std::shared_ptr<FileSystem> getFilesystem(const std::string& basePath);
+
+protected:
+    /**
+     * @brief Reads models from configuration file
+     * 
+     * @param jsonFilename configuration file
+     * @return Status 
+     */
+    Status loadConfig(const std::string& jsonFilename);
+
+    /**
+     * @brief Updates OVMS configuration with cached configuration file. Will check for newly added model versions
+     */
+    void updateConfigurationWithoutConfigFile();
 };
 
 }  // namespace ovms

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -35,6 +35,7 @@ Status toNodeKind(const std::string& str, NodeKind& nodeKind) {
 }
 
 Status PipelineDefinition::validate(ModelManager& manager) {
+    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Started validation of pipeline: {}", getName());
     ValidationResultNotifier notifier(status, loadedNotify);
     auto& models = manager.getModels();
     if (std::find_if(models.begin(), models.end(), [this](auto pair) { return this->pipelineName == pair.first; }) != models.end()) {
@@ -52,6 +53,7 @@ Status PipelineDefinition::validate(ModelManager& manager) {
         return validationResult;
     }
     notifier.passed = true;
+    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Finished validation of pipeline: {}", getName());
     return validationResult;
 }
 
@@ -90,11 +92,18 @@ Status PipelineDefinition::waitForLoaded(std::unique_ptr<PipelineDefinitionUnloa
     std::unique_lock<std::mutex> cvLock(cvMtx);
     while (waitCheckpointsCounter-- != 0) {
         if (status.isAvailable()) {
-            break;
+            SPDLOG_DEBUG("Successfully waited for pipeline definition: {}", getName());
+            return StatusCode::OK;
         }
         unloadGuard.reset();
-        if (!status.isLoadedOrRequiringValidation()) {
-            break;
+        if (!status.canEndLoaded()) {
+            if (status.getStateCode() != PipelineDefinitionStateCode::RETIRED) {
+                SPDLOG_DEBUG("Waiting for pipeline definition: {} ended due to timeout.", getName());
+                return StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET;
+            } else {
+                SPDLOG_DEBUG("Waiting for pipeline definition: {} ended since it failed to load.", getName());
+                return StatusCode::PIPELINE_DEFINITION_NOT_LOADED_ANYMORE;
+            }
         }
         SPDLOG_DEBUG("Waiting for available state for pipeline: {}, with timestep: {}us timeout: {}us check count: {}",
             getName(), waitLoadedTimestepMicroseconds, waitForLoadedTimeoutMicroseconds, waitCheckpointsCounter);
@@ -102,7 +111,7 @@ Status PipelineDefinition::waitForLoaded(std::unique_ptr<PipelineDefinitionUnloa
             std::chrono::microseconds(waitLoadedTimestepMicroseconds),
             [this]() {
                 return this->status.isAvailable() ||
-                       !this->status.isLoadedOrRequiringValidation();
+                       !this->status.canEndLoaded();
             });
         unloadGuard = std::make_unique<PipelineDefinitionUnloadGuard>(*this);
     }

--- a/src/pipelinedefinition.hpp
+++ b/src/pipelinedefinition.hpp
@@ -113,7 +113,7 @@ private:
     Status validateNode(ModelManager& manager, const NodeInfo& node);
 
 public:
-    static constexpr uint64_t WAIT_FOR_LOADED_DEFAULT_TIMEOUT_MICROSECONDS = 1000;
+    static constexpr uint64_t WAIT_FOR_LOADED_DEFAULT_TIMEOUT_MICROSECONDS = 10000;
     PipelineDefinition(const std::string& pipelineName,
         const std::vector<NodeInfo>& nodeInfos,
         const pipeline_connections_t& connections) :

--- a/src/pipelinedefinitionstatus.hpp
+++ b/src/pipelinedefinitionstatus.hpp
@@ -359,11 +359,12 @@ public:
         return (state == PipelineDefinitionStateCode::AVAILABLE) ||
                (state == PipelineDefinitionStateCode::AVAILABLE_REQUIRED_REVALIDATION);
     }
-    bool isLoadedOrRequiringValidation() const {
+    bool canEndLoaded() const {
         auto state = getStateCode();
         return isAvailable() ||
                (state == PipelineDefinitionStateCode::LOADING_PRECONDITION_FAILED_REQUIRED_REVALIDATION) ||
-               (state == PipelineDefinitionStateCode::BEGIN);
+               (state == PipelineDefinitionStateCode::BEGIN) ||
+               (state == PipelineDefinitionStateCode::RELOADING);
     }
     bool isRevalidationRequired() const {
         auto state = getStateCode();

--- a/src/status.hpp
+++ b/src/status.hpp
@@ -186,6 +186,8 @@ enum class StatusCode {
     CUSTOM_LOADER_NOT_PRESENT,
     CUSTOM_LOADER_INIT_FAILED,
     CUSTOM_LOADER_ERROR,
+
+    STATUS_CODE_END
 };
 
 class Status {

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -1,0 +1,817 @@
+
+//*****************************************************************************
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../get_model_metadata_impl.hpp"
+#include "../localfilesystem.hpp"
+#include "../logging.hpp"
+#include "../modelconfig.hpp"
+#include "../modelinstance.hpp"
+#include "../pipeline.hpp"
+#include "../pipeline_factory.hpp"
+#include "../prediction_service_utils.hpp"
+#include "../status.hpp"
+#include "test_utils.hpp"
+
+using namespace ovms;
+using namespace tensorflow;
+using namespace tensorflow::serving;
+
+using testing::_;
+using testing::Return;
+
+static const std::string PIPELINE_1_DUMMY_NAME = "pipeline1Dummy";
+
+static const char* stressTestPipelineOneDummyConfig = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "(1,10) "}
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+static const char* stressTestPipelineOneDummyRemovedConfig = R"(
+{
+    "model_config_list": [
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+static const char* stressTestPipelineOneDummyConfigChangedToAuto = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "auto"}
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+static const char* stressTestPipelineOneDummyConfigPipelineRemoved = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "(1,10) "}
+            }
+        }
+    ],
+    "pipeline_config_list": [
+    ]
+})";
+static const char* stressTestPipelineOneDummyConfigChangeConnectionName = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "(1,10) "}
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output_changed_name"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output_changed_name"}
+                }
+            ]
+        }
+    ]
+})";
+static const char* stressTestPipelineOneDummyConfigAddNewPipeline = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "(1,10) "}
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy2ndPipeline",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+    ]
+})";
+static const char* stressTestPipelineOneDummyConfigSpecificVersionUsed = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "(1,10) "}
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "version": 1,
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+
+class StressPipelineConfigChanges : public TestWithTempDir {
+    const uint loadThreadCount = 20;
+    const uint beforeConfigChangeLoadTimeMs = 30;
+    const uint afterConfigChangeLoadTimeMs = 50;
+    const int stressIterationsLimit = 5000;
+
+    std::string configFilePath;
+    std::string ovmsConfig;
+    std::string modelPath;
+
+    const std::string& pipelineName = PIPELINE_1_DUMMY_NAME;
+    const std::string pipelineInputName = "custom_dummy_input";
+    const std::string pipelineOutputName = "custom_dummy_output";
+
+    const std::vector<float> requestData{1., 2., 3., 7., 5., 6., 4., 9., 10., 8.};
+
+public:
+    void SetUpConfig(const std::string& configContent) {
+        ovmsConfig = configContent;
+        const std::string modelPathToReplace{"/ovms/src/test/dummy"};
+        ovmsConfig.replace(ovmsConfig.find(modelPathToReplace), modelPathToReplace.size(), modelPath);
+        configFilePath = directoryPath + "/ovms_config.json";
+    }
+    void TearDown() override {}
+    void SetUp() override {
+        TestWithTempDir::SetUp();
+        modelPath = directoryPath + "/dummy/";
+        SetUpConfig(stressTestPipelineOneDummyConfig);
+        std::filesystem::copy("/ovms/src/test/dummy", modelPath, std::filesystem::copy_options::recursive);
+    }
+    void defaultVersionRemove() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        ovmsConfig = stressTestPipelineOneDummyRemovedConfig;
+        createConfigFileWithContent(ovmsConfig, configFilePath);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void defaultVersionAdd() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        std::filesystem::copy("/ovms/src/test/dummy/1", modelPath + "/2", std::filesystem::copy_options::recursive);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void changeToAutoShape() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        ovmsConfig = stressTestPipelineOneDummyConfigChangedToAuto;
+        createConfigFileWithContent(ovmsConfig, configFilePath);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void removePipelineDefinition() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        ovmsConfig = stressTestPipelineOneDummyConfigPipelineRemoved;
+        createConfigFileWithContent(ovmsConfig, configFilePath);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void changeConnectionName() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        ovmsConfig = stressTestPipelineOneDummyConfigChangeConnectionName;
+        createConfigFileWithContent(ovmsConfig, configFilePath);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void addNewPipeline() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        ovmsConfig = stressTestPipelineOneDummyConfigAddNewPipeline;
+        createConfigFileWithContent(ovmsConfig, configFilePath);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void retireSpecificVersionUsed() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        std::filesystem::copy("/ovms/src/test/dummy/1", modelPath + "/2", std::filesystem::copy_options::recursive);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void performStressTest(
+        void (StressPipelineConfigChanges::*triggerLoadInALoop)(
+            std::future<void>&,
+            std::future<void>&,
+            ModelManager&,
+            const std::set<StatusCode>&,
+            const std::set<StatusCode>&,
+            std::unordered_map<StatusCode, std::atomic<uint64_t>>&),
+        void (StressPipelineConfigChanges::*configChangeOperation)(),
+        bool reloadWholeConfig,
+        std::set<StatusCode> requiredLoadResults,
+        std::set<StatusCode> allowedLoadResults) {
+        ConstructorEnabledModelManager manager;
+        createConfigFileWithContent(ovmsConfig, configFilePath);
+        auto status = manager.loadConfig(configFilePath);
+        ASSERT_TRUE(status.ok());
+
+        // setup helper variables for managing threads
+        std::vector<std::promise<void>> startSignals(loadThreadCount);
+        std::vector<std::promise<void>> stopSignals(loadThreadCount);
+        std::vector<std::future<void>> futureStartSignals;
+        std::vector<std::future<void>> futureStopSignals;
+        std::transform(startSignals.begin(),
+            startSignals.end(),
+            std::back_inserter(futureStartSignals),
+            [](auto& p) { return p.get_future(); });
+        std::transform(stopSignals.begin(),
+            stopSignals.end(),
+            std::back_inserter(futureStopSignals),
+            [](auto& p) { return p.get_future(); });
+
+        std::unordered_map<StatusCode, std::atomic<uint64_t>> createPipelineRetCodesCounters;
+        std::unordered_map<StatusCode, std::atomic<uint64_t>> executePipelineRetCodesCounters;
+        for (uint i = 0; i != static_cast<uint>(StatusCode::STATUS_CODE_END); ++i) {
+            createPipelineRetCodesCounters[static_cast<StatusCode>(i)] = 0;
+        }
+        for (uint i = 0; i != static_cast<uint>(StatusCode::STATUS_CODE_END); ++i) {
+            executePipelineRetCodesCounters[static_cast<StatusCode>(i)] = 0;
+        }
+        // create worker threads
+        std::vector<std::unique_ptr<std::thread>> workerThreads;
+        for (uint i = 0; i < loadThreadCount; ++i) {
+            workerThreads.emplace_back(std::make_unique<std::thread>(
+                [this,
+                    &triggerLoadInALoop,
+                    &futureStartSignals,
+                    &futureStopSignals,
+                    &manager,
+                    &requiredLoadResults,
+                    &allowedLoadResults,
+                    &createPipelineRetCodesCounters,
+                    i]() {
+                    ((*this).*triggerLoadInALoop)(futureStartSignals[i],
+                        futureStopSignals[i],
+                        manager,
+                        requiredLoadResults,
+                        allowedLoadResults,
+                        createPipelineRetCodesCounters);
+                }));
+        }
+        // start initial load
+        std::for_each(startSignals.begin(), startSignals.end(), [](auto& startSignal) { startSignal.set_value(); });
+        // sleep to allow all load threads to stress ovms during config changes
+        std::this_thread::sleep_for(std::chrono::milliseconds(beforeConfigChangeLoadTimeMs));
+        ((*this).*configChangeOperation)();
+        if (reloadWholeConfig) {
+            manager.loadConfig(configFilePath);
+        } else {
+            manager.updateConfigurationWithoutConfigFile();
+        }
+        // wait to work strictly on config operations after change
+        std::this_thread::sleep_for(std::chrono::milliseconds(afterConfigChangeLoadTimeMs));
+        std::for_each(stopSignals.begin(), stopSignals.end(), [](auto& stopSignal) { stopSignal.set_value(); });
+        std::for_each(workerThreads.begin(), workerThreads.end(), [](auto& t) { t->join(); });
+
+        for (auto& [retCode, counter] : createPipelineRetCodesCounters) {
+            SPDLOG_TRACE("Create:[{}]={} -- {}", static_cast<uint>(retCode), counter, ovms::Status(retCode).string());
+            if (requiredLoadResults.find(retCode) != requiredLoadResults.end()) {
+                EXPECT_GT(counter, 0) << static_cast<uint>(retCode) << ":" << ovms::Status(retCode).string() << " did not occur. This may indicate fail or fail in test setup";
+                continue;
+            }
+            if (counter == 0) {
+                continue;
+            }
+            EXPECT_TRUE(allowedLoadResults.find(retCode) != allowedLoadResults.end()) << "Ret code:"
+                                                                                      << static_cast<uint>(retCode) << " message: " << ovms::Status(retCode).string()
+                                                                                      << " was not allowed in test but occured during load";
+        }
+    }
+    bool isMetadataResponseCorrect(tensorflow::serving::GetModelMetadataResponse& response) {
+        tensorflow::serving::SignatureDefMap def;
+        EXPECT_EQ(response.model_spec().name(), pipelineName);
+        EXPECT_TRUE(response.model_spec().has_version());
+        EXPECT_EQ(response.model_spec().version().value(), 1);
+        EXPECT_EQ(response.metadata_size(), 1);
+        EXPECT_NE(
+            response.metadata().find("signature_def"),
+            response.metadata().end());
+        response.metadata().at("signature_def").UnpackTo(&def);
+        response.metadata().at("signature_def").UnpackTo(&def);
+        const auto& inputs = ((*def.mutable_signature_def())["serving_default"]).inputs();
+        const auto& outputs = ((*def.mutable_signature_def())["serving_default"]).outputs();
+
+        bool inputsSizeCorrect{inputs.size() == 1};
+        EXPECT_TRUE(inputsSizeCorrect) << "Expected: " << 1 << " actual: " << inputs.size();
+        bool outputsSizeCorrect{outputs.size() == 1};
+        EXPECT_TRUE(outputsSizeCorrect) << "Expected: " << 1 << " actual: " << outputs.size();
+        if (!inputsSizeCorrect || !outputsSizeCorrect) {
+            return false;
+        }
+        bool inputNameExist{inputs.find(pipelineInputName.c_str()) != inputs.end()};
+        EXPECT_TRUE(inputNameExist);
+        bool outputNameExist{outputs.find(pipelineOutputName.c_str()) != outputs.end()};
+        EXPECT_TRUE(outputNameExist);
+        if (!inputNameExist || !outputNameExist) {
+            return false;
+        }
+        bool inputNameCorrect{inputs.at(pipelineInputName.c_str()).name() == pipelineInputName};
+        EXPECT_TRUE(inputNameCorrect);
+        bool outputNameCorrect{outputs.at(pipelineOutputName.c_str()).name() == pipelineOutputName};
+        EXPECT_TRUE(outputNameCorrect);
+        if (!inputNameCorrect || !outputNameCorrect) {
+            return false;
+        }
+        bool inputTypeCorrect{inputs.at(pipelineInputName.c_str()).dtype() == tensorflow::DT_FLOAT};
+        EXPECT_TRUE(inputTypeCorrect);
+        bool outputTypeCorrect{outputs.at(pipelineOutputName.c_str()).dtype() == tensorflow::DT_FLOAT};
+        EXPECT_TRUE(outputTypeCorrect);
+        if (!inputTypeCorrect || !outputTypeCorrect) {
+            return false;
+        }
+        auto isShape = [](
+                           const tensorflow::TensorShapeProto& actual,
+                           const std::vector<size_t>&& expected) -> bool {
+            if (static_cast<unsigned int>(actual.dim_size()) != expected.size()) {
+                return false;
+            }
+            for (int i = 0; i < actual.dim_size(); i++) {
+                if (static_cast<unsigned int>(actual.dim(i).size()) != expected[i]) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        bool inputShapeCorrect{isShape(
+            inputs.at(pipelineInputName.c_str()).tensor_shape(),
+            {1, 10})};
+        EXPECT_TRUE(inputShapeCorrect);
+        bool outputShapeCorrect{isShape(
+            outputs.at(pipelineOutputName.c_str()).tensor_shape(),
+            {1, 10})};
+        EXPECT_TRUE(outputShapeCorrect);
+        if (!inputShapeCorrect || !outputShapeCorrect) {
+            return false;
+        }
+        return true;
+    }
+    void triggerGetPipelineMetadataInALoop(
+        std::future<void>& startSignal,
+        std::future<void>& stopSignal,
+        ModelManager& manager,
+        const std::set<StatusCode>& requiredLoadResults,
+        const std::set<StatusCode>& allowedLoadResults,
+        std::unordered_map<StatusCode, std::atomic<uint64_t>>& createPipelineRetCodesCounters) {
+        tensorflow::serving::GetModelMetadataRequest request;
+        tensorflow::serving::GetModelMetadataResponse response;
+        startSignal.get();
+        // stressIterationsCounter is additional safety measure
+        auto stressIterationsCounter = stressIterationsLimit;
+        while (stressIterationsCounter-- > 0) {
+            auto futureWaitResult = stopSignal.wait_for(std::chrono::milliseconds(0));
+            if (futureWaitResult == std::future_status::ready) {
+                SPDLOG_INFO("Got stop signal. Ending Load");
+                break;
+            }
+            auto status = ovms::GetModelMetadataImpl::createGrpcRequest(pipelineName, 1, &request);
+            status = ovms::GetModelMetadataImpl::getModelStatus(&request, &response, manager);
+            createPipelineRetCodesCounters[status.getCode()]++;
+            EXPECT_TRUE((requiredLoadResults.find(status.getCode()) != requiredLoadResults.end()) ||
+                        (allowedLoadResults.find(status.getCode()) != allowedLoadResults.end()))
+                << status.string() << "\n";
+            if (!status.ok()) {
+                continue;
+            }
+            // Check response if correct
+            EXPECT_TRUE(isMetadataResponseCorrect(response));
+            if (::testing::Test::HasFailure()) {
+                SPDLOG_INFO("Earlier fail detected. Stopping execution");
+                break;
+            }
+        }
+    }
+    void triggerPredictInALoop(
+        std::future<void>& startSignal,
+        std::future<void>& stopSignal,
+        ModelManager& manager,
+        const std::set<StatusCode>& requiredLoadResults,
+        const std::set<StatusCode>& allowedLoadResults,
+        std::unordered_map<StatusCode, std::atomic<uint64_t>>& createPipelineRetCodesCounters) {
+        startSignal.get();
+        // stressIterationsCounter is additional safety measure
+        auto stressIterationsCounter = stressIterationsLimit;
+        while (stressIterationsCounter-- > 0) {
+            auto futureWaitResult = stopSignal.wait_for(std::chrono::milliseconds(0));
+            if (futureWaitResult == std::future_status::ready) {
+                SPDLOG_INFO("Got stop signal. Ending Load");
+                break;
+            }
+            std::unique_ptr<Pipeline> pipelinePtr;
+            tensorflow::serving::PredictRequest request = preparePredictRequest(
+                {{pipelineInputName,
+                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
+            auto& input = (*request.mutable_inputs())[pipelineInputName];
+            std::vector<float> reqData = requestData;
+            input.mutable_tensor_content()->assign((char*)reqData.data(), reqData.size() * sizeof(float));
+            tensorflow::serving::PredictResponse response;
+            auto createPipelineStatus = manager.createPipeline(pipelinePtr, pipelineName, &request, &response);
+            // we need to make sure that expected status happened and still accept
+            // some that could happen but we may not hit them
+            EXPECT_TRUE((requiredLoadResults.find(createPipelineStatus.getCode()) != requiredLoadResults.end()) ||
+                        (allowedLoadResults.find(createPipelineStatus.getCode()) != allowedLoadResults.end()))
+                << createPipelineStatus.string() << "\n";
+            if (!createPipelineStatus.ok()) {
+                createPipelineRetCodesCounters[createPipelineStatus.getCode()]++;
+                continue;
+            }
+            ovms::Status executePipelineStatus = StatusCode::UNKNOWN_ERROR;
+            executePipelineStatus = pipelinePtr->execute();
+            createPipelineRetCodesCounters[executePipelineStatus.getCode()]++;
+            EXPECT_TRUE((requiredLoadResults.find(executePipelineStatus.getCode()) != requiredLoadResults.end()) ||
+                        (allowedLoadResults.find(executePipelineStatus.getCode()) != allowedLoadResults.end()))
+                << executePipelineStatus.string() << "\n";
+            if (executePipelineStatus.ok()) {
+                checkDummyResponse(pipelineOutputName, requestData, request, response, 1);
+            }
+            if (::testing::Test::HasFailure()) {
+                SPDLOG_INFO("Earlier fail detected. Stopping execution");
+                break;
+            }
+        }
+        for (auto& [retCode, counter] : createPipelineRetCodesCounters) {
+            if (counter > 0) {
+                SPDLOG_DEBUG("Create:[{}]={}:{}", static_cast<uint>(retCode), ovms::Status(retCode).string(), counter);
+            }
+        }
+        EXPECT_GT(stressIterationsCounter, 0) << "Reaching 0 means that we might not test enough \"after config change\" operation was applied";
+        std::stringstream ss;
+        ss << "Executed: " << stressIterationsLimit - stressIterationsCounter << " inferences by thread id: " << std::this_thread::get_id() << std::endl;
+        SPDLOG_INFO(ss.str());
+    }
+};
+
+TEST_F(StressPipelineConfigChanges, AddNewVersionDuringPredictLoad) {
+    bool performWholeConfigReload = false;                        // we just need to have all model versions rechecked
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::defaultVersionRemove,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, RemoveDefaultVersionDuringPredictLoad) {
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET,  // we hit when all config changes finish to propagate
+        StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE,    // we hit default version which is unloaded already but default is not changed yet
+        StatusCode::MODEL_VERSION_MISSING};              // there is no default version since all are either not loaded properly or retired
+    std::set<StatusCode> allowedLoadResults = {};
+    // we need whole config reload since there is no other way to dispose
+    // all model versions different than removing model from config
+    bool performWholeConfigReload = true;
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::defaultVersionRemove,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, ChangeToShapeAutoDuringPredictLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::changeToAutoShape,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, RemovePipelineDefinitionDuringPredictLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_ANYMORE};  // we expect to stop creating pipelines
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::removePipelineDefinition,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, ChangedPipelineConnectionNameDuringPredictLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::changeConnectionName,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, AddedNewPipelineDuringPredictLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::addNewPipeline,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, RetireSpecificVersionUsedDuringPredictLoad) {
+    // we declare specific version used (1) and latest model version policy with count=1
+    // then we add version 2 causing previous default to be retired
+    SetUpConfig(stressTestPipelineOneDummyConfigSpecificVersionUsed);
+    bool performWholeConfigReload = false;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET,          // we hit when all config changes finish to propagate
+        StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE};           // version is retired but pipeline not invalidated yet
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::retireSpecificVersionUsed,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, AddNewVersionDuringGetMetadataLoad) {
+    bool performWholeConfigReload = false;                        // we just need to have all model versions rechecked
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
+        &StressPipelineConfigChanges::defaultVersionRemove,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, RemoveDefaultVersionDuringGetMetadataLoad) {
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET,  // we hit when all config changes finish to propagate
+        StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE,    // we hit default version which is unloaded already but default is not changed yet
+        StatusCode::MODEL_MISSING};                      // model instance not found during metadata request
+    std::set<StatusCode> allowedLoadResults = {};
+    // we need whole config reload since there is no other way to dispose
+    // all model versions different than removing model from config
+    bool performWholeConfigReload = true;
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
+        &StressPipelineConfigChanges::defaultVersionRemove,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, ChangeToShapeAutoDuringGetMetadataLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
+        &StressPipelineConfigChanges::changeToAutoShape,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, RemovePipelineDefinitionDuringGetMetadataLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_ANYMORE,  // when pipeline is retired
+        StatusCode::MODEL_VERSION_NOT_LOADED_YET};           // we do not wait for models durign get metadata
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
+        &StressPipelineConfigChanges::removePipelineDefinition,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, ChangedPipelineConnectionNameDuringGetMetadataLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
+        StatusCode::MODEL_VERSION_NOT_LOADED_YET};               // we do not wait for models durign get metadata
+    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
+        &StressPipelineConfigChanges::changeConnectionName,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, AddedNewPipelineDuringGetMetadataLoad) {
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
+        &StressPipelineConfigChanges::addNewPipeline,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineConfigChanges, RetireSpecificVersionUsedDuringGetMetadataLoad) {
+    // we declare specific version used (1) and latest model version policy with count=1
+    // then we add version 2 causing previous default to be retired
+    SetUpConfig(stressTestPipelineOneDummyConfigSpecificVersionUsed);
+    bool performWholeConfigReload = false;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET,          // we hit when all config changes finish to propagate
+        StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE};           // version is retired but pipeline not invalidated yet
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
+        &StressPipelineConfigChanges::retireSpecificVersionUsed,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -26,6 +26,8 @@
 
 #include <stdlib.h>
 
+#include "../localfilesystem.hpp"
+#include "../logging.hpp"
 #include "../modelinstance.hpp"
 #include "../prediction_service_utils.hpp"
 #include "../status.hpp"
@@ -50,31 +52,20 @@ protected:
         config.setNireq(NIREQ);
 
         // Prepare request
+        prepareRequest(bs1requestData, request, customPipelineInputName);
+        requestData = bs1requestData;
+    }
+
+    void prepareRequest(const std::vector<float>& requestData, PredictRequest& request, const std::string& customPipelineInputName) {
         tensorflow::TensorProto& proto = (*request.mutable_inputs())[customPipelineInputName];
         proto.set_dtype(tensorflow::DataType::DT_FLOAT);
-        requestData = bs1requestData;
         proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
         proto.mutable_tensor_shape()->add_dim()->set_size(1);
         proto.mutable_tensor_shape()->add_dim()->set_size(DUMMY_MODEL_INPUT_SIZE);
     }
 
-    void checkResponse(int seriesLength, int batchSize = 1) {
-        ASSERT_EQ(response.outputs().count(customPipelineOutputName), 1);
-        const auto& output_proto = response.outputs().at(customPipelineOutputName);
-
-        ASSERT_EQ(output_proto.tensor_content().size(), batchSize * DUMMY_MODEL_OUTPUT_SIZE * sizeof(float));
-        ASSERT_EQ(output_proto.tensor_shape().dim_size(), 2);
-        ASSERT_EQ(output_proto.tensor_shape().dim(0).size(), batchSize);
-        ASSERT_EQ(output_proto.tensor_shape().dim(1).size(), DUMMY_MODEL_OUTPUT_SIZE);
-
-        auto responseData = requestData;
-        std::for_each(responseData.begin(), responseData.end(), [seriesLength](float& v) { v += 1.0 * seriesLength; });
-
-        float* actual_output = (float*)output_proto.tensor_content().data();
-        float* expected_output = responseData.data();
-        const int dataLengthToCheck = DUMMY_MODEL_OUTPUT_SIZE * batchSize * sizeof(float);
-        EXPECT_EQ(0, std::memcmp(actual_output, expected_output, dataLengthToCheck))
-            << readableError(expected_output, actual_output, dataLengthToCheck);
+    void checkDummyResponse(int seriesLength, int batchSize = 1) {
+        ::checkDummyResponse(customPipelineOutputName, requestData, request, response, seriesLength, batchSize);
     }
 
     std::string readableError(const float* expected_output, const float* actual_output, const size_t size) {
@@ -139,7 +130,7 @@ TEST_F(EnsembleFlowTest, DummyModel) {
 
     pipeline.execute();
     const int dummySeriallyConnectedCount = 1;
-    checkResponse(dummySeriallyConnectedCount);
+    checkDummyResponse(dummySeriallyConnectedCount);
 }
 
 TEST_F(EnsembleFlowTest, DummyModelDirectAndPipelineInference) {
@@ -195,7 +186,7 @@ TEST_F(EnsembleFlowTest, DummyModelDirectAndPipelineInference) {
 
     pipeline.execute();
     const int dummySeriallyConnectedCount = 1;
-    checkResponse(dummySeriallyConnectedCount);
+    checkDummyResponse(dummySeriallyConnectedCount);
 
     // Do the inference directly on dummy model after inference on pipeline
     ASSERT_EQ(inference(*model, &simpleModelRequest, &simpleModelResponse, unload_guard), ovms::StatusCode::OK);
@@ -253,7 +244,7 @@ TEST_F(EnsembleFlowTest, SeriesOfDummyModels) {
     timer.stop("pipeline::execute");
 
     timer.start("compare results");
-    checkResponse(N);
+    checkDummyResponse(N);
     timer.stop("compare results");
 
     std::cout << "prepare pipeline: " << timer.elapsed<std::chrono::microseconds>("prepare pipeline") / 1000 << "ms\n";
@@ -276,7 +267,6 @@ TEST_F(EnsembleFlowTest, ExecutePipelineWithDynamicBatchSize) {
     const int batchSize = 3;
     proto.mutable_tensor_shape()->mutable_dim(0)->set_size(batchSize);
     requestData = {
-        // std::vector<float> requestData = {
         -5, -4, -3, -2, -1, 1, 2, 3, 4, 5,            // batch 1
         -15, -14, -13, -12, -11, 11, 12, 13, 14, 15,  // batch 2
         -25, -24, -23, -22, -21, 21, 22, 23, 24, 25,  // batch 3
@@ -303,7 +293,7 @@ TEST_F(EnsembleFlowTest, ExecutePipelineWithDynamicBatchSize) {
 
     pipeline.execute();
     const int seriallyConnectedDummyModels = 1;
-    checkResponse(seriallyConnectedDummyModels, batchSize);
+    checkDummyResponse(seriallyConnectedDummyModels, batchSize);
 }
 
 TEST_F(EnsembleFlowTest, ExecutePipelineWithDynamicShape) {
@@ -485,7 +475,7 @@ TEST_F(EnsembleFlowTest, ExecutePipelineWithDynamicShape_RequestHasDifferentDim0
     ASSERT_EQ(pipeline.execute(), ovms::StatusCode::OK);
 
     const int seriallyConnectedDummyModels = 1;
-    checkResponse(seriallyConnectedDummyModels, BATCH_SIZE);
+    checkDummyResponse(seriallyConnectedDummyModels, BATCH_SIZE);
 }
 
 TEST_F(EnsembleFlowTest, ParallelDummyModels) {
@@ -1266,7 +1256,7 @@ TEST_F(EnsembleFlowTest, SimplePipelineFactoryCreation) {
     // Execute pipeline
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
     const int dummySeriallyConnectedCount = 1;
-    checkResponse(dummySeriallyConnectedCount);
+    checkDummyResponse(dummySeriallyConnectedCount);
 }
 
 TEST_F(EnsembleFlowTest, ParallelPipelineFactoryUsage) {
@@ -1460,7 +1450,7 @@ TEST_F(EnsembleFlowTest, PipelineFactoryWrongConfiguration_NodeNameDuplicate) {
     ASSERT_EQ(factory.createDefinition("pipeline", info, {}, managerWithDummyModel), StatusCode::PIPELINE_NODE_NAME_DUPLICATE);
 }
 
-const std::string PIPELINE_1_DUMMY_NAME = "pipeline1Dummy";
+static const std::string PIPELINE_1_DUMMY_NAME = "pipeline1Dummy";
 
 static const char* pipelineOneDummyConfig = R"(
 {
@@ -1517,7 +1507,7 @@ TEST_F(EnsembleFlowTest, PipelineFactoryCreationWithInputOutputsMappings) {
     ASSERT_EQ(status, ovms::StatusCode::OK) << status.string();
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
     const int dummySeriallyConnectedCount = 1;
-    checkResponse(dummySeriallyConnectedCount);
+    checkDummyResponse(dummySeriallyConnectedCount);
     managerWithDummyModel.join();
 }
 
@@ -2139,7 +2129,7 @@ TEST_F(EnsembleFlowTest, ExecuteOnPipelineCreatedBeforeRetireShouldPass) {
     pd.retire(managerWithDummyModel);
     pipelineBeforeRetire->execute();
     uint dummySeriallyConnectedCount = 1;
-    checkResponse(dummySeriallyConnectedCount);
+    checkDummyResponse(dummySeriallyConnectedCount);
 }
 
 class MockedPipelineDefinitionWithHandlingStatus : public PipelineDefinition {
@@ -2175,29 +2165,28 @@ TEST_F(EnsembleFlowTest, WaitForLoadingPipelineDefinitionFromBeginStatus) {
         std::this_thread::sleep_for(std::chrono::microseconds(PipelineDefinition::WAIT_FOR_LOADED_DEFAULT_TIMEOUT_MICROSECONDS / 4));
         auto status = pd.validate(managerWithDummyModel);
         ASSERT_TRUE(status.ok());
-        SPDLOG_ERROR("Made pd validated");
+        SPDLOG_INFO("Made pd validated");
     });
     auto status = pd.create(pipelineBeforeRetire, &request, &response, managerWithDummyModel);
-    ASSERT_TRUE(status.ok());
+    ASSERT_TRUE(status.ok()) << status.string();
     pd.getControlableStatus().handle(UsedModelChangedEvent(notifierDetails));
     pd.getControlableStatus().handle(ValidationFailedEvent());
     status = pd.create(pipelineBeforeRetire, &request, &response, managerWithDummyModel);
-    ASSERT_EQ(status, ovms::StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET);
-    pd.getControlableStatus().handle(UsedModelChangedEvent());
+    ASSERT_EQ(status, ovms::StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET) << status.string();
     pd.getControlableStatus().handle(UsedModelChangedEvent(notifierDetails));
     status = pd.create(pipelineBeforeRetire, &request, &response, managerWithDummyModel);
-    ASSERT_EQ(status, ovms::StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET);
+    ASSERT_EQ(status, ovms::StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET) << status.string();
     std::thread t2([&managerWithDummyModel, &pd]() {
         std::this_thread::sleep_for(std::chrono::microseconds(PipelineDefinition::WAIT_FOR_LOADED_DEFAULT_TIMEOUT_MICROSECONDS / 4));
         auto status = pd.validate(managerWithDummyModel);
-        ASSERT_TRUE(status.ok());
-        SPDLOG_ERROR("Made pd validated");
+        ASSERT_TRUE(status.ok()) << status.string();
+        SPDLOG_INFO("Made pd validated");
     });
     status = pd.create(pipelineBeforeRetire, &request, &response, managerWithDummyModel);
-    ASSERT_TRUE(status.ok());
+    ASSERT_TRUE(status.ok()) << status.string();
     uint dummySeriallyConnectedCount = 1;
     pipelineBeforeRetire->execute();
-    checkResponse(dummySeriallyConnectedCount);
+    checkDummyResponse(dummySeriallyConnectedCount);
     t.join();
     t2.join();
 }

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -14,10 +14,73 @@
 // limitations under the License.
 //*****************************************************************************
 #include "test_utils.hpp"
+
+#include "../prediction_service_utils.hpp"
+
+using tensorflow::serving::PredictRequest;
+using tensorflow::serving::PredictResponse;
+
 void waitForOVMSConfigReload(ovms::ModelManager& manager) {
     // This is effectively multiplying by 1.2 to have 1 config reload in between
     // two test steps
     const float WAIT_MULTIPLIER_FACTOR = 1.2;
     const uint waitTime = WAIT_MULTIPLIER_FACTOR * manager.getWatcherIntervalSec() * 1000;
     std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
+}
+
+std::string createConfigFileWithContent(const std::string& content, std::string filename) {
+    std::ofstream configFile{filename};
+    spdlog::info("Creating config file: {}\n with content:\n{}", filename, content);
+    configFile << content << std::endl;
+    configFile.close();
+    if (configFile.fail()) {
+        spdlog::info("Closing configFile failed");
+    } else {
+        spdlog::info("Closing configFile succeed");
+    }
+    return filename;
+}
+
+ovms::tensor_map_t prepareTensors(
+    const std::unordered_map<std::string, ovms::shape_t>&& tensors,
+    InferenceEngine::Precision precision) {
+    ovms::tensor_map_t result;
+    for (const auto& kv : tensors) {
+        result[kv.first] = std::make_shared<ovms::TensorInfo>(
+            kv.first,
+            precision,
+            kv.second);
+    }
+    return result;
+}
+
+void checkDummyResponse(const std::string outputName,
+    const std::vector<float>& requestData,
+    PredictRequest& request, PredictResponse& response, int seriesLength, int batchSize) {
+    ASSERT_EQ(response.outputs().count(outputName), 1);
+    const auto& output_proto = response.outputs().at(outputName);
+
+    ASSERT_EQ(output_proto.tensor_content().size(), batchSize * DUMMY_MODEL_OUTPUT_SIZE * sizeof(float));
+    ASSERT_EQ(output_proto.tensor_shape().dim_size(), 2);
+    ASSERT_EQ(output_proto.tensor_shape().dim(0).size(), batchSize);
+    ASSERT_EQ(output_proto.tensor_shape().dim(1).size(), DUMMY_MODEL_OUTPUT_SIZE);
+
+    std::vector<float> responseData = requestData;
+    std::for_each(responseData.begin(), responseData.end(), [seriesLength](float& v) { v += 1.0 * seriesLength; });
+
+    float* actual_output = (float*)output_proto.tensor_content().data();
+    float* expected_output = responseData.data();
+    const int dataLengthToCheck = DUMMY_MODEL_OUTPUT_SIZE * batchSize * sizeof(float);
+    EXPECT_EQ(0, std::memcmp(actual_output, expected_output, dataLengthToCheck))
+        << readableError(expected_output, actual_output, dataLengthToCheck / sizeof(float));
+}
+
+std::string readableError(const float* expected_output, const float* actual_output, const size_t size) {
+    std::stringstream ss;
+    for (size_t i = 0; i < size; ++i) {
+        if (actual_output[i] != expected_output[i]) {
+            ss << "Expected:" << expected_output[i] << ", actual:" << actual_output[i] << " at place:" << i << std::endl;
+        }
+    }
+    return ss.str();
 }

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -85,18 +85,9 @@ constexpr const ovms::model_version_t UNUSED_MODEL_VERSION = 42;  // Answer to t
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
-static ovms::tensor_map_t prepareTensors(
+ovms::tensor_map_t prepareTensors(
     const std::unordered_map<std::string, ovms::shape_t>&& tensors,
-    InferenceEngine::Precision precision = InferenceEngine::Precision::FP32) {
-    ovms::tensor_map_t result;
-    for (const auto& kv : tensors) {
-        result[kv.first] = std::make_shared<ovms::TensorInfo>(
-            kv.first,
-            precision,
-            kv.second);
-    }
-    return result;
-}
+    InferenceEngine::Precision precision = InferenceEngine::Precision::FP32);
 
 static tensorflow::serving::PredictRequest preparePredictRequest(inputs_info_t requestInputs) {
     tensorflow::serving::PredictRequest request;
@@ -116,6 +107,12 @@ static tensorflow::serving::PredictRequest preparePredictRequest(inputs_info_t r
     return request;
 }
 
+void checkDummyResponse(const std::string outputName,
+    const std::vector<float>& requestData,
+    tensorflow::serving::PredictRequest& request, tensorflow::serving::PredictResponse& response, int seriesLength, int batchSize = 1);
+
+std::string readableError(const float* expected_output, const float* actual_output, const size_t size);
+
 static std::vector<int> asVector(const tensorflow::TensorShapeProto& proto) {
     std::vector<int> shape;
     for (int i = 0; i < proto.dim_size(); i++) {
@@ -131,18 +128,7 @@ static std::vector<google::protobuf::int32> asVector(google::protobuf::RepeatedF
 }
 
 // returns path to a file.
-static std::string createConfigFileWithContent(const std::string& content, std::string filename = "/tmp/ovms_config_file.json") {
-    std::ofstream configFile{filename};
-    spdlog::info("Creating config file: {}\n with content:\n{}", filename, content);
-    configFile << content << std::endl;
-    configFile.close();
-    if (configFile.fail()) {
-        spdlog::info("Closing configFile failed");
-    } else {
-        spdlog::info("Closing configFile succeed");
-    }
-    return filename;
-}
+std::string createConfigFileWithContent(const std::string& content, std::string filename = "/tmp/ovms_config_file.json");
 #pragma GCC diagnostic pop
 
 template <typename T>
@@ -165,6 +151,16 @@ public:
         spdlog::info("Destructor of modelmanager(Enabled one). Models #:{}", models.size());
         models.clear();
         spdlog::info("Destructor of modelmanager(Enabled one). Models #:{}", models.size());
+    }
+    ovms::Status loadConfig(const std::string& jsonFilename) {
+        return ModelManager::loadConfig(jsonFilename);
+    }
+
+    /**
+     * @brief Updates OVMS configuration with cached configuration file. Will check for newly added model versions
+     */
+    void updateConfigurationWithoutConfigFile() {
+        ModelManager::updateConfigurationWithoutConfigFile();
     }
 };
 class TestWithTempDir : public ::testing::Test {


### PR DESCRIPTION
* Revert "Revert "Stress tests for DAG runtime modifications (#382)" (#413)"

This reverts commit c7ce3296ff8fa9206d9144b4f15e751181be96f0.

* Fix bug that reloading state was not considered in waitForLoaded

JIRA:CVS-45093

* Add pipeline Metadata stress tests

TODO:
-> getModelStatus

JIRA:CVS-41787