### PR TITLE
Integrate Node with NodeSession in DAG execution

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020,2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ cc_library(
     name = "ovms_lib",
     linkstatic = 1,
     srcs = [
+        "aliases.hpp",
+        "blobmap.hpp",
         "config.cpp",
         "config.hpp",
         "custom_node_interface.hpp",
@@ -30,11 +32,15 @@ cc_library(
         "deserialization.hpp",
         "dl_node.cpp",
         "dl_node.hpp",
+        "dlnodesession.cpp",
+        "dlnodesession.hpp",
         "entry_node.cpp",
         "entry_node.hpp",
         "executingstreamidguard.hpp",
         "exit_node.cpp",
         "exit_node.hpp",
+        "exitnodesession.cpp",
+        "exitnodesession.hpp",
         "filesystem.hpp",
         "get_model_metadata_impl.cpp",
         "get_model_metadata_impl.hpp",
@@ -60,12 +66,21 @@ cc_library(
         "modelinstance.hpp",
         "modelinstanceunloadguard.cpp",
         "modelinstanceunloadguard.hpp",
+        "modelversion.hpp",
         "modelversionstatus.hpp",
         "model_service.hpp",
         "model_service.cpp",
         "node.cpp",
         "node.hpp",
+        "nodeinfo.hpp",
         "node_library.hpp",
+        "nodesession.cpp",
+        "nodesession.hpp",
+        "nodesessionresult.hpp",
+        "nodeinputhandler.cpp",
+        "nodeinputhandler.hpp",
+        "nodeoutputhandler.cpp",
+        "nodeoutputhandler.hpp",
         "nodesessionmetadata.hpp",
         "nodesessionmetadata.cpp",
         "nodestreamidguard.hpp",
@@ -79,6 +94,7 @@ cc_library(
         "pipelinedefinitionstatus.hpp",
         "pipelinedefinitionunloadguard.cpp",
         "pipelinedefinitionunloadguard.hpp",
+        "pipelineeventqueue.hpp",
         "pipeline_factory.cpp",
         "pipeline_factory.hpp",
         "prediction_service.cpp",

--- a/src/aliases.hpp
+++ b/src/aliases.hpp
@@ -15,25 +15,11 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
 #include <string>
-#include <tuple>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace ovms {
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
-
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
-public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
-};
+using Aliases = std::vector<std::pair<std::string, std::string>>;
 }  // namespace ovms

--- a/src/blobmap.hpp
+++ b/src/blobmap.hpp
@@ -15,25 +15,13 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
 #include <string>
-#include <tuple>
 #include <unordered_map>
-#include <utility>
-#include <vector>
+
+#include <inference_engine.hpp>
 
 namespace ovms {
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
+using BlobMap = std::unordered_map<std::string, InferenceEngine::Blob::Ptr>;
 
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
-public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
-};
 }  // namespace ovms

--- a/src/dl_node.cpp
+++ b/src/dl_node.cpp
@@ -19,8 +19,9 @@
 #include <utility>
 
 #include <inference_engine.hpp>
-#include <spdlog/spdlog.h>
 
+#include "dlnodesession.hpp"
+#include "logging.hpp"
 #include "modelmanager.hpp"
 #include "ov_utils.hpp"
 #include "ovinferrequestsqueue.hpp"
@@ -30,135 +31,43 @@ namespace ovms {
 
 const uint WAIT_FOR_STREAM_ID_TIMEOUT_MICROSECONDS = 1;
 
-Status DLNode::execute(ThreadSafeQueue<std::reference_wrapper<Node>>& notifyEndQueue) {
+Status DLNode::execute(session_key_t sessionKey, PipelineEventQueue& notifyEndQueue) {
+    auto& nodeSession = getNodeSession(sessionKey);
+    auto& dlNodeSession = static_cast<DLNodeSession&>(nodeSession);
+    return dlNodeSession.execute(notifyEndQueue, WAIT_FOR_STREAM_ID_TIMEOUT_MICROSECONDS, *this);
+}
+
+Status DLNode::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) {
+    auto& dlNodeSession = static_cast<DLNodeSession&>(nodeSession);
+    const auto& sessionMetadata = nodeSession.getNodeSessionMetadata();
+    SessionResult sessionResults{sessionMetadata, {}};
+    auto it = nodeSessionOutputs.emplace(sessionMetadata.getSessionKey(), std::move(sessionResults));
+    if (!it.second) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Failed to put node: {} session: {} results in node session outputs",
+            getName(), nodeSession.getSessionKey());
+        return StatusCode::INTERNAL_ERROR;
+    }
+    auto& metadataBlobResultsPair = it.first->second;
+    auto& blobResults = metadataBlobResultsPair.second;
     Status status;
-    if (this->nodeStreamIdGuard == nullptr) {
-        status = requestExecuteRequiredResources();
-        if (!status.ok()) {
-            notifyEndQueue.push(*this);
-            return status;
-        }
-    }
-    auto streamId = this->nodeStreamIdGuard->tryGetId(WAIT_FOR_STREAM_ID_TIMEOUT_MICROSECONDS);
-    if (!streamId) {
-        SPDLOG_DEBUG("[Node: {}] Could not acquire stream Id right away", getName());
-        return StatusCode::PIPELINE_STREAM_ID_NOT_READY_YET;
-    }
-    auto& inferRequestsQueue = this->model->getInferRequestsQueue();
-    auto& inferRequest = inferRequestsQueue.getInferRequest(streamId.value());
-    status = setInputsForInference(inferRequest);
-    if (!status.ok()) {
-        notifyEndQueue.push(*this);
-        return status;
-    }
-    status = executeInference(notifyEndQueue, inferRequest);
-    if (!status.ok()) {
-        notifyEndQueue.push(*this);
-        return status;
-    }
+    const uint waitTimeMicroseconds = 1;
+    auto& inferRequest = dlNodeSession.getInferRequest(waitTimeMicroseconds);
+    auto& model = dlNodeSession.getModelInstance();
+    status = this->fetchResults(blobResults, inferRequest, model, nodeSession.getSessionKey());
+    // TODO outputhandler demultiplex
     return status;
 }
 
-Status DLNode::requestExecuteRequiredResources() {
-    Status status = StatusCode::OK;
-    status = this->modelManager.getModelInstance(
-        this->modelName,
-        this->modelVersion.value_or(0),
-        this->model,
-        this->modelUnloadGuard);
-
-    if (!status.ok()) {
-        SPDLOG_DEBUG("Getting modelInstance failed for node: {} with: {}", getName(), status.string());
-        return status;
-    }
-
-    status = prepareInputsAndModelForInference();
-    if (!status.ok()) {
-        return status;
-    }
-    auto& inferRequestsQueue = this->model->getInferRequestsQueue();
-    this->nodeStreamIdGuard = std::make_unique<NodeStreamIdGuard>(inferRequestsQueue);
-    return status;
-}
-
-Status DLNode::setInputsForInference(InferenceEngine::InferRequest& infer_request) {
-    Status status = StatusCode::OK;
-    try {
-        // Prepare inference request, fill with input blobs
-        for (const auto& kv : this->inputBlobs) {
-            std::string realModelInputName;
-            if (!getRealInputName(kv.first, &realModelInputName).ok()) {
-                SPDLOG_WARN("DLNode::{} [Node name: {}]; cannot find real model input name for alias: {}", __FUNCTION__, getName(), kv.first);
-                return StatusCode::INTERNAL_ERROR;
-            }
-            infer_request.SetBlob(realModelInputName, kv.second);
-        }
-        // OV implementation the InferenceEngineException is not
-        // a base class for all other exceptions thrown from OV.
-        // OV can throw exceptions derived from std::logic_error.
-    } catch (const InferenceEngine::details::InferenceEngineException& e) {
-        status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
-        SPDLOG_DEBUG("[Node: {}] {}; exception message: {}", getName(), status.string(), e.what());
-    } catch (std::logic_error& e) {
-        status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
-        SPDLOG_DEBUG("[Node: {}] {}; exception message: {}", getName(), status.string(), e.what());
-    } catch (...) {
-        status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
-        SPDLOG_DEBUG("[Node: {}] {}; with unknown exception", getName(), status.string());
-    }
-    return status;
-}
-
-Status DLNode::executeInference(ThreadSafeQueue<std::reference_wrapper<Node>>& notifyEndQueue, InferenceEngine::InferRequest& infer_request) {
-    try {
-        SPDLOG_DEBUG("Setting completion callback for node name: {}", this->getName());
-        infer_request.SetCompletionCallback([this, &notifyEndQueue, &infer_request]() {
-            SPDLOG_DEBUG("Completion callback received for node name: {}", this->getName());
-            // After inference is completed, input blobs are not needed anymore
-            this->inputBlobs.clear();
-            notifyEndQueue.push(*this);
-            infer_request.SetCompletionCallback([]() {});  // reset callback on infer request
-        });
-        SPDLOG_DEBUG("Starting infer async for node name: {}", getName());
-        infer_request.StartAsync();
-    } catch (const InferenceEngine::details::InferenceEngineException& e) {
-        SPDLOG_DEBUG("[Node: {}] Exception occured when starting async inference or setting completion callback on model: {}, error: {}",
-            getName(), modelName, e.what());
-        return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
-    } catch (const std::exception& e) {
-        SPDLOG_DEBUG("[Node: {}] Exception occured when starting async inference or setting completion callback on  model: {}, error: {}",
-            getName(), modelName, e.what());
-        return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
-    } catch (...) {
-        SPDLOG_DEBUG("[Node: {}] Unknown exception occured when starting async inference or setting completion callback on model: {}",
-            getName(), modelName);
-        return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
-    }
-    return StatusCode::OK;
-}
-
-Status DLNode::fetchResults(BlobMap& outputs) {
-    // ::execute needs to be executed before ::fetchResults
-    if (this->model == nullptr) {
-        SPDLOG_DEBUG("[Node: {}] Fetching results failed due to earlier execution failure", getName());
-        return StatusCode::UNKNOWN_ERROR;
-    }
-
-    // Get infer request corresponding to this node model
-    auto streamId = this->nodeStreamIdGuard->tryGetId();
-    if (!streamId) {
-        SPDLOG_DEBUG("[Node: {}] Fetching results failed - node had stream Id never assigned", getName());
-        return StatusCode::UNKNOWN_ERROR;
-    }
-    auto& infer_request = this->model->getInferRequestsQueue().getInferRequest(streamId.value());
+Status DLNode::fetchResults(BlobMap& outputs, InferenceEngine::InferRequest& inferRequest, ModelInstance& model, session_key_t sessionKey) {
     // Wait for blob results
-    SPDLOG_DEBUG("[Node: {}] Waiting for infer request with streamId: {} to finish", getName(), streamId.value());
-    auto ov_status = infer_request.Wait(InferenceEngine::IInferRequest::RESULT_READY);
-    SPDLOG_DEBUG("[Node: {}] Infer request with streamId: {} finished", getName(), streamId.value());
-    this->inputBlobs.clear();
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Waiting for infer request to finish", getName(), sessionKey);
+    auto ov_status = inferRequest.Wait(InferenceEngine::IInferRequest::RESULT_READY);
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} infer request finished", getName(), sessionKey);
+
+    static_cast<DLNodeSession&>(this->getNodeSession(sessionKey)).clearInputs();
     if (ov_status != InferenceEngine::StatusCode::OK) {
         Status status = StatusCode::OV_INTERNAL_INFERENCE_ERROR;
-        SPDLOG_DEBUG("[Node: {}] Async infer failed: {}; OV StatusCode: {}", getName(), status.string(), ov_status);
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Async infer failed: {}; OV StatusCode: {}", getName(), sessionKey, status.string(), ov_status);
         return status;
     }
 
@@ -172,19 +81,19 @@ Status DLNode::fetchResults(BlobMap& outputs) {
 
             try {
                 std::string realModelOutputName;
-                if (!getRealOutputName(output_name, &realModelOutputName).ok()) {
-                    SPDLOG_WARN("[Node: {}] Cannot find real model output name for alias{}", getName(), output_name);
+                if (!getRealOutputName(model, output_name, &realModelOutputName).ok()) {
+                    SPDLOG_LOGGER_WARN(dag_executor_logger, "Node: {} session: {} Cannot find real model output name for alias{}", getName(), sessionKey, output_name);
                     return StatusCode::INTERNAL_ERROR;
                 }
-                SPDLOG_DEBUG("[Node: {}] Getting blob from model: {}, inferRequestStreamId: {}, blobName: {}",
-                    getName(), modelName, streamId.value(), realModelOutputName);
-                const auto blob = infer_request.GetBlob(realModelOutputName);
-                SPDLOG_DEBUG("[Node: {}] Creating copy of blob from model: {}, inferRequestStreamId: {}, blobName: {}",
-                    getName(), modelName, streamId.value(), realModelOutputName);
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Getting blob from model: {}, inferRequestStreamId: {}, blobName: {}",
+                    getName(), sessionKey, modelName, sessionKey, realModelOutputName);
+                const auto blob = inferRequest.GetBlob(realModelOutputName);
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Creating copy of blob from model: {}, blobName: {}",
+                    getName(), sessionKey, modelName, realModelOutputName);
                 InferenceEngine::Blob::Ptr copiedBlob;
                 auto status = blobClone(copiedBlob, blob);
                 if (!status.ok()) {
-                    SPDLOG_DEBUG("Could not clone result blob; node name: {}; model name: {}; output: {}",
+                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Could not clone result blob; node: {}; session: {}; model name: {}; output: {}",
                         getName(),
                         this->modelName,
                         realModelOutputName);
@@ -193,14 +102,14 @@ Status DLNode::fetchResults(BlobMap& outputs) {
                 outputs.emplace(std::make_pair(output_name, std::move(copiedBlob)));
             } catch (const InferenceEngine::details::InferenceEngineException& e) {
                 Status status = StatusCode::OV_INTERNAL_SERIALIZATION_ERROR;
-                SPDLOG_DEBUG("[Node: {}] Error during getting blob {}; exception message: {}", getName(), status.string(), e.what());
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session:{} Error during getting blob {}; exception message: {}", getName(), sessionKey, status.string(), e.what());
                 return status;
             }
-            SPDLOG_DEBUG("[Node: {}]: Blob with name {} has been prepared", getName(), output_name);
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Blob with name {} has been prepared", getName(), sessionKey, output_name);
         }
     }
     // After results are fetched, model and inference request are not needed anymore
-    this->release();
+    this->getNodeSession(sessionKey).release();
     return StatusCode::OK;
 }
 
@@ -245,65 +154,17 @@ Status DLNode::validate(const InferenceEngine::Blob::Ptr& blob, const TensorInfo
     return StatusCode::OK;
 }
 
-Status DLNode::prepareInputsAndModelForInference() {
-    size_t requestedBatchSize = 0;
-    std::map<std::string, shape_t> requestedReshapes;
+void DLNode::release(session_key_t sessionId) {
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Release node: {} sessionKey: {}", getName(), sessionId);
+    getNodeSession(sessionId).release();
+}
+bool DLNode::tryDisarm(const session_key_t& sessionKey, const uint microseconds) {
+    return getNodeSession(sessionKey).tryDisarm(microseconds);
+}
 
-    // Validate each blob against its OV tensor info
-    const auto& inputsInfo = this->model->getInputsInfo();
-    for (const auto& kv : this->inputBlobs) {
-        const auto& name = kv.first;
-        auto& blob = kv.second;
-
-        if (inputsInfo.count(name) == 0) {
-            std::stringstream ss;
-            ss << "Required input: " << name;
-            const std::string details = ss.str();
-            SPDLOG_DEBUG("[Node: {}] Missing input with specific name - {}", getName(), details);
-            return Status(StatusCode::INVALID_MISSING_INPUT, details);
-        }
-        auto& inputInfo = *inputsInfo.at(name);
-        auto status = validate(blob, inputInfo);
-        if (status.ok()) {
-            continue;
-        }
-
-        // If precision is incorrect, perform conversion
-        if (status == StatusCode::INVALID_PRECISION) {
-            return status;
-        }
-
-        // If batch size is incorrect, perform network batch size change if allowed (shape mode=auto or batch size=auto)
-        if (status == StatusCode::INVALID_BATCH_SIZE) {
-            if (this->model->getModelConfig().getBatchingMode() == Mode::AUTO) {
-                requestedBatchSize = blob->getTensorDesc().getDims()[0];
-            } else if (this->model->getModelConfig().isShapeAuto(name)) {
-                requestedReshapes[name] = blob->getTensorDesc().getDims();
-            } else {
-                return status;
-            }
-        }
-
-        // If shape is incorrect, perform reshape if allowed (mode=auto)
-        if (status == StatusCode::INVALID_SHAPE) {
-            if (!this->model->getModelConfig().isShapeAuto(name)) {
-                return status;
-            }
-            requestedReshapes[name] = blob->getTensorDesc().getDims();
-        }
-    }
-    if (requestedReshapes.size() > 0) {
-        auto status = this->model->reloadModel(0, requestedReshapes, this->modelUnloadGuard);
-        if (!status.ok()) {
-            return status;
-        }
-    } else if (requestedBatchSize > 0) {
-        auto status = this->model->reloadModel(requestedBatchSize, {}, this->modelUnloadGuard);
-        if (!status.ok()) {
-            return status;
-        }
-    }
-    return StatusCode::OK;
+std::unique_ptr<NodeSession> DLNode::createNodeSession(const NodeSessionMetadata& metadata) {
+    return std::make_unique<DLNodeSession>(metadata, getName(), previous.size(),
+        this->modelManager, this->modelName, this->modelVersion.value_or(0));
 }
 
 }  // namespace ovms

--- a/src/dlnodesession.cpp
+++ b/src/dlnodesession.cpp
@@ -1,0 +1,291 @@
+//*****************************************************************************
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include "dlnodesession.hpp"
+
+#include <map>
+#include <string>
+
+#include "logging.hpp"
+#include "modelinstance.hpp"
+#include "modelinstanceunloadguard.hpp"
+#include "modelmanager.hpp"
+#include "nodeinputhandler.hpp"
+#include "nodeoutputhandler.hpp"
+#include "nodestreamidguard.hpp"
+#include "tensorinfo.hpp"
+
+namespace ovms {
+DLNodeSession::DLNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, ModelManager& manager, const std::string& modelName, model_version_t modelVersion) :
+    NodeSession(metadata, nodeName, inputsCount),
+    modelManager(manager),
+    modelName(modelName),
+    modelVersion(modelVersion) {}
+
+DLNodeSession::DLNodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount, ModelManager& manager, const std::string& modelName, model_version_t modelVersion) :
+    NodeSession(std::move(metadata), nodeName, inputsCount),
+    modelManager(manager),
+    modelName(modelName),
+    modelVersion(modelVersion) {}
+
+DLNodeSession::~DLNodeSession() = default;
+
+void DLNodeSession::clearInputs() {
+    this->inputHandler->clearInputs();
+}
+
+ModelInstance& DLNodeSession::getModelInstance() {
+    return *this->model;
+}
+
+InferenceEngine::InferRequest& DLNodeSession::getInferRequest(const uint microseconds) {
+    auto& inferRequestsQueue = this->model->getInferRequestsQueue();
+    auto streamIdOpt = this->nodeStreamIdGuard->tryGetId(microseconds);
+    if (!streamIdOpt) {
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Failed to get streamId on already executed node: {} session: {}", getName(), getSessionKey());
+        throw std::logic_error("Stream id is empty on already executed node");
+    }
+    return inferRequestsQueue.getInferRequest(streamIdOpt.value());
+}
+Status DLNodeSession::requestExecuteRequiredResources() {
+    Status status = modelManager.getModelInstance(
+        modelName,
+        modelVersion,
+        this->model,
+        this->modelUnloadGuard);
+
+    if (!status.ok()) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Getting modelInstance failed for node: {} session: {} with: {}", getName(), getSessionKey(), status.string());
+        return status;
+    }
+
+    status = prepareInputsAndModelForInference();
+    if (!status.ok()) {
+        return status;
+    }
+    this->nodeStreamIdGuard = std::make_unique<NodeStreamIdGuard>(model->getInferRequestsQueue());
+    return status;
+}
+
+Status DLNodeSession::prepareInputsAndModelForInference() {
+    size_t requestedBatchSize = 0;
+    std::map<std::string, shape_t> requestedReshapes;
+
+    // Validate each blob against its OV tensor info
+    const auto& inputsInfo = this->model->getInputsInfo();
+    for (const auto& kv : this->inputHandler->getInputs()) {
+        const auto& name = kv.first;
+        auto& blob = kv.second;
+
+        if (inputsInfo.count(name) == 0) {
+            std::stringstream ss;
+            ss << "Required input: " << name;
+            const std::string details = ss.str();
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Missing input with specific name - {}", getName(), details);
+            return Status(StatusCode::INVALID_MISSING_INPUT, details);
+        }
+        auto& inputInfo = *inputsInfo.at(name);
+        auto status = validate(blob, inputInfo);
+        if (status.ok()) {
+            continue;
+        }
+
+        // If precision is incorrect, perform conversion
+        if (status == StatusCode::INVALID_PRECISION) {
+            return status;
+        }
+
+        // If batch size is incorrect, perform network batch size change if allowed (shape mode=auto or batch size=auto)
+        if (status == StatusCode::INVALID_BATCH_SIZE) {
+            if (this->model->getModelConfig().getBatchingMode() == Mode::AUTO) {
+                requestedBatchSize = blob->getTensorDesc().getDims()[0];
+            } else if (this->model->getModelConfig().isShapeAuto(name)) {
+                requestedReshapes[name] = blob->getTensorDesc().getDims();
+            } else {
+                return status;
+            }
+        }
+
+        // If shape is incorrect, perform reshape if allowed (mode=auto)
+        if (status == StatusCode::INVALID_SHAPE) {
+            if (!this->model->getModelConfig().isShapeAuto(name)) {
+                return status;
+            }
+            requestedReshapes[name] = blob->getTensorDesc().getDims();
+        }
+    }
+    if (requestedReshapes.size() > 0) {
+        size_t bs = 0;
+        auto status = this->model->reloadModel(bs, requestedReshapes, this->modelUnloadGuard);
+        if (!status.ok()) {
+            return status;
+        }
+    } else if (requestedBatchSize > 0) {
+        auto status = this->model->reloadModel(requestedBatchSize, {}, this->modelUnloadGuard);
+        if (!status.ok()) {
+            return status;
+        }
+    }
+    return StatusCode::OK;
+}
+
+Status DLNodeSession::validate(const InferenceEngine::Blob::Ptr& blob, const TensorInfo& info) {
+    if (info.getPrecision() != blob->getTensorDesc().getPrecision()) {
+        std::stringstream ss;
+        ss << "Expected: " << info.getPrecisionAsString()
+           << "; Actual: " << TensorInfo::getPrecisionAsString(blob->getTensorDesc().getPrecision());
+        const std::string details = ss.str();
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Invalid precision - {}", getName(), details);
+        return Status(StatusCode::INVALID_PRECISION, details);
+    }
+
+    // If batch size differes, check if remaining dimensions are equal
+    if (info.getShape()[0] != blob->getTensorDesc().getDims()[0]) {
+        // If remaining dimensions are equal, it is invalid batch size
+        std::stringstream ss;
+        if (std::equal(info.getShape().begin() + 1, info.getShape().end(), blob->getTensorDesc().getDims().begin() + 1)) {
+            ss << "Expected: " << info.getShape()[0] << "; Actual: " << blob->getTensorDesc().getDims()[0];
+            const std::string details = ss.str();
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Invalid batch size - {}", getName(), details);
+            return Status(StatusCode::INVALID_BATCH_SIZE, details);
+        } else {
+            // Otherwise whole shape is incorrect
+            ss << "Expected: " << TensorInfo::shapeToString(info.getShape())
+               << "; Actual: " << TensorInfo::shapeToString(blob->getTensorDesc().getDims());
+            const std::string details = ss.str();
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {}] Invalid shape - {}", getName(), details);
+            return Status(StatusCode::INVALID_SHAPE, details);
+        }
+    }
+
+    if (info.getShape() != blob->getTensorDesc().getDims()) {
+        std::stringstream ss;
+        ss << "Expected: " << TensorInfo::shapeToString(info.getShape())
+           << "; Actual: " << TensorInfo::shapeToString(blob->getTensorDesc().getDims());
+        const std::string details = ss.str();
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {}] Invalid shape - {}", getName(), details);
+        return Status(StatusCode::INVALID_SHAPE, details);
+    }
+
+    return StatusCode::OK;
+}
+
+Status DLNodeSession::execute(PipelineEventQueue& notifyEndQueue, uint waitForStreamIdTimeoutMicroseconds, Node& node) {
+    Status status;
+    if (this->nodeStreamIdGuard == nullptr) {
+        status = requestExecuteRequiredResources();
+        if (!status.ok()) {
+            notifyEndQueue.push({node, getSessionKey()});
+            return status;
+        }
+    }
+    auto streamIdOpt = this->nodeStreamIdGuard->tryGetId(waitForStreamIdTimeoutMicroseconds);
+    if (!streamIdOpt) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Could not acquire stream Id right away", getName());
+        return StatusCode::PIPELINE_STREAM_ID_NOT_READY_YET;
+    }
+    auto& inferRequestsQueue = this->model->getInferRequestsQueue();
+    auto& inferRequest = inferRequestsQueue.getInferRequest(streamIdOpt.value());
+    status = setInputsForInference(inferRequest);
+    if (!status.ok()) {
+        notifyEndQueue.push({node, getSessionKey()});
+        return status;
+    }
+    status = executeInference(notifyEndQueue, inferRequest, node);
+    if (!status.ok()) {
+        notifyEndQueue.push({node, getSessionKey()});
+        return status;
+    }
+    return status;
+}
+
+Status DLNodeSession::getRealInputName(const std::string& alias, std::string* result) const {
+    if (this->model->getInputsInfo().count(alias) == 0) {
+        return StatusCode::INVALID_MISSING_INPUT;
+    }
+    *result = this->model->getInputsInfo().at(alias)->getName();
+    return StatusCode::OK;
+}
+Status DLNodeSession::setInputsForInference(InferenceEngine::InferRequest& inferRequest) {
+    Status status = StatusCode::OK;
+    try {
+        // Prepare inference request, fill with input blobs
+        for (const auto& kv : this->inputHandler->getInputs()) {
+            std::string realModelInputName;
+            if (!getRealInputName(kv.first, &realModelInputName).ok()) {
+                SPDLOG_LOGGER_WARN(dag_executor_logger, "DLNode::{} [Node name: {}]; cannot find real model input name for alias: {}", __FUNCTION__, getName(), kv.first);
+                return StatusCode::INTERNAL_ERROR;
+            }
+            inferRequest.SetBlob(realModelInputName, kv.second);
+        }
+        // OV implementation the InferenceEngineException is not
+        // a base class for all other exceptions thrown from OV.
+        // OV can throw exceptions derived from std::logic_error.
+    } catch (const InferenceEngine::details::InferenceEngineException& e) {
+        status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] {}; exception message: {}", getName(), status.string(), e.what());
+    } catch (std::logic_error& e) {
+        status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] {}; exception message: {}", getName(), status.string(), e.what());
+    } catch (...) {
+        status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] {}; with unknown exception", getName(), status.string());
+    }
+    return status;
+}
+
+Status DLNodeSession::executeInference(PipelineEventQueue& notifyEndQueue, InferenceEngine::InferRequest& inferRequest, Node& node) {
+    try {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Setting completion callback for node name: {}", this->getName());
+        inferRequest.SetCompletionCallback([this, &notifyEndQueue, &inferRequest, &node]() {
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Completion callback received for node name: {}", this->getName());
+            // After inference is completed, input blobs are not needed anymore
+            this->inputHandler->clearInputs();
+            notifyEndQueue.push({node, getSessionKey()});
+            inferRequest.SetCompletionCallback([]() {});  // reset callback on infer request
+        });
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Starting infer async for node name: {}", getName());
+        inferRequest.StartAsync();
+    } catch (const InferenceEngine::details::InferenceEngineException& e) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Exception occured when starting async inference or setting completion callback on model: {}, error: {}",
+            getName(), getModelName(), e.what());
+        return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
+    } catch (const std::exception& e) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Exception occured when starting async inference or setting completion callback on  model: {}, error: {}",
+            getName(), getModelName(), e.what());
+        return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
+    } catch (...) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Unknown exception occured when starting async inference or setting completion callback on model: {}",
+            getName(), getModelName());
+        return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
+    }
+    return StatusCode::OK;
+}
+
+void DLNodeSession::release() {
+    this->nodeStreamIdGuard.reset();
+    this->model.reset();
+    this->modelUnloadGuard.reset();
+}
+
+bool DLNodeSession::tryDisarm(uint microseconds) {
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Trying to disarm stream id guard of node: {}", getName());
+    if (this->nodeStreamIdGuard == nullptr) {
+        return true;
+    }
+    return this->nodeStreamIdGuard->tryDisarm(microseconds);
+}
+}  // namespace ovms

--- a/src/dlnodesession.hpp
+++ b/src/dlnodesession.hpp
@@ -1,0 +1,73 @@
+//*****************************************************************************
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <inference_engine.hpp>
+
+#include "modelversion.hpp"
+#include "nodesession.hpp"
+#include "pipelineeventqueue.hpp"
+#include "status.hpp"
+
+namespace ovms {
+
+class ModelManager;
+class ModelInstance;
+class Node;
+class NodeStreamIdGuard;
+class ModelInstanceUnloadGuard;
+class TensorInfo;
+
+class DLNodeSession : public NodeSession {
+    std::shared_ptr<ModelInstance> model;
+    std::unique_ptr<NodeStreamIdGuard> nodeStreamIdGuard;
+    std::unique_ptr<ModelInstanceUnloadGuard> modelUnloadGuard;
+
+    ModelManager& modelManager;
+    const std::string& modelName;
+    const model_version_t modelVersion;
+
+public:
+    DLNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, ModelManager& manager, const std::string& modelName, model_version_t modelVersion);
+    DLNodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount, ModelManager& manager, const std::string& modelName, model_version_t modelVersion);
+    virtual ~DLNodeSession();
+
+    InferenceEngine::InferRequest& getInferRequest(const uint microseconds);
+    ModelInstance& getModelInstance();
+
+private:
+    Status requestExecuteRequiredResources();
+
+public:
+    Status prepareInputsAndModelForInference();
+    Status validate(const InferenceEngine::Blob::Ptr& blob, const TensorInfo& info);
+    Status execute(PipelineEventQueue& notifyEndQueue, uint waitForStreamIdTimeoutMicroseconds, Node& node);
+    Status executeInference(PipelineEventQueue& notifyEndQueue, InferenceEngine::InferRequest&, Node& node);
+    Status setInputsForInference(InferenceEngine::InferRequest& inferRequest);
+    Status getRealInputName(const std::string& alias, std::string* result) const;
+    void release() override;
+
+    void clearInputs();
+
+    const std::string& getModelName() { return modelName; }
+    bool tryDisarm(uint microseconds) override;
+};
+}  // namespace ovms

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <utility>
 
-#include <spdlog/spdlog.h>
+#include "logging.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
@@ -27,6 +27,28 @@
 #pragma GCC diagnostic pop
 
 namespace ovms {
+
+Status EntryNode::execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) {
+    // TODO this should be created in EntryNode::SetInputs, or special method for entry node called
+    // in event loop can be done at the end of part 3 or in future release
+    NodeSessionMetadata metadata;
+    NodeSession& nodeSession = getNodeSession(metadata);  // call to create session
+    notifyEndQueue.push(NodeSessionKeyPair(*this, nodeSession.getSessionKey()));
+    return StatusCode::OK;
+}
+
+Status EntryNode::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) {
+    // TODO handle multiple sessions later on
+    BlobMap outputs;
+    auto status = fetchResults(outputs);
+    SessionResult metaOutputsPair{nodeSession.getNodeSessionMetadata(), std::move(outputs)};
+    auto it = nodeSessionOutputs.emplace(nodeSession.getSessionKey(), std::move(metaOutputsPair));
+    if (!it.second) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Failed to set entry node session results.");
+        return StatusCode::UNKNOWN_ERROR;
+    }
+    return StatusCode::OK;
+}
 
 Status EntryNode::fetchResults(BlobMap& outputs) {
     // Fill outputs map with tensorflow predict request inputs. Fetch only those that are required in following nodes
@@ -41,12 +63,12 @@ Status EntryNode::fetchResults(BlobMap& outputs) {
                 std::stringstream ss;
                 ss << "Required input: " << output_name;
                 const std::string details = ss.str();
-                SPDLOG_DEBUG("[Node: {}] Missing input with specific name", getName(), details);
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Missing input with specific name", getName(), details);
                 return Status(StatusCode::INVALID_MISSING_INPUT, details);
             }
             const auto& tensor_proto = request->inputs().at(output_name);
             InferenceEngine::Blob::Ptr blob;
-            SPDLOG_DEBUG("[Node: {}] Deserializing input: {}", getName(), output_name);
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Deserializing input: {}", getName(), output_name);
             auto status = deserialize(tensor_proto, blob);
             if (!status.ok()) {
                 return status;
@@ -54,7 +76,7 @@ Status EntryNode::fetchResults(BlobMap& outputs) {
 
             outputs[output_name] = blob;
 
-            SPDLOG_DEBUG("[Node: {}]: blob with name {} has been prepared", getName(), output_name);
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}]: blob with name {} has been prepared", getName(), output_name);
         }
     }
 
@@ -65,7 +87,7 @@ Status EntryNode::deserialize(const tensorflow::TensorProto& proto, InferenceEng
     InferenceEngine::TensorDesc description;
     if (proto.tensor_content().size() == 0) {
         const std::string details = "Tensor content size can't be 0";
-        SPDLOG_DEBUG("[Node: {}] {}", getName(), details);
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] {}", getName(), details);
         return Status(StatusCode::INVALID_CONTENT_SIZE, details);
     }
 
@@ -84,7 +106,7 @@ Status EntryNode::deserialize(const tensorflow::TensorProto& proto, InferenceEng
         std::stringstream ss;
         ss << "Expected: " << tensor_count * tensorflow::DataTypeSize(proto.dtype()) << "; Actual: " << proto.tensor_content().size();
         const std::string details = ss.str();
-        SPDLOG_DEBUG("[Node {}] Invalid size of tensor proto - {}", getName(), details);
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node {}] Invalid size of tensor proto - {}", getName(), details);
         return Status(StatusCode::INVALID_CONTENT_SIZE, details);
     }
 
@@ -118,18 +140,18 @@ Status EntryNode::deserialize(const tensorflow::TensorProto& proto, InferenceEng
             std::stringstream ss;
             ss << "Actual: " << TensorInfo::getDataTypeAsString(proto.dtype());
             const std::string details = ss.str();
-            SPDLOG_DEBUG("[Node: {}] Unsupported deserialization precision - {}", getName(), details);
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Unsupported deserialization precision - {}", getName(), details);
             return Status(StatusCode::OV_UNSUPPORTED_DESERIALIZATION_PRECISION, details);
         }
         }
     } catch (const InferenceEngine::details::InferenceEngineException& e) {
         Status status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
-        SPDLOG_DEBUG("[Node: {}] Exception thrown during deserialization from make_shared_blob; {}; exception message: {}",
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Exception thrown during deserialization from make_shared_blob; {}; exception message: {}",
             getName(), status.string(), e.what());
         return status;
     } catch (std::logic_error& e) {
         Status status = StatusCode::OV_INTERNAL_DESERIALIZATION_ERROR;
-        SPDLOG_DEBUG("[Node: {}] Exception thrown during deserialization from make_shared_blob; {}; exception message: {}",
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Exception thrown during deserialization from make_shared_blob; {}; exception message: {}",
             getName(), status.string(), e.what());
         return status;
     }

--- a/src/entry_node.hpp
+++ b/src/entry_node.hpp
@@ -36,15 +36,16 @@ public:
         Node(ENTRY_NODE_NAME),
         request(request) {}
 
-    Status execute(ThreadSafeQueue<std::reference_wrapper<Node>>& notifyEndQueue) override {
-        notifyEndQueue.push(*this);
-        return StatusCode::OK;
-    }
+    Status execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) override;
 
-    Status fetchResults(BlobMap& outputs) override;
+    Status fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) override;
 
+protected:
+    Status fetchResults(BlobMap& outputs);
+
+public:
     // Entry nodes have no dependency
-    void addDependency(Node&, const InputPairs&) override {
+    void addDependency(Node&, const Aliases&) override {
         throw std::logic_error("This node cannot have dependency");
     }
 

--- a/src/exit_node.cpp
+++ b/src/exit_node.cpp
@@ -18,18 +18,30 @@
 #include <string>
 #include <utility>
 
-#include <spdlog/spdlog.h>
+#include "logging.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #include "tensorflow/core/framework/tensor.h"
 #pragma GCC diagnostic pop
 
-namespace ovms {
+#include "exitnodesession.hpp"
 
-Status ExitNode::fetchResults(BlobMap&) {
+namespace ovms {
+Status ExitNode::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) {
+    auto& exitNodeSession = static_cast<ExitNodeSession&>(nodeSession);
+    return this->fetchResults(exitNodeSession.getInputBlobs());
+}
+
+Status ExitNode::execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) {
+    notifyEndQueue.push(NodeSessionKeyPair(*this, sessionId));
+
+    return StatusCode::OK;
+}
+
+Status ExitNode::fetchResults(const BlobMap& inputBlobs) {
     // Serialize results to proto
-    for (const auto& kv : this->inputBlobs) {
+    for (const auto& kv : inputBlobs) {
         const auto& output_name = kv.first;
         auto& blob = kv.second;
         SPDLOG_DEBUG("[Node: {}] Serializing response from pipeline. Output name: {}", getName(), output_name);
@@ -90,5 +102,9 @@ Status ExitNode::serialize(const InferenceEngine::Blob::Ptr& blob, tensorflow::T
     proto.mutable_tensor_content()->assign((char*)blob->buffer(), blob->byteSize());
 
     return StatusCode::OK;
+}
+
+std::unique_ptr<NodeSession> ExitNode::createNodeSession(const NodeSessionMetadata& metadata) {
+    return std::make_unique<ExitNodeSession>(metadata, getName(), previous.size());
 }
 }  // namespace ovms

--- a/src/exit_node.hpp
+++ b/src/exit_node.hpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //*****************************************************************************
 #pragma once
-
+#include <memory>
 #include <string>
 
 #pragma GCC diagnostic push
@@ -40,12 +40,13 @@ public:
 
     // Exit node does not have execute logic.
     // It serializes its received input blobs to proto in ::fetchResults
-    Status execute(ThreadSafeQueue<std::reference_wrapper<Node>>& notifyEndQueue) override {
-        notifyEndQueue.push(*this);
-        return StatusCode::OK;
-    }
+    Status execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) override;
 
-    Status fetchResults(BlobMap& outputs) override;
+protected:
+    Status fetchResults(const BlobMap& outputs);
+
+public:
+    Status fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) override;
 
     // Exit nodes have no dependants
     void addDependant(Node& node) override {
@@ -53,6 +54,7 @@ public:
     }
 
     Status serialize(const InferenceEngine::Blob::Ptr& blob, tensorflow::TensorProto& proto);
+    std::unique_ptr<NodeSession> createNodeSession(const NodeSessionMetadata& metadata) override;
 };
 
 }  // namespace ovms

--- a/src/exitnodesession.cpp
+++ b/src/exitnodesession.cpp
@@ -5,7 +5,6 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,27 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#pragma once
+#include "exitnodesession.hpp"
 
-#include <set>
-#include <string>
-#include <tuple>
-#include <unordered_map>
 #include <utility>
-#include <vector>
+
+#include "logging.hpp"
+#include "nodeinputhandler.hpp"
 
 namespace ovms {
+ExitNodeSession::ExitNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount) :
+    NodeSession(metadata, nodeName, inputsCount) {}
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
+ExitNodeSession::ExitNodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount) :
+    NodeSession(std::move(metadata), nodeName, inputsCount) {}
 
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
+ExitNodeSession::~ExitNodeSession() = default;
 
-public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
-};
+void ExitNodeSession::release() {}
+
+const BlobMap& ExitNodeSession::getInputBlobs() const {
+    return this->inputHandler->getInputBlobs();
+}
 }  // namespace ovms

--- a/src/exitnodesession.hpp
+++ b/src/exitnodesession.hpp
@@ -15,25 +15,27 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
 #include <string>
-#include <tuple>
-#include <unordered_map>
-#include <utility>
-#include <vector>
+
+#include <inference_engine.hpp>
+
+#include "blobmap.hpp"
+#include "nodesession.hpp"
+#include "nodesessionmetadata.hpp"
+#include "status.hpp"
 
 namespace ovms {
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
+class Node;
+class TensorInfo;
 
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
+class ExitNodeSession : public NodeSession {
 public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
+    ExitNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount);
+    ExitNodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount);
+    virtual ~ExitNodeSession();
+
+    const BlobMap& getInputBlobs() const;
+    void release() override;
 };
 }  // namespace ovms

--- a/src/get_model_metadata_impl.cpp
+++ b/src/get_model_metadata_impl.cpp
@@ -17,6 +17,8 @@
 
 #include <google/protobuf/util/json_util.h>
 
+#include "pipelinedefinition.hpp"
+
 using google::protobuf::util::JsonPrintOptions;
 using google::protobuf::util::MessageToJsonString;
 

--- a/src/get_model_metadata_impl.hpp
+++ b/src/get_model_metadata_impl.hpp
@@ -31,6 +31,8 @@ namespace ovms {
 
 using proto_signature_map_t = google::protobuf::Map<std::string, tensorflow::TensorInfo>;
 
+class PipelineDefinition;
+
 class GetModelMetadataImpl {
 public:
     static Status validate(

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -25,6 +25,7 @@
 #include "localfilesystem.hpp"
 #include "logging.hpp"
 #include "modelmanager.hpp"
+#include "pipelinedefinition.hpp"
 
 namespace ovms {
 

--- a/src/model_service.cpp
+++ b/src/model_service.cpp
@@ -30,6 +30,7 @@
 #pragma GCC diagnostic pop
 
 #include "modelmanager.hpp"
+#include "pipelinedefinition.hpp"
 #include "status.hpp"
 
 using google::protobuf::util::JsonPrintOptions;

--- a/src/model_version_policy.hpp
+++ b/src/model_version_policy.hpp
@@ -20,10 +20,9 @@
 #include <string>
 #include <vector>
 
-namespace ovms {
+#include "modelversion.hpp"
 
-using model_version_t = int64_t;
-using model_versions_t = std::vector<ovms::model_version_t>;
+namespace ovms {
 
 /**
  * @brief Base class for model version policy types
@@ -40,7 +39,7 @@ public:
      * @param versions model versions to filter
      * @return Filtered version list
      */
-    virtual std::vector<model_version_t> filter(std::vector<model_version_t> versions) const = 0;
+    virtual model_versions_t filter(model_versions_t versions) const = 0;
 
     /**
      * @brief Creates default model version policy, by default only one version (highest) should be served
@@ -72,7 +71,7 @@ public:
      * @param versions model versions to filter
      * @return Filtered version list
      */
-    std::vector<model_version_t> filter(std::vector<model_version_t> versions) const override {
+    model_versions_t filter(model_versions_t versions) const override {
         return versions;
     }
 
@@ -83,7 +82,7 @@ public:
  * @brief Model version policy for explicitely specifying which versions should be enabled
  */
 class SpecificModelVersionPolicy : public ModelVersionPolicy {
-    std::vector<model_version_t> specificVersions;
+    model_versions_t specificVersions;
 
 public:
     /**
@@ -91,7 +90,7 @@ public:
      * 
      * @param versions list of all model versions that should be served
      */
-    SpecificModelVersionPolicy(const std::vector<model_version_t>& versions) :
+    SpecificModelVersionPolicy(const model_versions_t& versions) :
         specificVersions(versions) {
         std::sort(specificVersions.begin(), specificVersions.end());
     }
@@ -102,7 +101,7 @@ public:
      * @param versions model versions to filter
      * @return Filtered version list
      */
-    std::vector<model_version_t> filter(std::vector<model_version_t> versions) const override;
+    model_versions_t filter(model_versions_t versions) const override;
 
     operator std::string() const override;
 };
@@ -128,7 +127,7 @@ public:
      * @param versions model versions to filter
      * @return Filtered version list
      */
-    std::vector<model_version_t> filter(std::vector<model_version_t> versions) const override;
+    model_versions_t filter(model_versions_t versions) const override;
 
     operator std::string() const override;
 };

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -35,12 +35,15 @@
 #include "config.hpp"
 #include "custom_node_library_manager.hpp"
 #include "customloaders.hpp"
+#include "entry_node.hpp"  // need for ENTRY_NODE_NAME
+#include "exit_node.hpp"   // need for EXIT_NODE_NAME
 #include "filesystem.hpp"
 #include "gcsfilesystem.hpp"
 #include "localfilesystem.hpp"
 #include "logging.hpp"
 #include "pipeline.hpp"
 #include "pipeline_factory.hpp"
+#include "pipelinedefinition.hpp"
 #include "s3filesystem.hpp"
 #include "schema.hpp"
 

--- a/src/modelversion.hpp
+++ b/src/modelversion.hpp
@@ -15,25 +15,10 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
-#include <string>
-#include <tuple>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 namespace ovms {
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
-
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
-public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
-};
-}  // namespace ovms
+using model_version_t = int64_t;
+using model_versions_t = std::vector<ovms::model_version_t>;
+}  //  namespace ovms

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -18,13 +18,28 @@
 #include <algorithm>
 #include <sstream>
 
-#include <spdlog/spdlog.h>
-
+#include "logging.hpp"
+#include "nodesession.hpp"
 #include "status.hpp"
 
 namespace ovms {
 
-void Node::printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const InputPairs& pairs) {
+Node::Node(const std::string& nodeName) :
+    nodeName(nodeName) {
+}
+Status Node::fetchResults(session_key_t sessionId, SessionResults& nodeSessionOutputs) {
+    auto it = nodeSessions.find(sessionId);
+    auto& nodeSession = it->second;
+    if (it == nodeSessions.end()) {
+        return StatusCode::UNKNOWN_ERROR;
+    }
+    auto status = fetchResults(*nodeSession, nodeSessionOutputs);
+    // TODO outputhandler->postprocessResults
+    nodeSessions.erase(sessionId);
+    return status;
+}
+
+void Node::printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const Aliases& pairs) {
     std::stringstream ss;
     ss << "Links from:" << sourceNode << " to:" << nodeName << ":\n";
     for (auto& pair : pairs) {
@@ -33,7 +48,51 @@ void Node::printNodeConnections(const std::string& nodeName, const std::string& 
     SPDLOG_DEBUG(ss.str());
 }
 
+Status Node::setInputs(const Node& dependency, SessionResults& sessionResults) {
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} setInputs from node: {}", getName(), dependency.getName());
+    for (auto& [sessionKey, metadataInputsPair] : sessionResults) {
+        auto& [metadata, inputs] = metadataInputsPair;
+        auto status = this->setInputs(dependency, inputs, metadata);
+        if (!status.ok()) {
+            return status;
+        }
+    }
+    return StatusCode::OK;
+}
+
+Status Node::setInputs(const Node& dependency, BlobMap& inputs, NodeSessionMetadata& metadata) {
+    // mapping for dependency - keeps mapping between dependency output name and this node input name
+    const auto& mapping_for_dependency = this->getMappingByDependency(dependency);
+    NodeSession& nodeSession = getNodeSession(metadata);
+    // assign all input blobs from inputs that are required by this node for future inference
+    for (const auto& pair : mapping_for_dependency) {
+        const auto& dependency_output_name = pair.first;
+        const auto& current_node_input_name = pair.second;
+
+        // possibly incorrectly constructed pipeline - required input missing from previous node
+        auto it = inputs.find(dependency_output_name);
+        if (it == inputs.end()) {
+            SPDLOG_LOGGER_WARN(dag_executor_logger, "Node::setInputs: error setting required input for (Node name {}) from (Node name {}): dependency is missing output name {}",
+                getName(),
+                dependency.getName(),
+                dependency_output_name);
+            return StatusCode::INVALID_MISSING_INPUT;
+        }
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node::setInputs: setting required input for (Node name {}) from (Node name {}), input name: {}, dependency output name: {}",
+            getName(),
+            dependency.getName(),
+            current_node_input_name,
+            dependency_output_name);
+        this->inputBlobs[current_node_input_name] = it->second;
+        nodeSession.setInput(current_node_input_name, it->second);
+    }
+    nodeSession.notifyFinishedDependency();  // TODO gatherer need to change this mechanism
+    finishedDependenciesCount++;
+    return StatusCode::OK;
+}
+
 Status Node::setInputs(const Node& dependency, BlobMap& inputs) {
+    SPDLOG_ERROR("setInputs for metadata4");
     // mapping for dependency - keeps mapping between dependency output name and this node input name
     const auto& mapping_for_dependency = this->getMappingByDependency(dependency);
 
@@ -57,10 +116,46 @@ Status Node::setInputs(const Node& dependency, BlobMap& inputs) {
             current_node_input_name,
             dependency_output_name);
         this->inputBlobs[current_node_input_name] = it->second;
+        NodeSessionMetadata metadata;
+        getNodeSession(metadata).setInput(current_node_input_name, it->second);
     }
-
     finishedDependenciesCount++;
     return StatusCode::OK;
+}
+
+NodeSession& Node::getNodeSession(const session_key_t& sessionKey) const {
+    auto it = nodeSessions.find(sessionKey);
+    if (it == nodeSessions.end()) {
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to get non-existing node: {} session: {}.", getName(), sessionKey);
+        throw std::logic_error("Tried to get non existing session");  // TODO some other kind of error
+    }
+    return *(*it).second;
+}
+
+NodeSession& Node::getNodeSession(const NodeSessionMetadata& metadata) {
+    auto it = nodeSessions.find(metadata.getSessionKey());
+    if (it != nodeSessions.end()) {
+        return *(*it).second;
+    }
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will create new session: {} for node: {}",
+        metadata.getSessionKey(), getName());
+    auto emplacePair = nodeSessions.emplace(metadata.getSessionKey(), createNodeSession(metadata));
+    return *(*(emplacePair.first)).second;
+}
+
+std::unique_ptr<NodeSession> Node::createNodeSession(const NodeSessionMetadata& metadata) {
+    return std::make_unique<NodeSession>(metadata, getName(), previous.size());
+}
+
+std::vector<session_key_t> Node::getReadySessions() const {
+    std::vector<session_key_t> readySessions;
+    for (auto& [sessionKey, nodeSession] : nodeSessions) {
+        SPDLOG_ERROR("Checking readiness of node: {} session: {}", getName(), nodeSession->getSessionKey());
+        if (nodeSession->isReady()) {
+            readySessions.emplace_back(sessionKey);
+        }
+    }
+    return std::move(readySessions);
 }
 
 }  // namespace ovms

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright 2020 Intel Corporation
+// Copyright 2020,2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -22,14 +23,17 @@
 
 #include <inference_engine.hpp>
 
+#include "aliases.hpp"
+#include "blobmap.hpp"
+#include "nodesession.hpp"
+#include "nodesessionresult.hpp"
+#include "pipelineeventqueue.hpp"
 #include "status.hpp"
-#include "threadsafequeue.hpp"
 
 namespace ovms {
 
-using BlobMap = std::unordered_map<std::string, InferenceEngine::Blob::Ptr>;
 using BlobNames = std::vector<std::string>;
-using InputPairs = std::vector<std::pair<std::string, std::string>>;
+using session_key_t = std::string;
 
 class Node {
 protected:
@@ -41,45 +45,56 @@ protected:
     size_t finishedDependenciesCount = 0;
 
     // Blobs ready and waiting for execution
+    std::unordered_map<session_key_t, std::unique_ptr<NodeSession>> nodeSessions;
     BlobMap inputBlobs;
 
     // Input/Output name mapping and list of required inputs from previous nodes
-    std::unordered_map<std::string, InputPairs> blobNamesMapping;
+    std::unordered_map<std::string, Aliases> blobNamesMapping;
 
 public:
-    Node(const std::string& nodeName) :
-        nodeName(nodeName) {
-    }
+    Node(const std::string& nodeName);
 
     virtual ~Node() = default;
 
     const std::string& getName() const { return this->nodeName; }
 
-    virtual Status execute(ThreadSafeQueue<std::reference_wrapper<Node>>& notifyEndQueue) = 0;
-    virtual Status fetchResults(BlobMap& outputs) = 0;
+    virtual Status execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) = 0;
+    Status fetchResults(session_key_t sessionId, SessionResults& nodeSessionOutputs);
 
+protected:
+    virtual Status fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) = 0;
+
+public:
+    Status setInputs(const Node& dependency, BlobMap& inputs, NodeSessionMetadata& metadata);
     Status setInputs(const Node& dependency, BlobMap& inputs);
+    Status setInputs(const Node& dependency, SessionResults& inputs);
 
-    virtual void addDependency(Node& node, const InputPairs& blobNamesMapping) {
+    virtual void addDependency(Node& node, const Aliases& blobNamesMapping) {
         this->previous.emplace_back(node);
         this->blobNamesMapping[node.getName()] = blobNamesMapping;
     }
 
     virtual void addDependant(Node& node) { this->next.emplace_back(node); }
 
-    const InputPairs& getMappingByDependency(const Node& dependency) {
+    const Aliases& getMappingByDependency(const Node& dependency) {
         return blobNamesMapping.at(dependency.getName());
     }
     bool isReady() const {
         return finishedDependenciesCount == previous.size();
     }
+    std::vector<session_key_t> getReadySessions() const;
     const std::vector<std::reference_wrapper<Node>>& getNextNodes() {
         return next;
     }
-    virtual void release() {}
-    virtual bool tryDisarmStreamIdGuard(const uint microseconds = 1) { return true; }
+    virtual void release(session_key_t sessionId) {}
+    virtual bool tryDisarm(const session_key_t& sessionKey, const uint microseconds = 1) { return true; }
 
-    static void printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const InputPairs& pairs);
+    static void printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const Aliases& pairs);
+
+protected:
+    NodeSession& getNodeSession(const NodeSessionMetadata& metadata);
+    NodeSession& getNodeSession(const session_key_t& sessionKey) const;
+    virtual std::unique_ptr<NodeSession> createNodeSession(const NodeSessionMetadata& metadata);
 };
 
 }  // namespace ovms

--- a/src/nodeinfo.hpp
+++ b/src/nodeinfo.hpp
@@ -1,0 +1,76 @@
+//*****************************************************************************
+// Copyright 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
+#pragma GCC diagnostic pop
+
+#include "aliases.hpp"
+#include "status.hpp"
+#include "tensorinfo.hpp"
+
+namespace ovms {
+
+class ModelManager;
+class Pipeline;
+
+using pipeline_connections_t = std::unordered_map<std::string, std::unordered_map<std::string, Aliases>>;
+using tensor_map_t = std::map<std::string, std::shared_ptr<TensorInfo>>;
+
+enum class NodeKind {
+    ENTRY,
+    DL,
+    EXIT
+};
+
+const std::string DL_NODE_CONFIG_TYPE = "DL model";
+
+Status toNodeKind(const std::string& str, NodeKind& nodeKind);
+
+struct NodeInfo {
+    NodeKind kind;
+    std::string nodeName;
+    std::string modelName;
+    std::optional<model_version_t> modelVersion;
+    std::unordered_map<std::string, std::string> outputNameAliases;
+    std::optional<size_t> demultiplyCount;
+    std::optional<std::string> gatherFromNode;
+
+    NodeInfo(NodeKind kind,
+        const std::string& nodeName,
+        const std::string& modelName = "",
+        std::optional<model_version_t> modelVersion = std::nullopt,
+        std::unordered_map<std::string, std::string> outputNameAliases = {},
+        std::optional<size_t> demultiplyCount = std::nullopt,
+        std::optional<std::string> gatherFromNode = std::nullopt) :
+        kind(kind),
+        nodeName(nodeName),
+        modelName(modelName),
+        modelVersion(modelVersion),
+        outputNameAliases(outputNameAliases),
+        demultiplyCount(demultiplyCount),
+        gatherFromNode(gatherFromNode) {}
+};
+}  // namespace ovms

--- a/src/nodeinputhandler.hpp
+++ b/src/nodeinputhandler.hpp
@@ -15,25 +15,30 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
+#include <memory>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
-#include <vector>
+
+#include <inference_engine.hpp>
+
+#include "blobmap.hpp"
 
 namespace ovms {
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
+using BlobMap = std::unordered_map<std::string, InferenceEngine::Blob::Ptr>;
 
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
+class NodeInputHandler {
+    BlobMap inputBlobs;
+    uint32_t expectedDependencies;
 
 public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
+    NodeInputHandler(uint32_t inputsMissingCount);
+    void setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr);
+    const BlobMap& getInputs() const { return inputBlobs; }
+    void clearInputs();
+    virtual bool isReady();
+    void notifyFinishedDependency();
+    const BlobMap& getInputBlobs() const;
 };
 }  // namespace ovms

--- a/src/nodeoutputhandler.cpp
+++ b/src/nodeoutputhandler.cpp
@@ -13,27 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#pragma once
+#include "nodeoutputhandler.hpp"
 
-#include <set>
-#include <string>
-#include <tuple>
-#include <unordered_map>
-#include <utility>
-#include <vector>
+#include <inference_engine.hpp>
+
+#include "logging.hpp"
 
 namespace ovms {
-
-using session_id_t = uint64_t;
-using session_key_t = std::string;
-
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
-public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
-};
+void NodeOutputHandler::setInput(const std::string& name, InferenceEngine::Blob::Ptr& ptr) {}
 }  // namespace ovms

--- a/src/nodeoutputhandler.hpp
+++ b/src/nodeoutputhandler.hpp
@@ -15,25 +15,15 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
+#include <memory>
 #include <string>
-#include <tuple>
-#include <unordered_map>
 #include <utility>
-#include <vector>
+
+#include <inference_engine.hpp>
 
 namespace ovms {
-
-using session_id_t = uint64_t;
-using session_key_t = std::string;
-
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
+class NodeOutputHandler {
 public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
+    void setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr);
 };
 }  // namespace ovms

--- a/src/nodesession.cpp
+++ b/src/nodesession.cpp
@@ -1,0 +1,55 @@
+//*****************************************************************************
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include "nodesession.hpp"
+
+#include "logging.hpp"
+#include "nodeinputhandler.hpp"
+#include "nodeoutputhandler.hpp"
+
+namespace ovms {
+NodeSession::~NodeSession() = default;
+
+const NodeSessionMetadata& NodeSession::getNodeSessionMetadata() const {
+    return this->metadata;
+}
+
+void NodeSession::setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr) {
+    inputHandler->setInput(inputName, blobPtr);
+}
+
+NodeSession::NodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount) :
+    metadata(metadata),
+    sessionKey(metadata.getSessionKey()),
+    nodeName(nodeName),
+    inputHandler(std::make_unique<NodeInputHandler>(inputsCount)),
+    outputHandler(std::make_unique<NodeOutputHandler>()) {}
+
+NodeSession::NodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount) :
+    metadata(std::move(metadata)),
+    sessionKey(this->metadata.getSessionKey()),
+    nodeName(nodeName),
+    inputHandler(std::make_unique<NodeInputHandler>(inputsCount)),
+    outputHandler(std::make_unique<NodeOutputHandler>()) {}
+
+bool NodeSession::isReady() const {
+    bool isReady = inputHandler->isReady();  // TODO gather input handler will influence result
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "node: {} session: {} isReady: {}", getName(), getSessionKey(), isReady);
+    return isReady;
+}
+void NodeSession::notifyFinishedDependency() {
+    this->inputHandler->notifyFinishedDependency();
+}
+}  // namespace ovms

--- a/src/nodesession.hpp
+++ b/src/nodesession.hpp
@@ -1,0 +1,52 @@
+//*****************************************************************************
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <inference_engine.hpp>
+
+#include "nodesessionmetadata.hpp"
+
+namespace ovms {
+struct NodeInputHandler;
+struct NodeOutputHandler;
+
+class NodeSession {
+    NodeSessionMetadata metadata;
+    session_key_t sessionKey;
+    const std::string& nodeName;
+
+protected:
+    std::unique_ptr<NodeInputHandler> inputHandler;
+    std::unique_ptr<NodeOutputHandler> outputHandler;
+
+public:
+    NodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount);
+    NodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount);
+    virtual ~NodeSession();
+    const std::string& getName() const { return nodeName; }
+    void setInput(const std::string& inputName, InferenceEngine::Blob::Ptr&);
+    const NodeSessionMetadata& getNodeSessionMetadata() const;
+    const session_key_t& getSessionKey() const { return sessionKey; }
+    bool isReady() const;
+    virtual void release() {}
+    virtual bool tryDisarm(uint microseconds) { return true; }
+    void notifyFinishedDependency();
+};
+}  // namespace ovms

--- a/src/nodesessionmetadata.cpp
+++ b/src/nodesessionmetadata.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 #include "logging.hpp"
 

--- a/src/nodesessionresult.hpp
+++ b/src/nodesessionresult.hpp
@@ -15,25 +15,15 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
-#include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
-#include <vector>
+
+#include "blobmap.hpp"
+#include "nodesessionmetadata.hpp"
 
 namespace ovms {
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
+using SessionResult = std::pair<NodeSessionMetadata, BlobMap>;
+using SessionResults = std::unordered_map<session_key_t, std::pair<NodeSessionMetadata, BlobMap>>;
 
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
-public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
-};
 }  // namespace ovms

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -17,15 +17,35 @@
 
 #include <algorithm>
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 
+#include "entry_node.hpp"
+#include "exit_node.hpp"
 #include "logging.hpp"
-#include "threadsafequeue.hpp"
+#include "node.hpp"
+#include "pipelineeventqueue.hpp"
 
 namespace ovms {
+Pipeline::~Pipeline() = default;
 
-void printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const InputPairs& pairs) {
+Pipeline::Pipeline(EntryNode& entry, ExitNode& exit, const std::string& name) :
+    name(name),
+    entry(entry),
+    exit(exit) {}
+
+void Pipeline::push(std::unique_ptr<Node> node) {
+    nodes.emplace_back(std::move(node));
+}
+void Pipeline::connect(Node& from, Node& to, const Aliases& blobNamesMapping) {
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Connecting from: {}, to: {}", from.getName(), to.getName());
+    printNodeConnections(to.getName(), from.getName(), blobNamesMapping);
+    from.addDependant(to);
+    to.addDependency(from, blobNamesMapping);
+}
+
+void printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const Aliases& pairs) {
     if (spdlog::default_logger()->level() > spdlog::level::debug) {
         return;
     }
@@ -37,14 +57,6 @@ void printNodeConnections(const std::string& nodeName, const std::string& source
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, ss.str());
 }
 
-std::map<const std::string, bool> Pipeline::prepareStatusMap() const {
-    std::map<const std::string, bool> nameFlagMap;
-    for (const auto& node : nodes) {
-        nameFlagMap.emplace(std::make_pair(node->getName(), false));
-    }
-    return std::move(nameFlagMap);
-}
-
 void setFailIfNotFailEarlier(ovms::Status& earlierStatusCode, ovms::Status& newFailStatus) {
     if (earlierStatusCode.ok()) {
         earlierStatusCode = newFailStatus;
@@ -53,7 +65,7 @@ void setFailIfNotFailEarlier(ovms::Status& earlierStatusCode, ovms::Status& newF
 
 #define IF_ERROR_OCCURRED_EARLIER_THEN_BREAK_IF_ALL_STARTED_FINISHED_CONTINUE_OTHERWISE \
     if (!firstErrorStatus.ok()) {                                                       \
-        if (finishedExecute == startedExecute) {                                        \
+        if (finishedSessions.size() == startedSessions.size()) {                        \
             break;                                                                      \
         } else {                                                                        \
             continue;                                                                   \
@@ -69,47 +81,50 @@ void setFailIfNotFailEarlier(ovms::Status& earlierStatusCode, ovms::Status& newF
 
 Status Pipeline::execute() {
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Started execution of pipeline: {}", getName());
-    ThreadSafeQueue<std::reference_wrapper<Node>> finishedNodeQueue;
+    PipelineEventQueue finishedNodeQueue;
     ovms::Status firstErrorStatus{ovms::StatusCode::OK};
-    auto startedExecute{prepareStatusMap()};
-    auto finishedExecute{prepareStatusMap()};
-    startedExecute.at(entry.getName()) = true;
-    ovms::Status status = entry.execute(finishedNodeQueue);  // first node will triger first message
+    std::set<std::string> startedSessions;
+    std::set<std::string> finishedSessions;
+    NodeSessionMetadata meta;
+    // TODO -> entry node does not have setInputsCalled so it has no
+    // session created. Here is just assumption that this meta has the same key
+    // that the one in EntryNode::execute();
+    auto entrySessionKey = meta.getSessionKey();
+    startedSessions.emplace(entry.getName() + entrySessionKey);
+    ovms::Status status = entry.execute(entrySessionKey, finishedNodeQueue);  // first node will triger first message
     if (!status.ok()) {
         SPDLOG_LOGGER_WARN(dag_executor_logger, "Executing pipeline: {} node: {} failed with: {}",
             getName(), entry.getName(), status.string());
         return status;
     }
-    std::vector<std::reference_wrapper<Node>> nodesWaitingForIdleInferenceStreamId;  // consider replacing with std::vector
-    // even though we can remove with random sequence it is probable that we will remove those in sequence
+    std::vector<std::pair<std::reference_wrapper<Node>, session_key_t>> deferredNodeSessions;
     const uint WAIT_FOR_FINISHED_NODE_TIMEOUT_MICROSECONDS = 5000;
     const uint WAIT_FOR_DEFERRED_NODE_DISARM_TIMEOUT_MICROSECONDS = 500;
-    // process finished nodes and if no one is finished check if any node with deferred execution
+    // process finished session nodes and if no one is finished check if any node session with deferred execution
     // has necessary resources already
     while (true) {
         spdlog::trace("Pipeline: {} waiting for message that node finished.", getName());
         auto optionallyFinishedNode = finishedNodeQueue.tryPull(WAIT_FOR_FINISHED_NODE_TIMEOUT_MICROSECONDS);
         if (optionallyFinishedNode) {
-            Node& finishedNode = optionallyFinishedNode.value().get();
-            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Pipeline: {} got message that node: {} finished.", getName(), finishedNode.getName());
-            finishedExecute.at(finishedNode.getName()) = true;
+            auto& [finishedNodeRef, sessionKey] = optionallyFinishedNode.value();
+            Node& finishedNode = finishedNodeRef.get();
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Pipeline: {} got message that node: {} session: {} finished.", getName(), finishedNode.getName(), sessionKey);
+            finishedSessions.emplace(finishedNode.getName() + sessionKey);
             if (!firstErrorStatus.ok()) {
-                finishedNode.release();
+                finishedNode.release(sessionKey);
             }
             IF_ERROR_OCCURRED_EARLIER_THEN_BREAK_IF_ALL_STARTED_FINISHED_CONTINUE_OTHERWISE
             BlobMap finishedNodeOutputBlobMap;
-            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Fetching results of pipeline: {} node: {}", getName(), finishedNode.getName());
-            status = finishedNode.fetchResults(finishedNodeOutputBlobMap);
+            SessionResults sessionResults;
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Fetching results of pipeline: {} node: {} session: {}", getName(), finishedNode.getName(), sessionKey);
+            status = finishedNode.fetchResults(sessionKey, sessionResults);
             CHECK_AND_LOG_ERROR(finishedNode)
             IF_ERROR_OCCURRED_EARLIER_THEN_BREAK_IF_ALL_STARTED_FINISHED_CONTINUE_OTHERWISE
-            if (std::all_of(finishedExecute.begin(), finishedExecute.end(), [](auto pair) { return pair.second; })) {
-                break;
-            }
             auto& nextNodesFromFinished = finishedNode.getNextNodes();
             for (auto& nextNode : nextNodesFromFinished) {
-                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "setting pipeline: {} node: {} outputs as inputs for node: {}",
-                    getName(), finishedNode.getName(), nextNode.get().getName());
-                status = nextNode.get().setInputs(finishedNode, finishedNodeOutputBlobMap);
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "setting pipeline: {} node: {} session: {} outputs as inputs for node: {}",
+                    getName(), finishedNode.getName(), sessionKey, nextNode.get().getName());
+                status = nextNode.get().setInputs(finishedNode, sessionResults);
                 CHECK_AND_LOG_ERROR(nextNode.get())
                 if (!firstErrorStatus.ok()) {
                     break;
@@ -117,13 +132,14 @@ Status Pipeline::execute() {
             }
             finishedNodeOutputBlobMap.clear();
             for (auto& nextNode : nextNodesFromFinished) {
-                if (nextNode.get().isReady()) {
-                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Started execution of pipeline: {} node: {}", getName(), nextNode.get().getName());
-                    startedExecute.at(nextNode.get().getName()) = true;
-                    status = nextNode.get().execute(finishedNodeQueue);
+                auto readySessions = nextNode.get().getReadySessions();
+                for (auto sessionKey : readySessions) {
+                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Started execution of pipeline: {} node: {} session: {}", getName(), nextNode.get().getName(), sessionKey);
+                    startedSessions.emplace(nextNode.get().getName() + sessionKey);
+                    status = nextNode.get().execute(sessionKey, finishedNodeQueue);
                     if (status == StatusCode::PIPELINE_STREAM_ID_NOT_READY_YET) {
-                        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} not ready for execution yet", nextNode.get().getName());
-                        nodesWaitingForIdleInferenceStreamId.push_back(nextNode.get());
+                        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} not ready for execution yet", nextNode.get().getName(), sessionKey);
+                        deferredNodeSessions.emplace_back(nextNode.get(), sessionKey);
                         status = StatusCode::OK;
                     }
                     CHECK_AND_LOG_ERROR(nextNode.get())
@@ -132,49 +148,52 @@ Status Pipeline::execute() {
                     }
                 }
             }
+            if (startedSessions.size() == finishedSessions.size()) {
+                break;
+            }
         } else {
             // If error occurred earlier, disarm stream id guards of all deferred nodes and exit
             if (!firstErrorStatus.ok()) {
-                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will try to disarm all stream id guards of all {} deferred nodes due to previous error in pipeline", nodesWaitingForIdleInferenceStreamId.size());
-                // Check if there are deferred nodes in queue to free
-                if (nodesWaitingForIdleInferenceStreamId.size() > 0) {
-                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Trying to disarm {} remaining deferred nodes...", nodesWaitingForIdleInferenceStreamId.size());
-                    for (auto it = nodesWaitingForIdleInferenceStreamId.begin(); it != nodesWaitingForIdleInferenceStreamId.end();) {
-                        auto& node = (*it).get();
-                        if (node.tryDisarmStreamIdGuard(WAIT_FOR_DEFERRED_NODE_DISARM_TIMEOUT_MICROSECONDS)) {
-                            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Stream id guard disarm of node {} has succeeded", node.getName());
-                            finishedExecute.at(node.getName()) = true;
-                            it = nodesWaitingForIdleInferenceStreamId.erase(it);
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will try to disarm all stream id guards of all {} deferred node sessions due to previous error in pipeline", deferredNodeSessions.size());
+                if (deferredNodeSessions.size() > 0) {
+                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Trying to disarm {} remaining deferred node sessions ...", deferredNodeSessions.size());
+                    for (auto it = deferredNodeSessions.begin(); it != deferredNodeSessions.end();) {
+                        auto& [nodeRef, sessionKey] = *it;
+                        auto& node = nodeRef.get();
+                        if (node.tryDisarm(sessionKey, WAIT_FOR_DEFERRED_NODE_DISARM_TIMEOUT_MICROSECONDS)) {
+                            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Stream id guard disarm of node {} session: {} has succeeded", node.getName(), sessionKey);
+                            finishedSessions.emplace(node.getName() + sessionKey);
+                            it = deferredNodeSessions.erase(it);
                         } else {
-                            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Cannot disarm stream id guard of node {} yet, will try again later", node.getName());
+                            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Cannot disarm stream id guard of node: {}, session: {} yet, will try again later", node.getName(), sessionKey);
                             it++;
                         }
                     }
-                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Disarming iteration completed, remaining deferred nodes count: {}", nodesWaitingForIdleInferenceStreamId.size());
+                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Disarming iteration completed, remaining deferred node sessions count: {}", deferredNodeSessions.size());
                 }
                 // Check for deferred node queue size again to indicate if all nodes got freed
-                if (nodesWaitingForIdleInferenceStreamId.size() > 0) {
+                if (deferredNodeSessions.size() > 0) {
                     continue;
                 } else {
                     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Disarming all stream id guards of deferred nodes completed, pipeline will shut down");
                     IF_ERROR_OCCURRED_EARLIER_THEN_BREAK_IF_ALL_STARTED_FINISHED_CONTINUE_OTHERWISE
                 }
             }
-
             // else scope could be executed always however it seems most reasonable at the time to
             // free blocked inferRequests from exeuction first rather than free models for reloading
-            for (auto it = nodesWaitingForIdleInferenceStreamId.begin(); it != nodesWaitingForIdleInferenceStreamId.end();) {
-                auto& node = (*it).get();
-                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Trying to trigger node: {} execution", node.getName());
-                status = node.execute(finishedNodeQueue);
+            for (auto it = deferredNodeSessions.begin(); it != deferredNodeSessions.end();) {
+                auto& [nodeRef, sessionKey] = *it;
+                auto& node = nodeRef.get();
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Trying to trigger node: {} session: {} execution", node.getName(), sessionKey);
+                status = node.execute(sessionKey, finishedNodeQueue);
                 if (status.ok()) {
-                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} ready yet:", node.getName());
-                    it = nodesWaitingForIdleInferenceStreamId.erase(it);
+                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} is ready", node.getName(), sessionKey);
+                    it = deferredNodeSessions.erase(it);
                     continue;
                 }
                 it++;
                 if (status == StatusCode::PIPELINE_STREAM_ID_NOT_READY_YET) {
-                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} not ready for execution yet", node.getName());
+                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} not ready for execution yet", node.getName(), sessionKey);
                     status = StatusCode::OK;
                 } else {
                     CHECK_AND_LOG_ERROR(node)

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -21,14 +21,16 @@
 #include <utility>
 #include <vector>
 
-#include "dl_node.hpp"
-#include "entry_node.hpp"
-#include "exit_node.hpp"
+#include "aliases.hpp"
 #include "status.hpp"
 
 namespace ovms {
 
-void printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const InputPairs& pairs);
+struct Node;
+struct EntryNode;
+struct ExitNode;
+
+void printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const Aliases& pairs);
 
 class Pipeline {
     std::vector<std::unique_ptr<Node>> nodes;
@@ -37,24 +39,15 @@ class Pipeline {
     ExitNode& exit;
 
 public:
-    Pipeline(EntryNode& entry, ExitNode& exit, const std::string& name = "default_name") :
-        name(name),
-        entry(entry),
-        exit(exit) {}
+    Pipeline(EntryNode& entry, ExitNode& exit, const std::string& name = "default_name");
 
-    void push(std::unique_ptr<Node> node) {
-        nodes.emplace_back(std::move(node));
-    }
+    void push(std::unique_ptr<Node> node);
+    ~Pipeline();
 
     EntryNode& getEntry() const { return this->entry; }
     ExitNode& getExit() const { return this->exit; }
 
-    static void connect(Node& from, Node& to, const InputPairs& blobNamesMapping) {
-        SPDLOG_DEBUG("Connecting from: {}, to: {}", from.getName(), to.getName());
-        printNodeConnections(to.getName(), from.getName(), blobNamesMapping);
-        from.addDependant(to);
-        to.addDependency(from, blobNamesMapping);
-    }
+    static void connect(Node& from, Node& to, const Aliases& blobNamesMapping);
 
     Status execute();
     const std::string& getName() const {

--- a/src/pipeline_factory.hpp
+++ b/src/pipeline_factory.hpp
@@ -29,13 +29,14 @@
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
 #pragma GCC diagnostic pop
 
-#include "pipeline.hpp"
-#include "pipelinedefinition.hpp"
+#include "nodeinfo.hpp"
 #include "status.hpp"
 
 namespace ovms {
 
 class ModelManager;
+class Pipeline;
+class PipelineDefinition;
 
 class PipelineFactory {
     std::map<std::string, std::unique_ptr<PipelineDefinition>> definitions;
@@ -47,10 +48,7 @@ public:
         const pipeline_connections_t& connections,
         ModelManager& manager);
 
-    bool definitionExists(const std::string& name) const {
-        std::shared_lock lock(definitionsMtx);
-        return definitions.count(name) == 1;
-    }
+    bool definitionExists(const std::string& name) const;
 
     Status create(std::unique_ptr<Pipeline>& pipeline,
         const std::string& name,
@@ -58,29 +56,13 @@ public:
         tensorflow::serving::PredictResponse* response,
         ModelManager& manager) const;
 
-    PipelineDefinition* findDefinitionByName(const std::string& name) const {
-        std::shared_lock lock(definitionsMtx);
-        auto it = definitions.find(name);
-        if (it == std::end(definitions)) {
-            return nullptr;
-        } else {
-            return it->second.get();
-        }
-    }
+    PipelineDefinition* findDefinitionByName(const std::string& name) const;
     Status reloadDefinition(const std::string& pipelineName,
         const std::vector<NodeInfo>&& nodeInfos,
         const pipeline_connections_t&& connections,
         ModelManager& manager);
 
-    void retireOtherThan(std::set<std::string>&& pipelinesInConfigFile, ModelManager& manager) {
-        std::for_each(definitions.begin(),
-            definitions.end(),
-            [&pipelinesInConfigFile, &manager](auto& nameDefinitionPair) {
-                if (pipelinesInConfigFile.find(nameDefinitionPair.second->getName()) == pipelinesInConfigFile.end() && nameDefinitionPair.second->getStateCode() != PipelineDefinitionStateCode::RETIRED) {
-                    nameDefinitionPair.second->retire(manager);
-                }
-            });
-    }
+    void retireOtherThan(std::set<std::string>&& pipelinesInConfigFile, ModelManager& manager);
     void revalidatePipelines(ModelManager&);
 };
 

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -19,8 +19,12 @@
 #include <set>
 #include <thread>
 
+#include "dl_node.hpp"
+#include "entry_node.hpp"
+#include "exit_node.hpp"
 #include "logging.hpp"
 #include "modelmanager.hpp"
+#include "pipeline.hpp"
 #include "pipelinedefinitionunloadguard.hpp"
 #include "prediction_service_utils.hpp"
 
@@ -438,7 +442,7 @@ public:
         return StatusCode::OK;
     }
 
-    Status validateConnection(const NodeInfo& dependencyNodeInfo, const InputPairs& mapping) {
+    Status validateConnection(const NodeInfo& dependencyNodeInfo, const Aliases& mapping) {
         // At this point dependency node can only be either DL model node or entry node.
         // Take care when adding new node types.
         std::unique_ptr<ModelInstanceUnloadGuard> dependencyModelUnloadGuard;

--- a/src/pipelinedefinition.hpp
+++ b/src/pipelinedefinition.hpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <map>
 #include <memory>
 #include <set>
 #include <shared_mutex>
@@ -30,53 +31,20 @@
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
 #pragma GCC diagnostic pop
 
-#include "model_version_policy.hpp"
-#include "node.hpp"
-#include "pipeline.hpp"
+#include "aliases.hpp"
+#include "modelversion.hpp"
+#include "nodeinfo.hpp"
 #include "pipelinedefinitionstatus.hpp"
 #include "pipelinedefinitionunloadguard.hpp"
 #include "status.hpp"
+#include "tensorinfo.hpp"
 
 namespace ovms {
 
 class ModelManager;
+class Pipeline;
 
-using pipeline_connections_t = std::unordered_map<std::string, std::unordered_map<std::string, InputPairs>>;
-
-enum class NodeKind {
-    ENTRY,
-    DL,
-    EXIT
-};
-
-const std::string DL_NODE_CONFIG_TYPE = "DL model";
-
-Status toNodeKind(const std::string& str, NodeKind& nodeKind);
-
-struct NodeInfo {
-    NodeKind kind;
-    std::string nodeName;
-    std::string modelName;
-    std::optional<model_version_t> modelVersion;
-    std::unordered_map<std::string, std::string> outputNameAliases;
-    std::optional<size_t> demultiplyCount;
-    std::optional<std::string> gatherFromNode;
-
-    NodeInfo(NodeKind kind,
-        const std::string& nodeName,
-        const std::string& modelName = "",
-        std::optional<model_version_t> modelVersion = std::nullopt,
-        std::unordered_map<std::string, std::string> outputNameAliases = {},
-        std::optional<size_t> demultiplyCount = std::nullopt,
-        std::optional<std::string> gatherFromNode = std::nullopt) :
-        kind(kind),
-        nodeName(nodeName),
-        modelName(modelName),
-        modelVersion(modelVersion),
-        outputNameAliases(outputNameAliases),
-        demultiplyCount(demultiplyCount),
-        gatherFromNode(gatherFromNode) {}
-};
+using tensor_map_t = std::map<std::string, std::shared_ptr<TensorInfo>>;
 
 class PipelineDefinition {
     struct ValidationResultNotifier {

--- a/src/pipelineeventqueue.hpp
+++ b/src/pipelineeventqueue.hpp
@@ -15,25 +15,14 @@
 //*****************************************************************************
 #pragma once
 
-#include <set>
-#include <string>
-#include <tuple>
-#include <unordered_map>
 #include <utility>
-#include <vector>
+
+#include "threadsafequeue.hpp"
 
 namespace ovms {
 
-using session_id_t = uint64_t;
-using session_key_t = std::string;
+class Node;
 
-class NodeSessionMetadata {
-    std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
-
-public:
-    std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
-    std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
-    NodeSessionMetadata getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;
-    session_id_t getSubsessionSize(const std::string& subsessionName) const;
-};
+using NodeSessionKeyPair = std::pair<std::reference_wrapper<Node>, session_key_t>;
+using PipelineEventQueue = ThreadSafeQueue<NodeSessionKeyPair>;
 }  // namespace ovms

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -24,6 +24,7 @@
 #include "../modelinstance.hpp"
 #include "../pipeline.hpp"
 #include "../pipeline_factory.hpp"
+#include "../pipelinedefinition.hpp"
 #include "../prediction_service_utils.hpp"
 #include "../status.hpp"
 #include "test_utils.hpp"

--- a/src/test/ensemble_mapping_config_tests.cpp
+++ b/src/test/ensemble_mapping_config_tests.cpp
@@ -18,10 +18,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "../entry_node.hpp"
+#include "../exit_node.hpp"
 #include "../modelconfig.hpp"
 #include "../modelmanager.hpp"
 #include "../pipeline.hpp"
 #include "../pipeline_factory.hpp"
+#include "../pipelinedefinition.hpp"
 #include "test_utils.hpp"
 
 using namespace ovms;

--- a/src/test/ensemble_metadata_test.cpp
+++ b/src/test/ensemble_metadata_test.cpp
@@ -16,7 +16,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "../entry_node.hpp"
+#include "../exit_node.hpp"
 #include "../pipeline_factory.hpp"
+#include "../pipelinedefinition.hpp"
 #include "test_utils.hpp"
 
 using namespace ovms;

--- a/src/test/get_pipeline_metadata_response_test.cpp
+++ b/src/test/get_pipeline_metadata_response_test.cpp
@@ -23,6 +23,7 @@
 #include <rapidjson/document.h>
 
 #include "../get_model_metadata_impl.hpp"
+#include "../pipelinedefinition.hpp"
 #include "test_utils.hpp"
 
 using namespace ovms;

--- a/src/test/model_service_test.cpp
+++ b/src/test/model_service_test.cpp
@@ -27,6 +27,7 @@
 #include "../model_service.hpp"
 #include "../modelmanager.hpp"
 #include "../modelversionstatus.hpp"
+#include "../pipelinedefinition.hpp"
 #include "gtest/gtest.h"
 #include "test_utils.hpp"
 

--- a/src/test/threadsafequeue_test.cpp
+++ b/src/test/threadsafequeue_test.cpp
@@ -52,7 +52,7 @@ TEST(TestThreadSafeQueue, PushElement) {
     queue.push(i);
 }
 
-const uint WAIT_FOR_ELEMENT_TIMEOUT_MICROSECONDS = 10'000'000;
+const uint WAIT_FOR_ELEMENT_TIMEOUT_MICROSECONDS = 1'000'000;
 
 TEST(TestThreadSafeQueue, SeveralElementsInFIFOOrder) {
     const std::vector<int> elements = {1, 2, 3, 4, 5, 6};

--- a/src/threadsafequeue.hpp
+++ b/src/threadsafequeue.hpp
@@ -21,11 +21,15 @@
 #include <thread>
 #include <utility>
 
+#include <spdlog/spdlog.h>
+
 namespace ovms {
 
 template <typename T>
 class ThreadSafeQueue {
 public:
+    ThreadSafeQueue() {}
+    ~ThreadSafeQueue() {}
     void push(const T& element) {
         std::unique_lock<std::mutex> lock(mtx);
         queue.push(std::move(element));


### PR DESCRIPTION
Integrate NodeSession with Node

-> Input handler + prepare for output handler as a placeholder for
gather/demultiplexer node.
-> extracted model_version_t out of model_version policy header.
-> Ensemble tests speedup - directly force model manager to reload config instead of waiting for
the config monitor thread.
-> Rewrite event loop end term - this is to take into account multiple sessions per node
-> Fix logging in dag event loop -> dag_executor_logger
InputPairs -> Aliases
-> Fix including headers in another headers when not needed

JIRA:CVS-46709, CVS-46704

https://jira.devtools.intel.com/browse/CVS-46709
