### PR TITLE
Enabling forgotten DISABLED tests

### DIFF
--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -2079,7 +2079,7 @@ TEST_F(EnsembleFlowTest, RevalidatePipelineDefinitionWhen1ModelVersionBecomesAva
     EXPECT_TRUE(status.ok()) << status.string();
 }
 
-TEST_F(EnsembleFlowTest, DISABLED_RetirePipelineDefinitionExecuteShouldFail) {
+TEST_F(EnsembleFlowTest, RetirePipelineDefinitionExecuteShouldFail) {
     ConstructorEnabledModelManager managerWithDummyModel;
     managerWithDummyModel.reloadModelWithVersions(config);
 

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -139,7 +139,7 @@ TEST_F(PredictValidation, RequestTooManyShapeDimensions) {
     EXPECT_EQ(status, ovms::StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS);
 }
 
-TEST_F(PredictValidation, DISABLED_RequestNotEnoughShapeDimensions) {
+TEST_F(PredictValidation, RequestNotEnoughShapeDimensions) {
     auto& input = (*request.mutable_inputs())["Input_FP32_1_3_224_224_NHWC"];
     input.mutable_tensor_shape()->clear_dim();
 


### PR DESCRIPTION
One was disabled without comment:
7fb870e64f69afb1e643be9e67d713748b0dd74c

The other one:
d19aa1c101550b25f3d103a553967e359296db71

Was disabled since the full integration was missing at this point (PipelineDefinitionStatus) which
is not true now.