### PR TITLE
Add tests for demultiplexer/gather/custom nodes integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ INSTALL_RPMS_FROM_URL ?=
 #         - adjust binary version path - version variable is not passed to WORKSPACE file!
 OV_SOURCE_BRANCH ?= releases/2021/2
 
-DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_latest.tgz
+DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_2021.3.263.tgz
 OV_USE_BINARY ?= 1
 YUM_OV_PACKAGE ?= intel-openvino-runtime-centos7
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ INSTALL_RPMS_FROM_URL ?=
 #         - adjust binary version path - version variable is not passed to WORKSPACE file!
 OV_SOURCE_BRANCH ?= releases/2021/2
 
-DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_2021.3.263.tgz
+DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_latest.tgz
 OV_USE_BINARY ?= 1
 YUM_OV_PACKAGE ?= intel-openvino-runtime-centos7
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -216,6 +216,15 @@ cc_binary(
 )
 
 cc_binary(
+    name = "lib_node_perform_different_operations.so",
+    srcs = [
+        "test/custom_nodes/node_perform_different_operations.cpp",
+        "custom_node_interface.h",
+    ],
+    linkshared = 1,
+)
+
+cc_binary(
     name = "ovms",
     srcs = [
         "main.cpp",
@@ -311,6 +320,7 @@ cc_test(
         "//src:lib_node_mock.so",
         "//src:lib_node_missing_implementation.so",
         "//src:lib_node_add_sub.so",
+        "//src:lib_node_perform_different_operations.so",
         "@com_google_googletest//:gtest",
     ],
     copts = [

--- a/src/BUILD
+++ b/src/BUILD
@@ -216,6 +216,14 @@ cc_binary(
 )
 
 cc_binary(
+    name = "lib_node_choose_maximum.so",
+    srcs = [
+        "test/custom_nodes/node_choose_maximum.cpp",
+        "custom_node_interface.h",
+    ],
+    linkshared = 1,
+)
+cc_binary(
     name = "lib_node_perform_different_operations.so",
     srcs = [
         "test/custom_nodes/node_perform_different_operations.cpp",
@@ -321,6 +329,7 @@ cc_test(
         "//src:lib_node_missing_implementation.so",
         "//src:lib_node_add_sub.so",
         "//src:lib_node_perform_different_operations.so",
+        "//src:lib_node_choose_maximum.so",
         "@com_google_googletest//:gtest",
     ],
     copts = [

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -41,6 +41,7 @@ Status Node::fetchResults(session_key_t sessionId, SessionResults& nodeSessionOu
     }
     auto status = fetchResults(*nodeSession, nodeSessionOutputs);
     if (status.ok() && demultiplexCount) {
+        SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will demultiply node: {} outputs to: {} shards", getName(), demultiplexCount.value());
         status = demultiplyOutputs(nodeSessionOutputs);
     }
     nodeSessions.erase(sessionId);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -31,10 +31,10 @@ Node::Node(const std::string& nodeName, uint32_t demultiplyCount, std::set<std::
     nodeName(nodeName),
     demultiplexCount(demultiplyCount ? std::optional<uint32_t>(demultiplyCount) : std::nullopt),
     gatherFrom(!gatherFromNode.empty() ? std::optional<std::set<std::string>>(gatherFromNode) : std::nullopt) {
-    SPDLOG_LOGGER_DEBUG("Will create node: {} with demultiply: {}, gatherFrom: {}",
+    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will create node: {} with demultiply: {}, gatherFrom: {}.",
         getName(),
         demultiplyCount,
-        gatherFromNode.begin() != gatherFromNode.end() ? *gatherFromNode.begin() : "NONE");
+        std::accumulate(gatherFromNode.begin(), gatherFromNode.end(), std::string(), [](const std::string& lhs, const std::string& rhs) { return lhs + ", " + rhs; }));
 }
 
 Status Node::fetchResults(session_key_t sessionId, SessionResults& nodeSessionOutputs) {

--- a/src/nodeinputhandler.cpp
+++ b/src/nodeinputhandler.cpp
@@ -42,6 +42,9 @@ void NodeInputHandler::clearInputs() {
 }
 
 bool NodeInputHandler::isReady() {
+    if (this->isUsed) {
+        return false;
+    }
     return remainingDependencies == 0;
 }
 

--- a/src/nodeinputhandler.hpp
+++ b/src/nodeinputhandler.hpp
@@ -41,7 +41,8 @@ public:
     virtual Status setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr, session_id_t shardId);
     const BlobMap& getInputs() {
         isUsed = true;
-        return inputBlobs; }
+        return inputBlobs;
+    }
     void clearInputs();
     bool isReady();
     virtual Status notifyFinishedDependency();

--- a/src/nodeinputhandler.hpp
+++ b/src/nodeinputhandler.hpp
@@ -34,11 +34,14 @@ class NodeInputHandler {
 protected:
     BlobMap inputBlobs;
     uint32_t remainingDependencies;
+    bool isUsed = false;
 
 public:
     NodeInputHandler(uint32_t inputsMissingCount);
     virtual Status setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr, session_id_t shardId);
-    virtual const BlobMap& getInputs() const { return inputBlobs; }
+    const BlobMap& getInputs() {
+        isUsed = true;
+        return inputBlobs; }
     void clearInputs();
     bool isReady();
     virtual Status notifyFinishedDependency();

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -161,7 +161,7 @@ Status PipelineDefinition::create(std::unique_ptr<Pipeline>& pipeline,
         SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Creating pipeline: {}. Adding nodeName: {}, modelName: {}",
             getName(), info.nodeName, info.modelName);
         if (info.gatherFromNode) {
-            demultipliers.erase(info.nodeName);
+            demultipliers.erase(info.gatherFromNode.value());
         }
         switch (info.kind) {
         case NodeKind::ENTRY: {

--- a/src/test/custom_nodes/node_choose_maximum.cpp
+++ b/src/test/custom_nodes/node_choose_maximum.cpp
@@ -1,0 +1,125 @@
+//*****************************************************************************
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+#include "../../custom_node_interface.h"
+
+static const size_t dummyInputSize = 10;
+
+extern "C" {
+enum OPS {
+ADD,
+SUB,
+MULTIPLY,
+DIVIDE
+};
+
+static const std::string INPUT_TENSOR_NAME = "input_tensors";
+
+int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct CustomNodeTensor** outputs, int* outputsLength, const struct CustomNodeParam* params, int paramsLength) {
+    // TODO validate inputs
+    // TODO validate no params
+    *outputsLength = 1;
+    *outputs = new CustomNodeTensor[*outputsLength];
+    std::cout << "Creating outputs:" << *outputs << std::endl;
+    // TODO check result
+    CustomNodeTensor& resultTensor = *outputs[*outputsLength - 1];
+    resultTensor.name = "maximum_tensor";
+    float* result = new float[4 * dummyInputSize]; // dummy input size * numbr of ops
+    resultTensor.data = reinterpret_cast<uint8_t*>(result);
+    resultTensor.dimsLength = 2;
+    resultTensor.dims = new uint64_t[resultTensor.dimsLength];
+    resultTensor.dims[0] = 1;
+    resultTensor.dims[1] = dummyInputSize;
+    resultTensor.dataLength = 1 * dummyInputSize * sizeof(float);
+    resultTensor.precision = FP32;
+
+    uint16_t selection_method = METHOD_COUNT;
+    if ( paramsLength != 1) {
+        std::cout << "Wrong number of parameters - expected 1" << std::endl;
+    }
+    for (int i = 0; i < paramsLength; i++) {
+        if (strcmp(params[i].key, "selection_criterium") == 0) {
+   //         addValue = atof(params[i].value);
+            selection_method = 1;
+        }
+    }
+    if (selection_method == METHOD_COUNT) {
+        std::cout << "Non recognized method string" << std::endl;
+        return 1;
+    }
+    // perform operations
+    float* inputTensor;
+    float* inputFactors;
+    for (size_t i = 0; i < inputsLength; ++i) {
+        if (INPUT_TENSOR_NAME == inputs[i].name) {
+            inputTensor = reinterpret_cast<float*>(inputs[i].data);
+        } else if (FACTORS_TENSOR_NAME == inputs[i].name) {
+            inputFactors = reinterpret_cast<float*>(inputs[i].data);
+        } else {
+            std::cout << "lacking inputs" << std::endl;
+            return 1; // TODO free
+        }
+    }
+    for (size_t opId = 0; opId < 4; ++opId) {
+        for (size_t dummyPos = 0; dummyPos < dummyInputSize; ++dummyPos) {
+            // TODO get dummyInputSize from input
+            auto resultIndex = opId * dummyInputSize + dummyPos;
+            switch(opId) {
+                case OPS::ADD:
+                    result[resultIndex] = inputTensor[dummyPos] + inputFactors[opId];
+                    break;
+                case OPS::SUB:
+                    result[resultIndex] = inputTensor[dummyPos] - inputFactors[opId];
+                    break;
+                case MULTIPLY:
+                    result[resultIndex] = inputTensor[dummyPos] * inputFactors[opId];
+                    break;
+                case DIVIDE:
+                    result[resultIndex] = inputTensor[dummyPos] / inputFactors[opId];
+                    break;
+                default:
+                    // TODO cleanup of ptrs
+                    return 2;
+            }
+            std::cout << "opId:" << opId
+                      << " dummyPos:" << dummyPos
+                      << " resultIndex:" << resultIndex
+                      << " result:" << result[resultIndex]
+                      << " inputTensor:" << inputTensor[dummyPos]
+                      << " inputFactor:" << inputFactors[opId]
+                      << std::endl;
+        }
+    }
+    return 0;
+}
+
+int releaseBuffer(struct CustomNodeTensor* output) {
+    std::cout << "DifferentOperationsCustomLibrary deleting "
+              << output->name << " buffer" << std::endl;
+    delete output->data;
+    delete output->dims;
+    return 0;
+}
+
+int releaseTensors(struct CustomNodeTensor* outputs) {
+    std::cout << "DifferentOperationsCustomLibrary deleting outputs:" << outputs << std::endl;
+    delete[] outputs;
+    return 0;
+}
+}

--- a/src/test/custom_nodes/node_choose_maximum.cpp
+++ b/src/test/custom_nodes/node_choose_maximum.cpp
@@ -41,11 +41,11 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
         return 1;
     }
     if (strcmp(params[0].key, "selection_criteria") == 0) {
-        if (strcmp(params[0].value, "MAXIMUM_MINIMUM") == Method::MAXIMUM_MINIMUM) {
+        if (strcmp(params[0].value, "MAXIMUM_MINIMUM") == 0) {
             selectionMethod = Method::MAXIMUM_MINIMUM;
-        } else if (strcmp(params[0].value, "MAXIMUM_MAXIMUM") == Method::MAXIMUM_MAXIMUM) {
+        } else if (strcmp(params[0].value, "MAXIMUM_MAXIMUM") == 0) {
             selectionMethod = Method::MAXIMUM_MAXIMUM;
-        } else if (strcmp(params[0].value, "MAXIMUM_AVERAGE") == Method::MAXIMUM_AVERAGE) {
+        } else if (strcmp(params[0].value, "MAXIMUM_AVERAGE") == 0) {
             selectionMethod = Method::MAXIMUM_AVERAGE;
         } else {
             std::cout << "Not allowed selection criteria chosen:" << params[0].value << std::endl;
@@ -63,28 +63,25 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     float* inputTensor;
     size_t valuesPerTensor = 0;
     size_t numberOfOps = 0;
-    for (size_t i = 0; i < inputsLength; ++i) {
-        if (INPUT_TENSOR_NAME == inputs[i].name) {
-            if (inputs[i].dimsLength != 3 ||
-                inputs[i].dims[0] != 1 ||
-                inputs[i].dims[1] == 0 ||
-                inputs[i].dims[2] == 0) {
-                std::cout << "improper " << INPUT_TENSOR_NAME
-                          << " dimensions: [" << inputs[i].dims[0]
-                          << ", " << inputs[i].dims[1]
-                          << ", " << inputs[i].dims[2] << "]" << std::endl;
-                return 1;
-            }
-            std::cout << "Input valuesPerTensor" << inputs[i].dims[1] << std::endl;
-            numberOfOps = inputs[i].dims[1];
-            valuesPerTensor = inputs[i].dims[2];
-            inputTensor = reinterpret_cast<float*>(inputs[i].data);
-        } else {
-            std::cout << "Lacking input:" << INPUT_TENSOR_NAME << std::endl;
-            return 1;  // TODO free
+    if (INPUT_TENSOR_NAME == inputs[0].name) {
+        if (inputs[0].dimsLength != 3 ||
+            inputs[0].dims[0] != 1 ||
+            inputs[0].dims[1] == 0 ||
+            inputs[0].dims[2] == 0) {
+            std::cout << "improper " << INPUT_TENSOR_NAME
+                      << " dimensions: [" << inputs[0].dims[0]
+                      << ", " << inputs[0].dims[1]
+                      << ", " << inputs[0].dims[2] << "]" << std::endl;
+            return 1;
         }
+        std::cout << "Input valuesPerTensor" << inputs[0].dims[1] << std::endl;
+        numberOfOps = inputs[0].dims[1];
+        valuesPerTensor = inputs[0].dims[2];
+        inputTensor = reinterpret_cast<float*>(inputs[0].data);
+    } else {
+        std::cout << "Lacking input: " << INPUT_TENSOR_NAME << std::endl;
+        return 1;
     }
-
     // prepare output
     *outputsLength = 1;
     *outputs = new CustomNodeTensor[*outputsLength];
@@ -117,6 +114,8 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
             case Method::MAXIMUM_AVERAGE:
                 averages[opId] += inputTensor[index];
                 break;
+            default:
+                return 1;
             }
             std::cout << "opId:" << opId
                       << " dummyPos:" << dummyPos
@@ -140,6 +139,8 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     case Method::MAXIMUM_AVERAGE:
         fromWhichContainerToChoose = &averages;
         break;
+    default:
+        return 1;
     }
     size_t whichTensor = std::distance(fromWhichContainerToChoose->begin(),
         std::max_element(fromWhichContainerToChoose->begin(),

--- a/src/test/custom_nodes/node_choose_maximum.cpp
+++ b/src/test/custom_nodes/node_choose_maximum.cpp
@@ -13,8 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
+#include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <iostream>
+#include <limits>
+#include <vector>
 #include <string>
 
 #include "../../custom_node_interface.h"
@@ -22,25 +26,46 @@
 static const size_t dummyInputSize = 10;
 
 extern "C" {
-enum OPS {
-ADD,
-SUB,
-MULTIPLY,
-DIVIDE
+enum METHOD {
+MAXIMUM_MINIMUM,
+MAXIMUM_AVERAGE,
+MAXIMUM_MAXIMUM,
+METHOD_COUNT
 };
 
 static const std::string INPUT_TENSOR_NAME = "input_tensors";
 
 int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct CustomNodeTensor** outputs, int* outputsLength, const struct CustomNodeParam* params, int paramsLength) {
+    // choose selection criteria
+    uint16_t selection_method = METHOD_COUNT;
+    if ( paramsLength != 1) {
+        std::cout << "Wrong number of parameters - expected 1" << std::endl;
+    }
+    for (int i = 0; i < paramsLength; i++) {
+        if (strcmp(params[i].key, "selection_criterium") == 0) {
+            if (strcmp(params[i].value, "MAXIMUM_MINIMUM") == 0) {
+                selection_method = MAXIMUM_MINIMUM;
+            } else if (strcmp(params[i].value, "MAXIMUM_MAXIMUM") == 0) {
+                selection_method = MAXIMUM_MAXIMUM;
+            } else if (strcmp(params[i].value, "MAXIMUM_AVERAGE") == 0) {
+                selection_method = MAXIMUM_AVERAGE;
+            } else {
+                std::cout << "Not allowed method chosen:" << params[i].value << std::endl;
+                return 1;
+            }
+        } else {
+            std::cout << "Non recognized param string" << std::endl;
+            return 1;
+        }
+    }
     // TODO validate inputs
-    // TODO validate no params
     *outputsLength = 1;
     *outputs = new CustomNodeTensor[*outputsLength];
     std::cout << "Creating outputs:" << *outputs << std::endl;
     // TODO check result
     CustomNodeTensor& resultTensor = *outputs[*outputsLength - 1];
     resultTensor.name = "maximum_tensor";
-    float* result = new float[4 * dummyInputSize]; // dummy input size * numbr of ops
+    float* result = new float[dummyInputSize];
     resultTensor.data = reinterpret_cast<uint8_t*>(result);
     resultTensor.dimsLength = 2;
     resultTensor.dims = new uint64_t[resultTensor.dimsLength];
@@ -48,63 +73,76 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     resultTensor.dims[1] = dummyInputSize;
     resultTensor.dataLength = 1 * dummyInputSize * sizeof(float);
     resultTensor.precision = FP32;
-
-    uint16_t selection_method = METHOD_COUNT;
-    if ( paramsLength != 1) {
-        std::cout << "Wrong number of parameters - expected 1" << std::endl;
-    }
-    for (int i = 0; i < paramsLength; i++) {
-        if (strcmp(params[i].key, "selection_criterium") == 0) {
-   //         addValue = atof(params[i].value);
-            selection_method = 1;
-        }
-    }
-    if (selection_method == METHOD_COUNT) {
-        std::cout << "Non recognized method string" << std::endl;
-        return 1;
-    }
-    // perform operations
+    // get input tensor
     float* inputTensor;
-    float* inputFactors;
     for (size_t i = 0; i < inputsLength; ++i) {
         if (INPUT_TENSOR_NAME == inputs[i].name) {
             inputTensor = reinterpret_cast<float*>(inputs[i].data);
-        } else if (FACTORS_TENSOR_NAME == inputs[i].name) {
-            inputFactors = reinterpret_cast<float*>(inputs[i].data);
         } else {
-            std::cout << "lacking inputs" << std::endl;
+            std::cout << "Lacking input:" << INPUT_TENSOR_NAME <<  std::endl;
             return 1; // TODO free
         }
     }
-    for (size_t opId = 0; opId < 4; ++opId) {
+    // get adjustable dim
+    size_t tensorsCount = inputs[0].dims[1];
+    // perform operations
+    std::vector<float> minimums(tensorsCount, std::numeric_limits<int>::max());
+    std::vector<float> maximums(tensorsCount, std::numeric_limits<int>::lowest());
+    std::vector<float> averages(tensorsCount, 0);
+    for (size_t opId = 0; opId < tensorsCount; ++opId) { // TODO adjustable opsId
         for (size_t dummyPos = 0; dummyPos < dummyInputSize; ++dummyPos) {
-            // TODO get dummyInputSize from input
-            auto resultIndex = opId * dummyInputSize + dummyPos;
-            switch(opId) {
-                case OPS::ADD:
-                    result[resultIndex] = inputTensor[dummyPos] + inputFactors[opId];
+            auto index = opId * dummyInputSize + dummyPos;
+            switch(selection_method) {
+                case METHOD::MAXIMUM_MAXIMUM:
+                    maximums[opId] = std::max(maximums[opId], inputTensor[index]);
                     break;
-                case OPS::SUB:
-                    result[resultIndex] = inputTensor[dummyPos] - inputFactors[opId];
+                case METHOD::MAXIMUM_MINIMUM:
+                    minimums[opId] = std::min(maximums[opId], inputTensor[index]);
                     break;
-                case MULTIPLY:
-                    result[resultIndex] = inputTensor[dummyPos] * inputFactors[opId];
-                    break;
-                case DIVIDE:
-                    result[resultIndex] = inputTensor[dummyPos] / inputFactors[opId];
+                case METHOD::MAXIMUM_AVERAGE:
+                    averages[opId] += inputTensor[index];
                     break;
                 default:
-                    // TODO cleanup of ptrs
                     return 2;
             }
             std::cout << "opId:" << opId
                       << " dummyPos:" << dummyPos
-                      << " resultIndex:" << resultIndex
-                      << " result:" << result[resultIndex]
-                      << " inputTensor:" << inputTensor[dummyPos]
-                      << " inputFactor:" << inputFactors[opId]
+                      << " input:" << inputTensor[index]
+                      << " minimums:" << minimums[opId]
+                      << " averages:" << averages[opId]
+                      << " maximums:" << maximums[opId]
                       << std::endl;
         }
+        averages[opId] /= dummyInputSize;
+    }
+    // find which tensor to choose
+    size_t whichTensor = 42;
+    const std::vector<float>* fromWhichContainerToChoose = &maximums;
+    switch (selection_method) {
+        case METHOD::MAXIMUM_MAXIMUM:
+            fromWhichContainerToChoose = &maximums;
+            break;
+        case METHOD::MAXIMUM_MINIMUM:
+            fromWhichContainerToChoose = &minimums;
+            break;
+        case METHOD::MAXIMUM_AVERAGE:
+            fromWhichContainerToChoose = &averages;
+            break;
+        default:
+            // TODO cleanup of ptrs
+            return 2;
+    }
+    whichTensor = std::distance(fromWhichContainerToChoose->begin(),
+                                std::max_element(fromWhichContainerToChoose->begin(),
+                                                 fromWhichContainerToChoose->end()));
+    std::cout << "Selected tensor pos: " << whichTensor << std::endl;
+    // copy appropiate tensor
+    for (size_t i = 0; i < dummyInputSize; ++i) {
+        size_t index = whichTensor * dummyInputSize + i;
+        std::cout << "Putting tensor:" << whichTensor
+                  << " index:" << index
+                  << " with value:" << inputTensor[index] << std::endl;
+        result[i] = inputTensor[index];
     }
     return 0;
 }

--- a/src/test/custom_nodes/node_choose_maximum.cpp
+++ b/src/test/custom_nodes/node_choose_maximum.cpp
@@ -18,8 +18,8 @@
 #include <cstring>
 #include <iostream>
 #include <limits>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "../../custom_node_interface.h"
 
@@ -27,10 +27,10 @@ static const size_t dummyInputSize = 10;
 
 extern "C" {
 enum METHOD {
-MAXIMUM_MINIMUM,
-MAXIMUM_AVERAGE,
-MAXIMUM_MAXIMUM,
-METHOD_COUNT
+    MAXIMUM_MINIMUM,
+    MAXIMUM_AVERAGE,
+    MAXIMUM_MAXIMUM,
+    METHOD_COUNT
 };
 
 static const std::string INPUT_TENSOR_NAME = "input_tensors";
@@ -38,7 +38,7 @@ static const std::string INPUT_TENSOR_NAME = "input_tensors";
 int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct CustomNodeTensor** outputs, int* outputsLength, const struct CustomNodeParam* params, int paramsLength) {
     // choose selection criteria
     uint16_t selection_method = METHOD_COUNT;
-    if ( paramsLength != 1) {
+    if (paramsLength != 1) {
         std::cout << "Wrong number of parameters - expected 1" << std::endl;
     }
     for (int i = 0; i < paramsLength; i++) {
@@ -79,8 +79,8 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
         if (INPUT_TENSOR_NAME == inputs[i].name) {
             inputTensor = reinterpret_cast<float*>(inputs[i].data);
         } else {
-            std::cout << "Lacking input:" << INPUT_TENSOR_NAME <<  std::endl;
-            return 1; // TODO free
+            std::cout << "Lacking input:" << INPUT_TENSOR_NAME << std::endl;
+            return 1;  // TODO free
         }
     }
     // get adjustable dim
@@ -89,21 +89,21 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     std::vector<float> minimums(tensorsCount, std::numeric_limits<int>::max());
     std::vector<float> maximums(tensorsCount, std::numeric_limits<int>::lowest());
     std::vector<float> averages(tensorsCount, 0);
-    for (size_t opId = 0; opId < tensorsCount; ++opId) { // TODO adjustable opsId
+    for (size_t opId = 0; opId < tensorsCount; ++opId) {  // TODO adjustable opsId
         for (size_t dummyPos = 0; dummyPos < dummyInputSize; ++dummyPos) {
             auto index = opId * dummyInputSize + dummyPos;
-            switch(selection_method) {
-                case METHOD::MAXIMUM_MAXIMUM:
-                    maximums[opId] = std::max(maximums[opId], inputTensor[index]);
-                    break;
-                case METHOD::MAXIMUM_MINIMUM:
-                    minimums[opId] = std::min(maximums[opId], inputTensor[index]);
-                    break;
-                case METHOD::MAXIMUM_AVERAGE:
-                    averages[opId] += inputTensor[index];
-                    break;
-                default:
-                    return 2;
+            switch (selection_method) {
+            case METHOD::MAXIMUM_MAXIMUM:
+                maximums[opId] = std::max(maximums[opId], inputTensor[index]);
+                break;
+            case METHOD::MAXIMUM_MINIMUM:
+                minimums[opId] = std::min(maximums[opId], inputTensor[index]);
+                break;
+            case METHOD::MAXIMUM_AVERAGE:
+                averages[opId] += inputTensor[index];
+                break;
+            default:
+                return 2;
             }
             std::cout << "opId:" << opId
                       << " dummyPos:" << dummyPos
@@ -119,22 +119,22 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     size_t whichTensor = 42;
     const std::vector<float>* fromWhichContainerToChoose = &maximums;
     switch (selection_method) {
-        case METHOD::MAXIMUM_MAXIMUM:
-            fromWhichContainerToChoose = &maximums;
-            break;
-        case METHOD::MAXIMUM_MINIMUM:
-            fromWhichContainerToChoose = &minimums;
-            break;
-        case METHOD::MAXIMUM_AVERAGE:
-            fromWhichContainerToChoose = &averages;
-            break;
-        default:
-            // TODO cleanup of ptrs
-            return 2;
+    case METHOD::MAXIMUM_MAXIMUM:
+        fromWhichContainerToChoose = &maximums;
+        break;
+    case METHOD::MAXIMUM_MINIMUM:
+        fromWhichContainerToChoose = &minimums;
+        break;
+    case METHOD::MAXIMUM_AVERAGE:
+        fromWhichContainerToChoose = &averages;
+        break;
+    default:
+        // TODO cleanup of ptrs
+        return 2;
     }
     whichTensor = std::distance(fromWhichContainerToChoose->begin(),
-                                std::max_element(fromWhichContainerToChoose->begin(),
-                                                 fromWhichContainerToChoose->end()));
+        std::max_element(fromWhichContainerToChoose->begin(),
+            fromWhichContainerToChoose->end()));
     std::cout << "Selected tensor pos: " << whichTensor << std::endl;
     // copy appropiate tensor
     for (size_t i = 0; i < dummyInputSize; ++i) {

--- a/src/test/custom_nodes/node_perform_different_operations.cpp
+++ b/src/test/custom_nodes/node_perform_different_operations.cpp
@@ -19,55 +19,70 @@
 
 #include "../../custom_node_interface.h"
 
-static const size_t dummyInputSize = 10;
-
 extern "C" {
 enum OPS {
     ADD,
     SUB,
     MULTIPLY,
-    DIVIDE
+    DIVIDE,
+    OPS_END
 };
 
 static const std::string INPUT_TENSOR_NAME = "input_numbers";
 static const std::string FACTORS_TENSOR_NAME = "op_factors";
 
 int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct CustomNodeTensor** outputs, int* outputsLength, const struct CustomNodeParam* params, int paramsLength) {
-    // TODO validate inputs
-    // TODO validate no params
+    // validate inputs
+    float* inputTensor;
+    float* inputFactors;
+    size_t valuesPerTensor = 0;
+    for (size_t i = 0; i < inputsLength; ++i) {
+        if (INPUT_TENSOR_NAME == inputs[i].name) {
+            if (inputs[i].dimsLength != 2 ||
+                inputs[i].dims[0] != 1 ||
+                inputs[i].dims[1] == 0) {
+                std::cout << "improper " << INPUT_TENSOR_NAME
+                          << " dimensions: [" << inputs[i].dims[0] << ", " << inputs[i].dims[1] << "]" << std::endl;
+                return 1;
+            }
+            std::cout << "Input valuesPerTensor" << inputs[i].dims[1] << std::endl;
+            valuesPerTensor = inputs[i].dims[1];
+            inputTensor = reinterpret_cast<float*>(inputs[i].data);
+        } else if (FACTORS_TENSOR_NAME == inputs[i].name) {
+            if (inputs[i].dimsLength != 2 ||
+                inputs[i].dims[0] != 1 ||
+                inputs[i].dims[1] != OPS_END) {
+                std::cout << "improper " << FACTORS_TENSOR_NAME
+                          << " dimensions:[" << inputs[i].dims[0] << ", " << inputs[i].dims[1] << "]" << std::endl;
+                return 1;
+            }
+            inputFactors = reinterpret_cast<float*>(inputs[i].data);
+        } else {
+            std::cout << "lacking inputs" << std::endl;
+            return 1;
+        }
+    }
+
+    // prepare outputs
     *outputsLength = 1;
     *outputs = new CustomNodeTensor[*outputsLength];
-    std::cout << "Creating outputs:" << *outputs << std::endl;
-    // TODO check result
+    float* result = new float[OPS_END * valuesPerTensor];  // dummy input size * numbr of ops
+
     CustomNodeTensor& resultTensor = *outputs[*outputsLength - 1];
     resultTensor.name = "different_ops_results";
-    float* result = new float[4 * dummyInputSize];  // dummy input size * numbr of ops
     resultTensor.data = reinterpret_cast<uint8_t*>(result);
     resultTensor.dimsLength = 3;
     resultTensor.dims = new uint64_t[resultTensor.dimsLength];
     resultTensor.dims[0] = 1;
-    resultTensor.dims[1] = 4;
-    resultTensor.dims[2] = dummyInputSize;
-    resultTensor.dataLength = 1 * 4 * dummyInputSize * sizeof(float);
+    resultTensor.dims[1] = OPS_END;
+    resultTensor.dims[2] = valuesPerTensor;
+    resultTensor.dataLength = resultTensor.dims[0] * resultTensor.dims[1] * resultTensor.dims[2] * sizeof(float);
     resultTensor.precision = FP32;
 
     // perform operations
-    float* inputTensor;
-    float* inputFactors;
-    for (size_t i = 0; i < inputsLength; ++i) {
-        if (INPUT_TENSOR_NAME == inputs[i].name) {
-            inputTensor = reinterpret_cast<float*>(inputs[i].data);
-        } else if (FACTORS_TENSOR_NAME == inputs[i].name) {
-            inputFactors = reinterpret_cast<float*>(inputs[i].data);
-        } else {
-            std::cout << "lacking inputs" << std::endl;
-            return 1;  // TODO free
-        }
-    }
-    for (size_t opId = 0; opId < 4; ++opId) {
-        for (size_t dummyPos = 0; dummyPos < dummyInputSize; ++dummyPos) {
-            // TODO get dummyInputSize from input
-            auto resultIndex = opId * dummyInputSize + dummyPos;
+    for (size_t opId = 0; opId < OPS_END; ++opId) {
+        for (size_t dummyPos = 0; dummyPos < valuesPerTensor; ++dummyPos) {
+            auto resultIndex = opId * valuesPerTensor + dummyPos;
             switch (opId) {
             case OPS::ADD:
                 result[resultIndex] = inputTensor[dummyPos] + inputFactors[opId];
@@ -75,15 +90,12 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
             case OPS::SUB:
                 result[resultIndex] = inputTensor[dummyPos] - inputFactors[opId];
                 break;
-            case MULTIPLY:
+            case OPS::MULTIPLY:
                 result[resultIndex] = inputTensor[dummyPos] * inputFactors[opId];
                 break;
-            case DIVIDE:
+            case OPS::DIVIDE:
                 result[resultIndex] = inputTensor[dummyPos] / inputFactors[opId];
                 break;
-            default:
-                // TODO cleanup of ptrs
-                return 2;
             }
             std::cout << "opId:" << opId
                       << " dummyPos:" << dummyPos

--- a/src/test/custom_nodes/node_perform_different_operations.cpp
+++ b/src/test/custom_nodes/node_perform_different_operations.cpp
@@ -1,0 +1,114 @@
+//*****************************************************************************
+// Copyright 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+#include "../../custom_node_interface.h"
+
+static const size_t dummyInputSize = 10;
+
+extern "C" {
+enum OPS {
+ADD,
+SUB,
+MULTIPLY,
+DIVIDE
+};
+
+static const std::string INPUT_TENSOR_NAME = "input_numbers";
+static const std::string FACTORS_TENSOR_NAME = "op_factors";
+
+int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct CustomNodeTensor** outputs, int* outputsLength, const struct CustomNodeParam* params, int paramsLength) {
+    // TODO validate inputs
+    // TODO validate no params
+    *outputsLength = 1;
+    *outputs = new CustomNodeTensor[*outputsLength];
+    std::cout << "Creating outputs:" << *outputs << std::endl;
+    // TODO check result
+    CustomNodeTensor& resultTensor = *outputs[*outputsLength - 1];
+    resultTensor.name = "different_ops_results";
+    float* result = new float[4 * dummyInputSize]; // dummy input size * numbr of ops
+    resultTensor.data = reinterpret_cast<uint8_t*>(result);
+    resultTensor.dimsLength = 3;
+    resultTensor.dims = new uint64_t[resultTensor.dimsLength];
+    resultTensor.dims[0] = 1;
+    resultTensor.dims[1] = 4;
+    resultTensor.dims[2] = dummyInputSize;
+    resultTensor.dataLength = 1 * 4 * dummyInputSize * sizeof(float);
+    resultTensor.precision = FP32;
+
+
+    // perform operations
+    float* inputTensor;
+    float* inputFactors;
+    for (size_t i = 0; i < inputsLength; ++i) {
+        if (INPUT_TENSOR_NAME == inputs[i].name) {
+            inputTensor = reinterpret_cast<float*>(inputs[i].data);
+        } else if (FACTORS_TENSOR_NAME == inputs[i].name) {
+            inputFactors = reinterpret_cast<float*>(inputs[i].data);
+        } else {
+            std::cout << "lacking inputs" << std::endl;
+            return 1; // TODO free
+        }
+    }
+    for (size_t opId = 0; opId < 4; ++opId) {
+        for (size_t dummyPos = 0; dummyPos < dummyInputSize; ++dummyPos) {
+            // TODO get dummyInputSize from input
+            auto resultIndex = opId * dummyInputSize + dummyPos;
+            switch(opId) {
+                case OPS::ADD:
+                    result[resultIndex] = inputTensor[dummyPos] + inputFactors[opId];
+                    break;
+                case OPS::SUB:
+                    result[resultIndex] = inputTensor[dummyPos] - inputFactors[opId];
+                    break;
+                case MULTIPLY:
+                    result[resultIndex] = inputTensor[dummyPos] * inputFactors[opId];
+                    break;
+                case DIVIDE:
+                    result[resultIndex] = inputTensor[dummyPos] / inputFactors[opId];
+                    break;
+                default:
+                    // TODO cleanup of ptrs
+                    return 2;
+            }
+            std::cout << "opId:" << opId
+                      << " dummyPos:" << dummyPos
+                      << " resultIndex:" << resultIndex
+                      << " result:" << result[resultIndex]
+                      << " inputTensor:" << inputTensor[dummyPos]
+                      << " inputFactor:" << inputFactors[opId]
+                      << std::endl;
+        }
+    }
+    return 0;
+}
+
+int releaseBuffer(struct CustomNodeTensor* output) {
+    std::cout << "DifferentOperationsCustomLibrary deleting "
+              << output->name << " buffer" << std::endl;
+    delete output->data;
+    delete output->dims;
+    return 0;
+}
+
+int releaseTensors(struct CustomNodeTensor* outputs) {
+    std::cout << "DifferentOperationsCustomLibrary deleting outputs:" << outputs << std::endl;
+    delete[] outputs;
+    return 0;
+}
+}

--- a/src/test/custom_nodes/node_perform_different_operations.cpp
+++ b/src/test/custom_nodes/node_perform_different_operations.cpp
@@ -23,10 +23,10 @@ static const size_t dummyInputSize = 10;
 
 extern "C" {
 enum OPS {
-ADD,
-SUB,
-MULTIPLY,
-DIVIDE
+    ADD,
+    SUB,
+    MULTIPLY,
+    DIVIDE
 };
 
 static const std::string INPUT_TENSOR_NAME = "input_numbers";
@@ -41,7 +41,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     // TODO check result
     CustomNodeTensor& resultTensor = *outputs[*outputsLength - 1];
     resultTensor.name = "different_ops_results";
-    float* result = new float[4 * dummyInputSize]; // dummy input size * numbr of ops
+    float* result = new float[4 * dummyInputSize];  // dummy input size * numbr of ops
     resultTensor.data = reinterpret_cast<uint8_t*>(result);
     resultTensor.dimsLength = 3;
     resultTensor.dims = new uint64_t[resultTensor.dimsLength];
@@ -50,7 +50,6 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     resultTensor.dims[2] = dummyInputSize;
     resultTensor.dataLength = 1 * 4 * dummyInputSize * sizeof(float);
     resultTensor.precision = FP32;
-
 
     // perform operations
     float* inputTensor;
@@ -62,29 +61,29 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
             inputFactors = reinterpret_cast<float*>(inputs[i].data);
         } else {
             std::cout << "lacking inputs" << std::endl;
-            return 1; // TODO free
+            return 1;  // TODO free
         }
     }
     for (size_t opId = 0; opId < 4; ++opId) {
         for (size_t dummyPos = 0; dummyPos < dummyInputSize; ++dummyPos) {
             // TODO get dummyInputSize from input
             auto resultIndex = opId * dummyInputSize + dummyPos;
-            switch(opId) {
-                case OPS::ADD:
-                    result[resultIndex] = inputTensor[dummyPos] + inputFactors[opId];
-                    break;
-                case OPS::SUB:
-                    result[resultIndex] = inputTensor[dummyPos] - inputFactors[opId];
-                    break;
-                case MULTIPLY:
-                    result[resultIndex] = inputTensor[dummyPos] * inputFactors[opId];
-                    break;
-                case DIVIDE:
-                    result[resultIndex] = inputTensor[dummyPos] / inputFactors[opId];
-                    break;
-                default:
-                    // TODO cleanup of ptrs
-                    return 2;
+            switch (opId) {
+            case OPS::ADD:
+                result[resultIndex] = inputTensor[dummyPos] + inputFactors[opId];
+                break;
+            case OPS::SUB:
+                result[resultIndex] = inputTensor[dummyPos] - inputFactors[opId];
+                break;
+            case MULTIPLY:
+                result[resultIndex] = inputTensor[dummyPos] * inputFactors[opId];
+                break;
+            case DIVIDE:
+                result[resultIndex] = inputTensor[dummyPos] / inputFactors[opId];
+                break;
+            default:
+                // TODO cleanup of ptrs
+                return 2;
             }
             std::cout << "opId:" << opId
                       << " dummyPos:" << dummyPos

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -55,8 +55,8 @@ protected:
     }
 
     template <typename T>
-    void prepareRequest(PredictRequest& request, const std::vector<T>& data) {
-        tensorflow::TensorProto& proto = (*request.mutable_inputs())[pipelineInputName];
+    void prepareRequest(PredictRequest& request, const std::vector<T>& data, const std::string& inputName = pipelineInputName) {
+        tensorflow::TensorProto& proto = (*request.mutable_inputs())[inputName];
         proto.set_dtype(tensorflow::DataTypeToEnum<T>::value);
         proto.mutable_tensor_content()->assign((char*)data.data(), data.size() * sizeof(T));
         proto.mutable_tensor_shape()->add_dim()->set_size(1);
@@ -92,6 +92,25 @@ protected:
     template <typename T>
     void checkResponse(const std::string& outputName, std::vector<T> data, std::function<T(T)> op) {
         this->checkResponse(outputName, this->response, data, op);
+    }
+
+    template <typename T>
+    void checkResponse(const std::string& outputName, const PredictResponse& response, const std::vector<T>& data, const shape_t& shape) {
+        ASSERT_TRUE(response.outputs().contains(outputName));
+        const auto& proto = response.outputs().at(outputName);
+
+        ASSERT_EQ(proto.tensor_content().size(), data.size() * sizeof(T));
+        ASSERT_EQ(proto.tensor_shape().dim_size(), shape.size());
+        for (size_t i = 0; i < shape.size(); ++i) {
+            ASSERT_EQ(proto.tensor_shape().dim(i).size(), shape[i]);
+        }
+
+        auto* ptr = reinterpret_cast<const T*>(proto.tensor_content().c_str());
+        const std::vector<T> actual(ptr, ptr + data.size());
+        for (size_t i = 0; i < actual.size(); i++) {
+            EXPECT_NEAR(actual[i], data[i], 0.001) << " i is: " << i;
+        }
+
     }
 
     template <typename T>
@@ -132,7 +151,7 @@ protected:
     const std::string libraryPath = "/ovms/bazel-bin/src/lib_node_add_sub.so";
     const std::string customNodeInputName = "input_numbers";
     const std::string customNodeOutputName = "output_numbers";
-    const std::string pipelineInputName = "pipeline_input";
+    static constexpr const char* pipelineInputName = "pipeline_input";
     const std::string pipelineOutputName = "pipeline_output";
 };
 
@@ -692,18 +711,17 @@ static const char* pipelineCustomNodeConfig = R"(
 class EnsembleFlowCustomNodeLoadConfigThenExecuteTest : public EnsembleFlowCustomNodePipelineExecutionTest {
 protected:
     void SetUp() override {
-        EnsembleFlowCustomNodePipelineExecutionTest::SetUp();
+        TestWithTempDir::SetUp();
         configJsonFilePath = directoryPath + "/ovms_config_file.json";
     }
 
     void loadCorrectConfiguration() {
-        createConfigFileWithContent(pipelineCustomNodeConfig, configJsonFilePath);
-        manager.loadConfig(configJsonFilePath);
+        this->loadConfiguration(pipelineCustomNodeConfig);
     }
 
     void loadConfiguration(const char* configContent) {
         createConfigFileWithContent(configContent, configJsonFilePath);
-        manager.loadConfig(configJsonFilePath);
+        ASSERT_EQ(manager.loadConfig(configJsonFilePath), StatusCode::OK);
     }
 
     void checkResponseForCorrectConfiguration() {
@@ -980,4 +998,212 @@ TEST_F(EnsembleFlowCustomNodeLoadConfigThenExecuteTest, ReferenceLibraryWithRest
     this->checkResponseForCorrectConfiguration();
 }
 
+static const char* pipelineCustomNodeDifferentOperationsConfig = R"(
+{
+    "model_config_list": [],
+    "custom_node_library_config_list": [
+        {
+            "name": "lib_perform_different_operations",
+            "base_path": "/ovms/bazel-bin/src/lib_node_perform_different_operations.so"
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "my_pipeline",
+            "inputs": ["pipeline_input", "pipeline_factors"],
+            "nodes": [
+                {
+                    "name": "custom_node",
+                    "library_name": "lib_perform_different_operations",
+                    "type": "custom",
+                    "inputs": [
+                        {"input_numbers": {"node_name": "request",
+                                           "data_item": "pipeline_input"}},
+                        {"op_factors": {"node_name": "request",
+                                           "data_item": "pipeline_factors"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "different_ops_results",
+                         "alias": "custom_node_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"pipeline_output": {"node_name": "custom_node",
+                                     "data_item": "custom_node_output"}
+                }
+            ]
+        }
+    ]
+})";
+
+class EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest : public EnsembleFlowCustomNodeLoadConfigThenExecuteTest {
+protected:
+    void SetUp() override {
+        EnsembleFlowCustomNodeLoadConfigThenExecuteTest::SetUp();
+        configJsonFilePath = directoryPath + "/ovms_config_file.json";
+    }
+    const std::string differentOpsInputName = "pipeline_input";
+    const std::string differentOpsFactorsName = "pipeline_factors";
+};
+
+enum OPS {
+ADD,
+SUB,
+MULTIPLY,
+DIVIDE
+};
+
+static void prepareDifferentOpsExpectedOutput(std::vector<float>& expectedOutput, const std::vector<float>& input, const std::vector<float>& factors) {
+    const size_t dummy_size = 10;
+    for (size_t j = 0; j < 4; ++j) { // iterate over ops
+        for (size_t i = 0; i < dummy_size; ++i) {
+            size_t index = dummy_size * j + i;
+            switch(j) {
+                case ADD:
+                    expectedOutput[index] = input[i] + factors[j];
+                    break;
+                case SUB:
+                    expectedOutput[index] = input[i] - factors[j];
+                    break;
+                case MULTIPLY:
+                    expectedOutput[index] = input[i] * factors[j];
+                    break;
+                case DIVIDE:
+                    expectedOutput[index] = input[i] / factors[j];
+                    break;
+            }
+        }
+    }
+}
+
+enum class HighestOption {
+    MAXIMUM_MAXIMUM,
+    MAXIMUM_MINIMUM,
+    MINIMUM_MINIMUM,
+    MINIMUM_MAXIMUM,
+    MAXIMUM_AVERAGE,
+    MINIMUM_AVERAGE
+};
+
+static void prepareGatherHighestExpectedOutput(std::vector<float>& expectedOutput, const std::vector<float>& input, HighestOption option) {
+    const size_t dummy_size = 10;
+    for (size_t j = 0; j < 4; ++j) { // iterate over ops
+        for (size_t i = 0; i < dummy_size; ++i) {
+            // size_t index = dummy_size * j + i;
+            switch(option) {
+                case HighestOption::MAXIMUM_MINIMUM:
+ //                   expectedOutput[index] = input[i] + factors[j];
+                    break;
+                    break;
+                    break;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+
+TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, JustDifferentOpsCustomNode) {
+    std::unique_ptr<Pipeline> pipeline;
+    std::cout << pipelineCustomNodeDifferentOperationsConfig << std::endl;
+
+    std::vector<float> input{0,1,2,3,4,5,6,7,8, 9};
+    std::vector<float> factors{1, 3, 2, 2}; // add/sub/multiply/divide
+    this->prepareRequest(request, input, differentOpsInputName);
+    this->prepareRequest(request, factors, differentOpsFactorsName);
+    this->loadConfiguration(pipelineCustomNodeDifferentOperationsConfig);
+    ASSERT_EQ(manager.createPipeline(pipeline, pipelineName, &request, &response), StatusCode::OK);
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+    SPDLOG_ERROR("ER");
+
+    const size_t dummy_size = 10;
+    std::vector<float> expectedOutput(4 * dummy_size);
+    prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
+    this->checkResponse("pipeline_output", response, expectedOutput, {1, 4, 10});
+}
+
+static const char* pipelineCustomNodeDifferentOperationsThenDummyConfig = R"(
+{
+    "custom_node_library_config_list": [
+        {
+            "name": "lib_perform_different_operations",
+            "base_path": "/ovms/bazel-bin/src/lib_node_perform_different_operations.so"
+        }
+    ],
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "my_pipeline",
+            "inputs": ["pipeline_input", "pipeline_factors"],
+            "nodes": [
+                {
+                    "name": "custom_node",
+                    "library_name": "lib_perform_different_operations",
+                    "type": "custom",
+                    "demultiply_count": 4,
+                    "inputs": [
+                        {"input_numbers": {"node_name": "request",
+                                           "data_item": "pipeline_input"}},
+                        {"op_factors": {"node_name": "request",
+                                           "data_item": "pipeline_factors"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "different_ops_results",
+                         "alias": "custom_node_output"}
+                    ]
+                },
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "custom_node",
+                               "data_item": "custom_node_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"pipeline_output": {"node_name": "dummyNode",
+                                     "data_item": "dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, DifferentOpsCustomNodeThenDummy) {
+    std::unique_ptr<Pipeline> pipeline;
+    std::vector<float> input{0,1,2,3,4,5,6,7,8, 9};
+    std::vector<float> factors{1, 3, 2, 2}; // add/sub/multiply/divide
+    this->prepareRequest(request, input, differentOpsInputName);
+    this->prepareRequest(request, factors, differentOpsFactorsName);
+    this->loadConfiguration(pipelineCustomNodeDifferentOperationsThenDummyConfig);
+    ASSERT_EQ(manager.createPipeline(pipeline, pipelineName, &request, &response), StatusCode::OK);
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+
+    const size_t dummy_size = 10;
+    std::vector<float> expectedOutput(4 * dummy_size);
+    prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
+    std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
+        [](float f) -> float { return f + 1;});
+    this->checkResponse("pipeline_output", response, expectedOutput, {1, 4, 10});
+    // TODO remove
+    prepareGatherHighestExpectedOutput(expectedOutput, expectedOutput, HighestOption::MAXIMUM_MINIMUM);
+}
 // TODO: Validation tests (PipelineDefinition::validateNodes/validateForCycles)
+

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1298,7 +1298,7 @@ static const char* pipelineCustomNodeDifferentOperationsThenDummyThenChooseMaxim
                     "type": "custom",
                     "gather_from_node": "custom_node",
                     "params": {
-                        "selection_criterium": "MAXIMUM_MAXIMUM"
+                        "selection_criteria": "MAXIMUM_MAXIMUM"
                     },
                     "inputs": [
                         {"input_tensors": {"node_name": "dummyNode",
@@ -1401,7 +1401,7 @@ static const char* pipelineCustomNodeDifferentOperationsThenDummyThenChooseMaxim
                     "type": "custom",
                     "gather_from_node": "custom_node",
                     "params": {
-                        "selection_criterium": "MAXIMUM_MAXIMUM"
+                        "selection_criteria": "MAXIMUM_MAXIMUM"
                     },
                     "inputs": [
                         {"input_tensors": {"node_name": "dummyNode",

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -110,7 +110,6 @@ protected:
         for (size_t i = 0; i < actual.size(); i++) {
             EXPECT_NEAR(actual[i], data[i], 0.001) << " i is: " << i;
         }
-
     }
 
     template <typename T>
@@ -1048,30 +1047,30 @@ protected:
 };
 
 enum OPS {
-ADD,
-SUB,
-MULTIPLY,
-DIVIDE
+    ADD,
+    SUB,
+    MULTIPLY,
+    DIVIDE
 };
 
 static void prepareDifferentOpsExpectedOutput(std::vector<float>& expectedOutput, const std::vector<float>& input, const std::vector<float>& factors) {
     const size_t dummy_size = 10;
-    for (size_t j = 0; j < 4; ++j) { // iterate over ops
+    for (size_t j = 0; j < 4; ++j) {  // iterate over ops
         for (size_t i = 0; i < dummy_size; ++i) {
             size_t index = dummy_size * j + i;
-            switch(j) {
-                case ADD:
-                    expectedOutput[index] = input[i] + factors[j];
-                    break;
-                case SUB:
-                    expectedOutput[index] = input[i] - factors[j];
-                    break;
-                case MULTIPLY:
-                    expectedOutput[index] = input[i] * factors[j];
-                    break;
-                case DIVIDE:
-                    expectedOutput[index] = input[i] / factors[j];
-                    break;
+            switch (j) {
+            case ADD:
+                expectedOutput[index] = input[i] + factors[j];
+                break;
+            case SUB:
+                expectedOutput[index] = input[i] - factors[j];
+                break;
+            case MULTIPLY:
+                expectedOutput[index] = input[i] * factors[j];
+                break;
+            case DIVIDE:
+                expectedOutput[index] = input[i] / factors[j];
+                break;
             }
         }
     }
@@ -1083,7 +1082,7 @@ enum class Method {
     MAXIMUM_AVERAGE,
 };
 
-std::vector<float> prepareGatherHighestExpectedOutput( std::vector<float> input, Method option) {
+std::vector<float> prepareGatherHighestExpectedOutput(std::vector<float> input, Method option) {
     const size_t dummy_size = 10;
     std::vector<float> expectedOutput(dummy_size);
     size_t tensorsCount = input.size() / dummy_size;
@@ -1091,22 +1090,22 @@ std::vector<float> prepareGatherHighestExpectedOutput( std::vector<float> input,
     std::vector<float> minimums(tensorsCount, std::numeric_limits<int>::max());
     std::vector<float> maximums(tensorsCount, std::numeric_limits<int>::lowest());
     std::vector<float> averages(tensorsCount, 0);
-    for (size_t opId = 0; opId < tensorsCount; ++opId) { // iterate over ops
+    for (size_t opId = 0; opId < tensorsCount; ++opId) {  // iterate over ops
         for (size_t i = 0; i < dummy_size; ++i) {
             size_t index = dummy_size * opId + i;
-            switch(option) {
-                case Method::MAXIMUM_MAXIMUM:
-                    maximums[opId] = std::max(maximums[opId], input[index]);
-                    break;
-                case Method::MAXIMUM_MINIMUM:
-                    minimums[opId] = std::min(maximums[opId], input[index]);
-                    break;
-                case Method::MAXIMUM_AVERAGE:
-                    averages[opId] += input[index];
-                    break;
-                default:
-                    throw std::logic_error(""); 
-                    break;
+            switch (option) {
+            case Method::MAXIMUM_MAXIMUM:
+                maximums[opId] = std::max(maximums[opId], input[index]);
+                break;
+            case Method::MAXIMUM_MINIMUM:
+                minimums[opId] = std::min(maximums[opId], input[index]);
+                break;
+            case Method::MAXIMUM_AVERAGE:
+                averages[opId] += input[index];
+                break;
+            default:
+                throw std::logic_error("");
+                break;
             }
         }
         averages[opId] /= dummy_size;
@@ -1115,25 +1114,25 @@ std::vector<float> prepareGatherHighestExpectedOutput( std::vector<float> input,
     size_t whichTensor = 42;
     const std::vector<float>* fromWhichContainerToChoose = &maximums;
     switch (option) {
-        case Method::MAXIMUM_MAXIMUM:
-            fromWhichContainerToChoose = &maximums;
-            break;
-        case Method::MAXIMUM_MINIMUM:
-            fromWhichContainerToChoose = &minimums;
-            break;
-        case Method::MAXIMUM_AVERAGE:
-            fromWhichContainerToChoose = &averages;
-            break;
-        default:
-            throw std::logic_error("");
+    case Method::MAXIMUM_MAXIMUM:
+        fromWhichContainerToChoose = &maximums;
+        break;
+    case Method::MAXIMUM_MINIMUM:
+        fromWhichContainerToChoose = &minimums;
+        break;
+    case Method::MAXIMUM_AVERAGE:
+        fromWhichContainerToChoose = &averages;
+        break;
+    default:
+        throw std::logic_error("");
     }
     whichTensor = std::distance(fromWhichContainerToChoose->begin(),
-                                std::max_element(fromWhichContainerToChoose->begin(),
-                                                 fromWhichContainerToChoose->end()));
+        std::max_element(fromWhichContainerToChoose->begin(),
+            fromWhichContainerToChoose->end()));
     // copy tensor
     std::copy(input.begin() + dummy_size * whichTensor,
-              input.begin() + dummy_size * (whichTensor + 1),
-              expectedOutput.begin());
+        input.begin() + dummy_size * (whichTensor + 1),
+        expectedOutput.begin());
     return expectedOutput;
 }
 
@@ -1141,8 +1140,8 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, JustDiff
     std::unique_ptr<Pipeline> pipeline;
     std::cout << pipelineCustomNodeDifferentOperationsConfig << std::endl;
 
-    std::vector<float> input{0,1,2,3,4,5,6,7,8, 9};
-    std::vector<float> factors{1, 3, 2, 2}; // add/sub/multiply/divide
+    std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<float> factors{1, 3, 2, 2};  // add/sub/multiply/divide
     this->prepareRequest(request, input, differentOpsInputName);
     this->prepareRequest(request, factors, differentOpsFactorsName);
     this->loadConfiguration(pipelineCustomNodeDifferentOperationsConfig);
@@ -1220,8 +1219,8 @@ static const char* pipelineCustomNodeDifferentOperationsThenDummyConfig = R"(
 })";
 TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, DifferentOpsCustomNodeThenDummy) {
     std::unique_ptr<Pipeline> pipeline;
-    std::vector<float> input{0,1,2,3,4,5,6,7,8, 9};
-    std::vector<float> factors{1, 3, 2, 2}; // add/sub/multiply/divide
+    std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<float> factors{1, 3, 2, 2};  // add/sub/multiply/divide
     this->prepareRequest(request, input, differentOpsInputName);
     this->prepareRequest(request, factors, differentOpsFactorsName);
     this->loadConfiguration(pipelineCustomNodeDifferentOperationsThenDummyConfig);
@@ -1232,7 +1231,7 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     std::vector<float> expectedOutput(4 * dummy_size);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
-        [](float f) -> float { return f + 1;});
+        [](float f) -> float { return f + 1; });
     this->checkResponse("pipeline_output", response, expectedOutput, {1, 4, 10});
 }
 
@@ -1322,8 +1321,8 @@ static const char* pipelineCustomNodeDifferentOperationsThenDummyThenChooseMaxim
 
 TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, DifferentOpsCustomNodeThenDummyThenChooseMaximum) {
     std::unique_ptr<Pipeline> pipeline;
-    std::vector<float> input{0,1,2,3,4,5,6,7,8, 9};
-    std::vector<float> factors{1, 3, 2, 2}; // add/sub/multiply/divide
+    std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<float> factors{1, 3, 2, 2};  // add/sub/multiply/divide
     this->prepareRequest(request, input, differentOpsInputName);
     this->prepareRequest(request, factors, differentOpsFactorsName);
     this->loadConfiguration(pipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
@@ -1334,7 +1333,7 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     std::vector<float> expectedOutput(4 * dummy_size);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
-        [](float f) -> float { return f + 1;});
+        [](float f) -> float { return f + 1; });
     std::vector<float> expectedResult = prepareGatherHighestExpectedOutput(expectedOutput, Method::MAXIMUM_MAXIMUM);
     this->checkResponse("pipeline_output", response, expectedResult, {1, 10});
 }
@@ -1437,8 +1436,8 @@ static const char* pipelineCustomNodeDifferentOperationsThenDummyThenChooseMaxim
 })";
 TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, DifferentOpsCustomNodeThenDummyThenChooseMaximumThenDummyAgain) {
     std::unique_ptr<Pipeline> pipeline;
-    std::vector<float> input{0,1,2,3,4,5,6,7,8, 9};
-    std::vector<float> factors{1, 3, 2, 2}; // add/sub/multiply/divide
+    std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<float> factors{1, 3, 2, 2};  // add/sub/multiply/divide
     this->prepareRequest(request, input, differentOpsInputName);
     this->prepareRequest(request, factors, differentOpsFactorsName);
     this->loadConfiguration(pipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumThenDummyConfig);
@@ -1449,11 +1448,10 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     std::vector<float> expectedOutput(4 * dummy_size);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
-        [](float f) -> float { return f + 1;});
+        [](float f) -> float { return f + 1; });
     std::vector<float> expectedResult = prepareGatherHighestExpectedOutput(expectedOutput, Method::MAXIMUM_MAXIMUM);
     std::transform(expectedResult.begin(), expectedResult.end(), expectedResult.begin(),
-        [](float f) -> float { return f + 1;});
+        [](float f) -> float { return f + 1; });
     this->checkResponse("pipeline_output", response, expectedResult, {1, 10});
 }
 // TODO: Validation tests (PipelineDefinition::validateNodes/validateForCycles)
-

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1291,7 +1291,7 @@ static const char* pipelineCustomNodeDifferentOperationsThenDummyThenChooseMaxim
                     "type": "custom",
                     "gather_from_node": "custom_node",
                     "params": {
-                        "selection_criteria": "MAXIMUM_MAXIMUM"
+                        "selection_criteria": "MAXIMUM_MINIMUM"
                     },
                     "inputs": [
                         {"input_tensors": {"node_name": "dummyNode",
@@ -1326,7 +1326,7 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
         [](float f) -> float { return f + 1; });
-    std::vector<float> expectedResult = prepareGatherHighestExpectedOutput(expectedOutput, Method::MAXIMUM_MAXIMUM);
+    std::vector<float> expectedResult = prepareGatherHighestExpectedOutput(expectedOutput, Method::MAXIMUM_MINIMUM);
     this->checkResponse("pipeline_output", response, expectedResult, {1, 10});
 }
 

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1054,10 +1054,9 @@ enum OPS {
 };
 
 static void prepareDifferentOpsExpectedOutput(std::vector<float>& expectedOutput, const std::vector<float>& input, const std::vector<float>& factors) {
-    const size_t dummy_size = 10;
     for (size_t j = 0; j < 4; ++j) {  // iterate over ops
-        for (size_t i = 0; i < dummy_size; ++i) {
-            size_t index = dummy_size * j + i;
+        for (size_t i = 0; i < DUMMY_MODEL_OUTPUT_SIZE; ++i) {
+            size_t index = DUMMY_MODEL_OUTPUT_SIZE * j + i;
             switch (j) {
             case ADD:
                 expectedOutput[index] = input[i] + factors[j];
@@ -1083,16 +1082,15 @@ enum class Method {
 };
 
 std::vector<float> prepareGatherHighestExpectedOutput(std::vector<float> input, Method option) {
-    const size_t dummy_size = 10;
-    std::vector<float> expectedOutput(dummy_size);
-    size_t tensorsCount = input.size() / dummy_size;
+    std::vector<float> expectedOutput(DUMMY_MODEL_OUTPUT_SIZE);
+    size_t tensorsCount = input.size() / DUMMY_MODEL_OUTPUT_SIZE;
     // perform operations
     std::vector<float> minimums(tensorsCount, std::numeric_limits<int>::max());
     std::vector<float> maximums(tensorsCount, std::numeric_limits<int>::lowest());
     std::vector<float> averages(tensorsCount, 0);
     for (size_t opId = 0; opId < tensorsCount; ++opId) {  // iterate over ops
-        for (size_t i = 0; i < dummy_size; ++i) {
-            size_t index = dummy_size * opId + i;
+        for (size_t i = 0; i < DUMMY_MODEL_OUTPUT_SIZE; ++i) {
+            size_t index = DUMMY_MODEL_OUTPUT_SIZE * opId + i;
             switch (option) {
             case Method::MAXIMUM_MAXIMUM:
                 maximums[opId] = std::max(maximums[opId], input[index]);
@@ -1108,7 +1106,7 @@ std::vector<float> prepareGatherHighestExpectedOutput(std::vector<float> input, 
                 break;
             }
         }
-        averages[opId] /= dummy_size;
+        averages[opId] /= DUMMY_MODEL_OUTPUT_SIZE;
     }
     // choose tensor
     size_t whichTensor = 42;
@@ -1130,16 +1128,14 @@ std::vector<float> prepareGatherHighestExpectedOutput(std::vector<float> input, 
         std::max_element(fromWhichContainerToChoose->begin(),
             fromWhichContainerToChoose->end()));
     // copy tensor
-    std::copy(input.begin() + dummy_size * whichTensor,
-        input.begin() + dummy_size * (whichTensor + 1),
+    std::copy(input.begin() + DUMMY_MODEL_OUTPUT_SIZE * whichTensor,
+        input.begin() + DUMMY_MODEL_OUTPUT_SIZE * (whichTensor + 1),
         expectedOutput.begin());
     return expectedOutput;
 }
 
 TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, JustDifferentOpsCustomNode) {
     std::unique_ptr<Pipeline> pipeline;
-    std::cout << pipelineCustomNodeDifferentOperationsConfig << std::endl;
-
     std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<float> factors{1, 3, 2, 2};  // add/sub/multiply/divide
     this->prepareRequest(request, input, differentOpsInputName);
@@ -1147,10 +1143,8 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, JustDiff
     this->loadConfiguration(pipelineCustomNodeDifferentOperationsConfig);
     ASSERT_EQ(manager.createPipeline(pipeline, pipelineName, &request, &response), StatusCode::OK);
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
-    SPDLOG_ERROR("ER");
 
-    const size_t dummy_size = 10;
-    std::vector<float> expectedOutput(4 * dummy_size);
+    std::vector<float> expectedOutput(4 * DUMMY_MODEL_OUTPUT_SIZE);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     this->checkResponse("pipeline_output", response, expectedOutput, {1, 4, 10});
 }
@@ -1227,8 +1221,7 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     ASSERT_EQ(manager.createPipeline(pipeline, pipelineName, &request, &response), StatusCode::OK);
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
 
-    const size_t dummy_size = 10;
-    std::vector<float> expectedOutput(4 * dummy_size);
+    std::vector<float> expectedOutput(4 * DUMMY_MODEL_OUTPUT_SIZE);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
         [](float f) -> float { return f + 1; });
@@ -1329,8 +1322,7 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     ASSERT_EQ(manager.createPipeline(pipeline, pipelineName, &request, &response), StatusCode::OK);
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
 
-    const size_t dummy_size = 10;
-    std::vector<float> expectedOutput(4 * dummy_size);
+    std::vector<float> expectedOutput(4 * DUMMY_MODEL_OUTPUT_SIZE);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
         [](float f) -> float { return f + 1; });
@@ -1444,8 +1436,7 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     ASSERT_EQ(manager.createPipeline(pipeline, pipelineName, &request, &response), StatusCode::OK);
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
 
-    const size_t dummy_size = 10;
-    std::vector<float> expectedOutput(4 * dummy_size);
+    std::vector<float> expectedOutput(4 * DUMMY_MODEL_OUTPUT_SIZE);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
         [](float f) -> float { return f + 1; });


### PR DESCRIPTION
Added two custom nodes:
1) Perform sum, substraction, mutliplication & division on input tensor with constant from second input.
2) Choose maximum tensor from several ones. Criterium is set by parameter

Additionaly fix:
* Fix multiple outputs handling for demultiply node
* Fix reporting node session as ready for execution when it is already executed
* Fix reading gather_from parameter from config for DAGs

JIRA:CVS-46715