### PR TITLE
Add DAG custom node runtime modifications stress tests

### DIFF
--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -41,6 +41,9 @@ Status EntryNode::fetchResults(NodeSession& nodeSession, SessionResults& nodeSes
     // TODO handle multiple sessions later on
     BlobMap outputs;
     auto status = fetchResults(outputs);
+    if (!status.ok()) {
+        return status;
+    }
     SessionResult metaOutputsPair{nodeSession.getNodeSessionMetadata(), std::move(outputs)};
     auto it = nodeSessionOutputs.emplace(nodeSession.getSessionKey(), std::move(metaOutputsPair));
     if (!it.second) {
@@ -63,7 +66,7 @@ Status EntryNode::fetchResults(BlobMap& outputs) {
                 std::stringstream ss;
                 ss << "Required input: " << output_name;
                 const std::string details = ss.str();
-                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Missing input with specific name", getName(), details);
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Missing input with specific name: {}", getName(), details);
                 return Status(StatusCode::INVALID_MISSING_INPUT, details);
             }
             const auto& tensor_proto = request->inputs().at(output_name);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -34,7 +34,12 @@ Node::Node(const std::string& nodeName, uint32_t demultiplyCount, std::set<std::
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will create node: {} with demultiply: {}, gatherFrom: {}.",
         getName(),
         demultiplyCount,
-        std::accumulate(gatherFromNode.begin(), gatherFromNode.end(), std::string(), [](const std::string& lhs, const std::string& rhs) { return lhs + ", " + rhs; }));
+        std::accumulate(gatherFromNode.begin(), gatherFromNode.end(), std::string("NA"), [](const std::string& lhs, const std::string& rhs) {
+            if (lhs == "NA") {
+                return rhs;
+            } else {
+                return lhs + ", " + rhs;
+            }}));
 }
 
 Status Node::fetchResults(session_key_t sessionId, SessionResults& nodeSessionOutputs) {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -39,7 +39,7 @@ Node::Node(const std::string& nodeName, uint32_t demultiplyCount, std::set<std::
                 return rhs;
             } else {
                 return lhs + ", " + rhs;
-            }}));
+            } }));
 }
 
 Status Node::fetchResults(session_key_t sessionId, SessionResults& nodeSessionOutputs) {

--- a/src/test/custom_nodes/node_choose_maximum.cpp
+++ b/src/test/custom_nodes/node_choose_maximum.cpp
@@ -18,8 +18,8 @@
 #include <cstring>
 #include <iostream>
 #include <limits>
-#include <string>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "../../custom_node_interface.h"

--- a/src/test/custom_nodes/node_choose_maximum.cpp
+++ b/src/test/custom_nodes/node_choose_maximum.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <limits>
 #include <string>
+#include <sstream>
 #include <vector>
 
 #include "../../custom_node_interface.h"
@@ -34,6 +35,7 @@ enum Method {
 static const std::string INPUT_TENSOR_NAME = "input_tensors";
 
 int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct CustomNodeTensor** outputs, int* outputsLength, const struct CustomNodeParam* params, int paramsLength) {
+    std::stringstream ss;
     // choose selection criteria
     Method selectionMethod = Method::METHOD_COUNT;
     if (paramsLength != 1) {
@@ -48,7 +50,8 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
         } else if (strcmp(params[0].value, "MAXIMUM_AVERAGE") == 0) {
             selectionMethod = Method::MAXIMUM_AVERAGE;
         } else {
-            std::cout << "Not allowed selection criteria chosen:" << params[0].value << std::endl;
+            ss << "Not allowed selection criteria chosen:" << params[0].value << std::endl;
+            std::cout << ss.str() << std::endl;
             return 1;
         }
     } else {
@@ -68,18 +71,20 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
             inputs[0].dims[0] != 1 ||
             inputs[0].dims[1] == 0 ||
             inputs[0].dims[2] == 0) {
-            std::cout << "improper " << INPUT_TENSOR_NAME
-                      << " dimensions: [" << inputs[0].dims[0]
-                      << ", " << inputs[0].dims[1]
-                      << ", " << inputs[0].dims[2] << "]" << std::endl;
+            ss << "improper " << INPUT_TENSOR_NAME
+               << " dimensions: [" << inputs[0].dims[0]
+               << ", " << inputs[0].dims[1]
+               << ", " << inputs[0].dims[2] << "]" << std::endl;
+            std::cout << ss.str() << std::endl;
             return 1;
         }
-        std::cout << "Input valuesPerTensor" << inputs[0].dims[1] << std::endl;
+        ss << "Input valuesPerTensor: " << inputs[0].dims[1] << std::endl;
         numberOfOps = inputs[0].dims[1];
         valuesPerTensor = inputs[0].dims[2];
         inputTensor = reinterpret_cast<float*>(inputs[0].data);
     } else {
-        std::cout << "Lacking input: " << INPUT_TENSOR_NAME << std::endl;
+        ss << "Lacking input: " << INPUT_TENSOR_NAME << std::endl;
+        std::cout << ss.str() << std::endl;
         return 1;
     }
     // prepare output
@@ -117,13 +122,13 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
             default:
                 return 1;
             }
-            std::cout << "opId:" << opId
-                      << " dummyPos:" << dummyPos
-                      << " input:" << inputTensor[index]
-                      << " minimums:" << minimums[opId]
-                      << " averages:" << averages[opId]
-                      << " maximums:" << maximums[opId]
-                      << std::endl;
+            ss << "opId:" << opId
+               << " dummyPos:" << dummyPos
+               << " input:" << inputTensor[index]
+               << " minimums:" << minimums[opId]
+               << " averages:" << averages[opId]
+               << " maximums:" << maximums[opId]
+               << std::endl;
         }
         averages[opId] /= valuesPerTensor;
     }
@@ -145,15 +150,16 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     size_t whichTensor = std::distance(fromWhichContainerToChoose->begin(),
         std::max_element(fromWhichContainerToChoose->begin(),
             fromWhichContainerToChoose->end()));
-    std::cout << "Selected tensor pos: " << whichTensor << std::endl;
+    ss << "Selected tensor pos: " << whichTensor << std::endl;
     // copy appropiate tensor
     for (size_t i = 0; i < valuesPerTensor; ++i) {
         size_t index = whichTensor * valuesPerTensor + i;
-        std::cout << "Putting tensor:" << whichTensor
-                  << " index:" << index
-                  << " with value:" << inputTensor[index] << std::endl;
+        ss << "Putting tensor:" << whichTensor
+           << " index:" << index
+           << " with value:" << inputTensor[index] << std::endl;
         result[i] = inputTensor[index];
     }
+    std::cout << ss.str() << std::endl;
     return 0;
 }
 

--- a/src/test/custom_nodes/node_choose_maximum.cpp
+++ b/src/test/custom_nodes/node_choose_maximum.cpp
@@ -114,7 +114,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
                 maximums[opId] = std::max(maximums[opId], inputTensor[index]);
                 break;
             case Method::MAXIMUM_MINIMUM:
-                minimums[opId] = std::min(maximums[opId], inputTensor[index]);
+                minimums[opId] = std::min(minimums[opId], inputTensor[index]);
                 break;
             case Method::MAXIMUM_AVERAGE:
                 averages[opId] += inputTensor[index];
@@ -128,6 +128,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
                << " minimums:" << minimums[opId]
                << " averages:" << averages[opId]
                << " maximums:" << maximums[opId]
+               << " selected method:" << selectionMethod
                << std::endl;
         }
         averages[opId] /= valuesPerTensor;

--- a/src/test/custom_nodes/node_perform_different_operations.cpp
+++ b/src/test/custom_nodes/node_perform_different_operations.cpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <iostream>
 #include <string>
+#include <sstream>
 
 #include "../../custom_node_interface.h"
 
@@ -32,6 +33,7 @@ static const std::string INPUT_TENSOR_NAME = "input_numbers";
 static const std::string FACTORS_TENSOR_NAME = "op_factors";
 
 int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct CustomNodeTensor** outputs, int* outputsLength, const struct CustomNodeParam* params, int paramsLength) {
+    std::stringstream ss;
     // validate inputs
     float* inputTensor;
     float* inputFactors;
@@ -41,19 +43,21 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
             if (inputs[i].dimsLength != 2 ||
                 inputs[i].dims[0] != 1 ||
                 inputs[i].dims[1] == 0) {
-                std::cout << "improper " << INPUT_TENSOR_NAME
-                          << " dimensions: [" << inputs[i].dims[0] << ", " << inputs[i].dims[1] << "]" << std::endl;
+                ss << "improper " << INPUT_TENSOR_NAME
+                   << " dimensions: [" << inputs[i].dims[0] << ", " << inputs[i].dims[1] << "]" << std::endl;
+                std::cout << ss.str() << std::endl;
                 return 1;
             }
-            std::cout << "Input valuesPerTensor" << inputs[i].dims[1] << std::endl;
+            ss << "Input valuesPerTensor:" << inputs[i].dims[1] << std::endl;
             valuesPerTensor = inputs[i].dims[1];
             inputTensor = reinterpret_cast<float*>(inputs[i].data);
         } else if (FACTORS_TENSOR_NAME == inputs[i].name) {
             if (inputs[i].dimsLength != 2 ||
                 inputs[i].dims[0] != 1 ||
                 inputs[i].dims[1] != OPS_END) {
-                std::cout << "improper " << FACTORS_TENSOR_NAME
-                          << " dimensions:[" << inputs[i].dims[0] << ", " << inputs[i].dims[1] << "]" << std::endl;
+                ss << "improper " << FACTORS_TENSOR_NAME
+                   << " dimensions:[" << inputs[i].dims[0] << ", " << inputs[i].dims[1] << "]" << std::endl;
+                std::cout << ss.str() << std::endl;
                 return 1;
             }
             inputFactors = reinterpret_cast<float*>(inputs[i].data);
@@ -97,15 +101,16 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
                 result[resultIndex] = inputTensor[dummyPos] / inputFactors[opId];
                 break;
             }
-            std::cout << "opId:" << opId
-                      << " dummyPos:" << dummyPos
-                      << " resultIndex:" << resultIndex
-                      << " result:" << result[resultIndex]
-                      << " inputTensor:" << inputTensor[dummyPos]
-                      << " inputFactor:" << inputFactors[opId]
-                      << std::endl;
+            ss << "opId:" << opId
+               << " dummyPos:" << dummyPos
+               << " resultIndex:" << resultIndex
+               << " result:" << result[resultIndex]
+               << " inputTensor:" << inputTensor[dummyPos]
+               << " inputFactor:" << inputFactors[opId]
+               << std::endl;
         }
     }
+    std::cout << ss.str() << std::endl;
     return 0;
 }
 

--- a/src/test/custom_nodes/node_perform_different_operations.cpp
+++ b/src/test/custom_nodes/node_perform_different_operations.cpp
@@ -15,8 +15,8 @@
 //*****************************************************************************
 #include <cstddef>
 #include <iostream>
-#include <string>
 #include <sstream>
+#include <string>
 
 #include "../../custom_node_interface.h"
 

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -316,7 +316,256 @@ static const char* stressTestPipelineOneDummyConfigSpecificVersionUsed = R"(
     ]
 })";
 
+static const char* stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig = R"(
+{
+    "custom_node_library_config_list": [
+        {
+            "name": "lib_perform_different_operations",
+            "base_path": "/ovms/bazel-bin/src/lib_node_perform_different_operations.so"
+        },
+        {
+            "name": "lib_choose_maximum",
+            "base_path": "/ovms/bazel-bin/src/lib_node_choose_maximum.so"
+        }
+    ],
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input", "pipeline_factors"],
+            "nodes": [
+                {
+                    "name": "custom_node",
+                    "library_name": "lib_perform_different_operations",
+                    "type": "custom",
+                    "demultiply_count": 4,
+                    "inputs": [
+                        {"input_numbers": {"node_name": "request",
+                                           "data_item": "custom_dummy_input"}},
+                        {"op_factors": {"node_name": "request",
+                                           "data_item": "pipeline_factors"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "different_ops_results",
+                         "alias": "custom_node_output"}
+                    ]
+                },
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "custom_node",
+                               "data_item": "custom_node_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "dummy_output"}
+                    ]
+                },
+                {
+                    "name": "choose_max",
+                    "library_name": "lib_choose_maximum",
+                    "type": "custom",
+                    "gather_from_node": "custom_node",
+                    "params": {
+                        "selection_criteria": "MAXIMUM_MINIMUM"
+                    },
+                    "inputs": [
+                        {"input_tensors": {"node_name": "dummyNode",
+                                           "data_item": "dummy_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "maximum_tensor",
+                         "alias": "maximum_tensor_alias"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "choose_max",
+                                     "data_item": "maximum_tensor_alias"}
+                }
+            ]
+        }
+    ]
+})";
+
+static const char* stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumRemovedLibraryConfig = R"(
+{
+    "custom_node_library_config_list": [
+        {
+            "name": "lib_perform_different_operations",
+            "base_path": "/ovms/bazel-bin/src/lib_node_perform_different_operations.so"
+        }
+    ],
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input", "pipeline_factors"],
+            "nodes": [
+                {
+                    "name": "custom_node",
+                    "library_name": "lib_perform_different_operations",
+                    "type": "custom",
+                    "demultiply_count": 4,
+                    "inputs": [
+                        {"input_numbers": {"node_name": "request",
+                                           "data_item": "custom_dummy_input"}},
+                        {"op_factors": {"node_name": "request",
+                                           "data_item": "pipeline_factors"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "different_ops_results",
+                         "alias": "custom_node_output"}
+                    ]
+                },
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "custom_node",
+                               "data_item": "custom_node_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "dummy_output"}
+                    ]
+                },
+                {
+                    "name": "choose_max",
+                    "library_name": "lib_choose_maximum",
+                    "type": "custom",
+                    "gather_from_node": "custom_node",
+                    "params": {
+                        "selection_criteria": "MAXIMUM_MINIMUM"
+                    },
+                    "inputs": [
+                        {"input_tensors": {"node_name": "dummyNode",
+                                           "data_item": "dummy_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "maximum_tensor",
+                         "alias": "maximum_tensor_alias"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "choose_max",
+                                         "data_item": "maximum_tensor_alias"}
+                }
+            ]
+        }
+    ]
+})";
+
+static const char* stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumChangedParamConfig = R"(
+{
+    "custom_node_library_config_list": [
+        {
+            "name": "lib_perform_different_operations",
+            "base_path": "/ovms/bazel-bin/src/lib_node_perform_different_operations.so"
+        },
+        {
+            "name": "lib_choose_maximum",
+            "base_path": "/ovms/bazel-bin/src/lib_node_choose_maximum.so"
+        }
+    ],
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input", "pipeline_factors"],
+            "nodes": [
+                {
+                    "name": "custom_node",
+                    "library_name": "lib_perform_different_operations",
+                    "type": "custom",
+                    "demultiply_count": 4,
+                    "inputs": [
+                        {"input_numbers": {"node_name": "request",
+                                           "data_item": "custom_dummy_input"}},
+                        {"op_factors": {"node_name": "request",
+                                           "data_item": "pipeline_factors"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "different_ops_results",
+                         "alias": "custom_node_output"}
+                    ]
+                },
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "custom_node",
+                               "data_item": "custom_node_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "dummy_output"}
+                    ]
+                },
+                {
+                    "name": "choose_max",
+                    "library_name": "lib_choose_maximum",
+                    "type": "custom",
+                    "gather_from_node": "custom_node",
+                    "params": {
+                        "selection_criteria": "MAXIMUM_AVERAGE"
+                    },
+                    "inputs": [
+                        {"input_tensors": {"node_name": "dummyNode",
+                                           "data_item": "dummy_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "maximum_tensor",
+                         "alias": "maximum_tensor_alias"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "choose_max",
+                                     "data_item": "maximum_tensor_alias"}
+                }
+            ]
+        }
+    ]
+})";
+
 class StressPipelineConfigChanges : public TestWithTempDir {
+protected:
     const uint loadThreadCount = 20;
     const uint beforeConfigChangeLoadTimeMs = 30;
     const uint afterConfigChangeLoadTimeMs = 50;
@@ -330,7 +579,7 @@ class StressPipelineConfigChanges : public TestWithTempDir {
     const std::string pipelineInputName = "custom_dummy_input";
     const std::string pipelineOutputName = "custom_dummy_output";
 
-    const std::vector<float> requestData{1., 2., 3., 7., 5., 6., 4., 9., 10., 8.};
+    const std::vector<float> requestData{1.1, 2., 3., 7., 5., 6., 4., 9., 10., 8.};
 
 public:
     void SetUpConfig(const std::string& configContent) {
@@ -339,7 +588,6 @@ public:
         ovmsConfig.replace(ovmsConfig.find(modelPathToReplace), modelPathToReplace.size(), modelPath);
         configFilePath = directoryPath + "/ovms_config.json";
     }
-    void TearDown() override {}
     void SetUp() override {
         TestWithTempDir::SetUp();
         modelPath = directoryPath + "/dummy/";
@@ -384,6 +632,18 @@ public:
     void retireSpecificVersionUsed() {
         SPDLOG_INFO("{} start", __FUNCTION__);
         std::filesystem::copy("/ovms/src/test/dummy/1", modelPath + "/2", std::filesystem::copy_options::recursive);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void removeCustomLibraryUsed() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumRemovedLibraryConfig);
+        createConfigFileWithContent(ovmsConfig, configFilePath);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void changeCustomLibraryParam() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumChangedParamConfig);
+        createConfigFileWithContent(ovmsConfig, configFilePath);
         SPDLOG_INFO("{} end", __FUNCTION__);
     }
     void performStressTest(
@@ -578,6 +838,20 @@ public:
             }
         }
     }
+    virtual tensorflow::serving::PredictRequest preparePipelinePredictRequest(inputs_info_t requestInputs) {
+            tensorflow::serving::PredictRequest request = preparePredictRequest(
+                {{pipelineInputName,
+                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
+            auto& input = (*request.mutable_inputs())[pipelineInputName];
+            input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+            return std::move(request);
+    }
+    virtual void checkPipelineResponse(const std::string& pipelineOutputName,
+            tensorflow::serving::PredictRequest& request,
+            tensorflow::serving::PredictResponse& response) {
+        checkDummyResponse(pipelineOutputName, requestData, request, response, 1);
+    }
+
     void triggerPredictInALoop(
         std::future<void>& startSignal,
         std::future<void>& stopSignal,
@@ -595,12 +869,15 @@ public:
                 break;
             }
             std::unique_ptr<Pipeline> pipelinePtr;
-            tensorflow::serving::PredictRequest request = preparePredictRequest(
+            
+            tensorflow::serving::PredictRequest request = preparePipelinePredictRequest(
+                {{pipelineInputName,
+                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
+            /*tensorflow::serving::PredictRequest request = preparePredictRequest(
                 {{pipelineInputName,
                     std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
             auto& input = (*request.mutable_inputs())[pipelineInputName];
-            std::vector<float> reqData = requestData;
-            input.mutable_tensor_content()->assign((char*)reqData.data(), reqData.size() * sizeof(float));
+            input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));*/
             tensorflow::serving::PredictResponse response;
             auto createPipelineStatus = manager.createPipeline(pipelinePtr, pipelineName, &request, &response);
             // we need to make sure that expected status happened and still accept
@@ -619,7 +896,7 @@ public:
                         (allowedLoadResults.find(executePipelineStatus.getCode()) != allowedLoadResults.end()))
                 << executePipelineStatus.string() << "\n";
             if (executePipelineStatus.ok()) {
-                checkDummyResponse(pipelineOutputName, requestData, request, response, 1);
+                checkPipelineResponse(pipelineOutputName, request, response);
             }
             if (::testing::Test::HasFailure()) {
                 SPDLOG_INFO("Earlier fail detected. Stopping execution");
@@ -812,6 +1089,67 @@ TEST_F(StressPipelineConfigChanges, RetireSpecificVersionUsedDuringGetMetadataLo
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
         &StressPipelineConfigChanges::retireSpecificVersionUsed,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+
+
+
+class StressPipelineCustomNodesConfigChanges : public StressPipelineConfigChanges {
+    const size_t differentOpsFactorsInputSize = 4;
+    const std::vector<float> factorsData {1., 3, 2, 2};
+    const std::string pipelineFactorsInputName {"pipeline_factors"};
+    public:
+    tensorflow::serving::PredictRequest preparePipelinePredictRequest(inputs_info_t requestInputs) override {
+            tensorflow::serving::PredictRequest request = preparePredictRequest(
+                {
+                    {pipelineInputName,
+                     std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}},
+                    {pipelineFactorsInputName,
+                     std::tuple<ovms::shape_t, tensorflow::DataType>{{1, differentOpsFactorsInputSize}, tensorflow::DataType::DT_FLOAT}}});
+            auto& input = (*request.mutable_inputs())[pipelineInputName];
+            input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+            auto& factors = (*request.mutable_inputs())[pipelineFactorsInputName];
+            factors.mutable_tensor_content()->assign((char*)factorsData.data(), factorsData.size() * sizeof(float));
+            return std::move(request);
+    }
+    void checkPipelineResponse(const std::string& pipelineOutputName,
+            tensorflow::serving::PredictRequest& request,
+            tensorflow::serving::PredictResponse& response) override {
+        // we need to imitate -> different ops then dummy then max
+        std::vector<float> result(requestData.begin(), requestData.end());
+        std::transform(result.begin(), result.end(), result.begin(), [this](float f) -> float { return f * factorsData[2];});
+        checkDummyResponse(pipelineOutputName, result, request, response, 1);
+    }
+};
+
+TEST_F(StressPipelineCustomNodesConfigChanges, RemoveCustomLibraryDuringPredictLoad) {
+    SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET}; // we may hit during pipeline reload
+    // TODO replace above with the one below when removing libraries will be fully implemented.
+    // std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
+    //    StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate
+    // std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::removeCustomLibraryUsed,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressPipelineCustomNodesConfigChanges, ChangeCustomLibraryParamDuringPredictLoad) {
+    // we change used PARAM durign load. This change does not effect results, but is should be enough to verify
+    // correctness of this operation - no segfaults etc.
+    SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
+    bool performWholeConfigReload = true;
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};                          // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerPredictInALoop,
+        &StressPipelineConfigChanges::changeCustomLibraryParam,
         performWholeConfigReload,
         requiredLoadResults,
         allowedLoadResults);

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -335,7 +335,7 @@ static const char* stressPipelineCustomNodeDifferentOperationsThenDummyThenChoos
                 "base_path": "/ovms/src/test/dummy",
                 "target_device": "CPU",
                 "model_version_policy": {"all": {}},
-                "nireq": 1
+                "nireq": 100
             }
         }
     ],
@@ -415,7 +415,7 @@ static const char* stressPipelineCustomNodeDifferentOperationsThenDummyThenChoos
                 "base_path": "/ovms/src/test/dummy",
                 "target_device": "CPU",
                 "model_version_policy": {"all": {}},
-                "nireq": 1
+                "nireq": 100
             }
         }
     ],
@@ -499,7 +499,7 @@ static const char* stressPipelineCustomNodeDifferentOperationsThenDummyThenChoos
                 "base_path": "/ovms/src/test/dummy",
                 "target_device": "CPU",
                 "model_version_policy": {"all": {}},
-                "nireq": 1
+                "nireq": 100
             }
         }
     ],
@@ -859,7 +859,7 @@ public:
                  std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}};
     }
 
-    virtual tensorflow::serving::PredictRequest preparePipelinePredictRequest(inputs_info_t requestInputs) {
+    virtual tensorflow::serving::PredictRequest preparePipelinePredictRequest() {
         tensorflow::serving::PredictRequest request = preparePredictRequest(getExpectedInputsInfo());
         auto& input = (*request.mutable_inputs())[pipelineInputName];
         input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
@@ -889,14 +889,7 @@ public:
             }
             std::unique_ptr<Pipeline> pipelinePtr;
 
-            tensorflow::serving::PredictRequest request = preparePipelinePredictRequest(
-                {{pipelineInputName,
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
-            /*tensorflow::serving::PredictRequest request = preparePredictRequest(
-                {{pipelineInputName,
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
-            auto& input = (*request.mutable_inputs())[pipelineInputName];
-            input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));*/
+            tensorflow::serving::PredictRequest request = preparePipelinePredictRequest();
             tensorflow::serving::PredictResponse response;
             auto createPipelineStatus = manager.createPipeline(pipelinePtr, pipelineName, &request, &response);
             // we need to make sure that expected status happened and still accept
@@ -1119,7 +1112,7 @@ class StressPipelineCustomNodesConfigChanges : public StressPipelineConfigChange
     const std::string pipelineFactorsInputName{"pipeline_factors"};
 
 public:
-    tensorflow::serving::PredictRequest preparePipelinePredictRequest(inputs_info_t requestInputs) override {
+    tensorflow::serving::PredictRequest preparePipelinePredictRequest() override {
         tensorflow::serving::PredictRequest request = preparePredictRequest(getExpectedInputsInfo());
         auto& input = (*request.mutable_inputs())[pipelineInputName];
         input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -578,7 +578,8 @@ protected:
     const std::string& pipelineName = PIPELINE_1_DUMMY_NAME;
     const std::string pipelineInputName = "custom_dummy_input";
     const std::string pipelineOutputName = "custom_dummy_output";
-
+    // 1.1 for different ops test to be sure that always demultiplication
+    // producess highest results
     const std::vector<float> requestData{1.1, 2., 3., 7., 5., 6., 4., 9., 10., 8.};
 
 public:
@@ -1139,8 +1140,8 @@ public:
 TEST_F(StressPipelineCustomNodesConfigChanges, RemoveCustomLibraryDuringPredictLoad) {
     SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
     bool performWholeConfigReload = true;
-    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};                                 // we expect full continuouity of operation
-    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};  // we may hit during pipeline reload
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {};
     // TODO replace above with the one below when removing libraries will be fully implemented.
     // std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
     //    StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -839,16 +839,16 @@ public:
         }
     }
     virtual tensorflow::serving::PredictRequest preparePipelinePredictRequest(inputs_info_t requestInputs) {
-            tensorflow::serving::PredictRequest request = preparePredictRequest(
-                {{pipelineInputName,
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
-            auto& input = (*request.mutable_inputs())[pipelineInputName];
-            input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
-            return std::move(request);
+        tensorflow::serving::PredictRequest request = preparePredictRequest(
+            {{pipelineInputName,
+                std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
+        auto& input = (*request.mutable_inputs())[pipelineInputName];
+        input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+        return std::move(request);
     }
     virtual void checkPipelineResponse(const std::string& pipelineOutputName,
-            tensorflow::serving::PredictRequest& request,
-            tensorflow::serving::PredictResponse& response) {
+        tensorflow::serving::PredictRequest& request,
+        tensorflow::serving::PredictResponse& response) {
         checkDummyResponse(pipelineOutputName, requestData, request, response, 1);
     }
 
@@ -869,7 +869,7 @@ public:
                 break;
             }
             std::unique_ptr<Pipeline> pipelinePtr;
-            
+
             tensorflow::serving::PredictRequest request = preparePipelinePredictRequest(
                 {{pipelineInputName,
                     std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}});
@@ -1094,32 +1094,30 @@ TEST_F(StressPipelineConfigChanges, RetireSpecificVersionUsedDuringGetMetadataLo
         allowedLoadResults);
 }
 
-
-
 class StressPipelineCustomNodesConfigChanges : public StressPipelineConfigChanges {
     const size_t differentOpsFactorsInputSize = 4;
-    const std::vector<float> factorsData {1., 3, 2, 2};
-    const std::string pipelineFactorsInputName {"pipeline_factors"};
-    public:
+    const std::vector<float> factorsData{1., 3, 2, 2};
+    const std::string pipelineFactorsInputName{"pipeline_factors"};
+
+public:
     tensorflow::serving::PredictRequest preparePipelinePredictRequest(inputs_info_t requestInputs) override {
-            tensorflow::serving::PredictRequest request = preparePredictRequest(
-                {
-                    {pipelineInputName,
-                     std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}},
-                    {pipelineFactorsInputName,
-                     std::tuple<ovms::shape_t, tensorflow::DataType>{{1, differentOpsFactorsInputSize}, tensorflow::DataType::DT_FLOAT}}});
-            auto& input = (*request.mutable_inputs())[pipelineInputName];
-            input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
-            auto& factors = (*request.mutable_inputs())[pipelineFactorsInputName];
-            factors.mutable_tensor_content()->assign((char*)factorsData.data(), factorsData.size() * sizeof(float));
-            return std::move(request);
+        tensorflow::serving::PredictRequest request = preparePredictRequest(
+            {{pipelineInputName,
+                 std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}},
+                {pipelineFactorsInputName,
+                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, differentOpsFactorsInputSize}, tensorflow::DataType::DT_FLOAT}}});
+        auto& input = (*request.mutable_inputs())[pipelineInputName];
+        input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+        auto& factors = (*request.mutable_inputs())[pipelineFactorsInputName];
+        factors.mutable_tensor_content()->assign((char*)factorsData.data(), factorsData.size() * sizeof(float));
+        return std::move(request);
     }
     void checkPipelineResponse(const std::string& pipelineOutputName,
-            tensorflow::serving::PredictRequest& request,
-            tensorflow::serving::PredictResponse& response) override {
+        tensorflow::serving::PredictRequest& request,
+        tensorflow::serving::PredictResponse& response) override {
         // we need to imitate -> different ops then dummy then max
         std::vector<float> result(requestData.begin(), requestData.end());
-        std::transform(result.begin(), result.end(), result.begin(), [this](float f) -> float { return f * factorsData[2];});
+        std::transform(result.begin(), result.end(), result.begin(), [this](float f) -> float { return f * factorsData[2]; });
         checkDummyResponse(pipelineOutputName, result, request, response, 1);
     }
 };
@@ -1127,8 +1125,8 @@ class StressPipelineCustomNodesConfigChanges : public StressPipelineConfigChange
 TEST_F(StressPipelineCustomNodesConfigChanges, RemoveCustomLibraryDuringPredictLoad) {
     SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
     bool performWholeConfigReload = true;
-    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
-    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET}; // we may hit during pipeline reload
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};                                 // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};  // we may hit during pipeline reload
     // TODO replace above with the one below when removing libraries will be fully implemented.
     // std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
     //    StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate
@@ -1145,7 +1143,7 @@ TEST_F(StressPipelineCustomNodesConfigChanges, ChangeCustomLibraryParamDuringPre
     // correctness of this operation - no segfaults etc.
     SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
     bool performWholeConfigReload = true;
-    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};                          // we expect full continuouity of operation
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
     std::set<StatusCode> allowedLoadResults = {};
     performStressTest(
         &StressPipelineConfigChanges::triggerPredictInALoop,

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -856,7 +856,7 @@ public:
     }
     virtual inputs_info_t getExpectedInputsInfo() {
         return {{pipelineInputName,
-                 std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}};
+            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}};
     }
 
     virtual tensorflow::serving::PredictRequest preparePipelinePredictRequest() {
@@ -1122,9 +1122,9 @@ public:
     }
     inputs_info_t getExpectedInputsInfo() override {
         return {{pipelineInputName,
-                 std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}},
-                {pipelineFactorsInputName,
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, differentOpsFactorsInputSize}, tensorflow::DataType::DT_FLOAT}}};
+                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}},
+            {pipelineFactorsInputName,
+                std::tuple<ovms::shape_t, tensorflow::DataType>{{1, differentOpsFactorsInputSize}, tensorflow::DataType::DT_FLOAT}}};
     }
     void checkPipelineResponse(const std::string& pipelineOutputName,
         tensorflow::serving::PredictRequest& request,
@@ -1185,8 +1185,8 @@ TEST_F(StressPipelineCustomNodesConfigChanges, RemoveCustomLibraryDuringGetMetad
 TEST_F(StressPipelineCustomNodesConfigChanges, ChangeCustomLibraryParamDuringGetMetadataLoad) {
     SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
     bool performWholeConfigReload = true;
-    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation most of the time
-    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET}; // might hit reload phase
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};                                 // we expect full continuouity of operation most of the time
+    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};  // might hit reload phase
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
         &StressPipelineConfigChanges::changeCustomLibraryParam,

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -57,7 +57,7 @@ ovms::tensor_map_t prepareTensors(
 void checkDummyResponse(const std::string outputName,
     const std::vector<float>& requestData,
     PredictRequest& request, PredictResponse& response, int seriesLength, int batchSize) {
-    ASSERT_EQ(response.outputs().count(outputName), 1);
+    ASSERT_EQ(response.outputs().count(outputName), 1) << "Did not find:" << outputName;
     const auto& output_proto = response.outputs().at(outputName);
 
     ASSERT_EQ(output_proto.tensor_content().size(), batchSize * DUMMY_MODEL_OUTPUT_SIZE * sizeof(float));


### PR DESCRIPTION
Make verifying DAG metadata in tests dependent from test.

Additionally:
* Make custom nodes log print in one batch to improve custom node stdout for parallel client tests
* Report NA when not gathering in node constructor
* Fix not returning early when error occured in entry_node
JIRA:CVS-48155