### PR TITLE
Add tests of pipelines with multiple demultiplexers/gathers

### DIFF
--- a/src/customnodesession.cpp
+++ b/src/customnodesession.cpp
@@ -59,7 +59,6 @@ Status CustomNodeSession::execute(PipelineEventQueue& notifyEndQueue, Node& node
         notifyEndQueue.push({node, getSessionKey()});
         return StatusCode::NODE_LIBRARY_EXECUTION_FAILED;
     }
-
     // In other cases we are responsible of cleaning whatever is possible.
     if (outputTensors == nullptr) {
         SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node {}; session: {}; has corrupted outputs handle", getName(), getSessionKey());
@@ -97,7 +96,6 @@ Status CustomNodeSession::execute(PipelineEventQueue& notifyEndQueue, Node& node
     }
 
     library.release(outputTensors);
-
     notifyEndQueue.push({node, getSessionKey()});
     return status;
 }
@@ -148,9 +146,10 @@ Status CustomNodeSession::createBlob(const struct CustomNodeTensor* tensor, Infe
 
     InferenceEngine::Precision precision = toInferenceEnginePrecision(tensor->precision);
     if (precision == InferenceEngine::Precision::UNSPECIFIED) {
-        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node {}; session: {}; Unspecified output precision from custom node",
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node {}; session: {}; Unspecified output precision from custom node tensor: {}",
             this->getName(),
-            this->getSessionKey());
+            this->getSessionKey(),
+            tensor->name);
         return StatusCode::NODE_LIBRARY_INVALID_PRECISION;
     }
     desc.setPrecision(precision);

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -76,10 +76,8 @@ Status EntryNode::fetchResults(BlobMap& outputs) {
             if (!status.ok()) {
                 return status;
             }
-
             outputs[output_name] = blob;
-
-            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}]: blob with name {} has been prepared", getName(), output_name);
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}]: blob with name: {} description: {} has been prepared", getName(), output_name, TensorInfo::tensorDescToString(blob->getTensorDesc()));
         }
     }
 
@@ -158,7 +156,6 @@ Status EntryNode::deserialize(const tensorflow::TensorProto& proto, InferenceEng
             getName(), status.string(), e.what());
         return status;
     }
-
     return StatusCode::OK;
 }
 }  // namespace ovms

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -72,11 +72,11 @@ void setFailIfNotFailEarlier(ovms::Status& earlierStatusCode, ovms::Status& newF
         }                                                                               \
     }
 
-#define CHECK_AND_LOG_ERROR(NODE)                                                                  \
-    if (!status.ok()) {                                                                            \
-        setFailIfNotFailEarlier(firstErrorStatus, status);                                         \
-        SPDLOG_LOGGER_WARN(dag_executor_logger, "Executing pipeline: {} node: {} failed with: {}", \
-            getName(), NODE.getName(), status.string());                                           \
+#define CHECK_AND_LOG_ERROR(NODE)                                                                                                          \
+    if (!status.ok()) {                                                                                                                    \
+        setFailIfNotFailEarlier(firstErrorStatus, status);                                                                                 \
+        SPDLOG_LOGGER_WARN(dag_executor_logger, "Executing pipeline: {} node: {} session: {} failed with ret code: {}, error message: {}", \
+            getName(), NODE.getName(), sessionKey, status.getCode(), status.string());                                                     \
     }
 
 Status Pipeline::execute() {

--- a/src/test/custom_nodes/node_perform_different_operations.cpp
+++ b/src/test/custom_nodes/node_perform_different_operations.cpp
@@ -68,11 +68,12 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     }
 
     // prepare outputs
-    *outputsLength = 1;
+    *outputsLength = 2;
     *outputs = (struct CustomNodeTensor*)malloc(*outputsLength * sizeof(CustomNodeTensor));
-    float* result = (float*)malloc(OPS_END * valuesPerTensor * sizeof(float));  // dummy input size * numbr of ops
+    float* result = (float*)malloc(OPS_END * valuesPerTensor * sizeof(float));  // dummy input size * number of ops
+    float* resultFactors = (float*)malloc(OPS_END * OPS_END * sizeof(float));   // dummy input size * number of ops
 
-    CustomNodeTensor& resultTensor = *outputs[*outputsLength - 1];
+    CustomNodeTensor& resultTensor = (*outputs)[0];
     resultTensor.name = "different_ops_results";
     resultTensor.data = reinterpret_cast<uint8_t*>(result);
     resultTensor.dimsLength = 3;
@@ -83,8 +84,21 @@ int execute(const struct CustomNodeTensor* inputs, int inputsLength, struct Cust
     resultTensor.dataLength = resultTensor.dims[0] * resultTensor.dims[1] * resultTensor.dims[2] * sizeof(float);
     resultTensor.precision = FP32;
 
+    CustomNodeTensor& resultFactorsTensor = (*outputs)[1];
+    resultFactorsTensor.name = "different_ops_factors_results";
+    resultFactorsTensor.data = reinterpret_cast<uint8_t*>(resultFactors);
+    resultFactorsTensor.dimsLength = 3;
+    resultFactorsTensor.dims = (uint64_t*)malloc(resultFactorsTensor.dimsLength * sizeof(uint64_t));
+    resultFactorsTensor.dims[0] = 1;
+    resultFactorsTensor.dims[1] = OPS_END;
+    resultFactorsTensor.dims[2] = OPS_END;
+    resultFactorsTensor.dataLength = resultFactorsTensor.dims[0] * resultFactorsTensor.dims[1] * resultFactorsTensor.dims[2] * sizeof(float);
+    resultFactorsTensor.precision = FP32;
     // perform operations
     for (size_t opId = 0; opId < OPS_END; ++opId) {
+        for (size_t factorsPos = 0; factorsPos < OPS_END; ++factorsPos) {
+            resultFactors[opId * OPS_END + factorsPos] = inputFactors[factorsPos];
+        }
         for (size_t dummyPos = 0; dummyPos < valuesPerTensor; ++dummyPos) {
             auto resultIndex = opId * valuesPerTensor + dummyPos;
             switch (opId) {
@@ -136,15 +150,23 @@ int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoLength, const str
 }
 
 int getOutputsInfo(struct CustomNodeTensorInfo** info, int* infoLength, const struct CustomNodeParam* params, int paramsLength) {
-    *infoLength = 1;
+    *infoLength = 2;
     *info = (struct CustomNodeTensorInfo*)malloc(*infoLength * sizeof(struct CustomNodeTensorInfo));
-    (*info)->name = "different_ops_results";
-    (*info)->dimsLength = 3;
-    (*info)->dims = (uint64_t*)malloc((*info)->dimsLength * sizeof(uint64_t));
-    (*info)->dims[0] = 1;
-    (*info)->dims[1] = 4;
-    (*info)->dims[2] = 10;
-    (*info)->precision = FP32;
+    (*info)[0].name = "different_ops_results";
+    (*info)[0].dimsLength = 3;
+    (*info)[0].dims = (uint64_t*)malloc((*info)[0].dimsLength * sizeof(uint64_t));
+    (*info)[0].dims[0] = 1;
+    (*info)[0].dims[1] = OPS_END;
+    (*info)[0].dims[2] = 10;
+    (*info)[0].precision = FP32;
+
+    (*info)[1].name = "factors_results";
+    (*info)[1].dimsLength = 3;
+    (*info)[1].dims = (uint64_t*)malloc((*info)[1].dimsLength * sizeof(uint64_t));
+    (*info)[1].dims[0] = 1;
+    (*info)[1].dims[1] = OPS_END;
+    (*info)[1].dims[2] = OPS_END;
+    (*info)[1].precision = FP32;
     return 0;
 }
 

--- a/src/test/nodesessionmetadata_test.cpp
+++ b/src/test/nodesessionmetadata_test.cpp
@@ -117,6 +117,9 @@ TEST_F(NodeSessionMetadataTest, CollapseSubsession1Level) {
     CollapseDetails collapsingDetails;
     std::tie(metaCollapsedOnExtract1st, collapsingDetails) = demultiplexedMetaLev3.getCollapsedSessionMetadata({"extract2nd"});
     auto hashCollapsed = metaCollapsedOnExtract1st.getSessionKey();
+    // need to ensure that generated collapsed session key before collapsing and after are the same
+    EXPECT_EQ(hashCollapsed, demultiplexedMetaLev3.getSessionKey({std::string("extract2nd")}));
+
     ASSERT_THAT(hashCollapsed, HasSubstr("request_2"));
     ASSERT_THAT(hashCollapsed, HasSubstr("extract1st_0"));
     ASSERT_THAT(hashCollapsed, Not(HasSubstr("extract2nd_2")));
@@ -355,5 +358,28 @@ TEST_F(NodeSessionMetadataTest, GetShardId4SubsessionLevelsCollapse3) {
     for (size_t i = 0; i < subsessionsLevel4.size(); ++i) {
         EXPECT_EQ(subsessionsLevel4[i].getShardId({subsessionName2, subsessionName3, subsessionName4}),
             i + subsessionSize4 * (subsessionLev3Index + subsessionSize3 * (subsessionLev2Index)));
+    }
+}
+
+TEST_F(NodeSessionMetadataTest, GetShardId4SubsessionLevelsCollapse1) {
+    NodeSessionMetadata metaStart;
+    uint subsessionSize1 = 13;
+    uint subsessionSize2 = 9;
+    uint subsessionSize3 = 7;
+    uint subsessionSize4 = 5;
+    const std::string subsessionName1 = "subsession1";
+    const std::string subsessionName2 = "subsession2";
+    const std::string subsessionName3 = "subsession3";
+    const std::string subsessionName4 = "subsession4";
+    const int subsessionLev1Index = 4;
+    const int subsessionLev2Index = 6;
+    const int subsessionLev3Index = 3;
+    auto subsessionsLevel1 = metaStart.generateSubsessions(subsessionName1, subsessionSize1);
+    auto subsessionsLevel2 = subsessionsLevel1[subsessionLev1Index].generateSubsessions(subsessionName2, subsessionSize2);
+    auto subsessionsLevel3 = subsessionsLevel2[subsessionLev2Index].generateSubsessions(subsessionName3, subsessionSize3);
+    auto subsessionsLevel4 = subsessionsLevel3[subsessionLev3Index].generateSubsessions(subsessionName4, subsessionSize4);
+    for (size_t i = 0; i < subsessionsLevel4.size(); ++i) {
+        EXPECT_EQ(subsessionsLevel4[i].getShardId({subsessionName4}),
+            i);
     }
 }


### PR DESCRIPTION
Add 2 complex tests for demultiplexer together with custom node.

Add 2 fixes:
* Fix issue when collapsing just one subsession levels
We got exception when we collapsed just one subsession level & there was
more than 2 levels of subsessions.
* Fix generating session key for collapsed session
Generating session key through uncollapsedMeta.getSessionKey(collapsedSesionNames) and
collapsedMetadata.getSessionKey() gave different key (differently
ordered substrings).

JIRA:CVS-46699