### PR TITLE
Changes for 2021.3 release

### DIFF
--- a/src/customloaderconfig.hpp
+++ b/src/customloaderconfig.hpp
@@ -133,7 +133,7 @@ public:
         try {
             this->setLoaderName(v["loader_name"].GetString());
             this->setLibraryPath(v["library_path"].GetString());
-            if (v.HasMember("config_path"))
+            if (v.HasMember("loader_config_file"))
                 this->setLoaderConfigFile(v["loader_config_file"].GetString());
         } catch (...) {
             SPDLOG_ERROR("There was an error parsing the custom loader config");

--- a/src/example/SampleCustomLoader/sampleCustLoader.cpp
+++ b/src/example/SampleCustomLoader/sampleCustLoader.cpp
@@ -275,7 +275,7 @@ void custSampleLoader::checkModelStatus() {
         }
 
         if (stateStr == "DISABLED") {
-            std::cout << "Balcklisting Model:: " << it.first.first << std::endl;
+            std::cout << "Blacklisting Model:: " << it.first.first << std::endl;
             models_blacklist_local.insert({it.first, true});
         }
     }

--- a/src/example/SampleCustomLoader/sampleCustLoader.cpp
+++ b/src/example/SampleCustomLoader/sampleCustLoader.cpp
@@ -59,6 +59,10 @@ using namespace ovms;
 
 // Time in seconds at which model status will be checked
 #define MODEL_CHECK_PERIOD 10
+
+// Custom Loader Config Keys
+#define ENABLE_FORCE_BLACKLIST_CHECK "ENABLE_FORCE_BLACKLIST_CHECK"
+
 typedef std::pair<std::string, int> model_id_t;
 
 /* 
@@ -97,6 +101,7 @@ protected:
     int watchIntervalSec = 0;
     bool watcherStarted = false;
     std::thread watcher_thread;
+    bool forceBlackListCheck = false;
 
 public:
     custSampleLoader();
@@ -136,7 +141,18 @@ custSampleLoader::~custSampleLoader() {
 }
 
 CustomLoaderStatus custSampleLoader::loaderInit(const std::string& loader_path) {
-    std::cout << "custSampleLoader: Custom loaderInit" << loader_path << std::endl;
+    if (!loader_path.empty()) {
+        std::cout << "Reading Sample Loader Config File:: " << loader_path << std::endl;
+        std::ifstream fileToRead(loader_path);
+        std::string stateStr;
+        if (fileToRead.is_open()) {
+            getline(fileToRead, stateStr);
+        }
+        if (stateStr.find(ENABLE_FORCE_BLACKLIST_CHECK) != std::string::npos) {
+            std::cout << "Force Blacklist Model Status Check Enabled" << std::endl;
+            forceBlackListCheck = true;
+        }
+    }
     return CustomLoaderStatus::OK;
 }
 
@@ -408,6 +424,10 @@ CustomLoaderStatus custSampleLoader::loaderDeInit() {
 
 CustomLoaderStatus custSampleLoader::getModelBlacklistStatus(const std::string& modelName, const int version) {
     std::cout << "custSampleLoader: Custom getModelBlacklistStatus" << std::endl;
+
+    if (forceBlackListCheck) {
+        checkModelStatus();
+    }
 
     model_id_t toFind = std::make_pair(modelName, version);
 

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -310,8 +310,10 @@ Status ModelInstance::loadOVCNNNetworkUsingCustomLoader() {
         std::string strModel(model.begin(), model.end());
 
         if (res == CustomLoaderStatus::MODEL_TYPE_IR) {
-            network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel,
-                make_shared_blob<uint8_t>({Precision::U8, {weights.size()}, C}, weights.data())));
+            Blob::Ptr blobWts = make_shared_blob<uint8_t>({Precision::U8, { weights.size() }, C });
+            blobWts->allocate();
+            std::memcpy(blobWts->buffer(), weights.data(), weights.size());
+            network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel,blobWts));
         } else if (res == CustomLoaderStatus::MODEL_TYPE_ONNX) {
             network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel, InferenceEngine::Blob::CPtr()));
         } else if (res == CustomLoaderStatus::MODEL_TYPE_BLOB) {
@@ -674,7 +676,6 @@ const Status ModelInstance::checkIfShapeValuesNegative(const tensorflow::TensorP
     }
     return StatusCode::OK;
 }
-
 const Status ModelInstance::validateNumberOfInputs(const tensorflow::serving::PredictRequest* request, const size_t expectedNumberOfInputs) {
     if (request->inputs_size() < 0 || expectedNumberOfInputs != static_cast<size_t>(request->inputs_size())) {
         std::stringstream ss;

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -310,10 +310,10 @@ Status ModelInstance::loadOVCNNNetworkUsingCustomLoader() {
         std::string strModel(model.begin(), model.end());
 
         if (res == CustomLoaderStatus::MODEL_TYPE_IR) {
-            Blob::Ptr blobWts = make_shared_blob<uint8_t>({Precision::U8, { weights.size() }, C });
+            Blob::Ptr blobWts = make_shared_blob<uint8_t>({Precision::U8, {weights.size()}, C});
             blobWts->allocate();
             std::memcpy(blobWts->buffer(), weights.data(), weights.size());
-            network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel,blobWts));
+            network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel, blobWts));
         } else if (res == CustomLoaderStatus::MODEL_TYPE_ONNX) {
             network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel, InferenceEngine::Blob::CPtr()));
         } else if (res == CustomLoaderStatus::MODEL_TYPE_BLOB) {

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -624,7 +624,7 @@ void ModelManager::getVersionsToChange(
                     SPDLOG_LOGGER_INFO(modelmanager_logger, "The model {} is blacklisted", versionInstance->getName());
                     requestedVersions.erase(std::remove(requestedVersions.begin(), requestedVersions.end(), version), requestedVersions.end());
                 } else {
-                  SPDLOG_LOGGER_DEBUG(modelmanager_logger, "The model {} is not blacklisted", versionInstance->getName());
+                    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "The model {} is not blacklisted", versionInstance->getName());
                 }
             }
         }

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -307,13 +307,13 @@ public:
     }
     void TearDown() {
         std::string configStr = empty_config;
-       // Create config file
-       std::string fileToReload = cl_models_path + "/cl_config.json";
-       createConfigFileWithContent(configStr, fileToReload);
-       ovms::ModelManager& manager = ovms::ModelManager::getInstance();
-       manager.startFromFile(fileToReload);
-       // Clean up temporary destination
-       std::filesystem::remove_all(cl_models_path);
+        // Create config file
+        std::string fileToReload = cl_models_path + "/cl_config.json";
+        createConfigFileWithContent(configStr, fileToReload);
+        ovms::ModelManager& manager = ovms::ModelManager::getInstance();
+        manager.startFromFile(fileToReload);
+        // Clean up temporary destination
+        std::filesystem::remove_all(cl_models_path);
     }
     /**
      * @brief This function should mimic most closely predict request to check for thread safety
@@ -337,7 +337,7 @@ public:
         auto blobOutput = inferRequest.GetBlob(DUMMY_MODEL_OUTPUT_NAME);
         ASSERT_EQ(blobOutput->byteSize(), outputSize * sizeof(float));
         std::memcpy(output.data(), blobOutput->cbuffer(), outputSize * sizeof(float));
-	EXPECT_THAT(output, Each(Eq(2.)));
+        EXPECT_THAT(output, Each(Eq(2.)));
     }
 
     ovms::Status performInferenceWithRequest(const tensorflow::serving::PredictRequest& request, tensorflow::serving::PredictResponse& response) {
@@ -1085,7 +1085,7 @@ TEST_F(TestCustomLoader, CustomLoaderMultipleLoaderWithSameLoaderName) {
 }
 
 TEST_F(TestCustomLoader, CustomLoaderBlackListingModel) {
-        // Copy dummy model to temporary destination
+    // Copy dummy model to temporary destination
     std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
     // Replace model path in the config string
     std::string configStr = custom_loader_config_model_blacklist;
@@ -1281,11 +1281,11 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     ASSERT_EQ(error_status, StatusCode::OK);
     EXPECT_EQ(json_output, expected_json_end);
 
-	// Remove status file
+    // Remove status file
     std::filesystem::remove(status_file);
-	//remove binary file
-	std::string bin_file = status_file_path + "/dummy.bin";
-	std::filesystem::remove(bin_file);
+    //remove binary file
+    std::string bin_file = status_file_path + "/dummy.bin";
+    std::filesystem::remove(bin_file);
 
     sleep(10);
     manager.startFromFile(fileToReload);
@@ -1308,7 +1308,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     EXPECT_EQ(json_output, expected_json_end);
 
     //try reload
-	sleep(10);
+    sleep(10);
     manager.startFromFile(fileToReload);
 
     ModelServiceImpl s3;

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -1089,7 +1089,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
-    
+
     tensorflow::serving::GetModelStatusRequest req;
     tensorflow::serving::GetModelStatusResponse res;
 

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -1089,8 +1089,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
-
-    //ModelServiceImpl s;
+    
     tensorflow::serving::GetModelStatusRequest req;
     tensorflow::serving::GetModelStatusResponse res;
 
@@ -1113,7 +1112,6 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     createConfigFileWithContent(status_str, status_file);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    //ModelServiceImpl s1;
     tensorflow::serving::GetModelStatusRequest req1;
     tensorflow::serving::GetModelStatusResponse res1;
 

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -1283,7 +1283,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
 
     // Remove status file
     std::filesystem::remove(status_file);
-    //remove binary file
+    // remove binary file
     std::string bin_file = status_file_path + "/dummy.bin";
     std::filesystem::remove(bin_file);
 
@@ -1307,7 +1307,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     ASSERT_EQ(error_status, StatusCode::OK);
     EXPECT_EQ(json_output, expected_json_end);
 
-    //try reload
+    // try reload
     sleep(10);
     manager.startFromFile(fileToReload);
 

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -55,6 +55,9 @@ using namespace ovms;
 
 namespace {
 
+// Custom Loader Config Keys
+#define ENABLE_FORCE_BLACKLIST_CHECK "ENABLE_FORCE_BLACKLIST_CHECK"
+
 // config_model_with_customloader
 const char* custom_loader_config_model = R"({
        "custom_loader_config_list":[
@@ -217,13 +220,8 @@ const char* custom_loader_config_model_blacklist = R"({
          {
           "config":{
             "loader_name":"sample-loader",
-            "library_path": "/ovms/bazel-bin/src/libsampleloader.so"
-          }
-         },
-         {
-          "config":{
-            "loader_name":"sample-loader",
-            "library_path": "/ovms/bazel-bin/src/libsampleloader.so"
+            "library_path": "/ovms/bazel-bin/src/libsampleloader.so",
+            "loader_config_file": "sample-loader-config"
           }
          }
        ],
@@ -272,22 +270,7 @@ const char* expected_json_end = R"({
 }
 )";
 
-class MockModel : public ovms::Model {
-public:
-    MockModel() :
-        Model("MOCK_NAME", false, nullptr) {}
-    MOCK_METHOD(ovms::Status, addVersion, (const ovms::ModelConfig&), (override));
-};
-
-std::shared_ptr<MockModel> modelMock;
 }  // namespace
-
-class MockModelManager : public ovms::ModelManager {
-public:
-    std::shared_ptr<ovms::Model> modelFactory(const std::string& name, const bool isStateful) override {
-        return modelMock;
-    }
-};
 
 class TestCustomLoader : public ::testing::Test {
 public:
@@ -306,15 +289,16 @@ public:
         std::filesystem::create_directories(cl_model_1_path);
     }
     void TearDown() {
+        // Create config file with an empty config & reload
         std::string configStr = empty_config;
-        // Create config file
         std::string fileToReload = cl_models_path + "/cl_config.json";
         createConfigFileWithContent(configStr, fileToReload);
-        ovms::ModelManager& manager = ovms::ModelManager::getInstance();
-        manager.startFromFile(fileToReload);
+        ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
+
         // Clean up temporary destination
         std::filesystem::remove_all(cl_models_path);
     }
+
     /**
      * @brief This function should mimic most closely predict request to check for thread safety
      */
@@ -354,7 +338,7 @@ public:
 
 public:
     ConstructorEnabledModelManager manager;
-    ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
+
     ~TestCustomLoader() {
         std::cout << "Destructor of TestCustomLoader()" << std::endl;
     }
@@ -363,13 +347,6 @@ public:
     std::string cl_model_1_path;
     std::string cl_model_2_path;
 };
-
-::grpc::Status test_PerformModelStatusRequestForCustomLoader(ModelServiceImpl& s, tensorflow::serving::GetModelStatusRequest& req, tensorflow::serving::GetModelStatusResponse& res) {
-    spdlog::info("reqx={} resx={}", req.DebugString(), res.DebugString());
-    ::grpc::Status ret = s.GetModelStatus(nullptr, &req, &res);
-    spdlog::info("returned grpc status: ok={} code={} msg='{}'", ret.ok(), ret.error_code(), ret.error_details());
-    return ret;
-}
 
 class MockModelInstance : public ovms::ModelInstance {
 public:
@@ -596,8 +573,8 @@ TEST_F(TestCustomLoader, CustomLoaderPrediction) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -605,19 +582,6 @@ TEST_F(TestCustomLoader, CustomLoaderPrediction) {
 }
 
 TEST_F(TestCustomLoader, CustomLoaderGetStatus) {
-    const char* expected_json_available = R"({
- "model_version_status": [
-  {
-   "version": "1",
-   "state": "AVAILABLE",
-   "status": {
-    "error_code": "OK",
-    "error_message": "OK"
-   }
-  }
- ]
-}
-)";
     // Copy dummy model to temporary destination
     std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
 
@@ -628,19 +592,16 @@ TEST_F(TestCustomLoader, CustomLoaderGetStatus) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ovms::ModelManager& manager = ovms::ModelManager::getInstance();
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s;
     tensorflow::serving::GetModelStatusRequest req;
     tensorflow::serving::GetModelStatusResponse res;
 
     auto model_spec = req.mutable_model_spec();
     model_spec->Clear();
     model_spec->set_name("dummy");
-
-    ::grpc::Status ret = test_PerformModelStatusRequestForCustomLoader(s, req, res);
+    model_spec->mutable_version()->set_value(1);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req, &res, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const = res;
     std::string json_output;
@@ -660,8 +621,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictDeletePredict) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -670,7 +631,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictDeletePredict) {
 
     // Re-create config file
     createConfigFileWithContent(custom_loader_config_model_deleted, fileToReload);
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
+
     ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::MODEL_VERSION_MISSING);
 }
 
@@ -685,8 +647,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewVersionPredict) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -695,8 +657,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewVersionPredict) {
     // Copy version 1 to version 2
     std::filesystem::create_directories(cl_model_1_path + "2");
     std::filesystem::copy(cl_model_1_path + "1", cl_model_1_path + "2", std::filesystem::copy_options::recursive);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -714,8 +676,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewModelPredict) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -731,8 +693,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewModelPredict) {
 
     // Re-create config file
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -751,8 +713,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictRemoveCustomLoaderOptionsPredict) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -764,7 +726,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictRemoveCustomLoaderOptionsPredict) {
 
     // Re-create config file
     createConfigFileWithContent(configStr, fileToReload);
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
+
     performPredict("dummy", 1, request);
 }
 
@@ -779,8 +742,8 @@ TEST_F(TestCustomLoader, PredictNormalModelAddCustomLoaderOptionsPredict) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -793,8 +756,8 @@ TEST_F(TestCustomLoader, PredictNormalModelAddCustomLoaderOptionsPredict) {
     // Create config file
     fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     performPredict("dummy", 1, request);
 }
 
@@ -809,8 +772,7 @@ TEST_F(TestCustomLoader, CustomLoaderOptionWithUnknownLibrary) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
-
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
@@ -827,8 +789,7 @@ TEST_F(TestCustomLoader, CustomLoaderWithMissingModelFiles) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
-
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
@@ -838,34 +799,6 @@ TEST_F(TestCustomLoader, CustomLoaderWithMissingModelFiles) {
 }
 
 TEST_F(TestCustomLoader, CustomLoaderGetStatusDeleteModelGetStatus) {
-    const char* expected_json_available = R"({
- "model_version_status": [
-  {
-   "version": "1",
-   "state": "AVAILABLE",
-   "status": {
-    "error_code": "OK",
-    "error_message": "OK"
-   }
-  }
- ]
-}
-)";
-
-    const char* expected_json_end = R"({
- "model_version_status": [
-  {
-   "version": "1",
-   "state": "END",
-   "status": {
-    "error_code": "OK",
-    "error_message": "OK"
-   }
-  }
- ]
-}
-)";
-
     // Copy dummy model to temporary destination
     std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
 
@@ -876,11 +809,8 @@ TEST_F(TestCustomLoader, CustomLoaderGetStatusDeleteModelGetStatus) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ovms::ModelManager& manager = ovms::ModelManager::getInstance();
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s;
     tensorflow::serving::GetModelStatusRequest req;
     tensorflow::serving::GetModelStatusResponse res;
 
@@ -888,8 +818,7 @@ TEST_F(TestCustomLoader, CustomLoaderGetStatusDeleteModelGetStatus) {
     model_spec->Clear();
     model_spec->set_name("dummy");
     model_spec->mutable_version()->set_value(1);
-
-    ::grpc::Status ret = test_PerformModelStatusRequestForCustomLoader(s, req, res);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req, &res, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const = res;
     std::string json_output;
@@ -899,9 +828,8 @@ TEST_F(TestCustomLoader, CustomLoaderGetStatusDeleteModelGetStatus) {
 
     // Re-create config file
     createConfigFileWithContent(custom_loader_config_model_deleted, fileToReload);
-    manager.startFromFile(fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ModelServiceImpl sx;
     tensorflow::serving::GetModelStatusRequest reqx;
     tensorflow::serving::GetModelStatusResponse resx;
 
@@ -910,7 +838,7 @@ TEST_F(TestCustomLoader, CustomLoaderGetStatusDeleteModelGetStatus) {
     model_specx->set_name("dummy");
     model_specx->mutable_version()->set_value(1);
 
-    ::grpc::Status retx = test_PerformModelStatusRequestForCustomLoader(sx, reqx, resx);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&reqx, &resx, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_constx = resx;
     json_output = "";
@@ -932,8 +860,8 @@ TEST_F(TestCustomLoader, CustomLoaderPredictionUsingManyCustomLoaders) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -1011,8 +939,7 @@ TEST_F(TestCustomLoader, CustomLoaderGetMetaData) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
-
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
     std::shared_ptr<ovms::ModelInstance> model;
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> unload_guard;
@@ -1076,8 +1003,8 @@ TEST_F(TestCustomLoader, CustomLoaderMultipleLoaderWithSameLoaderName) {
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ASSERT_EQ(manager.startFromFile(fileToReload), ovms::StatusCode::OK);
     tensorflow::serving::PredictRequest request = preparePredictRequest(
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
@@ -1087,18 +1014,23 @@ TEST_F(TestCustomLoader, CustomLoaderMultipleLoaderWithSameLoaderName) {
 TEST_F(TestCustomLoader, CustomLoaderBlackListingModel) {
     // Copy dummy model to temporary destination
     std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
+
+    // Create Sample Custom Loader Config
+    std::string cl_config_file_path = cl_models_path;
+    std::string cl_config_str = ENABLE_FORCE_BLACKLIST_CHECK;
+    std::string cl_config_file = cl_config_file_path + "/customloader_config";
+    createConfigFileWithContent(cl_config_str, cl_config_file);
+
     // Replace model path in the config string
     std::string configStr = custom_loader_config_model_blacklist;
     configStr.replace(configStr.find("/tmp/test_cl_models"), std::string("/tmp/test_cl_models").size(), cl_models_path);
+    configStr.replace(configStr.find("sample-loader-config"), std::string("sample-loader-config").size(), cl_config_file);
 
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ovms::ModelManager& manager = ovms::ModelManager::getInstance();
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s;
     tensorflow::serving::GetModelStatusRequest req;
     tensorflow::serving::GetModelStatusResponse res;
 
@@ -1106,10 +1038,9 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingModel) {
     model_spec->Clear();
     model_spec->set_name("dummy");
     model_spec->mutable_version()->set_value(1);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req, &res, manager), StatusCode::OK);
 
-    ::grpc::Status ret = test_PerformModelStatusRequestForCustomLoader(s, req, res);
-
-    const tensorflow::serving::GetModelStatusResponse response_const = res;
+    tensorflow::serving::GetModelStatusResponse response_const = res;
     std::string json_output;
     Status error_status = GetModelStatusImpl::serializeResponse2Json(&response_const, &json_output);
     ASSERT_EQ(error_status, StatusCode::OK);
@@ -1120,11 +1051,8 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingModel) {
     std::string status_str = "DISABLED";
     std::string status_file = status_file_path + "/dummy.status";
     createConfigFileWithContent(status_str, status_file);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    sleep(10);
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl sx;
     tensorflow::serving::GetModelStatusRequest reqx;
     tensorflow::serving::GetModelStatusResponse resx;
 
@@ -1133,7 +1061,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingModel) {
     model_specx->set_name("dummy");
     model_specx->mutable_version()->set_value(1);
 
-    ::grpc::Status retx = test_PerformModelStatusRequestForCustomLoader(sx, reqx, resx);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&reqx, &resx, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_constx = resx;
     json_output = "";
@@ -1145,18 +1073,24 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingModel) {
 TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     // Copy dummy model to temporary destination
     std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
+
+    // Create Sample Custom Loader Config
+    std::string cl_config_file_path = cl_models_path;
+    std::string cl_config_str = ENABLE_FORCE_BLACKLIST_CHECK;
+    std::string cl_config_file = cl_config_file_path + "/customloader_config";
+    createConfigFileWithContent(cl_config_str, cl_config_file);
+
     // Replace model path in the config string
     std::string configStr = custom_loader_config_model_blacklist;
     configStr.replace(configStr.find("/tmp/test_cl_models"), std::string("/tmp/test_cl_models").size(), cl_models_path);
+    configStr.replace(configStr.find("sample-loader-config"), std::string("sample-loader-config").size(), cl_config_file);
 
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ovms::ModelManager& manager = ovms::ModelManager::getInstance();
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s;
+    //ModelServiceImpl s;
     tensorflow::serving::GetModelStatusRequest req;
     tensorflow::serving::GetModelStatusResponse res;
 
@@ -1164,8 +1098,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     model_spec->Clear();
     model_spec->set_name("dummy");
     model_spec->mutable_version()->set_value(1);
-
-    ::grpc::Status ret = test_PerformModelStatusRequestForCustomLoader(s, req, res);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req, &res, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const = res;
     std::string json_output;
@@ -1174,16 +1107,13 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     EXPECT_EQ(json_output, expected_json_available);
 
     // copy status file
-
     std::string status_file_path = cl_model_1_path + "1";
     std::string status_str = "DISABLED";
     std::string status_file = status_file_path + "/dummy.status";
     createConfigFileWithContent(status_str, status_file);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    sleep(10);
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s1;
+    //ModelServiceImpl s1;
     tensorflow::serving::GetModelStatusRequest req1;
     tensorflow::serving::GetModelStatusResponse res1;
 
@@ -1191,8 +1121,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     model_spec1->Clear();
     model_spec1->set_name("dummy");
     model_spec1->mutable_version()->set_value(1);
-
-    ::grpc::Status ret1 = test_PerformModelStatusRequestForCustomLoader(s1, req1, res1);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req1, &res1, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const1 = res1;
     json_output = "";
@@ -1202,11 +1131,8 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
 
     // Remove status file
     std::filesystem::remove(status_file);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    sleep(10);
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s2;
     tensorflow::serving::GetModelStatusRequest req2;
     tensorflow::serving::GetModelStatusResponse res2;
 
@@ -1214,8 +1140,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
     model_spec2->Clear();
     model_spec2->set_name("dummy");
     model_spec2->mutable_version()->set_value(1);
-
-    ::grpc::Status ret2 = test_PerformModelStatusRequestForCustomLoader(s2, req2, res2);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req2, &res2, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const2 = res2;
     json_output = "";
@@ -1227,18 +1152,23 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListingRevoke) {
 TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     // Copy dummy model to temporary destination
     std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
+
+    // Create Sample Custom Loader Config
+    std::string cl_config_file_path = cl_models_path;
+    std::string cl_config_str = ENABLE_FORCE_BLACKLIST_CHECK;
+    std::string cl_config_file = cl_config_file_path + "/customloader_config";
+    createConfigFileWithContent(cl_config_str, cl_config_file);
+
     // Replace model path in the config string
     std::string configStr = custom_loader_config_model_blacklist;
     configStr.replace(configStr.find("/tmp/test_cl_models"), std::string("/tmp/test_cl_models").size(), cl_models_path);
+    configStr.replace(configStr.find("sample-loader-config"), std::string("sample-loader-config").size(), cl_config_file);
 
     // Create config file
     std::string fileToReload = cl_models_path + "/cl_config.json";
     createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ovms::ModelManager& manager = ovms::ModelManager::getInstance();
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s;
     tensorflow::serving::GetModelStatusRequest req;
     tensorflow::serving::GetModelStatusResponse res;
 
@@ -1246,8 +1176,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     model_spec->Clear();
     model_spec->set_name("dummy");
     model_spec->mutable_version()->set_value(1);
-
-    ::grpc::Status ret = test_PerformModelStatusRequestForCustomLoader(s, req, res);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req, &res, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const = res;
     std::string json_output;
@@ -1260,11 +1189,8 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     std::string status_str = "DISABLED";
     std::string status_file = status_file_path + "/dummy.status";
     createConfigFileWithContent(status_str, status_file);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    sleep(10);
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s1;
     tensorflow::serving::GetModelStatusRequest req1;
     tensorflow::serving::GetModelStatusResponse res1;
 
@@ -1272,8 +1198,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     model_spec1->Clear();
     model_spec1->set_name("dummy");
     model_spec1->mutable_version()->set_value(1);
-
-    ::grpc::Status ret1 = test_PerformModelStatusRequestForCustomLoader(s1, req1, res1);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req1, &res1, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const1 = res1;
     json_output = "";
@@ -1281,16 +1206,12 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     ASSERT_EQ(error_status, StatusCode::OK);
     EXPECT_EQ(json_output, expected_json_end);
 
-    // Remove status file
+    // Remove status file & the Dummy.bin file
     std::filesystem::remove(status_file);
-    // remove binary file
     std::string bin_file = status_file_path + "/dummy.bin";
     std::filesystem::remove(bin_file);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    sleep(10);
-    manager.startFromFile(fileToReload);
-
-    ModelServiceImpl s2;
     tensorflow::serving::GetModelStatusRequest req2;
     tensorflow::serving::GetModelStatusResponse res2;
 
@@ -1298,8 +1219,7 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     model_spec2->Clear();
     model_spec2->set_name("dummy");
     model_spec2->mutable_version()->set_value(1);
-
-    ::grpc::Status ret2 = test_PerformModelStatusRequestForCustomLoader(s2, req2, res2);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req2, &res2, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const2 = res2;
     json_output = "";
@@ -1307,11 +1227,10 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     ASSERT_EQ(error_status, StatusCode::OK);
     EXPECT_EQ(json_output, expected_json_end);
 
-    // try reload
-    sleep(10);
-    manager.startFromFile(fileToReload);
+    // Copy back the model files & try reload
+    std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    ModelServiceImpl s3;
     tensorflow::serving::GetModelStatusRequest req3;
     tensorflow::serving::GetModelStatusResponse res3;
 
@@ -1319,14 +1238,12 @@ TEST_F(TestCustomLoader, CustomLoaderBlackListModelReloadError) {
     model_spec3->Clear();
     model_spec3->set_name("dummy");
     model_spec3->mutable_version()->set_value(1);
-
-    ::grpc::Status ret3 = test_PerformModelStatusRequestForCustomLoader(s3, req3, res3);
+    ASSERT_EQ(GetModelStatusImpl::getModelStatus(&req3, &res3, manager), StatusCode::OK);
 
     const tensorflow::serving::GetModelStatusResponse response_const3 = res3;
     json_output = "";
     error_status = GetModelStatusImpl::serializeResponse2Json(&response_const3, &json_output);
     ASSERT_EQ(error_status, StatusCode::OK);
-    EXPECT_EQ(json_output, expected_json_end);
+    EXPECT_EQ(json_output, expected_json_available);
 }
-
 #pragma GCC diagnostic pop


### PR DESCRIPTION
1. 1. Fixed the issue with loading weights from buffer using ReadNetwork in customloader path

2. Added more tests to customloader
3. Fixed issue with blacklisting due to recent changes in OVMS for falling back to older version of model if new version fails to load