### PR TITLE
Remove DAG TODOs

### DIFF
--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -29,8 +29,9 @@
 namespace ovms {
 
 Status EntryNode::execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) {
-    // TODO this should be created in EntryNode::SetInputs, or special method for entry node called
-    // in event loop can be done at the end of part 3 or in future release
+    // this should be created in EntryNode::SetInputs, or special method for entry node called
+    // in event loop can be done in future release while implementing dynamic demultiplexing at 
+    // entry node
     NodeSessionMetadata metadata;
     NodeSession& nodeSession = getNodeSession(metadata);  // call to create session
     notifyEndQueue.push(NodeSessionKeyPair(*this, nodeSession.getSessionKey()));
@@ -38,7 +39,6 @@ Status EntryNode::execute(session_key_t sessionId, PipelineEventQueue& notifyEnd
 }
 
 Status EntryNode::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) {
-    // TODO handle multiple sessions later on
     BlobMap outputs;
     auto status = fetchResults(outputs);
     if (!status.ok()) {

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -30,11 +30,14 @@ namespace ovms {
 
 Status EntryNode::execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) {
     // this should be created in EntryNode::SetInputs, or special method for entry node called
-    // in event loop can be done in future release while implementing dynamic demultiplexing at 
+    // in event loop can be done in future release while implementing dynamic demultiplexing at
     // entry node
     NodeSessionMetadata metadata;
-    NodeSession& nodeSession = getNodeSession(metadata);  // call to create session
-    notifyEndQueue.push(NodeSessionKeyPair(*this, nodeSession.getSessionKey()));
+    auto nodeSession = getNodeSession(metadata);  // call to create session
+    if (!nodeSession) {
+        return StatusCode::INTERNAL_ERROR;
+    }
+    notifyEndQueue.push(NodeSessionKeyPair(*this, nodeSession->getSessionKey()));
     return StatusCode::OK;
 }
 

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -35,6 +35,7 @@ Status EntryNode::execute(session_key_t sessionId, PipelineEventQueue& notifyEnd
     NodeSessionMetadata metadata;
     auto nodeSession = getNodeSession(metadata);  // call to create session
     if (!nodeSession) {
+        notifyEndQueue.push(NodeSessionKeyPair(*this, nodeSession->getSessionKey()));
         return StatusCode::INTERNAL_ERROR;
     }
     notifyEndQueue.push(NodeSessionKeyPair(*this, nodeSession->getSessionKey()));

--- a/src/gathernodeinputhandler.cpp
+++ b/src/gathernodeinputhandler.cpp
@@ -53,8 +53,8 @@ Status GatherNodeInputHandler::setInput(const std::string& inputName, InferenceE
         }
         auto itDidEmplacePair = inputsShardsIt->second.emplace(shardId, ptr);
         if (!itDidEmplacePair.second) {
-            SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to put the same input shard twice");  // TODO  improve error msg
-            return StatusCode::UNKNOWN_ERROR;
+            SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to put the same input: {} shard: {} twice", inputName, shardId);
+            return StatusCode::INTERNAL_ERROR;
         }
     }
     return StatusCode::OK;

--- a/src/gathernodeinputhandler.cpp
+++ b/src/gathernodeinputhandler.cpp
@@ -40,7 +40,8 @@ Status GatherNodeInputHandler::setInput(const std::string& inputName, InferenceE
         shard_map_t shardMap{{shardId, ptr}};
         auto itDidInsertPair = shardsStorage.emplace(inputName, std::move(shardMap));
         if (!itDidInsertPair.second) {
-            throw std::runtime_error("Tried to insert the same input twice with the same shard id");
+            SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to insert the same input: {} twice with the same shardId: {}", inputName, shardId);
+            return StatusCode::INTERNAL_ERROR;
         }
     } else {
         auto firstShardTensor = inputsShardsIt->second.begin()->second;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -201,7 +201,7 @@ Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
     auto& [metadata, blobMap] = nodeSessionOutputs.begin()->second;
     auto& tensorDesc = blobMap.begin()->second->getTensorDesc();
     if (tensorDesc.getDims()[0] > DEMULTIPLY_LIMIT) {
-        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node: {} - too large dim[1] size: {} of blob: {}. Maximum allowed is: {}",
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node: {} - too large dim[0] size: {} of blob: {}. Maximum allowed is: {}",
             getName(), tensorDesc.getDims()[0], blobMap.begin()->first, DEMULTIPLY_LIMIT);
         return StatusCode::PIPELINE_TOO_LARGE_DIMENSION_SIZE_TO_DEMULTIPLY;
     }
@@ -225,7 +225,7 @@ Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
 
         if ((demultiplexCount.value() != 0) &&
             (newDims[0] != demultiplexCount.value())) {
-            SPDLOG_LOGGER_ERROR(dag_executor_logger, "Wrong dim[1] size: {} of blob: {} expected: {} to demultiply",
+            SPDLOG_LOGGER_ERROR(dag_executor_logger, "Wrong dim[0] size: {} of blob: {} expected: {} to demultiply",
                 newDims[0], blobName, demultiplexCount.value());
             return StatusCode::PIPELINE_WRONG_DIMENSION_SIZE_TO_DEMULTIPLY;
         }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -94,8 +94,17 @@ Status Node::setInputs(const Node& dependency, SessionResults& sessionResults) {
 Status Node::setInputs(const Node& dependency, BlobMap& inputs, NodeSessionMetadata& metadata) {
     // mapping for dependency - keeps mapping between dependency output name and this node input name
     const auto& mapping_for_dependency = this->getMappingByDependency(dependency);
-    NodeSession& nodeSession = getNodeSession(metadata);
-    const session_id_t shardId = metadata.getShardId(gatherFrom.value_or(std::set<std::string>()));
+    NodeSession* nodeSession = getNodeSession(metadata);
+    if (!nodeSession) {
+        return StatusCode::INTERNAL_ERROR;
+    }
+    session_id_t shardId;
+    try {
+        shardId = metadata.getShardId(gatherFrom.value_or(std::set<std::string>()));
+    } catch (const std::exception& e) {
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Failed to get shardId for node: {}", getName());
+        return StatusCode::INTERNAL_ERROR;
+    }
     // assign all input blobs from inputs that are required by this node for future inference
     for (const auto& pair : mapping_for_dependency) {
         const auto& dependency_output_name = pair.first;
@@ -115,13 +124,13 @@ Status Node::setInputs(const Node& dependency, BlobMap& inputs, NodeSessionMetad
             dependency.getName(),
             current_node_input_name,
             dependency_output_name);
-        auto status = nodeSession.setInput(current_node_input_name, it->second, shardId);
+        auto status = nodeSession->setInput(current_node_input_name, it->second, shardId);
         if (!status.ok()) {
             SPDLOG_LOGGER_ERROR(dag_executor_logger, "node: {} failed to set input: {}, shard: {}", getName(), current_node_input_name, shardId);
             return status;
         }
     }
-    return nodeSession.notifyFinishedDependency();
+    return nodeSession->notifyFinishedDependency();
 }
 
 NodeSession& Node::getNodeSession(const session_key_t& sessionKey) const {
@@ -130,32 +139,43 @@ NodeSession& Node::getNodeSession(const session_key_t& sessionKey) const {
         SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to get non-existing node: {} session: {}.", getName(), sessionKey);
         throw std::runtime_error("Tried to get non existing session");
     }
-    return *(*it).second;
+    return *it->second;
 }
 
-NodeSession& Node::getNodeSession(const NodeSessionMetadata& metadata) {
+NodeSession* Node::getNodeSession(const NodeSessionMetadata& metadata) {
     session_key_t sessionKey;
     if (gatherFrom) {
-        sessionKey = metadata.getSessionKey(gatherFrom.value());
+        try {
+            sessionKey = metadata.getSessionKey(gatherFrom.value());
+        } catch (const std::exception& e) {
+            SPDLOG_LOGGER_ERROR(dag_executor_logger, "Failed to create collapsed metadata session key for node: {}, incomming session key: {}",
+                getName(), metadata.getSessionKey());
+            return nullptr;
+        }
     } else {
         sessionKey = metadata.getSessionKey();
     }
     auto it = nodeSessions.find(sessionKey);
     if (it != nodeSessions.end()) {
-        return *(*it).second;
+        return it->second.get();
     }
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will create new session: {} for node: {}",
         sessionKey, getName());
     NodeSessionMetadata newSessionMetadata;
     CollapseDetails collapsingDetails;
     if (gatherFrom) {
-        std::tie(newSessionMetadata, collapsingDetails) = metadata.getCollapsedSessionMetadata(gatherFrom.value());
+        try {
+            std::tie(newSessionMetadata, collapsingDetails) = metadata.getCollapsedSessionMetadata(gatherFrom.value());
+        } catch (const std::exception& e) {
+            SPDLOG_LOGGER_ERROR(dag_executor_logger, "Failed to create collapsed metadata for node: {}", getName());
+            return nullptr;
+        }
     } else {
         newSessionMetadata = metadata;
     }
     std::unique_ptr<NodeSession> nodeSession = createNodeSession(newSessionMetadata, collapsingDetails);
     auto emplacePair = nodeSessions.emplace(sessionKey, std::move(nodeSession));
-    return *(emplacePair.first->second);
+    return emplacePair.first->second.get();
 }
 
 std::unique_ptr<NodeSession> Node::createNodeSession(const NodeSessionMetadata& metadata, const CollapseDetails& collapsingDetails) {
@@ -175,18 +195,25 @@ std::vector<session_key_t> Node::getReadySessions() const {
 
 Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
     if (!demultiplexCount) {
-        throw std::logic_error("Called demultiplyOutputs but node does not have demultiplexCount set");
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node: {} called demultiplyOutputs but node does not have demultiplexCount set", getName());
+        return StatusCode::INTERNAL_ERROR;
     }
     auto& [metadata, blobMap] = nodeSessionOutputs.begin()->second;
     auto& tensorDesc = blobMap.begin()->second->getTensorDesc();
     if (tensorDesc.getDims()[0] > DEMULTIPLY_LIMIT) {
-        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Too large dim[1] size: {} of blob: {}. Maximum allowed is: {}",
-            tensorDesc.getDims()[0], blobMap.begin()->first, DEMULTIPLY_LIMIT);
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node: {} - too large dim[1] size: {} of blob: {}. Maximum allowed is: {}",
+            getName(), tensorDesc.getDims()[0], blobMap.begin()->first, DEMULTIPLY_LIMIT);
         return StatusCode::PIPELINE_TOO_LARGE_DIMENSION_SIZE_TO_DEMULTIPLY;
     }
     uint32_t resultsDemultiplyCount = tensorDesc.getDims()[0];
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will demultiply node: {} outputs to: {} shards", getName(), resultsDemultiplyCount);
-    std::vector<NodeSessionMetadata> newSessionMetadatas(metadata.generateSubsessions(getName(), resultsDemultiplyCount));
+    std::vector<NodeSessionMetadata> newSessionMetadatas;
+    try {
+        newSessionMetadatas = std::move(metadata.generateSubsessions(getName(), resultsDemultiplyCount));
+    } catch (std::exception& e) {
+        SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node: {} failed to generate subsessions due to error: {}", getName(), e.what());
+        return StatusCode::INTERNAL_ERROR;
+    }
 
     for (auto& [blobName, blob] : blobMap) {
         auto tensorDesc = blob->getTensorDesc();

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -128,13 +128,12 @@ NodeSession& Node::getNodeSession(const session_key_t& sessionKey) const {
     auto it = nodeSessions.find(sessionKey);
     if (it == nodeSessions.end()) {
         SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to get non-existing node: {} session: {}.", getName(), sessionKey);
-        throw std::logic_error("Tried to get non existing session");  // TODO some other kind of error
+        throw std::runtime_error("Tried to get non existing session");
     }
     return *(*it).second;
 }
 
 NodeSession& Node::getNodeSession(const NodeSessionMetadata& metadata) {
-    // TODO check for exit node if no session levels remains
     session_key_t sessionKey;
     if (gatherFrom) {
         sessionKey = metadata.getSessionKey(gatherFrom.value());
@@ -204,8 +203,7 @@ Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
             return StatusCode::PIPELINE_WRONG_DIMENSION_SIZE_TO_DEMULTIPLY;
         }
         if (resultsDemultiplyCount == 0) {
-            // TODO handle dynamic demultiply_count == 0
-            SPDLOG_DEBUG("Node: {} has no results. Dynamic demultiplexer with demultiply == 0 is not supported yet.", this->getName());
+            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} has no results. Dynamic demultiplexer with demultiply == 0 is not supported yet.", this->getName());
             nodeSessionOutputs.erase(metadata.getSessionKey());
             return StatusCode::PIPELINE_DEMULTIPLEXER_NO_RESULTS;
         }

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -91,7 +91,7 @@ public:
     static void printNodeConnections(const std::string& nodeName, const std::string& sourceNode, const Aliases& pairs);
 
 protected:
-    NodeSession& getNodeSession(const NodeSessionMetadata& metadata);
+    NodeSession* getNodeSession(const NodeSessionMetadata& metadata);
     NodeSession& getNodeSession(const session_key_t& sessionKey) const;
     virtual std::unique_ptr<NodeSession> createNodeSession(const NodeSessionMetadata& metadata, const CollapseDetails& collapsingDetails);
 };

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -86,7 +86,7 @@ Status Pipeline::execute() {
     std::set<std::string> startedSessions;
     std::set<std::string> finishedSessions;
     NodeSessionMetadata meta;
-    // TODO -> entry node does not have setInputsCalled so it has no
+    // entry node does not have setInputsCalled so it has no
     // session created. Here is just assumption that this meta has the same key
     // that the one in EntryNode::execute();
     auto entrySessionKey = meta.getSessionKey();

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -708,7 +708,7 @@ public:
 
         if (dependantNodeInfo.kind == NodeKind::CUSTOM) {
             if (!dependantNodeInfo.library.isValid()) {
-                // TODO check if there is log
+                SPDLOG_LOGGER_ERROR(modelmanager_logger, "Pipeline: {} node: {} refers to incorrect library", pipelineName, dependantNodeInfo.nodeName);
                 return StatusCode::PIPELINE_DEFINITION_INVALID_NODE_LIBRARY;
             }
 
@@ -1136,7 +1136,7 @@ Status PipelineDefinition::getOutputsInfo(tensor_map_t& outputsInfo, const Model
 Status PipelineDefinition::getCustomNodeMetadata(const NodeInfo& customNodeInfo, tensor_map_t& inputsInfo, metadata_fn callback, const std::string& pipelineName) {
     struct CustomNodeTensorInfo* info = nullptr;
     int infoCount = 0;
-    auto paramArray = createCustomNodeParamArray(customNodeInfo.parameters);  // TODO: not create it in every call? prepare it once?
+    auto paramArray = createCustomNodeParamArray(customNodeInfo.parameters);
     int paramArrayLength = customNodeInfo.parameters.size();
     int result = callback(&info, &infoCount, paramArray.get(), paramArrayLength);
     if (result != 0) {

--- a/src/test/custom_nodes/node_add_sub.c
+++ b/src/test/custom_nodes/node_add_sub.c
@@ -77,7 +77,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     return 0;
 }
 
-// TODO: Some unit tests are based on a fact that this node library is dynamic and can take shape{1,3} as input.
+// Some unit tests are based on a fact that this node library is dynamic and can take shape{1,3} as input.
 // This needs to be addressed before release.
 int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const struct CustomNodeParam* params, int paramsCount) {
     *infoCount = 1;

--- a/src/test/custom_nodes/node_add_sub.c
+++ b/src/test/custom_nodes/node_add_sub.c
@@ -78,7 +78,6 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
 }
 
 // Some unit tests are based on a fact that this node library is dynamic and can take shape{1,3} as input.
-// This needs to be addressed before release.
 int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const struct CustomNodeParam* params, int paramsCount) {
     *infoCount = 1;
     *info = (struct CustomNodeTensorInfo*) malloc (*infoCount * sizeof(struct CustomNodeTensorInfo));
@@ -86,7 +85,7 @@ int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const stru
     (*info)->dimsCount = 2;
     (*info)->dims = (uint64_t*) malloc((*info)->dimsCount * sizeof(uint64_t));
     (*info)->dims[0] = 1;
-    (*info)->dims[1] = 50;
+    (*info)->dims[1] = 0;
     (*info)->precision = FP32;
     return 0;
 }
@@ -98,7 +97,7 @@ int getOutputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const str
     (*info)->dimsCount = 2;
     (*info)->dims = (uint64_t*) malloc((*info)->dimsCount * sizeof(uint64_t));
     (*info)->dims[0] = 1;
-    (*info)->dims[1] = 50;
+    (*info)->dims[1] = 0;
     (*info)->precision = FP32;
     return 0;
 }

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -1154,12 +1154,9 @@ TEST_F(StressPipelineCustomNodesConfigChanges, ChangeCustomLibraryParamDuringPre
 TEST_F(StressPipelineCustomNodesConfigChanges, RemoveCustomLibraryDuringGetMetadataLoad) {
     SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
     bool performWholeConfigReload = true;
-    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};                                 // we expect full continuouity of operation
-    std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};  // we may hit during pipeline reload
-    // TODO replace above with the one below when removing libraries will be fully implemented.
-    // std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
-    //    StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate
-    // std::set<StatusCode> allowedLoadResults = {};
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
+                                                StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate
+    std::set<StatusCode> allowedLoadResults = {};
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
         &StressPipelineConfigChanges::removeCustomLibraryUsed,

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -1155,7 +1155,7 @@ TEST_F(StressPipelineCustomNodesConfigChanges, RemoveCustomLibraryDuringGetMetad
     SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
     bool performWholeConfigReload = true;
     std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
-                                                StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate
     std::set<StatusCode> allowedLoadResults = {};
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,

--- a/src/test/ensemble_metadata_test.cpp
+++ b/src/test/ensemble_metadata_test.cpp
@@ -389,11 +389,11 @@ TEST(EnsembleMetadata, OneCustomNode) {
     ASSERT_NE(outputs.find("request_output_name"), outputs.end());
 
     const auto& input = inputs.at("request_input_name");
-    EXPECT_EQ(input->getShape(), shape_t({1, 50}));
+    EXPECT_EQ(input->getShape(), shape_t({1, 0}));
     EXPECT_EQ(input->getPrecision(), InferenceEngine::Precision::FP32);
 
     const auto& output = outputs.at("request_output_name");
-    EXPECT_EQ(output->getShape(), shape_t({1, 50}));
+    EXPECT_EQ(output->getShape(), shape_t({1, 0}));
     EXPECT_EQ(output->getPrecision(), InferenceEngine::Precision::FP32);
 }
 
@@ -446,12 +446,12 @@ TEST(EnsembleMetadata, ParallelCustomNodes) {
     ASSERT_NE(outputs.find("request_output_name_2"), outputs.end());
 
     const auto& input = inputs.at("request_input_name");
-    EXPECT_EQ(input->getShape(), shape_t({1, 50}));
+    EXPECT_EQ(input->getShape(), shape_t({1, 0}));
     EXPECT_EQ(input->getPrecision(), InferenceEngine::Precision::FP32);
 
     for (int i = 0; i < 3; i++) {
         const auto& output = outputs.at("request_output_name_" + std::to_string(i));
-        EXPECT_EQ(output->getShape(), shape_t({1, 50}));
+        EXPECT_EQ(output->getShape(), shape_t({1, 0}));
         EXPECT_EQ(output->getPrecision(), InferenceEngine::Precision::FP32);
     }
 }


### PR DESCRIPTION
Remove DAG TODOs
    TODOs were either:
    -> fixed
    -> have separate ticket to handle
    -> are not relevant anymore

Add catching exceptions for several DAG paths
    Those throws should not occur during runtime assuming configuration
    validation is done properly. Catching those exceptions on lower level than 
    grpc should lower the risk of hang during disarming node stream id
    guards in wrong order. This is additional level of safety.
    
JIRA:CVS-50645