### PR TITLE
CVS-51046/CVS-51057 Fix issue with ignoring config.json file modifications

### DIFF
--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -27,6 +27,7 @@
 
 #include <rapidjson/document.h>
 #include <spdlog/spdlog.h>
+#include <sys/stat.h>
 
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
 
@@ -139,7 +140,7 @@ private:
     /**
      * @brief Time of last config change
      */
-    int64_t lastConfigChangeTime;
+    timespec lastConfigChangeTime;
 
 public:
     /**


### PR DESCRIPTION
- keep config.json modification time nanoseconds together with seconds - this fixes issue where multiple modifications during one second timestamp were not recognized by OVMS
- save last config change time before model/pipeline/loader/node libraries loading - it was saved after loading previously which caused OVMS to not register config.json modifications made during model reloads