### PR TITLE
CVS-50536 Workaround for reshape errors for models with PriorBoxClustered layers

### DIFF
--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -298,6 +298,16 @@ private:
          */
     Status recoverFromReloadingError(const Status& status);
 
+    /**
+         * @brief Perform full engine/network reload with dynamic parameter
+         * 
+         * @param status returned from reload operation
+         * @param parameter requested dynamic parameter
+         * 
+         * @return Status
+         */
+    Status reshapeWithFullReload(const Status& status, const DynamicModelParameter& parameter);
+
 public:
     /**
          * @brief A default constructor

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -213,6 +213,7 @@ const std::map<const StatusCode, grpc::StatusCode> Status::grpcStatusMap = {
     {StatusCode::MODEL_SPEC_MISSING, grpc::StatusCode::INVALID_ARGUMENT},
     {StatusCode::INVALID_SIGNATURE_DEF, grpc::StatusCode::INVALID_ARGUMENT},
     {StatusCode::PIPELINE_DEMULTIPLEXER_NO_RESULTS, grpc::StatusCode::ABORTED},
+    {StatusCode::CANNOT_LOAD_NETWORK_INTO_TARGET_DEVICE, grpc::StatusCode::FAILED_PRECONDITION},
 
     // Sequence management
     {StatusCode::SEQUENCE_MISSING, grpc::StatusCode::NOT_FOUND},
@@ -302,6 +303,7 @@ const std::map<const StatusCode, net_http::HTTPStatusCode> Status::httpStatusMap
     {StatusCode::MODEL_SPEC_MISSING, net_http::HTTPStatusCode::BAD_REQUEST},
     {StatusCode::INVALID_SIGNATURE_DEF, net_http::HTTPStatusCode::BAD_REQUEST},
     {StatusCode::PIPELINE_DEMULTIPLEXER_NO_RESULTS, net_http::HTTPStatusCode::NO_CONTENT},
+    {StatusCode::CANNOT_LOAD_NETWORK_INTO_TARGET_DEVICE, net_http::HTTPStatusCode::PRECOND_FAILED},
 
     // Sequence management
     {StatusCode::SEQUENCE_MISSING, net_http::HTTPStatusCode::NOT_FOUND},

--- a/tests/functional/test_reshaping.py
+++ b/tests/functional/test_reshaping.py
@@ -37,7 +37,6 @@ fixed_shape = {'in': (1, 3, 600, 600), 'out': (1, 1, 200, 7)}
 
 
 class TestModelReshaping:
-    @pytest.mark.skip(reason="temporarily skipped")
     def test_single_local_model_reshaping_auto(self, start_server_face_detection_model_auto_shape):
 
         _, ports = start_server_face_detection_model_auto_shape
@@ -50,7 +49,6 @@ class TestModelReshaping:
             self.run_inference_grpc(imgs, FaceDetection.output_name, shape['out'],
                                     True, FaceDetection.name, stub)
 
-    @pytest.mark.skip(reason="temporarily skipped")
     @pytest.mark.parametrize("shape, is_correct",
                              [(fixed_shape['in'], True), (FaceDetection.input_shape,
                                                           False)])
@@ -68,7 +66,6 @@ class TestModelReshaping:
             self.run_inference_grpc(imgs, FaceDetection.output_name, fixed_shape['out'],
                                     is_correct, FaceDetection.name, stub)
 
-    @pytest.mark.skip(reason="temporarily skipped")
     @pytest.mark.parametrize("request_format",
                              ['row_name', 'row_noname',
                               'column_name', 'column_noname'])
@@ -82,7 +79,6 @@ class TestModelReshaping:
             self.run_inference_rest(imgs, FaceDetection.output_name, shape['out'], True,
                                     request_format, rest_url)
 
-    @pytest.mark.skip(reason="temporarily skipped")
     @pytest.mark.parametrize("shape, is_correct",
                              [(fixed_shape['in'], True), (FaceDetection.input_shape,
                                                           False)])
@@ -103,7 +99,6 @@ class TestModelReshaping:
             self.run_inference_rest(imgs, FaceDetection.output_name, fixed_shape['out'],
                                     is_correct, request_format, rest_url)
 
-    @pytest.mark.skip(reason="temporarily skipped")
     def test_multi_local_model_reshaping_auto(self, start_server_multi_model):
 
         _, ports = start_server_multi_model
@@ -116,7 +111,6 @@ class TestModelReshaping:
             self.run_inference_grpc(imgs, FaceDetection.output_name, shape['out'], True,
                                     "face_detection_auto", stub)
 
-    @pytest.mark.skip(reason="temporarily skipped")
     @pytest.mark.parametrize("shape, is_correct",
                              [(fixed_shape['in'], True), (FaceDetection.input_shape,
                                                           False)])
@@ -135,7 +129,6 @@ class TestModelReshaping:
             self.run_inference_grpc(imgs, FaceDetection.output_name, fixed_shape['out'],
                                     is_correct, model_name, stub)
 
-    @pytest.mark.skip(reason="temporarily skipped")
     @pytest.mark.parametrize("request_format",
                              ['row_name', 'row_noname',
                               'column_name', 'column_noname'])
@@ -149,7 +142,6 @@ class TestModelReshaping:
             self.run_inference_rest(imgs, FaceDetection.output_name, shape['out'], True,
                                     request_format, rest_url)
 
-    @pytest.mark.skip(reason="temporarily skipped")
     @pytest.mark.parametrize("shape, is_correct",
                              [(fixed_shape['in'], True), (FaceDetection.input_shape,
                                                           False)])
@@ -169,7 +161,6 @@ class TestModelReshaping:
                                     is_correct, request_format, rest_url)
 
     @staticmethod
-    @pytest.mark.skip(reason="temporarily skipped")
     def run_inference_rest(imgs, out_name, out_shape, is_correct,
                            request_format, rest_url):
         if is_correct:
@@ -188,7 +179,6 @@ class TestModelReshaping:
             assert not output
 
     @staticmethod
-    @pytest.mark.skip(reason="temporarily skipped")
     def run_inference_grpc(imgs, out_name, out_shape, is_correct, model_name, stub):
         if is_correct:
             output = infer(imgs, input_tensor=FaceDetection.input_name, grpc_stub=stub,


### PR DESCRIPTION
For models with shape=auto when reshape via request failed, we recovered model to original state with complete reload (core+execNetwork). Now, before recovery, we try to perform complete reload with requested shape which in some cases may succeed. If this action also fails, we recover to original state.