### PR TITLE
CVS-50622 Adjust east box extraction node

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -257,6 +257,11 @@ cc_binary(
             "@opencv//:opencv"
     ],
     linkshared = 1,
+    copts = [
+        "-Wall",
+        "-Wno-unknown-pragmas",
+        "-Werror"
+    ]
 )
 
 cc_binary(

--- a/src/custom_nodes/east_ocr/Dockerfile
+++ b/src/custom_nodes/east_ocr/Dockerfile
@@ -25,8 +25,5 @@ COPY . /custom_nodes/${NODE_NAME}/
 COPY custom_node_interface.h /
 WORKDIR /custom_nodes/${NODE_NAME}/
 RUN mkdir -p /custom_nodes/lib
-RUN /opt/rh/devtoolset-8/root/bin/g++  -c -std=c++17 ${NODE_NAME}.cpp -fpic  -I/opencv/include/
+RUN /opt/rh/devtoolset-8/root/bin/g++ -c -std=c++17 ${NODE_NAME}.cpp -fpic  -I/opencv/include/ -Wall -Wno-unknown-pragmas -Werror -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv -fstack-protector
 RUN /opt/rh/devtoolset-8/root/bin/g++ -shared -o /custom_nodes/lib/libcustom_node_${NODE_NAME}.so ${NODE_NAME}.o -L/opencv/lib/ -I/opencv/include/ -lopencv_core -lopencv_imgproc -lopencv_imgcodecs
-
-
-

--- a/src/custom_nodes/east_ocr/east_ocr.cpp
+++ b/src/custom_nodes/east_ocr/east_ocr.cpp
@@ -142,6 +142,8 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     int maxOutputBatch = get_int_parameter("max_output_batch", params, paramsCount, 100);
     NODE_ASSERT(maxOutputBatch > 0, "max output batch must be larger than 0");
     bool debugMode = get_string_parameter("debug", params, paramsCount) == "true";
+    float xCornerAdjustment = get_float_parameter("x_corner_adjustment", params, paramsCount, 0.12);
+    float yCornerAdjustment = get_float_parameter("y_corner_adjustment", params, paramsCount, 0.3);
 
     const CustomNodeTensor* imageTensor = nullptr;
     const CustomNodeTensor* scoresTensor = nullptr;
@@ -252,7 +254,10 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
                 std::cout << ss.str() << std::endl;
             }
 
-            rects.emplace_back(x1, y1, x2 - x1 - 1, y2 - y1 - 1);
+            x1 = std::max(0, (int)(x1 - (x2-x1) * xCornerAdjustment));
+            y1 = std::max(0, (int)(y1 - (y2-y1) * yCornerAdjustment));
+
+            rects.emplace_back(x1, y1, x2 - x1, y2 - y1);
             scores.emplace_back(score);
         }
     }

--- a/src/custom_nodes/east_ocr/east_ocr.cpp
+++ b/src/custom_nodes/east_ocr/east_ocr.cpp
@@ -139,7 +139,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     NODE_ASSERT(confidenceThreshold >= 0 && confidenceThreshold <= 1.0, "confidence threshold must be in 0-1 range");
     float overlapThreshold = get_float_parameter("overlap_threshold", params, paramsCount, 0.3);
     NODE_ASSERT(overlapThreshold >= 0 && overlapThreshold <= 1.0, "non max suppression filtering overlap threshold must be in 0-1 range");
-    int maxOutputBatch = get_int_parameter("max_output_batch", params, paramsCount, 100);
+    uint64_t maxOutputBatch = get_int_parameter("max_output_batch", params, paramsCount, 100);
     NODE_ASSERT(maxOutputBatch > 0, "max output batch must be larger than 0");
     bool debugMode = get_string_parameter("debug", params, paramsCount) == "true";
     float xCornerAdjustment = get_float_parameter("x_corner_adjustment", params, paramsCount, 0.12);

--- a/src/custom_nodes/east_ocr/utils.hpp
+++ b/src/custom_nodes/east_ocr/utils.hpp
@@ -71,10 +71,14 @@ const cv::Mat nchw_to_mat(const CustomNodeTensor* input) {
     return image;
 }
 
-cv::Mat crop_and_resize(cv::Mat originalImage, cv::Rect roi, cv::Size targetShape) {
-    cv::Mat resized;
-    cv::resize(originalImage(roi), resized, targetShape);
-    return resized;
+bool crop_and_resize(cv::Mat originalImage, cv::Mat& targetImage, cv::Rect roi, cv::Size targetShape) {
+    try {
+        cv::resize(originalImage(roi), targetImage, targetShape);
+    } catch (const cv::Exception& e) {
+        std::cout << e.what() << std::endl;
+        return false;
+    }
+    return true;
 }
 
 cv::Mat apply_grayscale(cv::Mat image) {


### PR DESCRIPTION
- workaround: improve accuracy by adding configurable box offset parameter
- get rid of compilation warnings
- add restrictive compilation flags
- catch opencv exception in case when EAST model output is broken and provides ROI out of original image
- deallocate outputs memory in case of errors