### PR TITLE
CVS-53268  Fix python snippet in ovms_wrapper

### DIFF
--- a/extras/nginx-mtls-auth/ovms_wrapper
+++ b/extras/nginx-mtls-auth/ovms_wrapper
@@ -104,7 +104,7 @@ echo "Requested ports: GRPC: $GRPC_ORIGINAL_PORT ; REST: $REST_ORIGINAL_PORT "
 SELECTED_PORTS=$(python -c '
 import sys
 import random
-not_allowed = [int(x) for x in sys.argv[1:] ]
+not_allowed = [int(x) if x else 0 for x in sys.argv[1:] ]
 first_port = random.choice([x for x in range(7000, 7999) if x not in not_allowed])
 not_allowed.append(first_port)
 second_port = random.choice([x for x in range(7000, 7999) if x not in not_allowed])


### PR DESCRIPTION
CVS-53268 Fix python snippet in ovms_wrapper.

python snippet tried to parse empty string '' passed as argument in sys.argv, it caused exception in int().
