### PR TITLE
Save DAG metadata during validation

### DIFF
--- a/src/get_model_metadata_impl.cpp
+++ b/src/get_model_metadata_impl.cpp
@@ -145,15 +145,8 @@ Status GetModelMetadataImpl::buildResponse(
         return status;
     }
 
-    tensor_map_t inputs, outputs;
-    status = pipelineDefinition.getInputsInfo(inputs, manager);
-    if (!status.ok()) {
-        return status;
-    }
-    status = pipelineDefinition.getOutputsInfo(outputs, manager);
-    if (!status.ok()) {
-        return status;
-    }
+    const tensor_map_t& inputs = pipelineDefinition.getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition.getOutputsInfo();
 
     response->Clear();
     response->mutable_model_spec()->set_name(pipelineDefinition.getName());

--- a/src/ov_utils.cpp
+++ b/src/ov_utils.cpp
@@ -89,4 +89,21 @@ std::string getNetworkInputsInfoString(const InferenceEngine::InputsDataMap& inp
     }
     return stringStream.str();
 }
+
+std::string getTensorMapString(const std::map<std::string, std::shared_ptr<TensorInfo>>& inputsInfo) {
+    std::stringstream stringStream;
+    for (const auto& pair : inputsInfo) {
+        const auto& name = pair.first;
+        auto inputInfo = pair.second;
+        auto precision = inputInfo->getPrecision();
+        auto layout = inputInfo->getLayout();
+        auto shape = inputInfo->getShape();
+
+        stringStream << "\nname: " << name
+                     << "; shape: " << TensorInfo::shapeToString(shape)
+                     << "; precision: " << TensorInfo::getPrecisionAsString(precision)
+                     << "; layout: " << TensorInfo::getStringFromLayout(layout);
+    }
+    return stringStream.str();
+}
 }  // namespace ovms

--- a/src/ov_utils.hpp
+++ b/src/ov_utils.hpp
@@ -26,9 +26,12 @@
 
 namespace ovms {
 
+class TensorInfo;
+
 Status createSharedBlob(InferenceEngine::Blob::Ptr& destinationBlob, InferenceEngine::TensorDesc tensorDesc);
 
 std::string getNetworkInputsInfoString(const InferenceEngine::InputsDataMap& inputsInfo, const ModelConfig& config);
+std::string getTensorMapString(const std::map<std::string, std::shared_ptr<TensorInfo>>& tensorMap);
 
 template <typename T>
 Status blobClone(InferenceEngine::Blob::Ptr& destinationBlob, const T sourceBlob) {

--- a/src/ov_utils.hpp
+++ b/src/ov_utils.hpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -69,9 +69,19 @@ Status PipelineDefinition::validate(ModelManager& manager) {
         return validationResult;
     }
 
-    notifier.passed = true;
     SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Finished validation of pipeline: {}", getName());
-    return validationResult;
+    validationResult = getInputsInfo(inputsInfo, manager);
+    if (!validationResult.ok()) {
+        return validationResult;
+    }
+    validationResult = getOutputsInfo(outputsInfo, manager);
+    if (!validationResult.ok()) {
+        return validationResult;
+    }
+    notifier.passed = true;
+    SPDLOG_LOGGER_INFO(modelmanager_logger, "Pipeline: {} inputs: {}", getName(), getTensorMapString(inputsInfo));
+    SPDLOG_LOGGER_INFO(modelmanager_logger, "Pipeline: {} outputs: {}", getName(), getTensorMapString(outputsInfo));
+    return std::move(validationResult);
 }
 
 Status PipelineDefinition::reload(ModelManager& manager, const std::vector<NodeInfo>&& nodeInfos, const pipeline_connections_t&& connections) {
@@ -970,6 +980,14 @@ Status PipelineDefinition::validateNodes(ModelManager& manager) {
         }
     }
     return StatusCode::OK;
+}
+
+const tensor_map_t& PipelineDefinition::getInputsInfo() const {
+    return inputsInfo;
+}
+
+const tensor_map_t& PipelineDefinition::getOutputsInfo() const {
+    return outputsInfo;
 }
 
 Status PipelineDefinition::getInputsInfo(tensor_map_t& inputsInfo, const ModelManager& manager) const {

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -69,7 +69,6 @@ Status PipelineDefinition::validate(ModelManager& manager) {
         return validationResult;
     }
 
-    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Finished validation of pipeline: {}", getName());
     validationResult = getInputsInfo(inputsInfo, manager);
     if (!validationResult.ok()) {
         return validationResult;
@@ -79,6 +78,7 @@ Status PipelineDefinition::validate(ModelManager& manager) {
         return validationResult;
     }
     notifier.passed = true;
+    SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Finished validation of pipeline: {}", getName());
     SPDLOG_LOGGER_INFO(modelmanager_logger, "Pipeline: {} inputs: {}", getName(), getTensorMapString(inputsInfo));
     SPDLOG_LOGGER_INFO(modelmanager_logger, "Pipeline: {} outputs: {}", getName(), getTensorMapString(outputsInfo));
     return std::move(validationResult);

--- a/src/pipelinedefinition.hpp
+++ b/src/pipelinedefinition.hpp
@@ -79,6 +79,7 @@ protected:
     tensor_map_t outputsInfo;
 
 private:
+    mutable std::shared_mutex metadataMtx;
     std::atomic<uint64_t> requestsHandlesCounter = 0;
     std::shared_mutex loadMtx;
 
@@ -139,12 +140,12 @@ public:
     void resetSubscriptions(ModelManager& manager);
 
 protected:
-    virtual Status getInputsInfo(tensor_map_t& inputsInfo, const ModelManager& manager) const;
-    virtual Status getOutputsInfo(tensor_map_t& outputsInfo, const ModelManager& manager) const;
+    virtual Status updateInputsInfo(const ModelManager& manager);
+    virtual Status updateOutputsInfo(const ModelManager& manager);
 
 public:
-    const tensor_map_t& getInputsInfo() const;
-    const tensor_map_t& getOutputsInfo() const;
+    const tensor_map_t getInputsInfo() const;
+    const tensor_map_t getOutputsInfo() const;
 
 private:
     static Status getCustomNodeMetadata(const NodeInfo& customNodeInfo, tensor_map_t& inputsInfo, metadata_fn callback, const std::string& pipelineName);

--- a/src/pipelinedefinition.hpp
+++ b/src/pipelinedefinition.hpp
@@ -73,9 +73,12 @@ class PipelineDefinition {
     const std::string pipelineName;
     std::vector<NodeInfo> nodeInfos;
     pipeline_connections_t connections;
+
+protected:
     tensor_map_t inputsInfo;
     tensor_map_t outputsInfo;
 
+private:
     std::atomic<uint64_t> requestsHandlesCounter = 0;
     std::shared_mutex loadMtx;
 
@@ -140,8 +143,8 @@ protected:
     virtual Status getOutputsInfo(tensor_map_t& outputsInfo, const ModelManager& manager) const;
 
 public:
-    virtual const tensor_map_t& getInputsInfo() const;
-    virtual const tensor_map_t& getOutputsInfo() const;
+    const tensor_map_t& getInputsInfo() const;
+    const tensor_map_t& getOutputsInfo() const;
 
 private:
     static Status getCustomNodeMetadata(const NodeInfo& customNodeInfo, tensor_map_t& inputsInfo, metadata_fn callback, const std::string& pipelineName);

--- a/src/tensorinfo.cpp
+++ b/src/tensorinfo.cpp
@@ -269,6 +269,7 @@ void TensorInfo::setShape(const shape_t& shape) {
 std::shared_ptr<TensorInfo> TensorInfo::createCopyWithNewShape(const shape_t& shape) const {
     auto copy = std::make_shared<TensorInfo>(*this);
     copy->setShape(shape);
+    copy->layout = InferenceEngine::Layout::ANY;
     return copy;
 }
 

--- a/src/tensorinfo.hpp
+++ b/src/tensorinfo.hpp
@@ -66,11 +66,6 @@ protected:
          */
     InferenceEngine::Layout layout;
 
-    /**
-         * @brief TensorDesc
-         */
-    InferenceEngine::TensorDesc tensorDesc;
-
 public:
     /**
          * @brief Construct a new Tensor Info object

--- a/src/tensorinfo.hpp
+++ b/src/tensorinfo.hpp
@@ -72,6 +72,7 @@ public:
          * 
          */
     TensorInfo() = default;
+    TensorInfo(const TensorInfo&) = default;
 
     /**
          * @brief Construct a new Tensor Info object

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -758,7 +758,6 @@ public:
         if (!inputsSizeCorrect || !outputsSizeCorrect) {
             return false;
         }
-        SPDLOG_ERROR("ExpectedInputsCount:{}", expectedInputs.size());
         for (auto& [expectedInputName, shapeTypeTuple] : expectedInputs) {
             bool inputNameExist = inputs.find(expectedInputName.c_str()) != inputs.end();
             EXPECT_TRUE(inputNameExist);
@@ -921,7 +920,7 @@ TEST_F(StressPipelineConfigChanges, AddNewVersionDuringPredictLoad) {
     std::set<StatusCode> allowedLoadResults = {};
     performStressTest(
         &StressPipelineConfigChanges::triggerPredictInALoop,
-        &StressPipelineConfigChanges::defaultVersionRemove,
+        &StressPipelineConfigChanges::defaultVersionAdd,
         performWholeConfigReload,
         requiredLoadResults,
         allowedLoadResults);
@@ -1009,16 +1008,14 @@ TEST_F(StressPipelineConfigChanges, AddNewVersionDuringGetMetadataLoad) {
     std::set<StatusCode> allowedLoadResults = {};
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
-        &StressPipelineConfigChanges::defaultVersionRemove,
+        &StressPipelineConfigChanges::defaultVersionAdd,
         performWholeConfigReload,
         requiredLoadResults,
         allowedLoadResults);
 }
 TEST_F(StressPipelineConfigChanges, RemoveDefaultVersionDuringGetMetadataLoad) {
     std::set<StatusCode> requiredLoadResults = {StatusCode::OK,
-        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET,  // we hit when all config changes finish to propagate
-        StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE,    // we hit default version which is unloaded already but default is not changed yet
-        StatusCode::MODEL_MISSING};                      // model instance not found during metadata request
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};  // we hit when all config changes finish to propagate
     std::set<StatusCode> allowedLoadResults = {};
     // we need whole config reload since there is no other way to dispose
     // all model versions different than removing model from config
@@ -1044,8 +1041,7 @@ TEST_F(StressPipelineConfigChanges, ChangeToShapeAutoDuringGetMetadataLoad) {
 TEST_F(StressPipelineConfigChanges, RemovePipelineDefinitionDuringGetMetadataLoad) {
     bool performWholeConfigReload = true;
     std::set<StatusCode> requiredLoadResults = {StatusCode::OK,
-        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_ANYMORE,  // when pipeline is retired
-        StatusCode::MODEL_VERSION_NOT_LOADED_YET};           // we do not wait for models durign get metadata
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_ANYMORE};  // when pipeline is retired
     std::set<StatusCode> allowedLoadResults = {};
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
@@ -1056,8 +1052,7 @@ TEST_F(StressPipelineConfigChanges, RemovePipelineDefinitionDuringGetMetadataLoa
 }
 TEST_F(StressPipelineConfigChanges, ChangedPipelineConnectionNameDuringGetMetadataLoad) {
     bool performWholeConfigReload = true;
-    std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
-        StatusCode::MODEL_VERSION_NOT_LOADED_YET};               // we do not wait for models durign get metadata
+    std::set<StatusCode> requiredLoadResults = {StatusCode::OK};  // we expect full continuouity of operation
     std::set<StatusCode> allowedLoadResults = {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
@@ -1083,8 +1078,7 @@ TEST_F(StressPipelineConfigChanges, RetireSpecificVersionUsedDuringGetMetadataLo
     SetUpConfig(stressTestPipelineOneDummyConfigSpecificVersionUsed);
     bool performWholeConfigReload = false;
     std::set<StatusCode> requiredLoadResults = {StatusCode::OK,  // we expect full continuouity of operation
-        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET,          // we hit when all config changes finish to propagate
-        StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE};           // version is retired but pipeline not invalidated yet
+        StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET};         // we hit when all config changes finish to propagate
     std::set<StatusCode> allowedLoadResults = {};
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -586,7 +586,10 @@ public:
     void SetUpConfig(const std::string& configContent) {
         ovmsConfig = configContent;
         const std::string modelPathToReplace{"/ovms/src/test/dummy"};
-        ovmsConfig.replace(ovmsConfig.find(modelPathToReplace), modelPathToReplace.size(), modelPath);
+        auto it = ovmsConfig.find(modelPathToReplace);
+        if (it != std::string::npos) {
+            ovmsConfig.replace(ovmsConfig.find(modelPathToReplace), modelPathToReplace.size(), modelPath);
+        }
         configFilePath = directoryPath + "/ovms_config.json";
     }
     void SetUp() override {
@@ -597,7 +600,7 @@ public:
     }
     void defaultVersionRemove() {
         SPDLOG_INFO("{} start", __FUNCTION__);
-        ovmsConfig = stressTestPipelineOneDummyRemovedConfig;
+        SetUpConfig(stressTestPipelineOneDummyRemovedConfig);
         createConfigFileWithContent(ovmsConfig, configFilePath);
         SPDLOG_INFO("{} end", __FUNCTION__);
     }
@@ -608,25 +611,25 @@ public:
     }
     void changeToAutoShape() {
         SPDLOG_INFO("{} start", __FUNCTION__);
-        ovmsConfig = stressTestPipelineOneDummyConfigChangedToAuto;
+        SetUpConfig(stressTestPipelineOneDummyConfigChangedToAuto);
         createConfigFileWithContent(ovmsConfig, configFilePath);
         SPDLOG_INFO("{} end", __FUNCTION__);
     }
     void removePipelineDefinition() {
         SPDLOG_INFO("{} start", __FUNCTION__);
-        ovmsConfig = stressTestPipelineOneDummyConfigPipelineRemoved;
+        SetUpConfig(stressTestPipelineOneDummyConfigPipelineRemoved);
         createConfigFileWithContent(ovmsConfig, configFilePath);
         SPDLOG_INFO("{} end", __FUNCTION__);
     }
     void changeConnectionName() {
         SPDLOG_INFO("{} start", __FUNCTION__);
-        ovmsConfig = stressTestPipelineOneDummyConfigChangeConnectionName;
+        SetUpConfig(stressTestPipelineOneDummyConfigChangeConnectionName);
         createConfigFileWithContent(ovmsConfig, configFilePath);
         SPDLOG_INFO("{} end", __FUNCTION__);
     }
     void addNewPipeline() {
         SPDLOG_INFO("{} start", __FUNCTION__);
-        ovmsConfig = stressTestPipelineOneDummyConfigAddNewPipeline;
+        SetUpConfig(stressTestPipelineOneDummyConfigAddNewPipeline);
         createConfigFileWithContent(ovmsConfig, configFilePath);
         SPDLOG_INFO("{} end", __FUNCTION__);
     }

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1335,11 +1335,10 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, JustDiff
     std::vector<float> expectedOutput(4 * DUMMY_MODEL_OUTPUT_SIZE);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     this->checkResponse("pipeline_output", response, expectedOutput, {4, 1, 10});
-    tensor_map_t inputs, outputs;
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -1423,17 +1422,15 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     this->loadConfiguration(pipelineCustomNodeDifferentOperationsThenDummyConfig);
     ASSERT_EQ(manager.createPipeline(pipeline, pipelineName, &request, &response), StatusCode::OK);
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
-
     std::vector<float> expectedOutput(4 * DUMMY_MODEL_OUTPUT_SIZE);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
         [](float f) -> float { return f + 1; });
     this->checkResponse("pipeline_output", response, expectedOutput, {4, 1, 10});
-    tensor_map_t inputs, outputs;
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -1511,11 +1508,10 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     std::vector<float> expectedOutput(4 * DUMMY_MODEL_OUTPUT_SIZE);
     prepareDifferentOpsExpectedOutput(expectedOutput, input, factors);
     this->checkResponse("pipeline_output", response, expectedOutput, {4, 1, 10});
-    tensor_map_t inputs, outputs;
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2389,10 +2385,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2427,10 +2421,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2460,10 +2452,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2608,10 +2598,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -3544,11 +3532,10 @@ TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, J
     std::transform(expectedOutput.begin(), expectedOutput.end(), expectedOutput.begin(),
         [](float f) -> float { return f + 1; });
     this->checkResponse("pipeline_output", response, expectedOutput, {dynamicDemultiplyCount, 1, 10});
-    tensor_map_t inputs, outputs;
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
     auto& input_A = inputs.at(pipelineInputName);
@@ -3569,18 +3556,16 @@ TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, J
     auto outputDummy = modelOutputs.at("a");
     EXPECT_EQ(outputDummy->getShape(), shape_t({1, 10}));
 
-    inputs.clear();
-    outputs.clear();
     modelInputs.clear();
     modelOutputs.clear();
 
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
-    ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
-    ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
-    auto input_A2 = inputs.at(pipelineInputName);
+    const tensor_map_t& inputs2 = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs2 = pipelineDefinition->getOutputsInfo();
+    ASSERT_NE(inputs2.find(pipelineInputName), inputs.end());
+    ASSERT_NE(outputs2.find(pipelineOutputName), outputs.end());
+    auto input_A2 = inputs2.at(pipelineInputName);
     EXPECT_EQ(input_A2->getShape(), shape_t({1, 10}));
-    auto output2 = outputs.at(pipelineOutputName);
+    auto output2 = outputs2.at(pipelineOutputName);
     EXPECT_EQ(output2->getShape(), shape_t({0, 1, 10}));
 
     status = manager.getModelInstance("dummy", 1, modelInstance, modelInstanceUnloadGuardPtr);
@@ -3662,11 +3647,9 @@ static const char* pipelineCustomNodeDynamicDemultiplexThenDummyDemultiplexerCon
 TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, JustDynamicDemultiplexerThenDummyBothConnectedToExitConfigMetadataCheck) {
     this->loadConfiguration(pipelineCustomNodeDynamicDemultiplexThenDummyDemultiplexerConnectedToExitConfig);
 
-    tensor_map_t inputs, outputs;
-
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
     const auto& input_A = inputs.at(pipelineInputName);
@@ -3746,9 +3729,8 @@ TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, D
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
     ASSERT_NE(pipelineDefinition, nullptr);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(pipelineDefinition->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(pipelineDefinition->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
+    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1337,8 +1337,8 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, JustDiff
     this->checkResponse("pipeline_output", response, expectedOutput, {4, 1, 10});
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -1429,8 +1429,8 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     this->checkResponse("pipeline_output", response, expectedOutput, {4, 1, 10});
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -1510,8 +1510,8 @@ TEST_F(EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest, Differen
     this->checkResponse("pipeline_output", response, expectedOutput, {4, 1, 10});
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2385,8 +2385,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2421,8 +2421,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2452,8 +2452,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -2598,8 +2598,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, SuccessfulConfiguration
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 
@@ -3534,8 +3534,8 @@ TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, J
     this->checkResponse("pipeline_output", response, expectedOutput, {dynamicDemultiplyCount, 1, 10});
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
     auto& input_A = inputs.at(pipelineInputName);
@@ -3559,8 +3559,8 @@ TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, J
     modelInputs.clear();
     modelOutputs.clear();
 
-    const tensor_map_t& inputs2 = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs2 = pipelineDefinition->getOutputsInfo();
+    auto inputs2 = pipelineDefinition->getInputsInfo();
+    auto outputs2 = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs2.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs2.find(pipelineOutputName), outputs.end());
     auto input_A2 = inputs2.at(pipelineInputName);
@@ -3648,8 +3648,8 @@ TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, J
     this->loadConfiguration(pipelineCustomNodeDynamicDemultiplexThenDummyDemultiplexerConnectedToExitConfig);
 
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
     const auto& input_A = inputs.at(pipelineInputName);
@@ -3729,8 +3729,8 @@ TEST_F(EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest, D
     auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(pipelineName);
     ASSERT_NE(pipelineDefinition, nullptr);
 
-    const tensor_map_t& inputs = pipelineDefinition->getInputsInfo();
-    const tensor_map_t& outputs = pipelineDefinition->getOutputsInfo();
+    auto inputs = pipelineDefinition->getInputsInfo();
+    auto outputs = pipelineDefinition->getOutputsInfo();
     ASSERT_NE(inputs.find(pipelineInputName), inputs.end());
     ASSERT_NE(outputs.find(pipelineOutputName), outputs.end());
 

--- a/src/test/ensemble_mapping_config_tests.cpp
+++ b/src/test/ensemble_mapping_config_tests.cpp
@@ -222,8 +222,8 @@ TEST_F(PipelineWithInputOutputNameMappedModel, SuccessfullyReferToMappedNamesAnd
 
     ASSERT_EQ(def->validate(managerWithDummyModel), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
     ASSERT_NE(inputs.find("vector"), inputs.end());

--- a/src/test/ensemble_mapping_config_tests.cpp
+++ b/src/test/ensemble_mapping_config_tests.cpp
@@ -220,12 +220,10 @@ TEST_F(PipelineWithInputOutputNameMappedModel, SuccessfullyReferToMappedNamesAnd
     auto def = std::make_unique<PipelineDefinition>(
         "my_new_pipeline", info, connections);
 
-    ASSERT_EQ(def->validateNodes(managerWithDummyModel), StatusCode::OK);
+    ASSERT_EQ(def->validate(managerWithDummyModel), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, managerWithDummyModel), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, managerWithDummyModel), StatusCode::OK);
-
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
     ASSERT_NE(inputs.find("vector"), inputs.end());

--- a/src/test/ensemble_metadata_test.cpp
+++ b/src/test/ensemble_metadata_test.cpp
@@ -54,8 +54,8 @@ TEST(EnsembleMetadata, OneNode) {
 
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
@@ -120,8 +120,8 @@ TEST(EnsembleMetadata, MultipleNodesOnDifferentLevelsUsingTheSamePipelineInputs)
 
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 2);
     ASSERT_EQ(outputs.size(), 3);
@@ -175,8 +175,8 @@ TEST(EnsembleMetadata, EmptyPipelineReturnsCorrectInputAndOutputInfo) {
 
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
@@ -265,8 +265,8 @@ TEST(EnsembleMetadata, ParallelDLModelNodesReferingToManyPipelineInputs) {
 
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 8);
     for (size_t i = 1; i <= 4; i++) {
@@ -326,8 +326,8 @@ TEST(EnsembleMetadata, OneUnavailableNode) {
     ASSERT_EQ(manager.reloadModelWithVersions(config), StatusCode::OK_RELOADED);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     config = DUMMY_MODEL_CONFIG;
     ASSERT_EQ(manager.reloadModelWithVersions(config), StatusCode::OK_RELOADED);
@@ -336,15 +336,15 @@ TEST(EnsembleMetadata, OneUnavailableNode) {
     instance->unloadModel();
 
     // we should still be able to get metadata since pipeline definition was not reloaded
-    const tensor_map_t& inputs2 = def->getInputsInfo();
-    const tensor_map_t& outputs2 = def->getOutputsInfo();
+    auto inputs2 = def->getInputsInfo();
+    auto outputs2 = def->getOutputsInfo();
 
     config.setLocalPath("/tmp/non_existing_path_j3nmc783n");
     ASSERT_EQ(instance->loadModel(config), StatusCode::PATH_INVALID);
 
     // we should still be able to get metadata since pipeline definition was not reloaded
-    const tensor_map_t& inputs3 = def->getInputsInfo();
-    const tensor_map_t& outputs3 = def->getOutputsInfo();
+    auto inputs3 = def->getInputsInfo();
+    auto outputs3 = def->getOutputsInfo();
 #pragma GCC diagnostic pop
 }
 
@@ -378,8 +378,8 @@ TEST(EnsembleMetadata, OneCustomNode) {
     ASSERT_EQ(def->validateDemultiplexerGatherNodesOrder(), StatusCode::OK);
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
@@ -433,8 +433,8 @@ TEST(EnsembleMetadata, ParallelCustomNodes) {
     ASSERT_EQ(def->validateDemultiplexerGatherNodesOrder(), StatusCode::OK);
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 3);
@@ -594,8 +594,8 @@ TEST(EnsembleMetadata, CustomNodeMultipleDemultiplexers) {
     ASSERT_EQ(def->validateDemultiplexerGatherNodesOrder(), StatusCode::OK);
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    const tensor_map_t& inputs = def->getInputsInfo();
-    const tensor_map_t& outputs = def->getOutputsInfo();
+    auto inputs = def->getInputsInfo();
+    auto outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 2);
     ASSERT_EQ(outputs.size(), 1);

--- a/src/test/ensemble_metadata_test.cpp
+++ b/src/test/ensemble_metadata_test.cpp
@@ -52,11 +52,10 @@ TEST(EnsembleMetadata, OneNode) {
     auto def = std::make_unique<PipelineDefinition>(
         "my_new_pipeline", info, connections);
 
-    ASSERT_EQ(def->validateNodes(manager), StatusCode::OK);
+    ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
@@ -119,11 +118,10 @@ TEST(EnsembleMetadata, MultipleNodesOnDifferentLevelsUsingTheSamePipelineInputs)
     auto def = std::make_unique<PipelineDefinition>(
         "my_new_pipeline", info, connections);
 
-    ASSERT_EQ(def->validateNodes(manager), StatusCode::OK);
+    ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 2);
     ASSERT_EQ(outputs.size(), 3);
@@ -175,11 +173,10 @@ TEST(EnsembleMetadata, EmptyPipelineReturnsCorrectInputAndOutputInfo) {
     auto def = std::make_unique<PipelineDefinition>(
         "my_new_pipeline", info, connections);
 
-    ASSERT_EQ(def->validateNodes(manager), StatusCode::OK);
+    ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
@@ -266,11 +263,10 @@ TEST(EnsembleMetadata, ParallelDLModelNodesReferingToManyPipelineInputs) {
     auto def = std::make_unique<PipelineDefinition>(
         "my_new_pipeline", info, connections);
 
-    ASSERT_EQ(def->validateNodes(manager), StatusCode::OK);
+    ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 8);
     for (size_t i = 1; i <= 4; i++) {
@@ -324,14 +320,14 @@ TEST(EnsembleMetadata, OneUnavailableNode) {
     auto def = std::make_unique<PipelineDefinition>(
         "my_new_pipeline", info, connections);
 
-    ASSERT_EQ(def->validateNodes(manager), StatusCode::OK);
+    ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
     config.setModelVersionPolicy(std::make_shared<SpecificModelVersionPolicy>(model_versions_t{UNAVAILABLE_DUMMY_VERSION}));
     ASSERT_EQ(manager.reloadModelWithVersions(config), StatusCode::OK_RELOADED);
-
-    tensor_map_t inputs, outputs;
-    EXPECT_EQ(def->getInputsInfo(inputs, manager), StatusCode::MODEL_MISSING);
-    EXPECT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::MODEL_MISSING);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     config = DUMMY_MODEL_CONFIG;
     ASSERT_EQ(manager.reloadModelWithVersions(config), StatusCode::OK_RELOADED);
@@ -339,14 +335,17 @@ TEST(EnsembleMetadata, OneUnavailableNode) {
     ASSERT_NE(instance, nullptr);
     instance->unloadModel();
 
-    EXPECT_EQ(def->getInputsInfo(inputs, manager), StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
-    EXPECT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
+    // we should still be able to get metadata since pipeline definition was not reloaded
+    const tensor_map_t& inputs2 = def->getInputsInfo();
+    const tensor_map_t& outputs2 = def->getOutputsInfo();
 
     config.setLocalPath("/tmp/non_existing_path_j3nmc783n");
     ASSERT_EQ(instance->loadModel(config), StatusCode::PATH_INVALID);
 
-    EXPECT_EQ(def->getInputsInfo(inputs, manager), StatusCode::MODEL_VERSION_NOT_LOADED_YET);
-    EXPECT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::MODEL_VERSION_NOT_LOADED_YET);
+    // we should still be able to get metadata since pipeline definition was not reloaded
+    const tensor_map_t& inputs3 = def->getInputsInfo();
+    const tensor_map_t& outputs3 = def->getOutputsInfo();
+#pragma GCC diagnostic pop
 }
 
 TEST(EnsembleMetadata, OneCustomNode) {
@@ -379,9 +378,8 @@ TEST(EnsembleMetadata, OneCustomNode) {
     ASSERT_EQ(def->validateDemultiplexerGatherNodesOrder(), StatusCode::OK);
     ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 1);
@@ -433,10 +431,10 @@ TEST(EnsembleMetadata, ParallelCustomNodes) {
     ASSERT_EQ(def->validateNodes(manager), StatusCode::OK);
     ASSERT_EQ(def->validateForCycles(), StatusCode::OK);
     ASSERT_EQ(def->validateDemultiplexerGatherNodesOrder(), StatusCode::OK);
+    ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 1);
     ASSERT_EQ(outputs.size(), 3);
@@ -594,10 +592,10 @@ TEST(EnsembleMetadata, CustomNodeMultipleDemultiplexers) {
     ASSERT_EQ(def->validateNodes(manager), StatusCode::OK);
     ASSERT_EQ(def->validateForCycles(), StatusCode::OK);
     ASSERT_EQ(def->validateDemultiplexerGatherNodesOrder(), StatusCode::OK);
+    ASSERT_EQ(def->validate(manager), StatusCode::OK);
 
-    tensor_map_t inputs, outputs;
-    ASSERT_EQ(def->getInputsInfo(inputs, manager), StatusCode::OK);
-    ASSERT_EQ(def->getOutputsInfo(outputs, manager), StatusCode::OK);
+    const tensor_map_t& inputs = def->getInputsInfo();
+    const tensor_map_t& outputs = def->getOutputsInfo();
 
     ASSERT_EQ(inputs.size(), 2);
     ASSERT_EQ(outputs.size(), 1);

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -2299,7 +2299,7 @@ TEST_F(EnsembleFlowTest, ReloadPipelineAfterLoadingSuccessfullyChangedInputName)
         PipelineDefinitionStateCode::AVAILABLE);
 
     auto pdPtr = manager.getPipelineFactory().findDefinitionByName(PIPELINE_1_DUMMY_NAME);
-    const tensor_map_t& inputsInfoBefore = pdPtr->getInputsInfo();
+    auto inputsInfoBefore = pdPtr->getInputsInfo();
     ASSERT_EQ(inputsInfoBefore.count(NEW_INPUT_NAME), 0);
 
     // now reload
@@ -2307,7 +2307,7 @@ TEST_F(EnsembleFlowTest, ReloadPipelineAfterLoadingSuccessfullyChangedInputName)
     manager.loadConfig(fileToReload);
     ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_1_DUMMY_NAME)->getStateCode(),
         PipelineDefinitionStateCode::AVAILABLE);
-    const tensor_map_t& inputsInfoAfter = pdPtr->getInputsInfo();
+    auto inputsInfoAfter = pdPtr->getInputsInfo();
     ASSERT_TRUE(status.ok()) << status.string();
     EXPECT_EQ(inputsInfoAfter.count(NEW_INPUT_NAME), 1);
 }
@@ -2559,7 +2559,7 @@ TEST_F(EnsembleFlowTest, RetireReloadAddPipelineAtTheSameTime) {
     ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_TO_ADD), nullptr);
 
     auto pipelineToReloadPtr = manager.getPipelineFactory().findDefinitionByName(PIPELINE_TO_RELOAD);
-    const tensor_map_t& inputsInfoBefore = pipelineToReloadPtr->getInputsInfo();
+    auto inputsInfoBefore = pipelineToReloadPtr->getInputsInfo();
     ASSERT_EQ(inputsInfoBefore.count(NEW_INPUT_NAME), 0);
 
     // now reload
@@ -2572,7 +2572,7 @@ TEST_F(EnsembleFlowTest, RetireReloadAddPipelineAtTheSameTime) {
     ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_TO_ADD)->getStateCode(),
         PipelineDefinitionStateCode::AVAILABLE);
 
-    const tensor_map_t& inputsInfoAfter = pipelineToReloadPtr->getInputsInfo();
+    auto inputsInfoAfter = pipelineToReloadPtr->getInputsInfo();
     EXPECT_EQ(inputsInfoAfter.count(NEW_INPUT_NAME), 1);
 }
 

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -2298,10 +2298,8 @@ TEST_F(EnsembleFlowTest, ReloadPipelineAfterLoadingSuccessfullyChangedInputName)
     ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_1_DUMMY_NAME)->getStateCode(),
         PipelineDefinitionStateCode::AVAILABLE);
 
-    tensor_map_t inputsInfoBefore;
     auto pdPtr = manager.getPipelineFactory().findDefinitionByName(PIPELINE_1_DUMMY_NAME);
-    status = pdPtr->getInputsInfo(inputsInfoBefore, manager);
-    ASSERT_TRUE(status.ok()) << status.string();
+    const tensor_map_t& inputsInfoBefore = pdPtr->getInputsInfo();
     ASSERT_EQ(inputsInfoBefore.count(NEW_INPUT_NAME), 0);
 
     // now reload
@@ -2309,8 +2307,7 @@ TEST_F(EnsembleFlowTest, ReloadPipelineAfterLoadingSuccessfullyChangedInputName)
     manager.loadConfig(fileToReload);
     ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_1_DUMMY_NAME)->getStateCode(),
         PipelineDefinitionStateCode::AVAILABLE);
-    tensor_map_t inputsInfoAfter;
-    status = pdPtr->getInputsInfo(inputsInfoAfter, manager);
+    const tensor_map_t& inputsInfoAfter = pdPtr->getInputsInfo();
     ASSERT_TRUE(status.ok()) << status.string();
     EXPECT_EQ(inputsInfoAfter.count(NEW_INPUT_NAME), 1);
 }
@@ -2561,10 +2558,8 @@ TEST_F(EnsembleFlowTest, RetireReloadAddPipelineAtTheSameTime) {
         PipelineDefinitionStateCode::AVAILABLE);
     ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_TO_ADD), nullptr);
 
-    tensor_map_t inputsInfoBefore;
     auto pipelineToReloadPtr = manager.getPipelineFactory().findDefinitionByName(PIPELINE_TO_RELOAD);
-    status = pipelineToReloadPtr->getInputsInfo(inputsInfoBefore, manager);
-    ASSERT_TRUE(status.ok()) << status.string();
+    const tensor_map_t& inputsInfoBefore = pipelineToReloadPtr->getInputsInfo();
     ASSERT_EQ(inputsInfoBefore.count(NEW_INPUT_NAME), 0);
 
     // now reload
@@ -2577,9 +2572,7 @@ TEST_F(EnsembleFlowTest, RetireReloadAddPipelineAtTheSameTime) {
     ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_TO_ADD)->getStateCode(),
         PipelineDefinitionStateCode::AVAILABLE);
 
-    tensor_map_t inputsInfoAfter;
-    status = pipelineToReloadPtr->getInputsInfo(inputsInfoAfter, manager);
-    ASSERT_TRUE(status.ok()) << status.string();
+    const tensor_map_t& inputsInfoAfter = pipelineToReloadPtr->getInputsInfo();
     EXPECT_EQ(inputsInfoAfter.count(NEW_INPUT_NAME), 1);
 }
 

--- a/src/test/get_pipeline_metadata_response_test.cpp
+++ b/src/test/get_pipeline_metadata_response_test.cpp
@@ -32,21 +32,12 @@ using namespace rapidjson;
 class GetPipelineMetadataResponse : public ::testing::Test {
 protected:
     class MockPipelineDefinitionGetInputsOutputsInfo : public PipelineDefinition {
-        tensor_map_t inputsInfo, outputsInfo;
         Status status = StatusCode::OK;
 
     public:
         MockPipelineDefinitionGetInputsOutputsInfo() :
             PipelineDefinition("pipeline_name", {}, {}) {
             PipelineDefinition::status.handle(ValidationPassedEvent());
-        }
-
-        const tensor_map_t& getInputsInfo() const override {
-            return this->inputsInfo;
-        }
-
-        const tensor_map_t& getOutputsInfo() const override {
-            return this->outputsInfo;
         }
 
         void mockMetadata(const tensor_map_t& inputsInfo, const tensor_map_t& outputsInfo) {

--- a/src/test/get_pipeline_metadata_response_test.cpp
+++ b/src/test/get_pipeline_metadata_response_test.cpp
@@ -41,14 +41,12 @@ protected:
             PipelineDefinition::status.handle(ValidationPassedEvent());
         }
 
-        Status getInputsInfo(tensor_map_t& inputsInfo, const ModelManager& manager) const override {
-            inputsInfo = this->inputsInfo;
-            return status;
+        const tensor_map_t& getInputsInfo() const override {
+            return this->inputsInfo;
         }
 
-        Status getOutputsInfo(tensor_map_t& outputsInfo, const ModelManager& manager) const override {
-            outputsInfo = this->outputsInfo;
-            return status;
+        const tensor_map_t& getOutputsInfo() const override {
+            return this->outputsInfo;
         }
 
         void mockMetadata(const tensor_map_t& inputsInfo, const tensor_map_t& outputsInfo) {
@@ -222,14 +220,14 @@ TEST_F(GetPipelineMetadataResponseBuild, HasCorrectShape) {
         {}));
 }
 
-TEST_F(GetPipelineMetadataResponse, ModelVersionNotLoadedAnymore) {
+TEST_F(GetPipelineMetadataResponse, ModelVersionNotLoadedAnymoreButPipelineNotReloadedYet) {
     pipelineDefinition.mockStatus(StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
-    EXPECT_EQ(ovms::GetModelMetadataImpl::buildResponse(pipelineDefinition, &response, manager), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
+    EXPECT_EQ(ovms::GetModelMetadataImpl::buildResponse(pipelineDefinition, &response, manager), ovms::StatusCode::OK);
 }
 
 TEST_F(GetPipelineMetadataResponse, ModelVersionNotLoadedYet) {
     pipelineDefinition.mockStatus(StatusCode::MODEL_VERSION_NOT_LOADED_YET);
-    EXPECT_EQ(ovms::GetModelMetadataImpl::buildResponse(pipelineDefinition, &response, manager), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_YET);
+    EXPECT_EQ(ovms::GetModelMetadataImpl::buildResponse(pipelineDefinition, &response, manager), ovms::StatusCode::OK);
 }
 
 TEST_F(GetPipelineMetadataResponse, PipelineNotLoadedAnymore) {


### PR DESCRIPTION
This is to enable binary inputs and minimize metadata workload during
metadata API calls.

Additionally:
* fixes stress config changes tests when test did nothing because the config file was changed but the ModelManager.loadConfig() method was not used.
* remove InferenceEngine::TensorDesc from TensorInfo since it is not used.
* change layout as well within TensorInfo.createCopyWithNewShape(), as it could cause exception when TensorShape.getTensorDesc() method was used on newly created object. (Inconsistend dims and layout)

JIRA:CVS-49029