### PR TITLE
WIP POC Create infer requests for each predict request

### DIFF
--- a/src/dl_node.cpp
+++ b/src/dl_node.cpp
@@ -103,18 +103,7 @@ Status DLNode::fetchResults(BlobMap& outputs, InferenceEngine::InferRequest& inf
                 SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Getting blob from model: {}, inferRequestStreamId: {}, blobName: {}",
                     getName(), sessionKey, modelName, sessionKey, realModelOutputName);
                 const auto blob = inferRequest.GetBlob(realModelOutputName);
-                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Creating copy of blob from model: {}, blobName: {}",
-                    getName(), sessionKey, modelName, realModelOutputName);
-                InferenceEngine::Blob::Ptr copiedBlob;
-                auto status = blobClone(copiedBlob, blob);
-                if (!status.ok()) {
-                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Could not clone result blob; node: {}; session: {}; model name: {}; output: {}",
-                        getName(),
-                        this->modelName,
-                        realModelOutputName);
-                    return status;
-                }
-                outputs.emplace(std::make_pair(output_name, std::move(copiedBlob)));
+                outputs.emplace(std::make_pair(output_name, std::move(blob)));
             } catch (const InferenceEngine::Exception& e) {
                 Status status = StatusCode::OV_INTERNAL_SERIALIZATION_ERROR;
                 SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session:{} Error during getting blob {}; exception message: {}", getName(), sessionKey, status.string(), e.what());

--- a/src/dlnodesession.cpp
+++ b/src/dlnodesession.cpp
@@ -278,7 +278,6 @@ Status DLNodeSession::executeInference(PipelineEventQueue& notifyEndQueue, Infer
             // After inference is completed, input blobs are not needed anymore
             this->inputHandler->clearInputs();
             notifyEndQueue.push({node, getSessionKey()});
-            inferRequest.SetCompletionCallback([]() {});  // reset callback on infer request
         });
         SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Starting infer async for node name: {}", getName());
         this->timer->start("inference");

--- a/src/ovinferrequestsqueue.cpp
+++ b/src/ovinferrequestsqueue.cpp
@@ -16,43 +16,65 @@
 
 #include "ovinferrequestsqueue.hpp"
 
+#include <numeric>
 #include <utility>
 
+#include <inference_engine.hpp>
+
 namespace ovms {
+
+OVInferRequestsQueue::~OVInferRequestsQueue() = default;
+
+OVInferRequestsQueue::OVInferRequestsQueue(InferenceEngine::ExecutableNetwork& network, int nireq) :
+    ireqs(nireq),
+    front_idx{0},
+    back_idx{0},
+    inferRequests(nireq),
+    network(network) {
+    std::iota(ireqs.begin(), ireqs.end(), 0);
+}
+
 std::future<int> OVInferRequestsQueue::getIdleStream() {
     int value;
     std::promise<int> idleStreamPromise;
     std::future<int> idleStreamFuture = idleStreamPromise.get_future();
     std::unique_lock<std::mutex> lk(front_mut);
-    if (streams[front_idx] < 0) {  // we need to wait for any idle stream to be returned
+    if (ireqs[front_idx] < 0) {  // we need to wait for any idle stream to be returned
         std::unique_lock<std::mutex> queueLock(queue_mutex);
         promises.push(std::move(idleStreamPromise));
     } else {  // we can give idle stream right away
-        value = streams[front_idx];
-        streams[front_idx] = -1;  // negative value indicate consumed vector index
-        front_idx = (front_idx + 1) % streams.size();
+        value = ireqs[front_idx];
+        ireqs[front_idx] = -1;  // negative value indicate consumed vector index
+        front_idx = (front_idx + 1) % ireqs.size();
         lk.unlock();
+        inferRequests[value] = std::make_unique<InferenceEngine::InferRequest>(network.CreateInferRequest());
         idleStreamPromise.set_value(value);
     }
     return std::move(idleStreamFuture);
 }
 
-void OVInferRequestsQueue::returnStream(int streamID) {
+void OVInferRequestsQueue::returnStream(int ireqId) {
     std::unique_lock<std::mutex> lk(queue_mutex);
     if (promises.size()) {
         std::promise<int> promise = std::move(promises.front());
         promises.pop();
         lk.unlock();
-        promise.set_value(streamID);
+        inferRequests[ireqId] = std::make_unique<InferenceEngine::InferRequest>(network.CreateInferRequest());
+        promise.set_value(ireqId);
         return;
     }
+    // need to clear infer request before unlocking that and
+    // potentially giving it for other thread to treat as ready
+    // slot for creating new infer request
+    inferRequests[ireqId].reset();
     std::uint32_t old_back = back_idx.load();
     while (!back_idx.compare_exchange_weak(
         old_back,
-        (old_back + 1) % streams.size(),
+        (old_back + 1) % ireqs.size(),
         std::memory_order_relaxed)) {
     }
-    streams[old_back] = streamID;
+    ireqs[old_back] = ireqId;
+    lk.unlock();
 }
 
 }  // namespace ovms

--- a/src/test/ovinferrequestqueue_test.cpp
+++ b/src/test/ovinferrequestqueue_test.cpp
@@ -22,6 +22,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <inference_engine.hpp>
 
 #include "../ovinferrequestsqueue.hpp"
 #include "../timer.hpp"


### PR DESCRIPTION
This is to avoid need for copying blobs in the DAG pipeline flow.
Since there is no interface of InferRequest that enables to gain
exclusive ownership of result blob we had to make copy of result when
passing it furhter down the pipeline. When we create new InferRequest
object each time there is no need for copyying as well as clearing
completion callback.

Added benefit is freeying memory otherwise taken by not active
inferRequests for other processess. While OV can manage that when
running multiple models in one process that is not the case for
multiple containers or applications on one host.

JIRA:CVS-58339