### PR TITLE
WIP POC No copies allowed

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -20,6 +20,7 @@ cc_library(
     srcs = [
         "aliases.hpp",
         "blobmap.hpp",
+        "blobwrapper.hpp",
         "config.cpp",
         "config.hpp",
         "custom_node.cpp",
@@ -31,8 +32,8 @@ cc_library(
         "customnodesession.cpp",
         "customnodesession.hpp",
         "customloaderconfig.hpp",
-	    "customloaders.hpp",
-	    "customloaders.cpp",
+        "customloaders.hpp",
+        "customloaders.cpp",
         "customloaderinterface.hpp",
         "deserialization.hpp",
         "dl_node.cpp",

--- a/src/blobmap.hpp
+++ b/src/blobmap.hpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 

--- a/src/blobmap.hpp
+++ b/src/blobmap.hpp
@@ -20,8 +20,12 @@
 
 #include <inference_engine.hpp>
 
+#include "blobwrapper.hpp"
+
 namespace ovms {
 
-using BlobMap = std::unordered_map<std::string, InferenceEngine::Blob::Ptr>;
+class BlobWrapper;
+
+using BlobMap = std::unordered_map<std::string, std::shared_ptr<BlobWrapper>>;
 
 }  // namespace ovms

--- a/src/blobwrapper.hpp
+++ b/src/blobwrapper.hpp
@@ -20,18 +20,20 @@
 namespace ovms {
 
 class BlobWrapper {
-    public:
-        BlobWrapper(InferenceEngine::Blob::Ptr& blob) : blob(blob) {}
- //       BlobWrapper(InferenceEngine::Blob::Ptr&& blob) : blob(blob) {}
-        void registerParent(InferenceEngine::Blob::Ptr ptr) {
-            parent = ptr;
-        }
-        virtual ~BlobWrapper() = default;
-        InferenceEngine::Blob::Ptr getUnderlyingBlob() const {
-            return blob;
-        }
-    private:
-        InferenceEngine::Blob::Ptr blob;
-        InferenceEngine::Blob::Ptr parent;
+public:
+    BlobWrapper(InferenceEngine::Blob::Ptr& blob) :
+        blob(blob) {}
+    //       BlobWrapper(InferenceEngine::Blob::Ptr&& blob) : blob(blob) {}
+    void registerParent(InferenceEngine::Blob::Ptr& ptr) {
+        parent = ptr;
+    }
+    virtual ~BlobWrapper() = default;
+    InferenceEngine::Blob::Ptr getUnderlyingBlob() const {
+        return blob;
+    }
+
+private:
+    InferenceEngine::Blob::Ptr blob;
+    InferenceEngine::Blob::Ptr parent;
 };
 }  // namespace ovms

--- a/src/blobwrapper.hpp
+++ b/src/blobwrapper.hpp
@@ -15,36 +15,23 @@
 //*****************************************************************************
 #pragma once
 
-#include <memory>
-#include <string>
-#include <unordered_map>
-#include <utility>
-
-//#include <inference_engine.hpp>
-
-#include "blobmap.hpp"
-#include "blobwrapper.hpp"
-#include "session_id.hpp"
-#include "status.hpp"
+#include <inference_engine.hpp>
 
 namespace ovms {
 
-class NodeInputHandler {
-protected:
-    BlobMap inputBlobs;
-    uint32_t remainingDependencies;
-    bool isUsed = false;
-
-public:
-    NodeInputHandler(uint32_t inputsMissingCount);
-    virtual Status setInput(const std::string& inputName, std::shared_ptr<BlobWrapper>& blobWrapper, session_id_t shardId);
-    const BlobMap& getInputs() {
-        isUsed = true;
-        return inputBlobs;
-    }
-    void clearInputs();
-    bool isReady();
-    virtual Status notifyFinishedDependency();
-    virtual ~NodeInputHandler() = default;
+class BlobWrapper {
+    public:
+        BlobWrapper(InferenceEngine::Blob::Ptr& blob) : blob(blob) {}
+ //       BlobWrapper(InferenceEngine::Blob::Ptr&& blob) : blob(blob) {}
+        void registerParent(InferenceEngine::Blob::Ptr ptr) {
+            parent = ptr;
+        }
+        virtual ~BlobWrapper() = default;
+        InferenceEngine::Blob::Ptr getUnderlyingBlob() const {
+            return blob;
+        }
+    private:
+        InferenceEngine::Blob::Ptr blob;
+        InferenceEngine::Blob::Ptr parent;
 };
 }  // namespace ovms

--- a/src/custom_node.cpp
+++ b/src/custom_node.cpp
@@ -77,7 +77,7 @@ Status CustomNode::fetchResults(BlobMap& outputs, session_key_t sessionKey) {
             SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Getting custom node output tensor with name: {}",
                 getName(), sessionKey, realOutputName);
 
-            InferenceEngine::Blob::Ptr resultBlob;
+            std::shared_ptr<BlobWrapper> resultBlob;
             auto status = session.fetchResult(realOutputName, resultBlob);
             if (!status.ok()) {
                 SPDLOG_LOGGER_ERROR(dag_executor_logger, "Node: {} session: {} Custom node output with name {} is missing",

--- a/src/customnodesession.cpp
+++ b/src/customnodesession.cpp
@@ -99,7 +99,8 @@ Status CustomNodeSession::execute(PipelineEventQueue& notifyEndQueue, Node& node
             }
             continue;
         }
-        this->resultBlobs.emplace(std::string(outputTensors[i].name), std::move(resultBlob));
+        auto blobWrapper = std::make_shared<BlobWrapper>(resultBlob);
+        this->resultBlobs.emplace(std::string(outputTensors[i].name), std::move(blobWrapper));
     }
 
     library.release(outputTensors);
@@ -107,7 +108,7 @@ Status CustomNodeSession::execute(PipelineEventQueue& notifyEndQueue, Node& node
     return status;
 }
 
-Status CustomNodeSession::fetchResult(const std::string& name, InferenceEngine::Blob::Ptr& resultBlob) {
+Status CustomNodeSession::fetchResult(const std::string& name, std::shared_ptr<BlobWrapper>& resultBlob) {
     auto it = resultBlobs.find(name);
     if (it == resultBlobs.end()) {
         return StatusCode::NODE_LIBRARY_MISSING_OUTPUT;

--- a/src/customnodesession.hpp
+++ b/src/customnodesession.hpp
@@ -45,7 +45,7 @@ public:
         std::unique_ptr<struct CustomNodeParam[]>& parameters,
         int parametersCount);
 
-    Status fetchResult(const std::string& name, InferenceEngine::Blob::Ptr& resultBlob);
+    Status fetchResult(const std::string& name, std::shared_ptr<BlobWrapper>& resultBlob);
 
     void clearInputs();
     void release() override;

--- a/src/dl_node.cpp
+++ b/src/dl_node.cpp
@@ -102,8 +102,11 @@ Status DLNode::fetchResults(BlobMap& outputs, InferenceEngine::InferRequest& inf
                 }
                 SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Getting blob from model: {}, inferRequestStreamId: {}, blobName: {}",
                     getName(), sessionKey, modelName, sessionKey, realModelOutputName);
-                const auto blob = inferRequest.GetBlob(realModelOutputName);
-                outputs.emplace(std::make_pair(output_name, std::move(blob)));
+                auto blob = inferRequest.GetBlob(realModelOutputName);
+                // TODO check how to move
+                //outputs.emplace(std::make_pair(output_name, std::make_shared<BlobWrapper>(std::move(blob))));
+                auto blobWrapper = std::make_shared<BlobWrapper>(blob);
+                outputs.emplace(std::make_pair(output_name, std::move(blobWrapper)));
             } catch (const InferenceEngine::Exception& e) {
                 Status status = StatusCode::OV_INTERNAL_SERIALIZATION_ERROR;
                 SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session:{} Error during getting blob {}; exception message: {}", getName(), sessionKey, status.string(), e.what());

--- a/src/dl_node.cpp
+++ b/src/dl_node.cpp
@@ -103,18 +103,7 @@ Status DLNode::fetchResults(BlobMap& outputs, InferenceEngine::InferRequest& inf
                 SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Getting blob from model: {}, inferRequestStreamId: {}, blobName: {}",
                     getName(), sessionKey, modelName, sessionKey, realModelOutputName);
                 const auto blob = inferRequest.GetBlob(realModelOutputName);
-                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session: {} Creating copy of blob from model: {}, blobName: {}",
-                    getName(), sessionKey, modelName, realModelOutputName);
-                InferenceEngine::Blob::Ptr copiedBlob;
-                auto status = blobClone(copiedBlob, blob);
-                if (!status.ok()) {
-                    SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Could not clone result blob; node: {}; session: {}; model name: {}; output: {}",
-                        getName(),
-                        this->modelName,
-                        realModelOutputName);
-                    return status;
-                }
-                outputs.emplace(std::make_pair(output_name, std::move(copiedBlob)));
+                outputs.emplace(std::make_pair(output_name, std::move(blob)));
             } catch (const InferenceEngine::Exception& e) {
                 Status status = StatusCode::OV_INTERNAL_SERIALIZATION_ERROR;
                 SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Node: {} session:{} Error during getting blob {}; exception message: {}", getName(), sessionKey, status.string(), e.what());

--- a/src/dl_node.cpp
+++ b/src/dl_node.cpp
@@ -104,7 +104,7 @@ Status DLNode::fetchResults(BlobMap& outputs, InferenceEngine::InferRequest& inf
                     getName(), sessionKey, modelName, sessionKey, realModelOutputName);
                 auto blob = inferRequest.GetBlob(realModelOutputName);
                 // TODO check how to move
-                //outputs.emplace(std::make_pair(output_name, std::make_shared<BlobWrapper>(std::move(blob))));
+                // outputs.emplace(std::make_pair(output_name, std::make_shared<BlobWrapper>(std::move(blob))));
                 auto blobWrapper = std::make_shared<BlobWrapper>(blob);
                 outputs.emplace(std::make_pair(output_name, std::move(blobWrapper)));
             } catch (const InferenceEngine::Exception& e) {

--- a/src/dlnodesession.cpp
+++ b/src/dlnodesession.cpp
@@ -278,7 +278,6 @@ Status DLNodeSession::executeInference(PipelineEventQueue& notifyEndQueue, Infer
             // After inference is completed, input blobs are not needed anymore
             this->inputHandler->clearInputs();
             notifyEndQueue.push({node, getSessionKey()});
-            inferRequest.SetCompletionCallback([]() {});  // reset callback on infer request
         });
         SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Starting infer async for node name: {}", getName());
         this->timer->start("inference");

--- a/src/dlnodesession.cpp
+++ b/src/dlnodesession.cpp
@@ -91,7 +91,8 @@ Status DLNodeSession::prepareInputsAndModelForInference() {
     const auto& inputsInfo = this->model->getInputsInfo();
     for (const auto& kv : this->inputHandler->getInputs()) {
         const auto& name = kv.first;
-        auto& blob = kv.second;
+        auto& blobWrapper = kv.second;
+        auto blob = blobWrapper->getUnderlyingBlob();
 
         auto it = inputsInfo.find(name);
         if (it == inputsInfo.end()) {
@@ -239,7 +240,8 @@ Status DLNodeSession::setInputsForInference(InferenceEngine::InferRequest& infer
     Status status = StatusCode::OK;
     try {
         // Prepare inference request, fill with input blobs
-        for (const auto& [name, blob] : this->inputHandler->getInputs()) {
+        for (const auto& [name, blobWrapper] : this->inputHandler->getInputs()) {
+            auto blob = blobWrapper->getUnderlyingBlob();
             std::string realModelInputName;
             if (!getRealInputName(name, &realModelInputName).ok()) {
                 SPDLOG_LOGGER_WARN(dag_executor_logger, "DLNode::{} [Node name: {}]; cannot find real model input name for alias: {}",

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -84,7 +84,7 @@ Status EntryNode::fetchResults(BlobMap& outputs) {
             if (!status.ok()) {
                 return status;
             }
-            outputs[outputName] = blob;
+            outputs.emplace(outputName, std::make_shared<BlobWrapper>(blob));
             SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}]: blob with name: {} description: {} has been prepared", getName(), outputName, TensorInfo::tensorDescToString(blob->getTensorDesc()));
         }
     }

--- a/src/exit_node.cpp
+++ b/src/exit_node.cpp
@@ -46,7 +46,7 @@ Status ExitNode::fetchResults(const BlobMap& inputBlobs) {
         auto& blob = kv.second;
         SPDLOG_DEBUG("[Node: {}] Serializing response from pipeline. Output name: {}", getName(), output_name);
         auto& proto = (*this->response->mutable_outputs())[output_name];
-        auto status = serialize(blob, proto);
+        auto status = serialize(blob->getUnderlyingBlob(), proto);
         if (!status.ok()) {
             return status;
         }

--- a/src/gathernodeinputhandler.hpp
+++ b/src/gathernodeinputhandler.hpp
@@ -27,7 +27,7 @@
 
 namespace ovms {
 
-using shard_map_t = std::unordered_map<session_id_t, InferenceEngine::Blob::Ptr>;
+using shard_map_t = std::unordered_map<session_id_t, std::shared_ptr<BlobWrapper>>;
 
 class CollapseDetails;
 
@@ -37,7 +37,7 @@ class GatherNodeInputHandler : public NodeInputHandler {
 
 public:
     GatherNodeInputHandler(uint32_t inputsMissingCount, const CollapseDetails& collapsingDetails);
-    Status setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr, session_id_t shardId) override;
+    Status setInput(const std::string& inputName, std::shared_ptr<BlobWrapper>& blobWrapper, session_id_t shardId) override;
     Status notifyFinishedDependency() override;
 };
 }  // namespace ovms

--- a/src/node_library_utils.cpp
+++ b/src/node_library_utils.cpp
@@ -78,13 +78,14 @@ std::unique_ptr<struct CustomNodeParam[]> createCustomNodeParamArray(const std::
     return std::move(libraryParameters);
 }
 
-std::unique_ptr<struct CustomNodeTensor[]> createCustomNodeTensorArray(const std::unordered_map<std::string, InferenceEngine::Blob::Ptr>& blobMap) {
+std::unique_ptr<struct CustomNodeTensor[]> createCustomNodeTensorArray(const BlobMap& blobMap) {
     if (blobMap.size() == 0) {
         return nullptr;
     }
     auto inputTensors = std::make_unique<struct CustomNodeTensor[]>(blobMap.size());
     int i = 0;
-    for (const auto& [name, blob] : blobMap) {
+    for (const auto& [name, blobWrapper] : blobMap) {
+        auto blob = blobWrapper->getUnderlyingBlob();
         const auto& dims = getEffectiveBlobShape(blob);
         inputTensors[i].name = static_cast<const char*>(name.c_str());
         inputTensors[i].data = static_cast<uint8_t*>(blob->buffer());

--- a/src/node_library_utils.hpp
+++ b/src/node_library_utils.hpp
@@ -22,6 +22,7 @@
 
 #include <inference_engine.hpp>
 
+#include "blobmap.hpp"
 #include "custom_node_interface.h"  // NOLINT
 #include "node_library.hpp"
 #include "status.hpp"
@@ -33,7 +34,7 @@ class TensorInfo;
 CustomNodeTensorPrecision toCustomNodeTensorPrecision(InferenceEngine::Precision precision);
 InferenceEngine::Precision toInferenceEnginePrecision(CustomNodeTensorPrecision precision);
 std::unique_ptr<struct CustomNodeParam[]> createCustomNodeParamArray(const std::unordered_map<std::string, std::string>& paramMap);
-std::unique_ptr<struct CustomNodeTensor[]> createCustomNodeTensorArray(const std::unordered_map<std::string, InferenceEngine::Blob::Ptr>& blobMap);
+std::unique_ptr<struct CustomNodeTensor[]> createCustomNodeTensorArray(const BlobMap& blobMap);
 Status createTensorInfoMap(struct CustomNodeTensorInfo* info, int infoCount, std::map<std::string, std::shared_ptr<TensorInfo>>& out, release_fn freeCallback);
 
 }  // namespace ovms

--- a/src/nodeinputhandler.cpp
+++ b/src/nodeinputhandler.cpp
@@ -23,7 +23,7 @@ NodeInputHandler::NodeInputHandler(uint32_t inputsMissingCount) :
     remainingDependencies(inputsMissingCount) {
 }
 
-Status NodeInputHandler::setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& ptr, session_id_t shardId) {
+Status NodeInputHandler::setInput(const std::string& inputName, std::shared_ptr<BlobWrapper>& blobWrapper, session_id_t shardId) {
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Setting input: {}, shardId: {}", inputName, shardId);
     if (shardId > 0) {
         SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to set input: {}, with shardId: {} >0 in NodeInputHandler.", inputName, shardId);
@@ -33,7 +33,7 @@ Status NodeInputHandler::setInput(const std::string& inputName, InferenceEngine:
         SPDLOG_LOGGER_ERROR(dag_executor_logger, "Tried to set the same input: {}, shardId: {} twice for the NodeInputHandler.", inputName, shardId);
         return StatusCode::PIPELINE_TRIED_TO_SET_THE_SAME_INPUT_TWICE;
     }
-    inputBlobs.emplace(inputName, ptr);
+    inputBlobs.emplace(inputName, blobWrapper);
     return StatusCode::OK;
 }
 

--- a/src/nodeinputhandler.hpp
+++ b/src/nodeinputhandler.hpp
@@ -20,8 +20,6 @@
 #include <unordered_map>
 #include <utility>
 
-//#include <inference_engine.hpp>
-
 #include "blobmap.hpp"
 #include "blobwrapper.hpp"
 #include "session_id.hpp"

--- a/src/nodesession.cpp
+++ b/src/nodesession.cpp
@@ -28,8 +28,8 @@ const NodeSessionMetadata& NodeSession::getNodeSessionMetadata() const {
     return this->metadata;
 }
 
-Status NodeSession::setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr, session_id_t shardId) {
-    return inputHandler->setInput(inputName, blobPtr, shardId);
+Status NodeSession::setInput(const std::string& inputName, std::shared_ptr<BlobWrapper>& blobWrapper, session_id_t shardId) {
+    return inputHandler->setInput(inputName, blobWrapper, shardId);
 }
 
 std::unique_ptr<NodeInputHandler> createNodeInputHandler(uint32_t inputsCount, const CollapseDetails& collapsingDetails) {

--- a/src/nodesession.hpp
+++ b/src/nodesession.hpp
@@ -25,6 +25,7 @@
 #include "status.hpp"
 
 namespace ovms {
+class BlobWrapper;
 struct NodeInputHandler;
 struct NodeOutputHandler;
 class Timer;
@@ -44,7 +45,7 @@ public:
     NodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails);
     virtual ~NodeSession();
     const std::string& getName() const { return nodeName; }
-    Status setInput(const std::string& inputName, InferenceEngine::Blob::Ptr&, session_id_t shardId);
+    Status setInput(const std::string& inputName, std::shared_ptr<BlobWrapper>& blobWrapper, session_id_t shardId);
     const NodeSessionMetadata& getNodeSessionMetadata() const;
     const session_key_t& getSessionKey() const { return sessionKey; }
     bool isReady() const;

--- a/src/ovinferrequestsqueue.cpp
+++ b/src/ovinferrequestsqueue.cpp
@@ -16,43 +16,65 @@
 
 #include "ovinferrequestsqueue.hpp"
 
+#include <numeric>
 #include <utility>
 
+#include <inference_engine.hpp>
+
 namespace ovms {
+
+OVInferRequestsQueue::~OVInferRequestsQueue() = default;
+
+OVInferRequestsQueue::OVInferRequestsQueue(InferenceEngine::ExecutableNetwork& network, int nireq) :
+    ireqs(nireq),
+    front_idx{0},
+    back_idx{0},
+    inferRequests(nireq),
+    network(network) {
+    std::iota(ireqs.begin(), ireqs.end(), 0);
+}
+
 std::future<int> OVInferRequestsQueue::getIdleStream() {
     int value;
     std::promise<int> idleStreamPromise;
     std::future<int> idleStreamFuture = idleStreamPromise.get_future();
     std::unique_lock<std::mutex> lk(front_mut);
-    if (streams[front_idx] < 0) {  // we need to wait for any idle stream to be returned
+    if (ireqs[front_idx] < 0) {  // we need to wait for any idle stream to be returned
         std::unique_lock<std::mutex> queueLock(queue_mutex);
         promises.push(std::move(idleStreamPromise));
     } else {  // we can give idle stream right away
-        value = streams[front_idx];
-        streams[front_idx] = -1;  // negative value indicate consumed vector index
-        front_idx = (front_idx + 1) % streams.size();
+        value = ireqs[front_idx];
+        ireqs[front_idx] = -1;  // negative value indicate consumed vector index
+        front_idx = (front_idx + 1) % ireqs.size();
         lk.unlock();
+        inferRequests[value] = std::make_unique<InferenceEngine::InferRequest>(network.CreateInferRequest());
         idleStreamPromise.set_value(value);
     }
     return std::move(idleStreamFuture);
 }
 
-void OVInferRequestsQueue::returnStream(int streamID) {
+void OVInferRequestsQueue::returnStream(int ireqId) {
     std::unique_lock<std::mutex> lk(queue_mutex);
     if (promises.size()) {
         std::promise<int> promise = std::move(promises.front());
         promises.pop();
         lk.unlock();
-        promise.set_value(streamID);
+        inferRequests[ireqId] = std::make_unique<InferenceEngine::InferRequest>(network.CreateInferRequest());
+        promise.set_value(ireqId);
         return;
     }
+    // need to clear infer request before unlocking that and
+    // potentially giving it for other thread to treat as ready
+    // slot for creating new infer request
+    inferRequests[ireqId].reset();
     std::uint32_t old_back = back_idx.load();
     while (!back_idx.compare_exchange_weak(
         old_back,
-        (old_back + 1) % streams.size(),
+        (old_back + 1) % ireqs.size(),
         std::memory_order_relaxed)) {
     }
-    streams[old_back] = streamID;
+    ireqs[old_back] = ireqId;
+    lk.unlock();
 }
 
 }  // namespace ovms

--- a/src/test/ovinferrequestqueue_test.cpp
+++ b/src/test/ovinferrequestqueue_test.cpp
@@ -22,6 +22,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <inference_engine.hpp>
 
 #include "../ovinferrequestsqueue.hpp"
 #include "../timer.hpp"


### PR DESCRIPTION
Remove copying when demultiplying blobs

JIRA:CVS-58339

Add blob wrapper to add possibility to avoid blob copies

JIRA:CVS-58339

Create infer requests for each predict request

This is to avoid need for copying blobs in the DAG pipeline flow.
Since there is no interface of InferRequest that enables to gain
exclusive ownership of result blob we had to make copy of result when
passing it furhter down the pipeline. When we create new InferRequest
object each time there is no need for copyying as well as clearing
completion callback.

Added benefit is freeying memory otherwise taken by not active
inferRequests for other processess. While OV can manage that when
running multiple models in one process that is not the case for
multiple containers or applications on one host.

JIRA:CVS-58339