### PR TITLE
CVS-59119 Add layout switch to east_ocr example custom node

### DIFF
--- a/docs/east_ocr.md
+++ b/docs/east_ocr.md
@@ -179,7 +179,7 @@ Now you can create directory for text images and run the client:
 mkdir results
 ```
 ```bash
-python east_ocr_client.py --grpc_port 9000 --image_input_path ../src/custom_nodes/east_ocr/demo_images/input.jpg --pipeline_name detect_text_images --text_images_save_path ./results/
+python east_ocr_client.py --grpc_port 9000 --image_input_path ../src/custom_nodes/east_ocr/demo_images/input.jpg --pipeline_name detect_text_images --text_images_save_path ./results/ --image_layout NHWC
 Output: name[text_coordinates]
     numpy => shape[(9, 1, 4)] data[int32]
 Output: name[texts]

--- a/example_client/east_ocr_client.py
+++ b/example_client/east_ocr_client.py
@@ -22,6 +22,7 @@ from tensorflow import make_tensor_proto, make_ndarray
 import argparse
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
+
 parser = argparse.ArgumentParser(description='Client for OCR pipeline')
 parser.add_argument('--grpc_address', required=False, default='localhost',  help='Specify url to grpc service. default:localhost')
 parser.add_argument('--grpc_port', required=False, default=9178, help='Specify port to grpc service. default: 9178')
@@ -33,6 +34,7 @@ parser.add_argument('--text_images_output_name', required=False, default='text_i
 parser.add_argument('--text_images_save_path', required=False, default='', help='If specified, images will be saved to disk.')
 parser.add_argument('--image_width', required=False, default=1920, help='Original image width. default: 1920')
 parser.add_argument('--image_height', required=False, default=1024, help='Original image height. default: 1024')
+parser.add_argument('--image_layout', required=False, default='NCHW', choices=['NCHW', 'NHWC', 'BINARY'], help='Pipeline input image layout. default: NCHW')
 
 args = vars(parser.parse_args())
 
@@ -43,10 +45,23 @@ def prepare_img_input_in_nchw_format(request, name, path, resize_to_shape):
     img = img.transpose(2,0,1).reshape(1,3,target_shape[0],target_shape[1])
     request.inputs[name].CopyFrom(make_tensor_proto(img, shape=img.shape))
 
-def nchw_to_image(output_nd, name, location):
+def prepare_img_input_in_nhwc_format(request, name, path, resize_to_shape):
+    img = cv2.imread(path).astype(np.float32)  # BGR color format, shape HWC
+    img = cv2.resize(img, (resize_to_shape[1], resize_to_shape[0]))
+    target_shape = (img.shape[0], img.shape[1])
+    img = img.reshape(1,target_shape[0],target_shape[1],3)
+    request.inputs[name].CopyFrom(make_tensor_proto(img, shape=img.shape))
+
+def prepare_img_input_in_binary_format(request, name, path):
+    with open(path, 'rb') as f:
+        data = f.read()
+        request.inputs[name].CopyFrom(make_tensor_proto(data, shape=[1]))
+
+def save_text_images_as_jpgs(output_nd, name, location):
     for i in range(output_nd.shape[0]):
         out = output_nd[i][0]
-        out = out.transpose(1,2,0)
+        if len(out.shape) == 3 and out.shape[0] == 3:  # NCHW
+            out = out.transpose(1,2,0)
         cv2.imwrite(os.path.join(location, name + '_' + str(i) + '.jpg'), out)
 
 def decode(text):
@@ -84,7 +99,13 @@ channel = grpc.insecure_channel(address,
 stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
 request = predict_pb2.PredictRequest()
 request.model_spec.name = args['pipeline_name']
-prepare_img_input_in_nchw_format(request, args['image_input_name'], args['image_input_path'], (int(args['image_height']), int(args['image_width'])))
+
+if args['image_layout'] == 'NCHW':
+    prepare_img_input_in_nchw_format(request, args['image_input_name'], args['image_input_path'], (int(args['image_height']), int(args['image_width'])))
+elif args['image_layout'] == 'NHWC':
+    prepare_img_input_in_nhwc_format(request, args['image_input_name'], args['image_input_path'], (int(args['image_height']), int(args['image_width'])))
+else:
+    prepare_img_input_in_binary_format(request, args['image_input_name'], args['image_input_path'])
 
 try:
     response = stub.Predict(request, 30.0)
@@ -101,6 +122,6 @@ for name in response.outputs:
     output_nd = make_ndarray(tensor_proto)
     print(f"    numpy => shape[{output_nd.shape}] data[{output_nd.dtype}]")
     if name == args['text_images_output_name'] and len(args['text_images_save_path']) > 0:
-        nchw_to_image(output_nd, name, args['text_images_save_path'])
+        save_text_images_as_jpgs(output_nd, name, args['text_images_save_path'])
     if name == args['texts_output_name']:
         crnn_output_to_text(output_nd)

--- a/src/custom_nodes/east_ocr/README.md
+++ b/src/custom_nodes/east_ocr/README.md
@@ -38,8 +38,10 @@ It will compile the library inside a docker container and save the results in `l
 | ------------- | ------------- | ------------- | ----------- |
 | original_image_width  | Required input image width |  | &check; |
 | original_image_height  | Required input image height |  | &check; |
+| original_image_layout  | Input image layout. Possible layouts: NCHW/NHWC. When using NHWC, it is possible to accept binary inputs. | NCHW | |
 | target_image_width | Target width of the text boxes in output. Boxes in the original image will be resized to that value.  |  | &check; |
 | target_image_height  | Target width of the text boxes in output. Boxes in the original image will be resized to that value. |  | &check; |
+| target_image_layout  | Output images layout. Possible layouts: NCHW/NHWC. When using NHWC, it is possible to accept binary inputs. | NCHW | |
 | convert_to_gray_scale  | Defines if output images should be in grayscale or in color  | false | |
 | confidence_threshold | Number in a range of 0-1 |  | &check; |
 | overlap_threshold | a ratio in a range of 0-1 for non-max suppression algorithm. Defines the overlapping ratio to reject detection as duplicated  | 0.3 | |

--- a/src/custom_nodes/east_ocr/config.json
+++ b/src/custom_nodes/east_ocr/config.json
@@ -4,6 +4,7 @@
             "config": {
                 "name": "east",
                 "base_path": "/OCR/east_fp32",
+                "layout": "NHWC",
                 "plugin_config": {
                     "CPU_THROUGHPUT_STREAMS":  "1"
                 }
@@ -12,6 +13,7 @@
         {
             "config": {
                 "name": "crnn",
+                "layout": "NHWC",
                 "base_path": "/OCR/crnn_tf"
             }
         }
@@ -50,8 +52,10 @@
                     "params": {
                         "original_image_width": "1920",
                         "original_image_height": "1024",
+                        "original_image_layout": "NHWC",
                         "target_image_width": "100",
                         "target_image_height": "32",
+                        "target_image_layout": "NHWC",
                         "convert_to_gray_scale": "false",
                         "confidence_threshold": "0.9",
                         "overlap_threshold": "0.2",

--- a/src/custom_nodes/east_ocr/east_ocr.cpp
+++ b/src/custom_nodes/east_ocr/east_ocr.cpp
@@ -35,7 +35,7 @@ struct BoxMetadata {
     float originalHeight;
 };
 
-bool copy_images_into_output(struct CustomNodeTensor* output, const std::vector<cv::Rect>& boxes, const std::vector<BoxMetadata>& metadata, const cv::Mat& originalImage, int targetImageHeight, int targetImageWidth, bool convertToGrayScale, int rotationAngleThreshold) {
+bool copy_images_into_output(struct CustomNodeTensor* output, const std::vector<cv::Rect>& boxes, const std::vector<BoxMetadata>& metadata, const cv::Mat& originalImage, int targetImageHeight, int targetImageWidth, const std::string& targetImageLayout, bool convertToGrayScale, int rotationAngleThreshold) {
     const uint64_t outputBatch = boxes.size();
     int channels = convertToGrayScale ? 1 : 3;
 
@@ -60,8 +60,12 @@ bool copy_images_into_output(struct CustomNodeTensor* output, const std::vector<
         if (convertToGrayScale) {
             image = apply_grayscale(image);
         }
-        auto imgBuffer = reorder_to_nchw((float*)image.data, image.rows, image.cols, image.channels());
-        std::memcpy(buffer + (i * channels * targetImageWidth * targetImageHeight), imgBuffer.data(), byteSize / outputBatch);
+        if (targetImageLayout == "NCHW") {
+            auto imgBuffer = reorder_to_nchw((float*)image.data, image.rows, image.cols, image.channels());
+            std::memcpy(buffer + (i * channels * targetImageWidth * targetImageHeight), imgBuffer.data(), byteSize / outputBatch);
+        } else {
+            std::memcpy(buffer + (i * channels * targetImageWidth * targetImageHeight), image.data, byteSize / outputBatch);
+        }
     }
 
     output->data = reinterpret_cast<uint8_t*>(buffer);
@@ -71,9 +75,15 @@ bool copy_images_into_output(struct CustomNodeTensor* output, const std::vector<
     NODE_ASSERT(output->dims != nullptr, "malloc has failed");
     output->dims[0] = outputBatch;
     output->dims[1] = 1;
-    output->dims[2] = channels;
-    output->dims[3] = targetImageHeight;
-    output->dims[4] = targetImageWidth;
+    if (targetImageLayout == "NCHW") {
+        output->dims[2] = channels;
+        output->dims[3] = targetImageHeight;
+        output->dims[4] = targetImageWidth;
+    } else {
+        output->dims[2] = targetImageHeight;
+        output->dims[3] = targetImageWidth;
+        output->dims[4] = channels;
+    }
     output->precision = FP32;
     return true;
 }
@@ -142,6 +152,10 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     int targetImageWidth = get_int_parameter("target_image_width", params, paramsCount, -1);
     NODE_ASSERT(targetImageHeight > 0, "target image height must be larger than 0");
     NODE_ASSERT(targetImageWidth > 0, "target image width must be larger than 0");
+    std::string originalImageLayout = get_string_parameter("original_image_layout", params, paramsCount, "NCHW");
+    NODE_ASSERT(originalImageLayout == "NCHW" || originalImageLayout == "NHWC", "original image layout must be NCHW or NHWC");
+    std::string targetImageLayout = get_string_parameter("target_image_layout", params, paramsCount, "NCHW");
+    NODE_ASSERT(targetImageLayout == "NCHW" || targetImageLayout == "NHWC", "target image layout must be NCHW or NHWC");
     bool convertToGrayScale = get_string_parameter("convert_to_gray_scale", params, paramsCount) == "true";
     float confidenceThreshold = get_float_parameter("confidence_threshold", params, paramsCount, -1.0);
     NODE_ASSERT(confidenceThreshold >= 0 && confidenceThreshold <= 1.0, "confidence threshold must be in 0-1 range");
@@ -181,8 +195,10 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     NODE_ASSERT(scoresTensor->precision == FP32, "image input is not FP32");
     NODE_ASSERT(geometryTensor->precision == FP32, "image input is not FP32");
 
-    uint64_t _imageHeight = imageTensor->dims[2];
-    uint64_t _imageWidth = imageTensor->dims[3];
+    NODE_ASSERT(imageTensor->dimsCount == 4, "input image shape must have 4 dimensions");
+    NODE_ASSERT(imageTensor->dims[0] == 1, "input image batch must be 1");
+    uint64_t _imageHeight = imageTensor->dims[originalImageLayout == "NCHW" ? 2 : 1];
+    uint64_t _imageWidth = imageTensor->dims[originalImageLayout == "NCHW" ? 3 : 2];
     NODE_ASSERT(_imageHeight <= std::numeric_limits<int>::max(), "image height is too large");
     NODE_ASSERT(_imageWidth <= std::numeric_limits<int>::max(), "image width is too large");
     int imageHeight = static_cast<int>(_imageHeight);
@@ -195,8 +211,12 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     NODE_ASSERT(imageHeight == originalImageHeight, "original image size parameter differs from original image tensor size");
     NODE_ASSERT(imageWidth == originalImageWidth, "original image size parameter differs from original image tensor size");
 
-    cv::Mat image = nchw_to_mat(imageTensor);
-    // cv::Mat image = nhwc_to_mat(imageTensor);  // here you can support other layouts
+    cv::Mat image;
+    if (originalImageLayout == "NHWC") {
+        image = nhwc_to_mat(imageTensor);
+    } else {
+        image = nchw_to_mat(imageTensor);
+    }
 
     NODE_ASSERT(image.cols == imageWidth, "Mat generation failed");
     NODE_ASSERT(image.rows == imageHeight, "Mat generation failed");
@@ -323,7 +343,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     NODE_ASSERT((*outputs) != nullptr, "malloc has failed");
     CustomNodeTensor& textImagesTensor = (*outputs)[0];
     textImagesTensor.name = TEXT_IMAGES_TENSOR_NAME;
-    if (!copy_images_into_output(&textImagesTensor, filteredBoxes, filteredMetadata, image, targetImageHeight, targetImageWidth, convertToGrayScale, rotationAngleThreshold)) {
+    if (!copy_images_into_output(&textImagesTensor, filteredBoxes, filteredMetadata, image, targetImageHeight, targetImageWidth, targetImageLayout, convertToGrayScale, rotationAngleThreshold)) {
         free(*outputs);
         return 1;
     }
@@ -355,6 +375,8 @@ int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const stru
     NODE_ASSERT(originalImageWidth > 0, "original image width must be larger than 0");
     NODE_ASSERT((originalImageHeight % 4) == 0, "original image height must be divisible by 4");
     NODE_ASSERT((originalImageWidth % 4) == 0, "original image width must be divisible by 4");
+    std::string originalImageLayout = get_string_parameter("original_image_layout", params, paramsCount, "NCHW");
+    NODE_ASSERT(originalImageLayout == "NCHW" || originalImageLayout == "NHWC", "original image layout must be NCHW or NHWC");
 
     *infoCount = 3;
     *info = (struct CustomNodeTensorInfo*)malloc(*infoCount * sizeof(struct CustomNodeTensorInfo));
@@ -365,9 +387,15 @@ int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const stru
     (*info)[0].dims = (uint64_t*)malloc((*info)->dimsCount * sizeof(uint64_t));
     NODE_ASSERT(((*info)[0].dims) != nullptr, "malloc has failed");
     (*info)[0].dims[0] = 1;
-    (*info)[0].dims[1] = 3;
-    (*info)[0].dims[2] = originalImageHeight;
-    (*info)[0].dims[3] = originalImageWidth;
+    if (originalImageLayout == "NCHW") {
+        (*info)[0].dims[1] = 3;
+        (*info)[0].dims[2] = originalImageHeight;
+        (*info)[0].dims[3] = originalImageWidth;
+    } else {
+        (*info)[0].dims[1] = originalImageHeight;
+        (*info)[0].dims[2] = originalImageWidth;
+        (*info)[0].dims[3] = 3;
+    }
     (*info)[0].precision = FP32;
 
     (*info)[1].name = SCORES_TENSOR_NAME;
@@ -397,6 +425,8 @@ int getOutputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const str
     int targetImageWidth = get_int_parameter("target_image_width", params, paramsCount, -1);
     NODE_ASSERT(targetImageHeight > 0, "target image height must be larger than 0");
     NODE_ASSERT(targetImageWidth > 0, "target image width must be larger than 0");
+    std::string targetImageLayout = get_string_parameter("target_image_layout", params, paramsCount, "NCHW");
+    NODE_ASSERT(targetImageLayout == "NCHW" || targetImageLayout == "NHWC", "target image layout must be NCHW or NHWC");
     bool convertToGrayScale = get_string_parameter("convert_to_gray_scale", params, paramsCount) == "true";
 
     *infoCount = 3;
@@ -409,9 +439,15 @@ int getOutputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const str
     NODE_ASSERT(((*info)[0].dims) != nullptr, "malloc has failed");
     (*info)[0].dims[0] = 0;
     (*info)[0].dims[1] = 1;
-    (*info)[0].dims[2] = convertToGrayScale ? 1 : 3;
-    (*info)[0].dims[3] = targetImageHeight;
-    (*info)[0].dims[4] = targetImageWidth;
+    if (targetImageLayout == "NCHW") {
+        (*info)[0].dims[2] = convertToGrayScale ? 1 : 3;
+        (*info)[0].dims[3] = targetImageHeight;
+        (*info)[0].dims[4] = targetImageWidth;
+    } else {
+        (*info)[0].dims[2] = targetImageHeight;
+        (*info)[0].dims[3] = targetImageWidth;
+        (*info)[0].dims[4] = convertToGrayScale ? 1 : 3;
+    }
     (*info)[0].precision = FP32;
 
     (*info)[1].name = COORDINATES_TENSOR_NAME;


### PR DESCRIPTION
- add layout switch to east_ocr example custom node
- update example client to be able to send NHWC/BINARY data
- update documentation to suggest using NHWC for performance purposes