### PR TITLE
Cvs 59163 - Improve error message when incorrect connection occurs in DAG configuration

### DIFF
--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -904,22 +904,20 @@ Status PipelineDefinition::validateDemultiplexerGatherNodesOrder() {
                 newDemultiplyStack.emplace_back(connectedNodeInfo.gatherFromNode);
             }
             if (connectedNodeInfo.kind == NodeKind::ENTRY && !newDemultiplyStack.empty()) {
-                SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} exists path that gathers from demultiplexer nodes that are not in path: {}.",
+                SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} exists path that gathers from demultiplexer nodes that are not in path: {}. Consider changing inputs of the node that gathers from mentioned demultiplexer nodes",
                     getName(),
                     std::accumulate(newDemultiplyStack.back().begin(), newDemultiplyStack.back().end(), std::string{}, [](const std::string& lhs, const std::string& rhs) {
                         if (lhs.empty()) {
                             return rhs;
                         }
                         return lhs + ", " + rhs; }));
-                SPDLOG_LOGGER_WARN(modelmanager_logger, "Consider changing inputs of the node that gathers from mentioned demultiplexer nodes");
                 return StatusCode::PIPELINE_WRONG_DEMULTIPLEXER_GATHER_NODES_ORDER;
             }
             auto visitedNode = std::find_if(std::begin(visitedNodes), std::end(visitedNodes),
                 [&connectedNodeName](const auto& visitedNode) { return visitedNode.first == connectedNodeName; });
             if (visitedNode != visitedNodes.end()) {
                 if (visitedNode->second != newDemultiplyStack) {
-                    SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} after node: {} exist paths that have different demultiply levels", getName(), connectedNodeName);
-                    SPDLOG_LOGGER_WARN(modelmanager_logger, "Consider changing output connections of node: {}", connectedNodeName);
+                    SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} after node: {} exist paths that have different demultiply levels. Consider changing output connections of node: {}", getName(), connectedNodeName, connectedNodeName);
                     return StatusCode::PIPELINE_WRONG_DEMULTIPLEXER_GATHER_NODES_ORDER;
                 }
             } else {

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -911,7 +911,7 @@ Status PipelineDefinition::validateDemultiplexerGatherNodesOrder() {
                             return rhs;
                         }
                         return lhs + ", " + rhs; }));
-                SPDLOG_LOGGER_WARN(modelmanager_logger ,"Consider changing inputs of the node that gathers from mentioned demultiplexer nodes");
+                SPDLOG_LOGGER_WARN(modelmanager_logger, "Consider changing inputs of the node that gathers from mentioned demultiplexer nodes");
                 return StatusCode::PIPELINE_WRONG_DEMULTIPLEXER_GATHER_NODES_ORDER;
             }
             auto visitedNode = std::find_if(std::begin(visitedNodes), std::end(visitedNodes),
@@ -919,7 +919,7 @@ Status PipelineDefinition::validateDemultiplexerGatherNodesOrder() {
             if (visitedNode != visitedNodes.end()) {
                 if (visitedNode->second != newDemultiplyStack) {
                     SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} after node: {} exist paths that have different demultiply levels", getName(), connectedNodeName);
-                    SPDLOG_LOGGER_WARN(modelmanager_logger ,"Consider changing output connections of node: {}", connectedNodeName);
+                    SPDLOG_LOGGER_WARN(modelmanager_logger, "Consider changing output connections of node: {}", connectedNodeName);
                     return StatusCode::PIPELINE_WRONG_DEMULTIPLEXER_GATHER_NODES_ORDER;
                 }
             } else {

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -911,6 +911,7 @@ Status PipelineDefinition::validateDemultiplexerGatherNodesOrder() {
                             return rhs;
                         }
                         return lhs + ", " + rhs; }));
+                SPDLOG_LOGGER_WARN(modelmanager_logger ,"Consider changing inputs of the node that gathers from mentioned demultiplexer nodes");
                 return StatusCode::PIPELINE_WRONG_DEMULTIPLEXER_GATHER_NODES_ORDER;
             }
             auto visitedNode = std::find_if(std::begin(visitedNodes), std::end(visitedNodes),
@@ -918,6 +919,7 @@ Status PipelineDefinition::validateDemultiplexerGatherNodesOrder() {
             if (visitedNode != visitedNodes.end()) {
                 if (visitedNode->second != newDemultiplyStack) {
                     SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} after node: {} exist paths that have different demultiply levels", getName(), connectedNodeName);
+                    SPDLOG_LOGGER_WARN(modelmanager_logger ,"Consider changing output connections of node: {}", connectedNodeName);
                     return StatusCode::PIPELINE_WRONG_DEMULTIPLEXER_GATHER_NODES_ORDER;
                 }
             } else {

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -904,7 +904,7 @@ Status PipelineDefinition::validateDemultiplexerGatherNodesOrder() {
                 newDemultiplyStack.emplace_back(connectedNodeInfo.gatherFromNode);
             }
             if (connectedNodeInfo.kind == NodeKind::ENTRY && !newDemultiplyStack.empty()) {
-                SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} exists path that gathers from demultiplexer nodes that are not in path: {}. Consider changing inputs of the node that gathers from mentioned demultiplexer nodes",
+                SPDLOG_LOGGER_ERROR(modelmanager_logger, "In pipeline: {} exists path that gathers from nodes that are not in path: {}. Consider changing inputs of the node that gathers from mentioned demultiplexer nodes",
                     getName(),
                     std::accumulate(newDemultiplyStack.back().begin(), newDemultiplyStack.back().end(), std::string{}, [](const std::string& lhs, const std::string& rhs) {
                         if (lhs.empty()) {


### PR DESCRIPTION
There are two edge cases where incorrect connections to node that gathers from demultiplexer are made.
This is how pipeline config looks like. The problem is the connection between response and dummy nodes.
![Screen Shot 2021-07-06 at 14 24 30](https://user-images.githubusercontent.com/84376535/124759382-ded6ad00-df2f-11eb-9838-f68ce0cea643.png)
There is a discussion whether the error messages are clear enough for a user. I would really like to hear others opinions on this topic.