### PR TITLE
Check fix with yum clean all

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -39,6 +39,7 @@ ARG build_type=dbg
 ARG debug_bazel_flags=--strip=never\ --copt="-g"\ -c\ dbg
 ENV HDDL_INSTALL_DIR=/opt/intel/openvino/deployment_tools/inference_engine/external/hddl
 
+RUN yum clean all
 RUN yum update -d6 -y && yum install -d6 -y epel-release centos-release-scl && yum install -d6 -y \
             boost-atomic \
             boost-chrono \


### PR DESCRIPTION
Cleaning yum cache after the update may be not enough when the base
image is too old. In such cases yum|dnf clean all is required.