### PR TITLE
Fix EAST OCR custom node metadata reporting

### DIFF
--- a/src/custom_nodes/east_ocr/east_ocr.cpp
+++ b/src/custom_nodes/east_ocr/east_ocr.cpp
@@ -456,7 +456,7 @@ int getOutputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const str
     NODE_ASSERT(((*info)[1].dims) != nullptr, "malloc has failed");
     (*info)[1].dims[0] = 0;
     (*info)[1].dims[1] = 1;
-    (*info)[1].dims[2] = 5;
+    (*info)[1].dims[2] = 4;
     (*info)[1].precision = I32;
 
     (*info)[2].name = CONFIDENCE_TENSOR_NAME;


### PR DESCRIPTION
East ocr custom node reported for text_coordinates that its shape would be (0,1,5) while producing (0,1,4).

JIRA:CVS-59804