### PR TITLE
CVS-60502_CVS-59189 Switch to using system curl & openssl

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -138,8 +138,8 @@ COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 
 ENV BAZEL_LINKLIBS=-l%:libstdc++.a
-RUN TF_SYSTEM_LIBS=boringssl bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
-RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
+RUN TF_SYSTEM_LIBS="curl" bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
+RUN TF_SYSTEM_LIBS="curl" bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
 
 ####### Azure SDK needs new boost:
 WORKDIR /boost
@@ -191,12 +191,12 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
 RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s#REPLACE_OPENVINO_NAME#`find /opt/intel/ -maxdepth 1 -type d | grep openvino | cut -d'_' -f2`#g" /ovms/src/version.hpp
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
+RUN TF_SYSTEM_LIBS="curl" bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN TF_SYSTEM_LIBS="curl" bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN if [ -f /opt/intel/openvino/bin/setupvars.sh ];  then cd /ovms/src/test/cpu_extension/ && make ; fi
 
-RUN bazel test ${debug_bazel_flags} --jobs $JOBS --test_summary=detailed --test_output=all //src:ovms_test
+RUN TF_SYSTEM_LIBS="curl" bazel test ${debug_bazel_flags} --jobs $JOBS --test_summary=detailed --test_output=all //src:ovms_test
 
 COPY ${ovms_metadata_file} metadata.json
 

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -135,8 +135,8 @@ RUN if [ -f /opt/intel/openvino/deployment_tools/inference_engine/samples/cpp/bu
 WORKDIR /ovms
 COPY .bazelrc WORKSPACE /ovms/
 # since bazel does not have easy way to pass if down the dependencies to have select the sources
-# for libcurl & ssl we hack it this way
-RUN sed -i "s:lib/x86_64-linux-gnu:lib64:g" WORKSPACE
+# for libcurl & ssl we hack it this way for the linker
+RUN ln -s /usr/lib64 /usr/lib/x86_64-linux-gnu
 COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -63,6 +63,7 @@ RUN yum update -d6 -y && yum install -d6 -y epel-release centos-release-scl && y
             make \
             numactl-libs \
             ocl-icd \
+            openssl-devel \
             patch \
             pkg-config \
             python3 \
@@ -150,12 +151,6 @@ RUN wget https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.
 		--with-log --with-locale \
 		install
 
-# OPENSSL
-WORKDIR /openssl
-
-RUN git clone https://github.com/openssl/openssl && cd openssl && git checkout tags/OpenSSL_1_1_1k
-RUN cd openssl && ./config --prefix=/usr/local/ssl --openssldir=/etc/pki/tls shared && make --jobs=$JOBS && make --jobs=$JOBS install || true && make --jobs=$JOBS install_runtime
-
 ####### Azure SDK
 
 WORKDIR /azure
@@ -178,7 +173,7 @@ RUN cd azure-storage-cpp/Microsoft.WindowsAzure.Storage/build.release && CASABLA
 # Build AWS S3 SDK
 RUN git clone https://github.com/aws/aws-sdk-cpp.git --branch 1.7.129 --single-branch --depth 1 /awssdk
 WORKDIR /awssdk/build
-RUN OPENSSL_ROOT_DIR=/usr/local/ssl/ cmake3 -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=s3 -DENABLE_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DFORCE_SHARED_CRT=OFF -DSIMPLE_INSTALL=OFF -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 " ..
+RUN cmake3 -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=s3 -DENABLE_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DFORCE_SHARED_CRT=OFF -DSIMPLE_INSTALL=OFF -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 " ..
 RUN make --jobs=$JOBS
 RUN mv .deps/install/lib64 .deps/install/lib
 
@@ -196,7 +191,7 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
 RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s#REPLACE_OPENVINO_NAME#`find /opt/intel/ -maxdepth 1 -type d | grep openvino | cut -d'_' -f2`#g" /ovms/src/version.hpp
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN TF_SYSTEM_LIBS=boringssl bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN if [ -f /opt/intel/openvino/bin/setupvars.sh ];  then cd /ovms/src/test/cpu_extension/ && make ; fi

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -138,7 +138,7 @@ COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 
 ENV BAZEL_LINKLIBS=-l%:libstdc++.a
-RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
+RUN TF_SYSTEM_LIBS=boringssl bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
 
 ####### Azure SDK needs new boost:
@@ -191,7 +191,7 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
 RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s#REPLACE_OPENVINO_NAME#`find /opt/intel/ -maxdepth 1 -type d | grep openvino | cut -d'_' -f2`#g" /ovms/src/version.hpp
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN TF_SYSTEM_LIBS=boringssl bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN if [ -f /opt/intel/openvino/bin/setupvars.sh ];  then cd /ovms/src/test/cpu_extension/ && make ; fi

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -134,6 +134,9 @@ RUN if [ -f /opt/intel/openvino/deployment_tools/inference_engine/samples/cpp/bu
 # Build OpenVINO Model Server
 WORKDIR /ovms
 COPY .bazelrc WORKSPACE /ovms/
+# since bazel does not have easy way to pass if down the dependencies to have select the sources
+# for libcurl & ssl we hack it this way
+RUN sed -i "s:lib/x86_64-linux-gnu:lib64:g" WORKSPACE
 COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -99,7 +99,7 @@ WORKDIR /ovms
 COPY .bazelrc WORKSPACE /ovms/
 # since bazel does not have easy way to pass if down the dependencies to have select the sources
 # for libcurl & ssl we hack it this way
-RUN sed -i "s:lib/x86_64-linux-gnu:lib64:g" WORKSPACE
+RUN ln -s /usr/lib64 /usr/lib/x86_64-linux-gnu
 COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -58,6 +58,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
             libuuid-devel \
             libxml2-devel \
             make \
+            openssl-devel \
             patch \
             pkg-config \
             python3 \
@@ -113,12 +114,6 @@ RUN wget https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.
 		--with-log --with-locale \
 		install
 
-# OPENSSL
-WORKDIR /openssl
-
-RUN git clone https://github.com/openssl/openssl && cd openssl && git checkout tags/OpenSSL_1_1_1k
-RUN cd openssl && ./config --prefix=/usr/local/ssl --openssldir=/etc/pki/tls shared && make --jobs=$JOBS && make --jobs=$JOBS install || true && make --jobs=$JOBS install_runtime
-
 ####### Azure SDK
 
 WORKDIR /azure
@@ -141,7 +136,7 @@ RUN cd azure-storage-cpp/Microsoft.WindowsAzure.Storage/build.release && CASABLA
 # Build AWS S3 SDK
 RUN git clone https://github.com/aws/aws-sdk-cpp.git --branch 1.7.129 --single-branch --depth 1 /awssdk
 WORKDIR /awssdk/build
-RUN OPENSSL_ROOT_DIR=/usr/local/ssl/ cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=s3 -DENABLE_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DFORCE_SHARED_CRT=OFF -DSIMPLE_INSTALL=OFF -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 " ..
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=s3 -DENABLE_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DFORCE_SHARED_CRT=OFF -DSIMPLE_INSTALL=OFF -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 " ..
 RUN make --jobs=$JOBS
 RUN mv .deps/install/lib64 .deps/install/lib
 
@@ -160,7 +155,7 @@ RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN TF_SYSTEM_LIBS=boringssl bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/test/cpu_extension/ && make

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -101,7 +101,7 @@ COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 
 RUN alternatives --set python /usr/bin/python3
-RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
+RUN TF_SYSTEM_LIBS=boringssl bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
 
 ####### Azure SDK needs new boost:
@@ -155,7 +155,7 @@ RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN TF_SYSTEM_LIBS=boringssl bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/test/cpu_extension/ && make

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -101,8 +101,8 @@ COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 
 RUN alternatives --set python /usr/bin/python3
-RUN TF_SYSTEM_LIBS=boringssl bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
-RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
+RUN TF_SYSTEM_LIBS="curl" bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
+RUN TF_SYSTEM_LIBS="curl" bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
 
 ####### Azure SDK needs new boost:
 WORKDIR /boost
@@ -155,12 +155,12 @@ RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
+RUN TF_SYSTEM_LIBS="curl" bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN TF_SYSTEM_LIBS="curl" bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/test/cpu_extension/ && make
 
-RUN bazel test ${debug_bazel_flags} --jobs $JOBS --test_summary=detailed --test_output=all //src:ovms_test
+RUN TF_SYSTEM_LIBS="curl" bazel test ${debug_bazel_flags} --jobs $JOBS --test_summary=detailed --test_output=all //src:ovms_test
 
 COPY ${ovms_metadata_file} metadata.json
 

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -97,6 +97,9 @@ RUN if [ "$ov_use_binary" == "1" ] && [ "$DLDT_PACKAGE_URL" != "" ]; then true ;
 # Build OpenVINO Model Server
 WORKDIR /ovms
 COPY .bazelrc WORKSPACE /ovms/
+# since bazel does not have easy way to pass if down the dependencies to have select the sources
+# for libcurl & ssl we hack it this way
+RUN sed -i "s:lib/x86_64-linux-gnu:lib64:g" WORKSPACE
 COPY external /ovms/external/
 COPY third_party /ovms/third_party/
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -60,6 +60,7 @@ RUN apt update && apt install -y \
             libtool \
             libxml2-dev \
             libnuma-dev \
+            openssl-devel \
             patch \
             pkg-config \
             python2 \
@@ -150,12 +151,6 @@ tar xvf boost_1_68_0.tar.gz && cd boost_1_68_0 && ./bootstrap.sh && \
 --with-log --with-locale \
 install
 
-# OPENSSL
-WORKDIR /openssl
-
-RUN git clone https://github.com/openssl/openssl && cd openssl && git checkout tags/OpenSSL_1_1_1k
-RUN cd openssl && ./config --prefix=/usr/local/ssl --openssldir=/etc/pki/tls shared && make --jobs=$JOBS && make --jobs=$JOBS install || true && make --jobs=$JOBS install_runtime
-
 ####### Azure SDK
 
 WORKDIR /azure
@@ -179,7 +174,7 @@ RUN cd azure-storage-cpp/Microsoft.WindowsAzure.Storage/build.release && CASABLA
 # Build AWS S3 SDK
 RUN git clone https://github.com/aws/aws-sdk-cpp.git --branch 1.7.129 --single-branch --depth 1 /awssdk
 WORKDIR /awssdk/build
-RUN OPENSSL_ROOT_DIR=/usr/local/ssl/ cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=s3 -DENABLE_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DFORCE_SHARED_CRT=OFF -DSIMPLE_INSTALL=OFF -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 " ..
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY=s3 -DENABLE_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DFORCE_SHARED_CRT=OFF -DSIMPLE_INSTALL=OFF -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 " ..
 RUN make --jobs=$JOBS
 #RUN mv .deps/install/lib64 .deps/install/lib
 
@@ -195,7 +190,7 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
 RUN if [ "$ov_use_binary" = "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s#REPLACE_OPENVINO_NAME#`find /opt/intel/ -maxdepth 1 -type d | grep openvino | cut -d'_' -f2`#g" /ovms/src/version.hpp
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN TF_SYSTEM_LIBS=boringssl bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/test/cpu_extension/ && make

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -138,7 +138,7 @@ COPY third_party /ovms/third_party/
 
 ENV BAZEL_LINKLIBS=-l%:libstdc++.a
 RUN apt install -y python-is-python3
-RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
+RUN TF_SYSTEM_LIBS=boringssl bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
 
 ####### Azure SDK needs new boost:
@@ -190,7 +190,7 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
 RUN if [ "$ov_use_binary" = "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s#REPLACE_OPENVINO_NAME#`find /opt/intel/ -maxdepth 1 -type d | grep openvino | cut -d'_' -f2`#g" /ovms/src/version.hpp
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN TF_SYSTEM_LIBS=boringssl bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/test/cpu_extension/ && make

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -60,7 +60,7 @@ RUN apt update && apt install -y \
             libtool \
             libxml2-dev \
             libnuma-dev \
-            openssl-devel \
+            libssl-dev \
             patch \
             pkg-config \
             python2 \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -138,8 +138,8 @@ COPY third_party /ovms/third_party/
 
 ENV BAZEL_LINKLIBS=-l%:libstdc++.a
 RUN apt install -y python-is-python3
-RUN TF_SYSTEM_LIBS=boringssl bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
-RUN bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
+RUN TF_SYSTEM_LIBS="curl" bazel build --jobs=$JOBS ${debug_bazel_flags} @org_tensorflow//tensorflow/core:framework
+RUN TF_SYSTEM_LIBS="curl" bazel build --jobs=$JOBS ${debug_bazel_flags} @tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto
 
 ####### Azure SDK needs new boost:
 WORKDIR /boost
@@ -190,12 +190,12 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
 RUN if [ "$ov_use_binary" = "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s#REPLACE_OPENVINO_NAME#`find /opt/intel/ -maxdepth 1 -type d | grep openvino | cut -d'_' -f2`#g" /ovms/src/version.hpp
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/:/opt/intel/openvino/deployment_tools/ngraph/lib/:/opt/intel/openvino/inference_engine/external/tbb/lib/:/openvino/bin/intel64/Release/lib/:/opt/intel/openvino/opencv/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
+RUN TF_SYSTEM_LIBS="curl" bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN TF_SYSTEM_LIBS="curl" bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/test/cpu_extension/ && make
 
-RUN bazel test ${debug_bazel_flags} --jobs $JOBS --test_summary=detailed --test_output=all //src:ovms_test
+RUN TF_SYSTEM_LIBS="curl" bazel test ${debug_bazel_flags} --jobs $JOBS --test_summary=detailed --test_output=all //src:ovms_test
 
 COPY ${ovms_metadata_file} metadata.json
 

--- a/DockerfileMakePackage
+++ b/DockerfileMakePackage
@@ -53,7 +53,6 @@ RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; find /opt/in
 RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; find /opt/intel/openvino/deployment_tools/inference_engine/external/ -iname '*.so*' -exec cp -v {} /ovms_release/lib/ \;
 RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; find /opt/intel/openvino/opencv/lib/ -iname '*.so*' -exec cp -vP {} /ovms_release/lib/ \; && rm /ovms_release/lib/libopencv_highgui*
 RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; cp /opt/intel/openvino/opencv/etc/licenses/* /ovms/release_files/thirdparty-licenses/;
-RUN find /usr/local/ssl/lib -iname 'libcrypto.so*' -exec cp -vP {} /ovms_release/lib/ \;
 
 RUN if [ -f /ovms_release/lib/libbsl.so.0 ] ; then cd /ovms_release/lib/ ; rm -f libbsl.so.0 ; ln -s libbsl.so libbsl.so.0 ; fi
 RUN if [ -f /ovms_release/lib/libmvnc-hddl.so.0 ] ; then cd /ovms_release/lib/ ; rm -f libmvnc-hddl.so.0 ; ln -s libmvnc-hddl.so libmvnc-hddl.so.0 ; fi

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ OV_SOURCE_BRANCH ?= master
 DLDT_PACKAGE_URL ?=
 OV_USE_BINARY ?= 1
 YUM_OV_PACKAGE ?= intel-openvino-runtime-centos7
-APT_OV_PACKAGE ?= intel-openvino-runtime-ubuntu20-2021.3.394
+APT_OV_PACKAGE ?= intel-openvino-runtime-ubuntu20-2021.4.582
 # opt, dbg:
 BAZEL_BUILD_TYPE ?= opt
 
@@ -71,6 +71,8 @@ DIST_OS_TAG ?= $(BASE_OS_TAG)
 ifeq ($(BASE_OS),ubuntu)
   BASE_OS_TAG=$(BASE_OS_TAG_UBUNTU)
   BASE_IMAGE=ubuntu:$(BASE_OS_TAG_UBUNTU)
+  # Temporarily build from APT
+  DLDT_PACKAGE_URL=""
 endif
 ifeq ($(BASE_OS),centos)
   BASE_OS_TAG=$(BASE_OS_TAG_CENTOS)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,17 +26,26 @@ new_local_repository(
     name = "boringssl",
     path = "/usr/",
     build_file_content = """
+#constraint_setting(name = "linux_distribution_family")
+#constraint_value(constraint_setting = "linux_distribution_family", name = "fedora") # like RHEL/CentOS
+#constraint_value(constraint_setting = "linux_distribution_family", name = "debian") # like Ubuntu
 cc_library(
     name = "ssl",
     hdrs = glob(["include/openssl/*"]),
-    srcs = glob(["lib/x86_64-linux-gnu/libssl.so"]),
+    srcs = select({
+        ":debian": glob(["lib64/libssl.so"]),
+        ":fedora": glob(["lib/x86_64-linux-gnu/libssl.so"])
+        }),
     copts = ["-lcrypto", "-lssl"],
     visibility = ["//visibility:public"],
 )
 cc_library(
     name = "crypto",
     hdrs = glob(["include/openssl/*"]),
-    srcs = glob(["lib/x86_64-linux-gnu/libssl.so"]),
+    srcs = select({
+        ":debian": glob(["lib64/libssl.so"]),
+        ":fedora": glob(["lib/x86_64-linux-gnu/libssl.so"])
+        }),
     copts = ["-lcrypto", "-lssl"],
     visibility = ["//visibility:public"],
 )
@@ -50,7 +59,10 @@ new_local_repository(
 cc_library(
     name = "curl",
     hdrs = glob(["include/x86_64/curl/*"]),
-    srcs = glob(["lib/x86_64-linux-gnu/libcurl.so"]),
+    srcs = select(
+        ":debian": glob(["lib64/libcurl.so"]),
+        ":fedora": glob(["lib/x86_64-linux-gnu/libcurl.so"])
+        }),
     copts = ["-lcrypto", "-lssl"],
     visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,26 +26,17 @@ new_local_repository(
     name = "boringssl",
     path = "/usr/",
     build_file_content = """
-#constraint_setting(name = "linux_distribution_family")
-#constraint_value(constraint_setting = "linux_distribution_family", name = "fedora") # like RHEL/CentOS
-#constraint_value(constraint_setting = "linux_distribution_family", name = "debian") # like Ubuntu
 cc_library(
     name = "ssl",
     hdrs = glob(["include/openssl/*"]),
-    srcs = select({
-        ":debian": glob(["lib64/libssl.so"]),
-        ":fedora": glob(["lib/x86_64-linux-gnu/libssl.so"])
-        }),
+    srcs = glob(["lib/x86_64-linux-gnu/libssl.so"]),
     copts = ["-lcrypto", "-lssl"],
     visibility = ["//visibility:public"],
 )
 cc_library(
     name = "crypto",
     hdrs = glob(["include/openssl/*"]),
-    srcs = select({
-        ":debian": glob(["lib64/libssl.so"]),
-        ":fedora": glob(["lib/x86_64-linux-gnu/libssl.so"])
-        }),
+    srcs = glob(["lib/x86_64-linux-gnu/libssl.so"]),
     copts = ["-lcrypto", "-lssl"],
     visibility = ["//visibility:public"],
 )
@@ -59,10 +50,7 @@ new_local_repository(
 cc_library(
     name = "curl",
     hdrs = glob(["include/x86_64/curl/*"]),
-    srcs = select(
-        ":debian": glob(["lib64/libcurl.so"]),
-        ":fedora": glob(["lib/x86_64-linux-gnu/libcurl.so"])
-        }),
+    srcs = glob(["lib/x86_64-linux-gnu/libcurl.so"]),
     copts = ["-lcrypto", "-lssl"],
     visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,19 +62,6 @@ workspace()
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
-# LIBCRYPTO
-new_local_repository(
-    name = "crypto_lib",
-    path = "/usr/local/ssl/lib",
-    build_file_content = """
-cc_library(
-    name = "libcrypto",
-    srcs = ["libcrypto.so","libcrypto.so.1.1"],
-    visibility = ["//visibility:public"],
-)
-""",
-)
-
 # AWS S3 SDK
 new_local_repository(
     name = "awssdk",

--- a/release_files/Dockerfile.ubuntu
+++ b/release_files/Dockerfile.ubuntu
@@ -43,8 +43,9 @@ WORKDIR /
 RUN	set -e ; \
 	set -x ; \
         apt update -y ; \
+        apt install -y curl; \
 	if [ "$GPU" == "1" ] ; then \
-                apt install -y libnuma1 ocl-icd-libopencl1 curl; \
+                apt install -y libnuma1 ocl-icd-libopencl1; \
 	        case $INSTALL_DRIVER_VERSION in \
                 "19.41.14441") \
                         mkdir /tmp/gpu_deps && cd /tmp/gpu_deps ; \

--- a/src/BUILD
+++ b/src/BUILD
@@ -322,7 +322,6 @@ cc_binary(
     ],
     deps = [
         "//src:ovms_lib",
-        "@crypto_lib//:libcrypto",
     ]
 )
 
@@ -413,7 +412,6 @@ cc_test(
         "//src:libcustom_node_model_zoo_intel_object_detection.so",
         "//src:libcustom_node_image_transformation.so",
         "@com_google_googletest//:gtest",
-        "@crypto_lib//:libcrypto",
     ],
     copts = [
         "-Wall",

--- a/src/BUILD
+++ b/src/BUILD
@@ -13,6 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#config_setting(
+#    name = "linux_distribution_family",
+#    constraint_values = [
+#        ":debian", # like Ubuntu
+#        ":fedora", # like RHEL/CentOS
+#    ],
+#)
+
+constraint_setting(name = "linux_distribution_family")
+constraint_value(constraint_setting = "linux_distribution_family", name = "fedora") # like RHEL/CentOS
+constraint_value(constraint_setting = "linux_distribution_family", name = "debian") # like Ubuntu
 
 cc_library(
     name = "ovms_lib",

--- a/src/BUILD
+++ b/src/BUILD
@@ -398,6 +398,7 @@ cc_test(
         "-luuid",
         "-lstdc++fs",
         "-lcrypto",
+        "-lssl",
     ],
     deps = [
         "//src:ovms_lib",

--- a/third_party/azure/azure_sdk.patch
+++ b/third_party/azure/azure_sdk.patch
@@ -2,27 +2,12 @@ diff --git a/Microsoft.WindowsAzure.Storage/CMakeLists.txt b/Microsoft.WindowsAz
 index ac9e65d..fd2aca4 100644
 --- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
 +++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
-@@ -43,8 +43,13 @@ if(UNIX)
-   endif()
- 
-   set(_OPENSSL_VERSION "")
--  find_package(OpenSSL 1.0.0 REQUIRED)
-+  #find_package(OpenSSL 1.0.0 REQUIRED)
- 
-+set(OPENSSL_INCLUDE_DIR "/usr/local/ssl/include" CACHE INTERNAL "")
-+    set(OPENSSL_LIBRARIES
-+    "/usr/local/ssl/lib/libssl.a"
-+    "/usr/local/ssl/lib/libcrypto.a"
-+    )
- 
-   find_package(UUID REQUIRED)
-   find_package(Casablanca REQUIRED)
 @@ -83,15 +88,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
    set(LINUX_SUPPRESSIONS "-Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-unused-function -Wno-char-subscripts -Wno-switch -Wno-unused-but-set-parameter -Wno-unused-value -Wno-unused-local-typedefs -Wno-unused-parameter")
    set(WARNINGS "${WARNINGS} ${LINUX_SUPPRESSIONS}")
  
 -  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
-+  set(LD_FLAGS "${LD_FLAGS} -Bstatic,-lcrypto,-lssl,-Bdynamic,-Wl,-z,defs,--exclude-libs,ALL")
++  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs,--exclude-libs,ALL")
  
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
  

--- a/third_party/cpprest/rest_sdk_v2.10.16.patch
+++ b/third_party/cpprest/rest_sdk_v2.10.16.patch
@@ -7,7 +7,7 @@ index 13a3f01d..8f326366 100644
  
    set(WARNINGS -Wall -Wextra -Wunused-parameter -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls -Wunreachable-code)
 -  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
-+  set(LD_FLAGS "${LD_FLAGS} -Bstatic,-lcrypto,-lssl,-Bdynamic,-Wl,-z,defs,--exclude-libs,ALL")
++  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs,--exclude-libs,ALL")
  
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
@@ -40,97 +40,4 @@ index 3c857baf..d3f27bcd 100644
      else()
        target_link_libraries(cpprestsdk_boost_internal INTERFACE
          Boost::boost
-diff --git a/Release/cmake/cpprest_find_openssl.cmake b/Release/cmake/cpprest_find_openssl.cmake
-index 93336636..40024f69 100644
---- a/Release/cmake/cpprest_find_openssl.cmake
-+++ b/Release/cmake/cpprest_find_openssl.cmake
-@@ -3,67 +3,23 @@ function(cpprest_find_openssl)
-     return()
-   endif()
- 
--  if(IOS)
--    set(IOS_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../Build_iOS")
- 
--    set(OPENSSL_INCLUDE_DIR "${IOS_SOURCE_DIR}/openssl/include" CACHE INTERNAL "")
-+    set(OPENSSL_INCLUDE_DIR "/usr/local/ssl/include" CACHE INTERNAL "")
-     set(OPENSSL_LIBRARIES
--      "${IOS_SOURCE_DIR}/openssl/lib/libcrypto.a"
--      "${IOS_SOURCE_DIR}/openssl/lib/libssl.a"
--      CACHE INTERNAL ""
--      )
--    set(_SSL_LEAK_SUPPRESS_AVAILABLE ON CACHE INTERNAL "")
--  elseif(ANDROID)
--    if(ARM)
--      set(OPENSSL_INCLUDE_DIR "${CMAKE_BINARY_DIR}/../openssl/armeabi-v7a/include" CACHE INTERNAL "")
--      set(OPENSSL_LIBRARIES
--        "${CMAKE_BINARY_DIR}/../openssl/armeabi-v7a/lib/libssl.a"
--        "${CMAKE_BINARY_DIR}/../openssl/armeabi-v7a/lib/libcrypto.a"
--        CACHE INTERNAL ""
--        )
--    else()
--      set(OPENSSL_INCLUDE_DIR "${CMAKE_BINARY_DIR}/../openssl/x86/include" CACHE INTERNAL "")
--      set(OPENSSL_LIBRARIES
--        "${CMAKE_BINARY_DIR}/../openssl/x86/lib/libssl.a"
--        "${CMAKE_BINARY_DIR}/../openssl/x86/lib/libcrypto.a"
--        CACHE INTERNAL ""
--        )
--    endif()
--    set(_SSL_LEAK_SUPPRESS_AVAILABLE ON CACHE INTERNAL "")
--  else()
--    if(APPLE)
--      if(NOT DEFINED OPENSSL_ROOT_DIR)
--        # Prefer a homebrew version of OpenSSL over the one in /usr/lib
--        file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl*/*)
--        # Prefer the latest (make the latest one first)
--        list(REVERSE OPENSSL_ROOT_DIR)
--        list(GET OPENSSL_ROOT_DIR 0 OPENSSL_ROOT_DIR)
--      endif()
--      # This should prevent linking against the system provided 0.9.8y
--      message(STATUS "OPENSSL_ROOT_DIR = ${OPENSSL_ROOT_DIR}")
--      set(_OPENSSL_VERSION "")
--    endif()
--    if(UNIX)
--      find_package(PkgConfig)
--      pkg_search_module(OPENSSL openssl)
--    endif()
--    if(OPENSSL_FOUND)
--      target_link_libraries(cpprest PRIVATE ${OPENSSL_LDFLAGS})
--    else()
--      find_package(OpenSSL 1.0.0 REQUIRED)
--    endif()
-+    "/usr/local/ssl/lib/libssl.a"
-+    "/usr/local/ssl/lib/libcrypto.a"
-+    )
- 
-     INCLUDE(CheckCXXSourceCompiles)
-     set(CMAKE_REQUIRED_INCLUDES "${OPENSSL_INCLUDE_DIR}")
-     set(CMAKE_REQUIRED_LIBRARIES "${OPENSSL_LIBRARIES}")
-     CHECK_CXX_SOURCE_COMPILES("
--      #include <openssl/ssl.h>
--      int main()
--      {
--      ::SSL_COMP_free_compression_methods();
--      }
-+        #include <openssl/ssl.h>
-+        int main()
-+        {
-+        ::SSL_COMP_free_compression_methods();
-+        }
-     " _SSL_LEAK_SUPPRESS_AVAILABLE)
--  endif()
- 
-   add_library(cpprestsdk_openssl_internal INTERFACE)
-   if(TARGET OpenSSL::SSL)
-diff --git a/Release/src/CMakeLists.txt b/Release/src/CMakeLists.txt
-index a2d4d30b..b8b45c55 100644
---- a/Release/src/CMakeLists.txt
-+++ b/Release/src/CMakeLists.txt
-@@ -190,6 +190,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-     target_compile_options(cpprest PRIVATE -Werror)
-   endif()
-   target_compile_options(cpprest PRIVATE -pedantic ${WARNINGS})
-+  target_link_libraries(cpprest PRIVATE "-Wl,--exclude-libs,ALL")
- elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-   if(WERROR)
-     target_compile_options(cpprest PRIVATE /WX ${WARNINGS})
 


### PR DESCRIPTION
Till now we used several versions of openssl due to our dependencies. It was mainly due to boringssl usage in Google products which is used by both Google Cloud Storage as well as TFS/TF. Since boringssl is implementing the same interface that openssl does this caused symbol conflicts during linking/loading/running stages.

Solution for now is to mask system openssl as boringssl dependency. GCS additionally build curl with different openssl flags than the system libs which resulted in having deprecated symbol present thus the replacement of curl.

Unfortunately the plain simple "select" clause did not work for the system libs path selection so workaround for now for this is to have symbolic link in case of fedora family OS's.