### PR TITLE
WIP fuller unification of serialization

### DIFF
--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -1029,7 +1029,8 @@ Status ModelInstance::infer(const tensorflow::serving::PredictRequest* requestPr
         requestProto->model_spec().name(), getVersion(), executingInferId, timer.elapsed<microseconds>("prediction") / 1000);
 
     timer.start("serialize");
-    status = serializePredictResponse(inferRequest, getOutputsInfo(), responseProto);
+    OutputGetter<InferenceEngine::InferRequest&> outputGetter(inferRequest);
+    status = serializePredictResponse(outputGetter, getOutputsInfo(), responseProto);
     timer.stop("serialize");
     if (!status.ok())
         return status;

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -119,13 +119,6 @@ Status serializePredictResponse(
         if (!status.ok()) {
             return status;
         }
-        try {
-            blob = inferRequest.GetBlob(networkOutput->getName());
-        } catch (const InferenceEngine::Exception& e) {
-            status = StatusCode::OV_INTERNAL_SERIALIZATION_ERROR;
-            SPDLOG_ERROR("{}: {}", status.string(), e.what());
-            return status;
-        }
         auto& tensorProto = (*response->mutable_outputs())[networkOutput->getMappedName()];
         status = serializeBlobToTensorProto(tensorProto, networkOutput, blob);
         if (!status.ok()) {

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -110,23 +110,8 @@ Status serializePredictResponse(
     InferenceEngine::InferRequest& inferRequest,
     const tensor_map_t& outputMap,
     tensorflow::serving::PredictResponse* response) {
-    Status status;
-    for (const auto& pair : outputMap) {
-        auto networkOutput = pair.second;
-        InferenceEngine::Blob::Ptr blob;
-        OutputGetter<InferenceEngine::InferRequest&> outputGetter(inferRequest);
-        status = outputGetter.get(networkOutput->getName(), blob);
-        if (!status.ok()) {
-            return status;
-        }
-        auto& tensorProto = (*response->mutable_outputs())[networkOutput->getMappedName()];
-        status = serializeBlobToTensorProto(tensorProto, networkOutput, blob);
-        if (!status.ok()) {
-            return status;
-        }
-    }
-
-    return status;
+    OutputGetter<InferenceEngine::InferRequest&> outputGetter(inferRequest);
+    return serializePredictResponse(outputGetter, outputMap, response);
 }
 
 }  // namespace ovms

--- a/src/statefulmodelinstance.cpp
+++ b/src/statefulmodelinstance.cpp
@@ -243,7 +243,8 @@ Status StatefulModelInstance::infer(const tensorflow::serving::PredictRequest* r
         requestProto->model_spec().name(), getVersion(), executingInferId, timer.elapsed<microseconds>("prediction") / 1000);
 
     timer.start("serialize");
-    status = serializePredictResponse(inferRequest, getOutputsInfo(), responseProto);
+    OutputGetter<InferenceEngine::InferRequest&> outputGetter(inferRequest);
+    status = serializePredictResponse(outputGetter, getOutputsInfo(), responseProto);
     timer.stop("serialize");
     if (!status.ok())
         return status;


### PR DESCRIPTION
Removing unnecessary GetBlob() call to fix perf drop.

After rewrite of serialization/deserialization tests with the new OV API serializePredictResponse taking as argument InferRequest is to be removed as well. For now to avoid conflicts it is left.

JIRA:CVS-60621