### PR TITLE
CVS-60949 Revert "CVS-60758 std::move. (#798)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(ACTIVATE):
 	@test -d $(VIRTUALENV_DIR) || $(VIRTUALENV_EXE) $(VIRTUALENV_DIR)
 	@. $(ACTIVATE); pip$(PY_VERSION) install --upgrade pip
 	@. $(ACTIVATE); pip$(PY_VERSION) install -vUqq setuptools
-	@. $(ACTIVATE); pip$(PY_VERSION) install -qq -r tests/requirements.txt
+	@. $(ACTIVATE); pip$(PY_VERSION) install -r tests/requirements.txt --use-deprecated=legacy-resolver
 	@touch $(ACTIVATE)
 
 style: venv clang-format

--- a/src/custom_nodes/east_ocr/utils.hpp
+++ b/src/custom_nodes/east_ocr/utils.hpp
@@ -39,7 +39,7 @@ std::vector<T> reorder_to_nhwc(const T* nchwVector, int rows, int cols, int chan
             }
         }
     }
-    return std::move(nhwcVector);
+    return nhwcVector;
 }
 
 template <typename T>
@@ -52,7 +52,7 @@ std::vector<T> reorder_to_nchw(const T* nhwcVector, int rows, int cols, int chan
             }
         }
     }
-    return std::move(nchwVector);
+    return nchwVector;
 }
 
 const cv::Mat nhwc_to_mat(const CustomNodeTensor* input) {

--- a/src/custom_nodes/image_transformation/utils.hpp
+++ b/src/custom_nodes/image_transformation/utils.hpp
@@ -49,7 +49,7 @@ template <typename T>
 std::vector<T> reorder_to_nhwc(const T* nchwVector, int rows, int cols, int channels) {
     std::vector<T> nhwcVector(rows * cols * channels);
     reorder_to_nhwc_2(nchwVector, nhwcVector.data(), rows, cols, channels);
-    return std::move(nhwcVector);
+    return nhwcVector;
 }
 
 template <typename T>
@@ -67,7 +67,7 @@ template <typename T>
 std::vector<T> reorder_to_nchw(const T* nhwcVector, int rows, int cols, int channels) {
     std::vector<T> nchwVector(rows * cols * channels);
     reorder_to_nchw_2(nhwcVector, nchwVector.data(), rows, cols, channels);
-    return std::move(nchwVector);
+    return nchwVector;
 }
 
 const cv::Mat nhwc_to_mat(const CustomNodeTensor* input) {

--- a/src/custom_nodes/model_zoo_intel_object_detection/utils.hpp
+++ b/src/custom_nodes/model_zoo_intel_object_detection/utils.hpp
@@ -39,7 +39,7 @@ std::vector<T> reorder_to_nhwc(const T* nchwVector, int rows, int cols, int chan
             }
         }
     }
-    return std::move(nhwcVector);
+    return nhwcVector;
 }
 
 template <typename T>
@@ -52,7 +52,7 @@ std::vector<T> reorder_to_nchw(const T* nhwcVector, int rows, int cols, int chan
             }
         }
     }
-    return std::move(nchwVector);
+    return nchwVector;
 }
 
 const cv::Mat nhwc_to_mat(const CustomNodeTensor* input) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -73,7 +73,7 @@ const std::map<model_version_t, const ModelInstance&> Model::getModelVersionsMap
     for (auto& [modelVersion, modelInstancePtr] : modelVersions) {
         modelInstancesMapCopy.insert({modelVersion, *modelInstancePtr});
     }
-    return std::move(modelInstancesMapCopy);
+    return modelInstancesMapCopy;
 }
 
 const std::map<model_version_t, std::shared_ptr<ModelInstance>>& Model::getModelVersions() const {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -191,7 +191,7 @@ std::vector<session_key_t> Node::getReadySessions() const {
             readySessions.emplace_back(sessionKey);
         }
     }
-    return std::move(readySessions);
+    return readySessions;
 }
 
 Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {

--- a/src/node_library_utils.cpp
+++ b/src/node_library_utils.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<struct CustomNodeParam[]> createCustomNodeParamArray(const std::
         libraryParameters[i].value = value.c_str();
         i++;
     }
-    return std::move(libraryParameters);
+    return libraryParameters;
 }
 
 std::unique_ptr<struct CustomNodeTensor[]> createCustomNodeTensorArray(const std::unordered_map<std::string, InferenceEngine::Blob::Ptr>& blobMap) {
@@ -94,7 +94,7 @@ std::unique_ptr<struct CustomNodeTensor[]> createCustomNodeTensorArray(const std
         inputTensors[i].precision = toCustomNodeTensorPrecision(blob->getTensorDesc().getPrecision());
         i++;
     }
-    return std::move(inputTensors);
+    return inputTensors;
 }
 
 Status createTensorInfoMap(struct CustomNodeTensorInfo* info, int infoCount, std::map<std::string, std::shared_ptr<TensorInfo>>& out, release_fn freeCallback) {

--- a/src/nodesessionmetadata.cpp
+++ b/src/nodesessionmetadata.cpp
@@ -53,7 +53,7 @@ std::vector<NodeSessionMetadata> NodeSessionMetadata::generateSubsessions(const 
                     return rhs;
                 }
                 return lhs + ", " + rhs; }));
-    return std::move(metas);
+    return metas;
 }
 
 std::string NodeSessionMetadata::getSessionKey(const std::set<std::string>& ignoredNodeNames) const {

--- a/src/ovinferrequestsqueue.cpp
+++ b/src/ovinferrequestsqueue.cpp
@@ -34,7 +34,7 @@ std::future<int> OVInferRequestsQueue::getIdleStream() {
         lk.unlock();
         idleStreamPromise.set_value(value);
     }
-    return std::move(idleStreamFuture);
+    return idleStreamFuture;
 }
 
 void OVInferRequestsQueue::returnStream(int streamID) {

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -75,14 +75,14 @@ Status PipelineDefinition::validate(ModelManager& manager) {
     }
     validationResult = updateOutputsInfo(manager);
     if (!validationResult.ok()) {
-        return std::move(validationResult);
+        return validationResult;
     }
     lock.unlock();
     notifier.passed = true;
     SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Finished validation of pipeline: {}", getName());
     SPDLOG_LOGGER_INFO(modelmanager_logger, "Pipeline: {} inputs: {}", getName(), getTensorMapString(inputsInfo));
     SPDLOG_LOGGER_INFO(modelmanager_logger, "Pipeline: {} outputs: {}", getName(), getTensorMapString(outputsInfo));
-    return std::move(validationResult);
+    return validationResult;
 }
 
 Status PipelineDefinition::reload(ModelManager& manager, const std::vector<NodeInfo>&& nodeInfos, const pipeline_connections_t&& connections) {
@@ -999,13 +999,13 @@ Status PipelineDefinition::validateNodes(ModelManager& manager) {
 const tensor_map_t PipelineDefinition::getInputsInfo() const {
     std::shared_lock lock(metadataMtx);
     tensor_map_t copy = inputsInfo;
-    return std::move(copy);
+    return copy;
 }
 
 const tensor_map_t PipelineDefinition::getOutputsInfo() const {
     std::shared_lock lock(metadataMtx);
     tensor_map_t copy = outputsInfo;
-    return std::move(copy);
+    return copy;
 }
 
 std::shared_ptr<TensorInfo> applyDemultiplexerShapeForTensor(const std::shared_ptr<TensorInfo>& tensorInfo, uint32_t demultiplyCount) {
@@ -1298,7 +1298,7 @@ shape_t PipelineDefinition::getNodeGatherShape(const NodeInfo& info) const {
     }
 
     std::reverse(shape.begin(), shape.end());
-    return std::move(shape);
+    return shape;
 }
 
 }  // namespace ovms

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -853,7 +853,7 @@ public:
         tensorflow::serving::PredictRequest request = preparePredictRequest(getExpectedInputsInfo());
         auto& input = (*request.mutable_inputs())[pipelineInputName];
         input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
-        return std::move(request);
+        return request;
     }
     virtual void checkPipelineResponse(const std::string& pipelineOutputName,
         tensorflow::serving::PredictRequest& request,
@@ -1103,7 +1103,7 @@ public:
         input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
         auto& factors = (*request.mutable_inputs())[pipelineFactorsInputName];
         factors.mutable_tensor_content()->assign((char*)factorsData.data(), factorsData.size() * sizeof(float));
-        return std::move(request);
+        return request;
     }
     inputs_info_t getExpectedInputsInfo() override {
         return {{pipelineInputName,


### PR DESCRIPTION
This reverts commit 31d66cf6173b180b685fb049cfb89715e3cefc52.
The commit was supposed to fix: https://jira.devtools.intel.com/browse/CVS-60758
The commit was not causing the regression.

This commit has caused the regression: https://github.com/openvinotoolkit/model_server/commit/5b516f9c10aeb10e4ac3fd5209f6005427f514d8

And this commit fixed it, so there is no more actions required:
https://github.com/openvinotoolkit/model_server/commit/6c726c097f64183583299e79ee9ba8c2bb0b0d46