### PR TITLE
Fix container shutdown procedure:

### DIFF
--- a/tests/functional/fixtures/server_detection_model_fixtures.py
+++ b/tests/functional/fixtures/server_detection_model_fixtures.py
@@ -21,7 +21,7 @@ from model.models_information import FaceDetection
 from object_model.server import Server
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_face_detection_model_auto_shape(request):
 
     start_server_command_args = {"model_name": FaceDetection.name,
@@ -33,10 +33,10 @@ def start_server_face_detection_model_auto_shape(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_face_detection_model_named_shape(request):
 
     start_server_command_args = {"model_name": FaceDetection.name,
@@ -49,10 +49,10 @@ def start_server_face_detection_model_named_shape(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_face_detection_model_nonamed_shape(request):
 
     start_server_command_args = {"model_name": FaceDetection.name,
@@ -64,4 +64,4 @@ def start_server_face_detection_model_nonamed_shape(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()

--- a/tests/functional/fixtures/server_for_update_fixtures.py
+++ b/tests/functional/fixtures/server_for_update_fixtures.py
@@ -38,7 +38,7 @@ def start_server_update_flow_latest(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
 @pytest.fixture(scope="function")
@@ -55,4 +55,4 @@ def start_server_update_flow_specific(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()

--- a/tests/functional/fixtures/server_local_models_fixtures.py
+++ b/tests/functional/fixtures/server_local_models_fixtures.py
@@ -23,7 +23,7 @@ from model.models_information import Resnet, ResnetONNX, AgeGender
 from object_model.server import Server
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_single_model(request):
 
     start_server_command_args = {"model_name": Resnet.name,
@@ -37,9 +37,9 @@ def start_server_single_model(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     env_variables, target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_single_model_onnx(request):
 
     start_server_command_args = {"model_name": ResnetONNX.name,
@@ -53,9 +53,9 @@ def start_server_single_model_onnx(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     env_variables, target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_with_mapping(request):
 
     def delete_mapping_file():
@@ -73,4 +73,4 @@ def start_server_with_mapping(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()

--- a/tests/functional/fixtures/server_multi_model_fixtures.py
+++ b/tests/functional/fixtures/server_multi_model_fixtures.py
@@ -50,4 +50,4 @@ def start_server_multi_model(request, start_minio_server, get_minio_server_s3):
     container_name_infix = "test-multi"
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command, envs)
-    return server.start()
+    yield server.start()

--- a/tests/functional/fixtures/server_remote_models_fixtures.py
+++ b/tests/functional/fixtures/server_remote_models_fixtures.py
@@ -27,7 +27,7 @@ from object_model.server import Server
 from utils.parametrization import get_tests_suffix
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_single_model_from_gc(request):
 
     start_server_command_args = {"model_name": Resnet.name,
@@ -42,7 +42,7 @@ def start_server_single_model_from_gc(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command, envs,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
 @pytest.fixture(scope="session")
@@ -137,7 +137,7 @@ def get_minio_server_s3(start_minio_server):
     return s3, ports, minio_container
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_single_model_from_minio(request, get_minio_server_s3):
 
     aws_access_key_id = os.getenv('MINIO_ACCESS_KEY')
@@ -165,4 +165,4 @@ def start_server_single_model_from_minio(request, get_minio_server_s3):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command, envs,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()

--- a/tests/functional/fixtures/server_with_batching_fixtures.py
+++ b/tests/functional/fixtures/server_with_batching_fixtures.py
@@ -21,19 +21,18 @@ from model.models_information import ResnetBS8, AgeGender
 from object_model.server import Server
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_batch_model(request):
-
     start_server_command_args = {"model_name": ResnetBS8.name,
                                  "model_path": ResnetBS8.model_path}
     container_name_infix = "test-batch"
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_batch_model_2out(request):
 
     start_server_command_args = {"model_name": AgeGender.name,
@@ -42,10 +41,10 @@ def start_server_batch_model_2out(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_batch_model_auto(request):
 
     start_server_command_args = {"model_name": ResnetBS8.name,
@@ -55,10 +54,10 @@ def start_server_batch_model_auto(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_batch_model_auto_2out(request):
 
     start_server_command_args = {"model_name": AgeGender.name,
@@ -68,10 +67,10 @@ def start_server_batch_model_auto_2out(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_batch_model_bs4(request):
 
     start_server_command_args = {"model_name": ResnetBS8.name,
@@ -81,10 +80,10 @@ def start_server_batch_model_bs4(request):
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command,
                     target_device=config.target_device)
-    return server.start()
+    yield server.start()
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_batch_model_auto_bs4_2out(request):
 
     start_server_command_args = {"model_name": AgeGender.name,
@@ -93,4 +92,4 @@ def start_server_batch_model_auto_bs4_2out(request):
     container_name_infix = "test-batch4-2out"
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command)
-    return server.start()
+    yield server.start()

--- a/tests/functional/fixtures/server_with_version_policy_fixtures.py
+++ b/tests/functional/fixtures/server_with_version_policy_fixtures.py
@@ -24,7 +24,7 @@ from model.models_information import FaceDetection, PVBFaceDetectionV2, AgeGende
 from object_model.server import Server
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def start_server_model_ver_policy(request):
 
     shutil.copyfile('tests/functional/mapping_config.json',
@@ -35,7 +35,7 @@ def start_server_model_ver_policy(request):
 
     server = Server(request, start_server_command_args,
                     container_name_infix, config.start_container_command)
-    return server.start()
+    yield server.start()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/functional/object_model/docker.py
+++ b/tests/functional/object_model/docker.py
@@ -47,18 +47,18 @@ class Docker:
         self.env_vars_container = env_vars_container if env_vars_container else []
         self.container_log_line = container_log_line
 
+    def __del__(self):
+        self.stop_container()
+
+    def stop_container(self):
+        if self.container is not None:
+            logger.info(f"Stopping container: {self.container_name}")
+            self.save_container_logs()
+            self.container.stop()
+            self.container.remove()
+            logger.info(f"Container successfully closed and removed: {self.container_name}")
+
     def start(self):
-
-        def finalizer():
-            if self.container is not None:
-                logger.info(f"Stopping container: {self.container_name}")
-                self.save_container_logs()
-                self.container.stop()
-                self.container.remove()
-                logger.info(f"Container successfully closed and removed: {self.container_name}")
-
-        self.request.addfinalizer(finalizer)
-
         logger.info(f"Starting container: {self.container_name}")
 
         volumes_dict = {'{}'.format(config.path_to_mount): {'bind': '/opt/ml',

--- a/tests/functional/object_model/server.py
+++ b/tests/functional/object_model/server.py
@@ -37,9 +37,9 @@ class Server:
 
     def start(self):
         if config.ovms_binary_path is not None:
-            ovms = OvmsBinary(self.request, self.command_args, self.start_container_command, self.env_vars)
+            self.ovms = OvmsBinary(self.request, self.command_args, self.start_container_command, self.env_vars)
         else:
-            ovms = OvmsDocker(self.request, self.command_args, self.container_name_infix,
+            self.ovms = OvmsDocker(self.request, self.command_args, self.container_name_infix,
                               self.start_container_command, self.env_vars,
                               self.image, self.container_log_line, self.server_log_level, self.target_device)
-        return ovms.start()
+        return self.ovms.start()


### PR DESCRIPTION
- Previously all dockers were stopped and cleaned at end class/scope of test.
- Currently dockers should are cleaned at end of test