### PR TITLE
Add sleep before retrying to read config file

### DIFF
--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -578,6 +578,7 @@ Status ModelManager::loadConfig(const std::string& jsonFilename) {
             SPDLOG_LOGGER_ERROR(modelmanager_logger, "Configuration file is invalid {}", jsonFilename);
             intermediateStatus = StatusCode::CONFIG_FILE_INVALID;
             loud.log();
+            std::this_thread::sleep_for(std::chrono::seconds(1));
             continue;
         }
         rapidjson::IStreamWrapper isw(ifs);
@@ -587,6 +588,7 @@ Status ModelManager::loadConfig(const std::string& jsonFilename) {
                 rapidjson::GetParseError_En(parseResult.Code()));
             intermediateStatus = StatusCode::JSON_INVALID;
             loud.log();
+            std::this_thread::sleep_for(std::chrono::seconds(1));
             continue;
         }
     } while (++counter < MAX_CONFIG_JSON_READ_RETRY_COUNT && !intermediateStatus.ok());


### PR DESCRIPTION
After doing test in isolation it seems that it is possible to write
several(~1400) lines with flushing into file without changing its modification time.

This would explain why we could have empty or improper config.json
read by OVMS & why retry without sleep failed. Its modification time
would not change but its content would.

Sleep time of 1s because not all filesystems support 1ns resolution of time of modification.

JIRA:CVS-61368