### PR TITLE
Add new label for imagestream build progress

### DIFF
--- a/extras/openvino-operator-openshift/helm-charts/rhods-ov-image-stream/templates/imagestream.yaml
+++ b/extras/openvino-operator-openshift/helm-charts/rhods-ov-image-stream/templates/imagestream.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     application: openvino-notebook
     opendatahub.io/notebook-image: "true"
+    opendatahub.io/build_type: "notebook_image"
   annotations:
     opendatahub.io/notebook-image-desc: >-
       Jupyter notebook image with OpenVINO Toolkit


### PR DESCRIPTION
RHODS added a new label to provide a progress dialog to users for an imagestream where a build is in progress. Helpful for first time users