### PR TITLE
Make OVMS use just one IE::Core to load models (#929)

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -110,20 +110,20 @@ const std::shared_ptr<ModelInstance> Model::getDefaultModelInstance() const {
     return modelInstanceIt->second;
 }
 
-std::shared_ptr<ovms::ModelInstance> Model::modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion) {
+std::shared_ptr<ovms::ModelInstance> Model::modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion, InferenceEngine::Core& ieCore) {
     if (isStateful()) {
         SPDLOG_DEBUG("Creating new stateful model instance - model name: {}; model version: {};", modelName, modelVersion);
         return std::move(std::static_pointer_cast<ModelInstance>(
-            std::make_shared<StatefulModelInstance>(modelName, modelVersion, this->globalSequencesViewer)));
+            std::make_shared<StatefulModelInstance>(modelName, modelVersion, ieCore, this->globalSequencesViewer)));
     } else {
         SPDLOG_DEBUG("Creating new model instance - model name: {}; model version: {};", modelName, modelVersion);
-        return std::move(std::make_shared<ModelInstance>(modelName, modelVersion));
+        return std::move(std::make_shared<ModelInstance>(modelName, modelVersion, ieCore));
     }
 }
 
-Status Model::addVersion(const ModelConfig& config) {
+Status Model::addVersion(const ModelConfig& config, InferenceEngine::Core& ieCore) {
     const auto& version = config.getVersion();
-    std::shared_ptr<ModelInstance> modelInstance = modelInstanceFactory(config.getName(), version);
+    std::shared_ptr<ModelInstance> modelInstance = modelInstanceFactory(config.getName(), version, ieCore);
 
     std::unique_lock lock(modelVersionsMtx);
     modelVersions.emplace(version, modelInstance);
@@ -137,7 +137,7 @@ Status Model::addVersion(const ModelConfig& config) {
     return StatusCode::OK;
 }
 
-Status Model::addVersions(std::shared_ptr<model_versions_t> versionsToStart, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, std::shared_ptr<model_versions_t> versionsFailed) {
+Status Model::addVersions(std::shared_ptr<model_versions_t> versionsToStart, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, std::shared_ptr<model_versions_t> versionsFailed) {
     Status result = StatusCode::OK;
     downloadModels(fs, config, versionsToStart);
     versionsFailed->clear();
@@ -145,7 +145,7 @@ Status Model::addVersions(std::shared_ptr<model_versions_t> versionsToStart, ovm
         SPDLOG_INFO("Will add model: {}; version: {} ...", getName(), version);
         config.setVersion(version);
         config.parseModelMapping();
-        auto status = addVersion(config);
+        auto status = addVersion(config, ieCore);
         if (!status.ok()) {
             SPDLOG_ERROR("Error occurred while loading model: {}; version: {}; error: {}",
                 getName(),
@@ -243,7 +243,7 @@ void Model::cleanupAllVersions() {
     subscriptionManager.notifySubscribers();
 }
 
-Status Model::reloadVersions(std::shared_ptr<model_versions_t> versionsToReload, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, std::shared_ptr<model_versions_t> versionsFailed) {
+Status Model::reloadVersions(std::shared_ptr<model_versions_t> versionsToReload, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, std::shared_ptr<model_versions_t> versionsFailed) {
     Status result = StatusCode::OK;
     for (const auto version : *versionsToReload) {
         SPDLOG_INFO("Will reload model: {}; version: {} ...", getName(), version);

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -87,14 +87,14 @@ protected:
          *
          * @return status
          */
-    virtual Status addVersion(const ModelConfig& config);
+    virtual Status addVersion(const ModelConfig& config, InferenceEngine::Core& ieCore);
 
     /**
          * @brief ModelInstances factory
          *
          * @return modelInstance
          */
-    virtual std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion);
+    virtual std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion, InferenceEngine::Core& ieCore);
 
     ModelChangeSubscription subscriptionManager;
 
@@ -175,7 +175,7 @@ public:
          *
          * @return status
          */
-    Status addVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, std::shared_ptr<model_versions_t> versionsFailed);
+    Status addVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, std::shared_ptr<model_versions_t> versionsFailed);
 
     /**
          * @brief Retires versions of Model
@@ -212,7 +212,7 @@ public:
          *
          * @return status
          */
-    Status reloadVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, std::shared_ptr<model_versions_t> versionsFailed);
+    Status reloadVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, std::shared_ptr<model_versions_t> versionsFailed);
 
     void subscribe(PipelineDefinition& pd);
     void unsubscribe(PipelineDefinition& pd);

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -275,27 +275,8 @@ uint ModelInstance::getNumOfParallelInferRequests(const ModelConfig& modelConfig
     return nireq;
 }
 
-void ModelInstance::loadOVEngine() {
-    engine = std::make_unique<InferenceEngine::Core>();
-    if (ovms::Config::instance().cpuExtensionLibraryPath() != "") {
-        SPDLOG_INFO("Loading custom CPU extension from {}", ovms::Config::instance().cpuExtensionLibraryPath());
-        try {
-            auto extension_ptr = std::make_shared<InferenceEngine::Extension>(ovms::Config::instance().cpuExtensionLibraryPath());
-            SPDLOG_INFO("Custom CPU extention loaded. Adding it.");
-            engine->AddExtension(extension_ptr, "CPU");
-            SPDLOG_INFO("Extention added.");
-        } catch (std::exception& ex) {
-            SPDLOG_CRITICAL("Custom CPU extention loading has failed! Reason: {}", ex.what());
-            throw;
-        } catch (...) {
-            SPDLOG_CRITICAL("Custom CPU extention loading has failed with an unknown error!");
-            throw;
-        }
-    }
-}
-
 std::unique_ptr<InferenceEngine::CNNNetwork> ModelInstance::loadOVCNNNetworkPtr(const std::string& modelFile) {
-    return std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(modelFile));
+    return std::make_unique<InferenceEngine::CNNNetwork>(ieCore.ReadNetwork(modelFile));
 }
 
 Status ModelInstance::loadOVCNNNetwork() {
@@ -347,9 +328,9 @@ Status ModelInstance::loadOVCNNNetworkUsingCustomLoader() {
             Blob::Ptr blobWts = make_shared_blob<uint8_t>({Precision::U8, {weights.size()}, C});
             blobWts->allocate();
             std::memcpy(InferenceEngine::as<InferenceEngine::MemoryBlob>(blobWts)->wmap(), weights.data(), weights.size());
-            network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel, blobWts));
+            network = std::make_unique<InferenceEngine::CNNNetwork>(ieCore.ReadNetwork(strModel, blobWts));
         } else if (res == CustomLoaderStatus::MODEL_TYPE_ONNX) {
-            network = std::make_unique<InferenceEngine::CNNNetwork>(engine->ReadNetwork(strModel, InferenceEngine::Blob::CPtr()));
+            network = std::make_unique<InferenceEngine::CNNNetwork>(ieCore.ReadNetwork(strModel, InferenceEngine::Blob::CPtr()));
         } else if (res == CustomLoaderStatus::MODEL_TYPE_BLOB) {
             return StatusCode::INTERNAL_ERROR;
         }
@@ -361,7 +342,7 @@ Status ModelInstance::loadOVCNNNetworkUsingCustomLoader() {
 }
 
 void ModelInstance::loadExecutableNetworkPtr(const plugin_config_t& pluginConfig) {
-    execNetwork = std::make_shared<InferenceEngine::ExecutableNetwork>(engine->LoadNetwork(*network, targetDevice, pluginConfig));
+    execNetwork = std::make_shared<InferenceEngine::ExecutableNetwork>(ieCore.LoadNetwork(*network, targetDevice, pluginConfig));
 }
 
 plugin_config_t ModelInstance::prepareDefaultPluginConfig(const ModelConfig& config) {
@@ -477,8 +458,6 @@ Status ModelInstance::loadModelImpl(const ModelConfig& config, const DynamicMode
         return status;
     }
     try {
-        if (!this->engine)
-            loadOVEngine();
         if (!this->network) {
             if (this->config.isCustomLoaderRequiredToLoadModel()) {
                 // loading the model using the custom loader
@@ -710,7 +689,6 @@ void ModelInstance::unloadModelComponents() {
     inferRequestsQueue.reset();
     execNetwork.reset();
     network.reset();
-    engine.reset();
     outputsInfo.clear();
     inputsInfo.clear();
     modelFiles.clear();

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -86,7 +86,7 @@ protected:
     /**
          * @brief Inference Engine core object
          */
-    std::unique_ptr<InferenceEngine::Core> engine;
+    InferenceEngine::Core& ieCore;
 
     /**
          * @brief Inference Engine CNNNetwork object
@@ -322,7 +322,8 @@ public:
     /**
          * @brief A default constructor
          */
-    ModelInstance(const std::string& name, model_version_t version) :
+    ModelInstance(const std::string& name, model_version_t version, InferenceEngine::Core& ieCore) :
+        ieCore(ieCore),
         name(name),
         version(version),
         subscriptionManager(std::string("model: ") + name + std::string(" version: ") + std::to_string(version)) { isCustomLoaderConfigChanged = false; }

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -55,8 +55,24 @@ static uint16_t MAX_CONFIG_JSON_READ_RETRY_COUNT = 2;
 static bool watcherStarted = false;
 
 ModelManager::ModelManager() :
+    ieCore(std::make_unique<InferenceEngine::Core>()),
     waitForModelLoadedTimeoutMs(DEFAULT_WAIT_FOR_MODEL_LOADED_TIMEOUT_MS) {
     this->customNodeLibraryManager = std::make_unique<CustomNodeLibraryManager>();
+    if (ovms::Config::instance().cpuExtensionLibraryPath() != "") {
+        SPDLOG_INFO("Loading custom CPU extension from {}", ovms::Config::instance().cpuExtensionLibraryPath());
+        try {
+            auto extension_ptr = std::make_shared<InferenceEngine::Extension>(ovms::Config::instance().cpuExtensionLibraryPath());
+            SPDLOG_INFO("Custom CPU extention loaded. Adding it.");
+            ieCore->AddExtension(extension_ptr, "CPU");
+            SPDLOG_INFO("Extention added.");
+        } catch (std::exception& ex) {
+            SPDLOG_CRITICAL("Custom CPU extention loading has failed! Reason: {}", ex.what());
+            throw;
+        } catch (...) {
+            SPDLOG_CRITICAL("Custom CPU extention loading has failed with an unknown error!");
+            throw;
+        }
+    }
 }
 
 ModelManager::~ModelManager() = default;
@@ -924,7 +940,7 @@ Status ModelManager::readAvailableVersions(std::shared_ptr<FileSystem>& fs, cons
 Status ModelManager::addModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToStart, std::shared_ptr<model_versions_t> versionsFailed) {
     Status status = StatusCode::OK;
     try {
-        status = model->addVersions(versionsToStart, config, fs, versionsFailed);
+        status = model->addVersions(versionsToStart, config, fs, *ieCore, versionsFailed);
         if (!status.ok()) {
             SPDLOG_LOGGER_ERROR(modelmanager_logger, "Error occurred while loading model: {} versions; error: {}",
                 config.getName(),
@@ -941,7 +957,7 @@ Status ModelManager::reloadModelVersions(std::shared_ptr<ovms::Model>& model, st
     Status status = StatusCode::OK;
     SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Reloading model versions");
     try {
-        auto status = model->reloadVersions(versionsToReload, config, fs, versionsFailed);
+        auto status = model->reloadVersions(versionsToReload, config, fs, *ieCore, versionsFailed);
         if (!status.ok()) {
             SPDLOG_LOGGER_ERROR(modelmanager_logger, "Error occurred while reloading model: {}; versions; error: {}",
                 config.getName(),

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -63,6 +63,7 @@ protected:
      * 
      */
     std::map<std::string, std::shared_ptr<Model>> models;
+    std::unique_ptr<InferenceEngine::Core> ieCore;
 
     PipelineFactory pipelineFactory;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -23,6 +23,7 @@
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
+#include <inference_engine.hpp>
 #include <netinet/in.h>
 #include <signal.h>
 #include <stdlib.h>

--- a/src/statefulmodelinstance.hpp
+++ b/src/statefulmodelinstance.hpp
@@ -32,8 +32,8 @@ public:
     /**
          * @brief A default constructor
          */
-    StatefulModelInstance(const std::string& name, model_version_t version, GlobalSequencesViewer* globalSequencesViewer) :
-        ModelInstance(name, version),
+    StatefulModelInstance(const std::string& name, model_version_t version, InferenceEngine::Core& ieCore, GlobalSequencesViewer* globalSequencesViewer) :
+        ModelInstance(name, version, ieCore),
         globalSequencesViewer(globalSequencesViewer) {
         sequenceManager = std::make_shared<SequenceManager>(config.getMaxSequenceNumber(), name, version);
     }

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -364,8 +364,8 @@ public:
 
 class MockModelInstance : public ovms::ModelInstance {
 public:
-    MockModelInstance() :
-        ModelInstance("UNUSED_NAME", 42) {}
+    MockModelInstance(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", 42, ieCore) {}
     const ovms::Status mockValidate(const tensorflow::serving::PredictRequest* request) {
         return validate(request);
     }

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -2874,8 +2874,8 @@ class DummyModelWithMockedMetadata : public ovms::ModelInstance {
     ovms::tensor_map_t mockedInputsInfo, mockedOutputsInfo;
 
 public:
-    DummyModelWithMockedMetadata(const ovms::tensor_map_t& inputsInfo, const ovms::tensor_map_t& outputsInfo) :
-        ovms::ModelInstance("dummy", 1),
+    DummyModelWithMockedMetadata(InferenceEngine::Core& ieCore, const ovms::tensor_map_t& inputsInfo, const ovms::tensor_map_t& outputsInfo) :
+        ovms::ModelInstance("dummy", 1, ieCore),
         mockedInputsInfo(inputsInfo),
         mockedOutputsInfo(outputsInfo) {}
 
@@ -2903,7 +2903,7 @@ public:
     ModelWithDummyModelWithMockedMetadata(const std::string& name, std::shared_ptr<DummyModelWithMockedMetadata> modelInstance) :
         Model(name, false, nullptr),
         modelInstance(modelInstance) {}
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t) override {
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t, InferenceEngine::Core& ieCore) override {
         return modelInstance;
     }
 };
@@ -2943,8 +2943,9 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, ShapesNotMatchBetweenDL
 
     connections[EXIT_NODE_NAME] = {
         {"custom_node", {{"out", pipelineOutputName}}}};
-
+    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
+        *ieCore,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
                                          DUMMY_MODEL_INPUT_NAME,
@@ -3166,7 +3167,9 @@ TEST_F(EnsembleConfigurationValidationWithGather, SuccessfulConfigurationWithDLN
     connections[EXIT_NODE_NAME] = {
         {"custom_node_2", {{"out", pipelineOutputName}}}};
 
+    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
+        *ieCore,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
                                          DUMMY_MODEL_INPUT_NAME,
@@ -3217,7 +3220,9 @@ TEST_F(EnsembleConfigurationValidationWithGather, SuccessfulConfigurationWithDLN
     connections[EXIT_NODE_NAME] = {
         {"dummy_node", {{DUMMY_MODEL_OUTPUT_NAME, pipelineOutputName}}}};
 
+    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
+        *ieCore,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
                                          DUMMY_MODEL_INPUT_NAME,
@@ -3311,7 +3316,9 @@ TEST_F(EnsembleConfigurationValidationWithGather, ShapesNotMatchBetweenDLModelAn
     connections[EXIT_NODE_NAME] = {
         {"custom_node_2", {{"out", pipelineOutputName}}}};
 
+    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
+        *ieCore,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
                                          DUMMY_MODEL_INPUT_NAME,
@@ -3362,7 +3369,9 @@ TEST_F(EnsembleConfigurationValidationWithGather, ShapesNotMatchBetweenCustomNod
     connections[EXIT_NODE_NAME] = {
         {"dummy_node", {{DUMMY_MODEL_OUTPUT_NAME, pipelineOutputName}}}};
 
+    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
+        *ieCore,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
                                          DUMMY_MODEL_INPUT_NAME,

--- a/src/test/get_model_metadata_response_test.cpp
+++ b/src/test/get_model_metadata_response_test.cpp
@@ -39,8 +39,8 @@ class GetModelMetadataResponse : public ::testing::Test {
 
     class MockModelInstance : public MockModelInstanceChangingStates {
     public:
-        MockModelInstance() :
-            MockModelInstanceChangingStates("UNUSED_NAME", UNUSED_MODEL_VERSION) {
+        MockModelInstance(InferenceEngine::Core& ieCore) :
+            MockModelInstanceChangingStates("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {
             status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_MODEL_VERSION, ovms::ModelVersionState::AVAILABLE);
         }
 
@@ -67,9 +67,10 @@ protected:
 
     std::shared_ptr<NiceMock<MockModelInstance>> instance;
     tensorflow::serving::GetModelMetadataResponse response;
+    std::unique_ptr<InferenceEngine::Core> ieCore;
 
     virtual void prepare() {
-        instance = std::make_shared<NiceMock<MockModelInstance>>();
+        instance = std::make_shared<NiceMock<MockModelInstance>>(*ieCore);
 
         inputTensors = tensor_desc_map_t({
             {"Input_FP32_1_3_224_224", {
@@ -117,7 +118,11 @@ protected:
     }
 
     void SetUp() override {
+        ieCore = std::make_unique<InferenceEngine::Core>();
         this->prepare();
+    }
+    void TearDown() override {
+        ieCore.reset();
     }
 };
 

--- a/src/test/mockmodelinstancechangingstates.hpp
+++ b/src/test/mockmodelinstancechangingstates.hpp
@@ -26,8 +26,8 @@
 
 class MockModelInstanceChangingStates : public ovms::ModelInstance {
 public:
-    MockModelInstanceChangingStates(const std::string& modelName = "UNUSED_NAME", const ovms::model_version_t modelVersion = UNUSED_MODEL_VERSION) :
-        ModelInstance(modelName, modelVersion) {
+    MockModelInstanceChangingStates(const std::string& modelName, const ovms::model_version_t modelVersion, InferenceEngine::Core& ieCore) :
+        ModelInstance(modelName, modelVersion, ieCore) {
         status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_MODEL_VERSION, ovms::ModelVersionState::START);
     }
     virtual ~MockModelInstanceChangingStates() {}
@@ -62,8 +62,8 @@ public:
     virtual ~MockModelWithInstancesJustChangingStates() {}
 
 protected:
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory() { return modelInstanceFactory("UNUSED_NAME", UNUSED_MODEL_VERSION); }
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t version) override {
-        return std::move(std::make_shared<MockModelInstanceChangingStates>(modelName, version));
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(InferenceEngine::Core& ieCore) { return modelInstanceFactory("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore); }
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t version, InferenceEngine::Core& ieCore) override {
+        return std::move(std::make_shared<MockModelInstanceChangingStates>(modelName, version, ieCore));
     }
 };

--- a/src/test/model_test.cpp
+++ b/src/test/model_test.cpp
@@ -24,7 +24,16 @@
 #include "mockmodelinstancechangingstates.hpp"
 #include "test_utils.hpp"
 
-class ModelDefaultVersions : public ::testing::Test {};
+class ModelDefaultVersions : public ::testing::Test {
+protected:
+    std::unique_ptr<InferenceEngine::Core> ieCore;
+    void SetUp() {
+        ieCore = std::make_unique<InferenceEngine::Core>();
+    }
+    void TearDown() {
+        ieCore.reset();
+    }
+};
 
 TEST_F(ModelDefaultVersions, DefaultVersionNullWhenNoVersionAdded) {
     MockModelWithInstancesJustChangingStates mockModel;
@@ -40,7 +49,7 @@ TEST_F(ModelDefaultVersions, DefaultVersionNullWhenVersionRetired) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    mockModel.addVersions(versionsToChange, config, fs, versionsFailed);
+    mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed);
     mockModel.retireVersions(versionsToChange);
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;
@@ -55,7 +64,7 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnValidWhen1Added) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;
     defaultInstance = mockModel.getDefaultModelInstance();
@@ -70,11 +79,11 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighest) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;
     defaultInstance = mockModel.getDefaultModelInstance();
@@ -89,12 +98,12 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighestNonRetired) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
@@ -114,12 +123,12 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighestWhenVersionReloade
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
@@ -128,7 +137,7 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighestWhenVersionReloade
 
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.reloadVersions(versionsToChange, config, fs, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.reloadVersions(versionsToChange, config, fs, *ieCore, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;

--- a/src/test/modelinstance_test.cpp
+++ b/src/test/modelinstance_test.cpp
@@ -40,25 +40,31 @@ class MockModelInstanceInState : public ovms::ModelInstance {
     static const ovms::model_version_t UNUSED_VERSION = 987789;
 
 public:
-    MockModelInstanceInState(ovms::ModelVersionState state) :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {
+    MockModelInstanceInState(InferenceEngine::Core& ieCore, ovms::ModelVersionState state) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {
         status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_VERSION, state);
     }
 };
 
 class MockModelInstance : public ovms::ModelInstance {
 public:
-    MockModelInstance() :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {}
+    MockModelInstance(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
     MOCK_METHOD(bool, canUnloadInstance, (), (const));
 };
 
 }  // namespace
 
-class TestUnloadModel : public ::testing::Test {};
+class TestUnloadModel : public ::testing::Test {
+protected:
+    std::unique_ptr<InferenceEngine::Core> ieCore;
+    void SetUp() {
+        ieCore = std::make_unique<InferenceEngine::Core>();
+    }
+};
 
 TEST_F(TestUnloadModel, SuccessfulUnload) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ASSERT_EQ(modelInstance.loadModel(DUMMY_MODEL_CONFIG), ovms::StatusCode::OK);
     ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance.getStatus().getState());
     modelInstance.retireModel();
@@ -66,7 +72,7 @@ TEST_F(TestUnloadModel, SuccessfulUnload) {
 }
 
 TEST_F(TestUnloadModel, CantUnloadModelWhilePredictPathAcquiredAndLockedInstance) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ovms::Status status = modelInstance.loadModel(DUMMY_MODEL_CONFIG);
     ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance.getStatus().getState());
     ASSERT_EQ(status, ovms::StatusCode::OK);
@@ -75,7 +81,7 @@ TEST_F(TestUnloadModel, CantUnloadModelWhilePredictPathAcquiredAndLockedInstance
 }
 
 TEST_F(TestUnloadModel, CanUnloadModelNotHoldingModelInstanceAtPredictPath) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ovms::Status status = modelInstance.loadModel(DUMMY_MODEL_CONFIG);
     ASSERT_EQ(status, ovms::StatusCode::OK);
     ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance.getStatus().getState());
@@ -90,8 +96,8 @@ TEST_F(TestUnloadModel, UnloadWaitsUntilMetadataResponseIsBuilt) {
 
     class MockModelInstanceTriggeringUnload : public ovms::ModelInstance {
     public:
-        MockModelInstanceTriggeringUnload() :
-            ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {}
+        MockModelInstanceTriggeringUnload(InferenceEngine::Core& ieCore) :
+            ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
         // This is to trigger model unloading in separate thread during GetModelMetadataImpl::buildResponse call.
         const ovms::tensor_map_t& getInputsInfo() const override {
             thread = std::thread([]() {
@@ -102,7 +108,7 @@ TEST_F(TestUnloadModel, UnloadWaitsUntilMetadataResponseIsBuilt) {
             return ovms::ModelInstance::getInputsInfo();
         }
     };
-    instance = std::make_shared<MockModelInstanceTriggeringUnload>();
+    instance = std::make_shared<MockModelInstanceTriggeringUnload>(*ieCore);
     ovms::Status status = instance->loadModel(DUMMY_MODEL_CONFIG);
     ASSERT_EQ(status, ovms::StatusCode::OK);
     ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, instance->getStatus().getState());
@@ -124,7 +130,7 @@ TEST_F(TestUnloadModel, UnloadWaitsUntilMetadataResponseIsBuilt) {
 }
 
 TEST_F(TestUnloadModel, CheckIfCanUnload) {
-    MockModelInstance mockModelInstance;
+    MockModelInstance mockModelInstance(*ieCore);
     mockModelInstance.loadModel(DUMMY_MODEL_CONFIG);
     ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, mockModelInstance.getStatus().getState());
     EXPECT_CALL(mockModelInstance, canUnloadInstance())
@@ -136,8 +142,8 @@ TEST_F(TestUnloadModel, CheckIfCanUnload) {
 
 class MockModelInstanceCheckingUnloadingState : public ovms::ModelInstance {
 public:
-    MockModelInstanceCheckingUnloadingState() :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {}
+    MockModelInstanceCheckingUnloadingState(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
     virtual bool canUnloadInstance() const {
         EXPECT_EQ(ovms::ModelVersionState::UNLOADING, getStatus().getState());
         return true;
@@ -145,19 +151,25 @@ public:
 };
 
 TEST_F(TestUnloadModel, CheckIfStateIsUnloadingDuringUnloading) {
-    MockModelInstanceCheckingUnloadingState mockModelInstance;
+    MockModelInstanceCheckingUnloadingState mockModelInstance(*ieCore);
     mockModelInstance.loadModel(DUMMY_MODEL_CONFIG);
     ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, mockModelInstance.getStatus().getState());
     mockModelInstance.retireModel();
     EXPECT_EQ(ovms::ModelVersionState::END, mockModelInstance.getStatus().getState());
 }
 
-class TestLoadModel : public ::testing::Test {};
+class TestLoadModel : public ::testing::Test {
+protected:
+    std::unique_ptr<InferenceEngine::Core> ieCore;
+    void SetUp() {
+        ieCore = std::make_unique<InferenceEngine::Core>();
+    }
+};
 
 class MockModelInstanceThrowingFileNotFoundForLoadingCNN : public ovms::ModelInstance {
 public:
-    MockModelInstanceThrowingFileNotFoundForLoadingCNN() :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {}
+    MockModelInstanceThrowingFileNotFoundForLoadingCNN(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
 
 protected:
     std::unique_ptr<InferenceEngine::CNNNetwork> loadOVCNNNetworkPtr(const std::string& modelFile) override {
@@ -168,15 +180,15 @@ protected:
 
 TEST_F(TestLoadModel, CheckIfOVNonExistingXMLFileErrorIsCatched) {
     // Check if handling file removal after file existence was checked
-    MockModelInstanceThrowingFileNotFoundForLoadingCNN mockModelInstance;
+    MockModelInstanceThrowingFileNotFoundForLoadingCNN mockModelInstance(*ieCore);
     auto status = mockModelInstance.loadModel(DUMMY_MODEL_CONFIG);
     EXPECT_EQ(status, ovms::StatusCode::INTERNAL_ERROR) << status.string();
 }
 
 class MockModelInstanceThrowingFileNotFoundForLoadingExecutableNetwork : public ovms::ModelInstance {
 public:
-    MockModelInstanceThrowingFileNotFoundForLoadingExecutableNetwork() :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {}
+    MockModelInstanceThrowingFileNotFoundForLoadingExecutableNetwork(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
 
 protected:
     void loadExecutableNetworkPtr(const ovms::plugin_config_t& pluginConfig) override {
@@ -186,13 +198,13 @@ protected:
 
 TEST_F(TestLoadModel, CheckIfOVNonExistingBinFileErrorIsCatched) {
     // Check if handling file removal after file existence was checked
-    MockModelInstanceThrowingFileNotFoundForLoadingExecutableNetwork mockModelInstance;
+    MockModelInstanceThrowingFileNotFoundForLoadingExecutableNetwork mockModelInstance(*ieCore);
     auto status = mockModelInstance.loadModel(DUMMY_MODEL_CONFIG);
     EXPECT_EQ(status, ovms::StatusCode::CANNOT_LOAD_NETWORK_INTO_TARGET_DEVICE) << status.string();
 }
 
 TEST_F(TestLoadModel, CheckIfNonExistingXmlFileReturnsFileInvalid) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
 
     const std::string modelPath = "/tmp/test_load_model";
     std::filesystem::create_directories(modelPath);
@@ -227,7 +239,7 @@ TEST_F(TestLoadModel, CheckIfNonExistingXmlFileReturnsFileInvalid) {
 }
 
 TEST_F(TestLoadModel, CheckIfNonExistingBinFileReturnsFileInvalid) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
 
     const std::string modelPath = "/tmp/test_load_model";
     std::filesystem::create_directories(modelPath);
@@ -262,30 +274,36 @@ TEST_F(TestLoadModel, CheckIfNonExistingBinFileReturnsFileInvalid) {
 }
 
 TEST_F(TestLoadModel, SuccessfulLoad) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     EXPECT_EQ(modelInstance.loadModel(DUMMY_MODEL_CONFIG), ovms::StatusCode::OK);
     EXPECT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance.getStatus().getState());
 }
 
 TEST_F(TestLoadModel, UnSuccessfulLoadWhenNireqTooHigh) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     auto config = DUMMY_MODEL_CONFIG;
     config.setNireq(100000 + 1);
     EXPECT_EQ(modelInstance.loadModel(config), ovms::StatusCode::INVALID_NIREQ);
     EXPECT_EQ(ovms::ModelVersionState::LOADING, modelInstance.getStatus().getState()) << modelInstance.getStatus().getStateString();
 }
 
-class TestReloadModel : public ::testing::Test {};
+class TestReloadModel : public ::testing::Test {
+protected:
+    std::unique_ptr<InferenceEngine::Core> ieCore;
+    void SetUp() {
+        ieCore = std::make_unique<InferenceEngine::Core>();
+    }
+};
 
 TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyLoaded) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ASSERT_TRUE(modelInstance.loadModel(DUMMY_MODEL_CONFIG).ok());
     EXPECT_TRUE(modelInstance.reloadModel(DUMMY_MODEL_CONFIG).ok());
     EXPECT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance.getStatus().getState());
 }
 
 TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyLoadedWithChangedModelMapping) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     ASSERT_TRUE(modelInstance.loadModel(config).ok());
     ovms::mapping_config_t mappingOutputs{{"a", "output"}};
@@ -309,7 +327,7 @@ TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyLoadedWithChangedModelMapping
 }
 
 TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyUnloaded) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ASSERT_TRUE(modelInstance.loadModel(DUMMY_MODEL_CONFIG).ok());
     modelInstance.retireModel();
     ASSERT_EQ(ovms::ModelVersionState::END, modelInstance.getStatus().getState());
@@ -318,7 +336,7 @@ TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyUnloaded) {
 }
 
 TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyLoadedWithNewBatchSize) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchSize(1);
     ASSERT_EQ(modelInstance.loadModel(config), ovms::StatusCode::OK);
@@ -330,7 +348,7 @@ TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyLoadedWithNewBatchSize) {
 }
 
 TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyLoadedWithNewShape) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.parseShapeParameter("{\"b\": \"auto\"}");
     std::map<std::string, ovms::shape_t> requestShapes = {{"b", {2, 10}}};
@@ -342,7 +360,7 @@ TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyLoadedWithNewShape) {
 }
 
 TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyUnloadedWithNewBatchSize) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchSize(1);
     ASSERT_EQ(modelInstance.loadModel(config), ovms::StatusCode::OK);
@@ -356,7 +374,7 @@ TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyUnloadedWithNewBatchSize) {
 }
 
 TEST_F(TestReloadModel, SuccessfulReloadFromAlreadyUnloadedWithNewShape) {
-    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION);
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.parseShapeParameter("auto");
     std::map<std::string, ovms::shape_t> requestShapes = {{"b", {2, 10}}};

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -73,7 +73,7 @@ class MockModel : public ovms::Model {
 public:
     MockModel() :
         Model("MOCK_NAME", false, nullptr) {}
-    MOCK_METHOD(ovms::Status, addVersion, (const ovms::ModelConfig&), (override));
+    MOCK_METHOD(ovms::Status, addVersion, (const ovms::ModelConfig&, InferenceEngine::Core&), (override));
 };
 
 std::shared_ptr<MockModel> modelMock;
@@ -452,7 +452,7 @@ TEST(ModelManager, StartFromFile) {
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
 
-    EXPECT_CALL(*modelMock, addVersion(_))
+    EXPECT_CALL(*modelMock, addVersion(_, _))
         .Times(1)
         .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
     auto status = manager.startFromFile(fileToReload);
@@ -479,7 +479,7 @@ TEST(ModelManager, ConfigReloadingShouldAddNewModel) {
     createConfigFileWithContent(config_1_model, fileToReload);
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
-    EXPECT_CALL(*modelMock, addVersion(_))
+    EXPECT_CALL(*modelMock, addVersion(_, _))
         .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
 
     auto status = manager.startFromFile(fileToReload);
@@ -700,7 +700,7 @@ TEST(ModelManager, ConfigReloadingWithTwoModelsWithTheSameName) {
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
 
-    EXPECT_CALL(*modelMock, addVersion(_))
+    EXPECT_CALL(*modelMock, addVersion(_, _))
         .Times(1)
         .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
     auto status = manager.startFromFile(fileToReload);
@@ -772,8 +772,8 @@ class MockModelInstanceInStateWithConfig : public ovms::ModelInstance {
     static const ovms::model_version_t UNUSED_VERSION = 987789;
 
 public:
-    MockModelInstanceInStateWithConfig(ovms::ModelVersionState state, const ovms::ModelConfig& modelConfig) :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {
+    MockModelInstanceInStateWithConfig(ovms::ModelVersionState state, const ovms::ModelConfig& modelConfig, InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {
         status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_VERSION, state);
         config = modelConfig;
     }
@@ -781,6 +781,7 @@ public:
 
 std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> getMockedModelVersionInstances(
     std::map<ovms::ModelVersionState, ovms::model_versions_t> initialVersionStates,
+    InferenceEngine::Core& ieCore,
     const ovms::ModelConfig& modelConfig = ovms::ModelConfig{}) {
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> modelVersions;
     std::array<ovms::ModelVersionState, 5> states{
@@ -791,13 +792,16 @@ std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> getMockedM
         ovms::ModelVersionState::END};
     for (auto& state : states) {
         for (auto& version : initialVersionStates[state]) {
-            modelVersions[version] = std::make_shared<MockModelInstanceInStateWithConfig>(state, modelConfig);
+            modelVersions[version] = std::make_shared<MockModelInstanceInStateWithConfig>(state, modelConfig, ieCore);
         }
     }
     return modelVersions;
 }
 
 class ModelManagerVersionsReload : public ::testing::Test {
+protected:
+    std::unique_ptr<InferenceEngine::Core> ieCore;
+
 public:
     ModelManagerVersionsReload() {
         versionsToRetire = std::make_shared<ovms::model_versions_t>();
@@ -805,6 +809,7 @@ public:
         versionsToStart = std::make_shared<ovms::model_versions_t>();
     }
     void SetUp() {
+        ieCore = std::make_unique<InferenceEngine::Core>();
         initialVersions.clear();
         versionsToRetire->clear();
         versionsToReload->clear();
@@ -825,7 +830,7 @@ TEST_F(ModelManagerVersionsReload, RetireOldAddNew) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{2};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{2};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -843,7 +848,7 @@ TEST_F(ModelManagerVersionsReload, NoVersionsChange) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{2, 3};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -861,7 +866,7 @@ TEST_F(ModelManagerVersionsReload, KeepOldAddNewNoRetired) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{1, 2, 3};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{3};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -879,7 +884,7 @@ TEST_F(ModelManagerVersionsReload, KeepOldAddNewWithRetiredVersions) {
     initialVersions[ovms::ModelVersionState::END] = {1};
     ovms::model_versions_t requestedVersions{2, 3, 4};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{4};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -897,7 +902,7 @@ TEST_F(ModelManagerVersionsReload, JustAddNewVersions) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{1, 2};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{1, 2};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -915,7 +920,7 @@ TEST_F(ModelManagerVersionsReload, JustRetireVersion) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{2, 3};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -933,7 +938,7 @@ TEST_F(ModelManagerVersionsReload, ResurrectRetiredVersion) {
     initialVersions[ovms::ModelVersionState::END] = {1};
     ovms::model_versions_t requestedVersions{1, 2};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{1};
@@ -951,7 +956,7 @@ TEST_F(ModelManagerVersionsReload, RessurectRetireAddAtTheSameTime) {
     initialVersions[ovms::ModelVersionState::END] = {1};
     ovms::model_versions_t requestedVersions{1, 3};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{3};
     ovms::model_versions_t expectedVersionsToReload{1};
@@ -969,7 +974,7 @@ TEST_F(ModelManagerVersionsReload, DontStartAlreadyStartingVersion) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{1};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -987,7 +992,7 @@ TEST_F(ModelManagerVersionsReload, DontStartAlreadyLoadingVersion) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{1};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -1005,7 +1010,7 @@ TEST_F(ModelManagerVersionsReload, DontRetireAlreadyUnloadingVersion) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -1022,7 +1027,7 @@ TEST_F(ModelManagerVersionsReload, RetireLoadingVersion) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -1040,7 +1045,7 @@ TEST_F(ModelManagerVersionsReload, RetireStartingVersion) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{};
@@ -1058,7 +1063,7 @@ TEST_F(ModelManagerVersionsReload, ReloadUnloadingVersion) {
     initialVersions[ovms::ModelVersionState::END] = {};
     ovms::model_versions_t requestedVersions{1};
     std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> mockModelVersionInstances =
-        getMockedModelVersionInstances(initialVersions);
+        getMockedModelVersionInstances(initialVersions, *ieCore);
     ovms::ModelManager::getVersionsToChange(oldConfig, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     ovms::model_versions_t expectedVersionsToStart{};
     ovms::model_versions_t expectedVersionsToReload{1};
@@ -1068,14 +1073,18 @@ TEST_F(ModelManagerVersionsReload, ReloadUnloadingVersion) {
     EXPECT_THAT(expectedVersionsToRetire, ContainerEq(*versionsToRetire));
 }
 
-class ReloadAvailabileModelDueToConfigChange : public ::testing::Test {
+class ReloadAvailableModelDueToConfigChange : public ::testing::Test {
+protected:
+    std::unique_ptr<InferenceEngine::Core> ieCore;
+
 public:
-    ReloadAvailabileModelDueToConfigChange() {
+    ReloadAvailableModelDueToConfigChange() {
         versionsToRetire = std::make_shared<ovms::model_versions_t>();
         versionsToReload = std::make_shared<ovms::model_versions_t>();
         versionsToStart = std::make_shared<ovms::model_versions_t>();
     }
     void SetUp() {
+        ieCore = std::make_unique<InferenceEngine::Core>();
         initialVersions.clear();
         versionsToRetire->clear();
         versionsToReload->clear();
@@ -1096,111 +1105,111 @@ public:
     ovms::ModelConfig config;
 };
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, SameConfig_ExpectNoReloads) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, SameConfig_ExpectNoReloads) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre());
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToBasePathChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToBasePathChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setBasePath("new/custom/path");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToTargetDeviceChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToTargetDeviceChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setTargetDevice("GPU");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToBatchingModeChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToBatchingModeChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setBatchingParams("auto");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToBatchSizeChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToBatchSizeChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setBatchingParams("20");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToNireqChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToNireqChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setNireq(50);
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToPluginConfigChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToPluginConfigChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setPluginConfig({{"A", "B"}});
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToLayoutChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToLayoutChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setLayout("NEW_LAYOUT");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToNamedLayoutChange) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToNamedLayoutChange) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setLayouts({{"A", "B"}});
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_Auto) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_Auto) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.parseShapeParameter("auto");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectNoReloadWhenShapeConfigurationStill_Auto) {
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectNoReloadWhenShapeConfigurationStill_Auto) {
     config.parseShapeParameter("auto");
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.parseShapeParameter("auto");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre());
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectNoReloadWhenShapeConfigurationStill_Fixed) {
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectNoReloadWhenShapeConfigurationStill_Fixed) {
     config.parseShapeParameter("(1,3,224,224)");
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.parseShapeParameter("(1,3,224,224)");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre());
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_AnonymousToNamed) {
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_AnonymousToNamed) {
     config.parseShapeParameter("auto");
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.parseShapeParameter("{\"a\": \"auto\"");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_NoNamed) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_NoNamed) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.parseShapeParameter("(1,3,224,224)");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToMultipleInputShapeChange) {
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToMultipleInputShapeChange) {
     ovms::ModelConfig previouslyLoadedConfig = config;
     previouslyLoadedConfig.setShapes({{"A", {ovms::Mode::FIXED, {1, 3, 224, 224}}},
         {"B", {ovms::Mode::FIXED, {1, 100}}}});
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, previouslyLoadedConfig);
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, previouslyLoadedConfig);
     ovms::ModelConfig newConfig = config;
     newConfig.setShapes({{"A", {ovms::Mode::FIXED, {3, 3, 224, 224}}},
         {"B", {ovms::Mode::FIXED, {1, 100}}}});
@@ -1208,8 +1217,8 @@ TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToMultipleInputSha
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }
 
-TEST_F(ReloadAvailabileModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_Named) {
-    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, config);
+TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToShapeConfigurationChange_Named) {
+    mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
     config.setShapes({{"A", {ovms::Mode::FIXED, {1, 3, 224, 224}}}});
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
@@ -1249,8 +1258,8 @@ TEST_F(GetModelInstanceTest, WithRequestedUnexistingVersionShouldReturnModelVers
 
 class MockModelInstanceFakeLoad : public ovms::ModelInstance {
 public:
-    MockModelInstanceFakeLoad() :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {}
+    MockModelInstanceFakeLoad(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
 
 protected:
     ovms::Status loadModel(const ovms::ModelConfig& config) override {
@@ -1264,8 +1273,8 @@ class ModelWithModelInstanceFakeLoad : public ovms::Model {
 public:
     ModelWithModelInstanceFakeLoad(const std::string& name) :
         Model(name, false, nullptr) {}
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t) override {
-        return std::make_shared<MockModelInstanceFakeLoad>();
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t, InferenceEngine::Core& ieCore) override {
+        return std::make_shared<MockModelInstanceFakeLoad>(ieCore);
     }
 };
 
@@ -1301,8 +1310,8 @@ TEST_F(GetModelInstanceTest, WithRequestedVersion1ShouldReturnModelVersionNotLoa
 
 class ModelInstanceLoadedStuckInLoadingState : public ovms::ModelInstance {
 public:
-    ModelInstanceLoadedStuckInLoadingState() :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION) {}
+    ModelInstanceLoadedStuckInLoadingState(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
 
 protected:
     ovms::Status loadModel(const ovms::ModelConfig& config) override {
@@ -1316,8 +1325,8 @@ class ModelWithModelInstanceLoadedStuckInLoadingState : public ovms::Model {
 public:
     ModelWithModelInstanceLoadedStuckInLoadingState(const std::string& name) :
         Model(name, false, nullptr) {}
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t) override {
-        return std::make_shared<ModelInstanceLoadedStuckInLoadingState>();
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t, InferenceEngine::Core& ieCore) override {
+        return std::make_shared<ModelInstanceLoadedStuckInLoadingState>(ieCore);
     }
 };
 
@@ -1334,8 +1343,8 @@ const int AVAILABLE_STATE_DELAY_MILLISECONDS = 5;
 
 class ModelInstanceLoadedWaitInLoadingState : public ovms::ModelInstance {
 public:
-    ModelInstanceLoadedWaitInLoadingState(const uint modelInstanceLoadDelayInMilliseconds) :
-        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION),
+    ModelInstanceLoadedWaitInLoadingState(InferenceEngine::Core& ieCore, const uint modelInstanceLoadDelayInMilliseconds) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore),
         modelInstanceLoadDelayInMilliseconds(modelInstanceLoadDelayInMilliseconds) {}
 
 protected:
@@ -1360,8 +1369,8 @@ public:
     ModelWithModelInstanceLoadedWaitInLoadingState(const std::string& name, const uint modelInstanceLoadDelayInMilliseconds) :
         Model(name, false, nullptr),
         modelInstanceLoadDelayInMilliseconds(modelInstanceLoadDelayInMilliseconds) {}
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t) override {
-        return std::make_shared<ModelInstanceLoadedWaitInLoadingState>(modelInstanceLoadDelayInMilliseconds);
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string&, const ovms::model_version_t, InferenceEngine::Core& ieCore) override {
+        return std::make_shared<ModelInstanceLoadedWaitInLoadingState>(ieCore, modelInstanceLoadDelayInMilliseconds);
     }
 
 private:

--- a/src/test/ovinferrequestqueue_test.cpp
+++ b/src/test/ovinferrequestqueue_test.cpp
@@ -31,9 +31,9 @@ using namespace testing;
 const std::string DUMMY_MODEL_PATH = std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml";
 
 TEST(OVInferRequestQueue, ShortQueue) {
-    InferenceEngine::Core engine;
-    InferenceEngine::CNNNetwork network = engine.ReadNetwork(DUMMY_MODEL_PATH);
-    InferenceEngine::ExecutableNetwork execNetwork = engine.LoadNetwork(network, "CPU");
+    InferenceEngine::Core ieCore;
+    InferenceEngine::CNNNetwork network = ieCore.ReadNetwork(DUMMY_MODEL_PATH);
+    InferenceEngine::ExecutableNetwork execNetwork = ieCore.LoadNetwork(network, "CPU");
     ovms::OVInferRequestsQueue inferRequestsQueue(execNetwork, 3);
     int reqid;
     reqid = inferRequestsQueue.getIdleStream().get();
@@ -54,9 +54,9 @@ void releaseStream(ovms::OVInferRequestsQueue& requestsQueue) {
 
 TEST(OVInferRequestQueue, FullQueue) {
     ovms::Timer timer;
-    InferenceEngine::Core engine;
-    InferenceEngine::CNNNetwork network = engine.ReadNetwork(DUMMY_MODEL_PATH);
-    InferenceEngine::ExecutableNetwork execNetwork = engine.LoadNetwork(network, "CPU");
+    InferenceEngine::Core ieCore;
+    InferenceEngine::CNNNetwork network = ieCore.ReadNetwork(DUMMY_MODEL_PATH);
+    InferenceEngine::ExecutableNetwork execNetwork = ieCore.LoadNetwork(network, "CPU");
     ovms::OVInferRequestsQueue inferRequestsQueue(execNetwork, 50);
     int reqid;
     for (int i = 0; i < 50; i++) {
@@ -90,9 +90,9 @@ void inferenceSimulate(ovms::OVInferRequestsQueue& ms, std::vector<int>& tv) {
 TEST(OVInferRequestQueue, MultiThread) {
     int nireq = 10;            // represnet queue size
     int number_clients = 100;  // represent number of serving clients
-    InferenceEngine::Core engine;
-    InferenceEngine::CNNNetwork network = engine.ReadNetwork(DUMMY_MODEL_PATH);
-    InferenceEngine::ExecutableNetwork execNetwork = engine.LoadNetwork(network, "CPU");
+    InferenceEngine::Core ieCore;
+    InferenceEngine::CNNNetwork network = ieCore.ReadNetwork(DUMMY_MODEL_PATH);
+    InferenceEngine::ExecutableNetwork execNetwork = ieCore.LoadNetwork(network, "CPU");
 
     ovms::OVInferRequestsQueue inferRequestsQueue(execNetwork, nireq);
 
@@ -108,9 +108,9 @@ TEST(OVInferRequestQueue, MultiThread) {
 }
 
 TEST(OVInferRequestQueue, AsyncGetInferRequest) {
-    InferenceEngine::Core engine;
-    InferenceEngine::CNNNetwork network = engine.ReadNetwork(DUMMY_MODEL_PATH);
-    InferenceEngine::ExecutableNetwork execNetwork = engine.LoadNetwork(network, "CPU");
+    InferenceEngine::Core ieCore;
+    InferenceEngine::CNNNetwork network = ieCore.ReadNetwork(DUMMY_MODEL_PATH);
+    InferenceEngine::ExecutableNetwork execNetwork = ieCore.LoadNetwork(network, "CPU");
     const int nireq = 1;
     ovms::OVInferRequestsQueue inferRequestsQueue(execNetwork, nireq);
 

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -207,8 +207,8 @@ public:
 
 class MockModelInstance : public ovms::ModelInstance {
 public:
-    MockModelInstance() :
-        ModelInstance("UNUSED_NAME", 42) {}
+    MockModelInstance(InferenceEngine::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", 42, ieCore) {}
     const ovms::Status mockValidate(const tensorflow::serving::PredictRequest* request) {
         return validate(request);
     }

--- a/src/test/serialization_tests.cpp
+++ b/src/test/serialization_tests.cpp
@@ -200,9 +200,9 @@ TEST_P(SerializeTFTensorProtoNegative, SerializeTensorProtoShouldSucceedForPreci
 
 TEST(SerializeTFGRPCPredictResponse, ShouldSuccessForSupportedPrecision) {
     PredictResponse response;
-    InferenceEngine::Core engine;
-    InferenceEngine::CNNNetwork network = engine.ReadNetwork(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
-    InferenceEngine::ExecutableNetwork execNetwork = engine.LoadNetwork(network, "CPU");
+    InferenceEngine::Core ieCore;
+    InferenceEngine::CNNNetwork network = ieCore.ReadNetwork(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
+    InferenceEngine::ExecutableNetwork execNetwork = ieCore.LoadNetwork(network, "CPU");
     InferenceEngine::InferRequest inferRequest = execNetwork.CreateInferRequest();
     ovms::tensor_map_t tenMap;
     InferenceEngine::TensorDesc tensorDesc(Precision::FP32, shape_t{1, 10}, InferenceEngine::Layout::NC);

--- a/src/test/stateful_modelinstance_test.cpp
+++ b/src/test/stateful_modelinstance_test.cpp
@@ -97,6 +97,7 @@ public:
     inputs_info_t modelInput;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
+    std::unique_ptr<InferenceEngine::Core> ieCore;
 
     void SetUpConfig(const std::string& configContent) {
         ovmsConfig = configContent;
@@ -107,6 +108,7 @@ public:
     }
     void SetUp() override {
         TestWithTempDir::SetUp();
+        ieCore = std::make_unique<InferenceEngine::Core>();
         modelVersion = 1;
         // Prepare manager
         modelPath = directoryPath + "/dummy/";
@@ -127,21 +129,24 @@ public:
     inputs_info_t modelInput;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
+    std::unique_ptr<InferenceEngine::Core> ieCore;
 
     void SetUp() override {
         modelInput = {};
+        ieCore = std::make_unique<InferenceEngine::Core>();
     }
 
     void TearDown() override {
         modelInput.clear();
+        ieCore.reset();
     }
 };
 
 class MockedValidateStatefulModelInstance : public ovms::StatefulModelInstance {
 public:
     ovms::GlobalSequencesViewer sequencesViewer;
-    MockedValidateStatefulModelInstance(const std::string& name, ovms::model_version_t version) :
-        StatefulModelInstance(name, version, &sequencesViewer) {}
+    MockedValidateStatefulModelInstance(const std::string& name, ovms::model_version_t version, InferenceEngine::Core& ieCore) :
+        StatefulModelInstance(name, version, ieCore, &sequencesViewer) {}
 
     const ovms::Status mockValidate(const tensorflow::serving::PredictRequest* request, ovms::SequenceProcessingSpec& processingSpec) {
         return validate(request, processingSpec);
@@ -160,8 +165,8 @@ public:
     ovms::GlobalSequencesViewer sequencesViewer;
     std::unique_ptr<MockedSequenceManager> mockedSequenceManager = std::make_unique<MockedSequenceManager>(60, "dummy", 1);
 
-    MockedStatefulModelInstance(const std::string& name, ovms::model_version_t version) :
-        StatefulModelInstance(name, version, &sequencesViewer) {}
+    MockedStatefulModelInstance(const std::string& name, ovms::model_version_t version, InferenceEngine::Core& ieCore) :
+        StatefulModelInstance(name, version, ieCore, &sequencesViewer) {}
 
     const std::unique_ptr<MockedSequenceManager>& getMockedSequenceManager() const {
         return this->mockedSequenceManager;
@@ -279,6 +284,7 @@ public:
     Blob::Ptr defaultBlob;
     Blob::Ptr currentBlob;
     Blob::Ptr newBlob;
+    std::unique_ptr<InferenceEngine::Core> ieCore;
 
     std::vector<float> defaultState{0};
     std::vector<float> currentState{10};
@@ -287,7 +293,8 @@ public:
     size_t elementsCount;
 
     void SetUp() override {
-        modelInstance = std::make_shared<MockedStatefulModelInstance>("model", 1);
+        ieCore = std::make_unique<InferenceEngine::Core>();
+        modelInstance = std::make_shared<MockedStatefulModelInstance>("model", 1, *ieCore);
         // Prepare states blob desc
         shape = std::vector<size_t>{1, 1};
         elementsCount = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
@@ -1041,7 +1048,7 @@ TEST_F(StatefulModelInstanceTempDir, statefulInferStandardFlow) {
 
 TEST_F(StatefulModelInstanceTempDir, loadModel) {
     ovms::GlobalSequencesViewer sequencesViewer;
-    ovms::StatefulModelInstance modelInstance(dummyModelName, modelVersion, &sequencesViewer);
+    ovms::StatefulModelInstance modelInstance(dummyModelName, modelVersion, *ieCore, &sequencesViewer);
 
     const ovms::ModelConfig config1{
         dummyModelName,
@@ -1083,7 +1090,7 @@ TEST_F(StatefulModelInstanceTempDir, loadModel) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, positiveValidate) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore);
     uint64_t seqId = 1;
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, seqId);
 
@@ -1110,7 +1117,7 @@ TEST_F(StatefulModelInstanceInputValidation, positiveValidate) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, missingSeqId) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     setRequestSequenceControl(&request, ovms::SEQUENCE_END);
@@ -1120,7 +1127,7 @@ TEST_F(StatefulModelInstanceInputValidation, missingSeqId) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdEnd) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     setRequestSequenceControl(&request, ovms::SEQUENCE_END);
@@ -1132,7 +1139,7 @@ TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdEnd) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdNoControl) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     setRequestSequenceControl(&request, ovms::NO_CONTROL_INPUT);
@@ -1144,7 +1151,7 @@ TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdNoControl) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, wrongProtoKeywords) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     auto& input = (*request.mutable_inputs())["sequenceid"];
@@ -1156,7 +1163,7 @@ TEST_F(StatefulModelInstanceInputValidation, wrongProtoKeywords) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, badControlInput) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     request = preparePredictRequest(modelInput);
@@ -1169,7 +1176,7 @@ TEST_F(StatefulModelInstanceInputValidation, badControlInput) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, invalidProtoTypes) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     {
         tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);

--- a/src/test/stateful_test_utils.hpp
+++ b/src/test/stateful_test_utils.hpp
@@ -89,9 +89,9 @@ private:
 
 public:
     DummyStatefulModel() {
-        InferenceEngine::Core engine;
-        cnnNetworkPtr = std::make_shared<InferenceEngine::CNNNetwork>(engine.ReadNetwork(MODEL_PATH));
-        execNetworkPtr = std::make_shared<InferenceEngine::ExecutableNetwork>(engine.LoadNetwork(*cnnNetworkPtr, "CPU"));
+        InferenceEngine::Core ieCore;
+        cnnNetworkPtr = std::make_shared<InferenceEngine::CNNNetwork>(ieCore.ReadNetwork(MODEL_PATH));
+        execNetworkPtr = std::make_shared<InferenceEngine::ExecutableNetwork>(ieCore.LoadNetwork(*cnnNetworkPtr, "CPU"));
     }
 
     InferenceEngine::InferRequest createInferRequest() {


### PR DESCRIPTION
This fixes issue with loading multiple models on NCS.
Rename engine/ovCore to ieCore.
This resolves #914

JIRA:CVS-65928
(cherry picked from commit 42fb00233ab17c149301911631f4dc7aa3714d3c)