### PR TITLE
[WIP] Avoid using latest tag due to caching on nodes

### DIFF
--- a/extras/openvino-operator-openshift/helm-charts/rhods-ov-image-stream/templates/imagestream.yaml
+++ b/extras/openvino-operator-openshift/helm-charts/rhods-ov-image-stream/templates/imagestream.yaml
@@ -31,7 +31,7 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: latest
+    - name: "2021-09-27"
       annotations:
         opendatahub.io/notebook-python-dependencies: >-
           [{"name":"JupyterLab","version":"3.0.14"},{"name":"Notebook","version":"6.3.0"}]


### PR DESCRIPTION
Ideally this tag could get populated on a given build date, but this avoids the problem of caching the :latest tag on the nodes