### PR TITLE
Layout API 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ DIST_OS_TAG ?= $(BASE_OS_TAG)
 ifeq ($(BASE_OS),ubuntu)
   BASE_OS_TAG=$(BASE_OS_TAG_UBUNTU)
   BASE_IMAGE ?= ubuntu:$(BASE_OS_TAG_UBUNTU)
-  DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_offline_latest.sh
+  DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_2022.1.0.355_offline.sh
 endif
 ifeq ($(BASE_OS),centos)
   BASE_OS_TAG=$(BASE_OS_TAG_CENTOS)

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -141,12 +141,12 @@ bool hasOutputWithName(std::shared_ptr<ov::Function>& network, const std::string
 Status validateConfigurationAgainstNetwork_2(const ModelConfig& config, std::shared_ptr<ov::Function>& network) {
     if (config.isShapeAnonymousFixed() && network->inputs().size() > 1) {
         Status status = StatusCode::ANONYMOUS_FIXED_SHAPE_NOT_ALLOWED;
-        SPDLOG_WARN(status.string());
+        SPDLOG_LOGGER_WARN(modelmanager_logger, status.string());
         return status;
     }
     if (!config.getLayout().empty() && network->inputs().size() > 1) {
         Status status = StatusCode::ANONYMOUS_FIXED_LAYOUT_NOT_ALLOWED;
-        SPDLOG_WARN(status.string());
+        SPDLOG_LOGGER_WARN(modelmanager_logger, status.string());
         return status;
     }
     for (const auto& [name, _] : config.getShapes()) {
@@ -154,22 +154,22 @@ Status validateConfigurationAgainstNetwork_2(const ModelConfig& config, std::sha
             continue;
         }
         if (hasInputWithName(network, name) && config.getMappingInputByKey(name) != "") {
-            SPDLOG_WARN("Config shape - {} is mapped by {}. Changes will not apply", name, config.getMappingInputByKey(name));
+            SPDLOG_LOGGER_WARN(modelmanager_logger, "Config shape - {} is mapped by {}. Changes will not apply", name, config.getMappingInputByKey(name));
             return StatusCode::CONFIG_SHAPE_MAPPED_BUT_USED_REAL_NAME;
         } else if (!hasInputWithName(network, name) && !hasInputWithName(network, config.getRealInputNameByValue(name))) {
-            SPDLOG_WARN("Config shape - {} not found in network", name);
+            SPDLOG_LOGGER_WARN(modelmanager_logger, "Config shape - {} not found in network", name);
             return StatusCode::CONFIG_SHAPE_IS_NOT_IN_NETWORK;
         }
     }
     for (const auto& [name, _] : config.getLayouts()) {
         if (hasInputWithName(network, name) && config.getMappingInputByKey(name) != "") {
-            SPDLOG_WARN("Config layout - {} is mapped by {}. Changes will not apply", name, config.getMappingInputByKey(name));
+            SPDLOG_LOGGER_WARN(modelmanager_logger, "Config layout - {} is mapped by {}. Changes will not apply", name, config.getMappingInputByKey(name));
             return StatusCode::CONFIG_LAYOUT_MAPPED_BUT_USED_REAL_NAME;
         } else if (hasOutputWithName(network, name) && config.getMappingOutputByKey(name) != "") {
-            SPDLOG_WARN("Config layout - {} is mapped by {}. Changes will not apply", name, config.getMappingOutputByKey(name));
+            SPDLOG_LOGGER_WARN(modelmanager_logger, "Config layout - {} is mapped by {}. Changes will not apply", name, config.getMappingOutputByKey(name));
             return StatusCode::CONFIG_LAYOUT_MAPPED_BUT_USED_REAL_NAME;
         } else if (!hasInputWithName(network, name) && !hasOutputWithName(network, name) && !hasInputWithName(network, config.getRealInputNameByValue(name)) && !hasOutputWithName(network, config.getRealOutputNameByValue(name))) {
-            SPDLOG_WARN("Config layout - {} not found in network", name);
+            SPDLOG_LOGGER_WARN(modelmanager_logger, "Config layout - {} not found in network", name);
             return StatusCode::CONFIG_LAYOUT_IS_NOT_IN_NETWORK;
         }
     }

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -252,6 +252,13 @@ private:
     std::atomic<uint64_t> predictRequestsHandlesCount = 0;
 
     /**
+         * @brief Internal method for loading tensors
+         *
+         * @param config
+         */
+    Status loadTensors(const ModelConfig& config, const DynamicModelParameter& parameter = DynamicModelParameter());
+
+    /**
          * @brief Internal method for loading inputs
          *
          * @param config

--- a/src/predict_request_validation_utils.cpp
+++ b/src/predict_request_validation_utils.cpp
@@ -299,7 +299,6 @@ Status RequestValidator::validate() {
         return status;
 
     for (const auto& [name, inputInfo] : inputsInfo) {
-        SPDLOG_INFO("UUUUUUUUUU {}", name);
         status = validateAndGetInput(request, name, it);
         if (!status.ok())
             return status;

--- a/src/predict_request_validation_utils.cpp
+++ b/src/predict_request_validation_utils.cpp
@@ -166,7 +166,7 @@ Status RequestValidator::checkBinaryBatchSizeMismatch(const tensorflow::TensorPr
 }
 
 Status RequestValidator::checkShapeMismatch(const tensorflow::TensorProto& proto, const ovms::TensorInfo& inputInfo, Status& finalStatus, Mode batchingMode, Mode shapeMode) const {
-    const auto& shape = inputInfo.getEffectiveShape();
+    const auto& shape = inputInfo.getShape();
     int i = (batchingMode == AUTO) ? 1 : 0;  // If batch size is automatic, omit first dimension
     bool mismatch = false;
     for (; i < proto.tensor_shape().dim_size(); i++) {
@@ -183,7 +183,7 @@ Status RequestValidator::checkShapeMismatch(const tensorflow::TensorProto& proto
         return StatusCode::OK;
     } else {
         std::stringstream ss;
-        ss << "Expected: " << TensorInfo::shapeToString(inputInfo.getEffectiveShape())
+        ss << "Expected: " << TensorInfo::shapeToString(inputInfo.getShape())
            << "; Actual: " << TensorInfo::tensorShapeToString(proto.tensor_shape())
            << "; input name: " << getCurrentlyValidatedInputName();
         const std::string details = ss.str();
@@ -250,7 +250,7 @@ Status RequestValidator::validateTensorContentSize(const tensorflow::TensorProto
 
 Status RequestValidator::validateNumberOfShapeDimensions(const ovms::TensorInfo& inputInfo, const tensorflow::TensorProto& proto) const {
     // Network and request must have the same number of shape dimensions, higher than 0
-    const auto& shape = inputInfo.getEffectiveShape();
+    const auto& shape = inputInfo.getShape();
     if (proto.tensor_shape().dim_size() <= 0 ||
         shape.size() != static_cast<size_t>(proto.tensor_shape().dim_size())) {
         std::stringstream ss;
@@ -299,6 +299,7 @@ Status RequestValidator::validate() {
         return status;
 
     for (const auto& [name, inputInfo] : inputsInfo) {
+        SPDLOG_INFO("UUUUUUUUUU {}", name);
         status = validateAndGetInput(request, name, it);
         if (!status.ok())
             return status;

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -128,7 +128,7 @@ Status serializeBlobToTensorProto_2(
     }
     }
     responseOutput.mutable_tensor_shape()->Clear();
-    auto& effectiveNetworkOutputShape = networkOutput->getEffectiveShape();
+    auto& effectiveNetworkOutputShape = networkOutput->getShape();
     // TODO: getEffectiveBlobShape(blob);
     ov::Shape actualBlobShape = blob.get_shape();
     if (effectiveNetworkOutputShape.size() != actualBlobShape.size()) {

--- a/src/tensorinfo.cpp
+++ b/src/tensorinfo.cpp
@@ -333,12 +333,14 @@ void TensorInfo::setLayout(InferenceEngine::Layout layout) {
 }
 
 void TensorInfo::updateEffectiveShape() {
-    this->effectiveShape = this->getTensorDesc().getBlockingDesc().getBlockDims();
-    if (effectiveShape.size() == 0) {
-        this->shape_2 = this->shape;
-    } else {
-        this->shape_2 = effectiveShape;
-    }
+    // TODO: Get rid of this.
+
+    // this->effectiveShape = this->getTensorDesc().getBlockingDesc().getBlockDims();
+    // if (effectiveShape.size() == 0) {
+    //     this->shape_2 = this->shape;
+    // } else {
+    //     this->shape_2 = effectiveShape;
+    // }
 }
 
 std::shared_ptr<TensorInfo> TensorInfo::createCopyWithNewShape(const shape_t& shape) const {

--- a/src/tensorinfo.cpp
+++ b/src/tensorinfo.cpp
@@ -97,6 +97,18 @@ TensorInfo::TensorInfo(const std::string& name,
 }
 TensorInfo::TensorInfo(const std::string& name,
     const std::string& mapping,
+    const ovms::Precision& precision,
+    const shape_t& shape,
+    const InferenceEngine::Layout& layout) :
+    name(name),
+    mapping(mapping),
+    precision_2(precision),
+    shape(shape),
+    layout(layout) {
+    this->updateEffectiveShape();
+}
+TensorInfo::TensorInfo(const std::string& name,
+    const std::string& mapping,
     const Precision& precision,
     const shape_t& shape) :
     name(name),

--- a/src/tensorinfo.hpp
+++ b/src/tensorinfo.hpp
@@ -132,6 +132,11 @@ public:
         const InferenceEngine::Layout& layout);
     TensorInfo(const std::string& name,
         const std::string& mapping,
+        const ovms::Precision& precision,
+        const shape_t& shape,
+        const InferenceEngine::Layout& layout);
+    TensorInfo(const std::string& name,
+        const std::string& mapping,
         const Precision& precision,
         const shape_t& shape);
     //        const InferenceEngine::Layout& layout);

--- a/src/test/binaryutils_test.cpp
+++ b/src/test/binaryutils_test.cpp
@@ -57,7 +57,7 @@ TEST_F(BinaryUtilsTest, tensorWithInvalidImage) {
     std::string invalidImage = "INVALID_IMAGE";
     stringValInvalidImage.add_string_val(invalidImage);
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 3, 1, 1}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 1, 1, 3}, InferenceEngine::Layout::NHWC);
 
     EXPECT_EQ(convertStringValToBlob(stringValInvalidImage, blob, tensorInfo, false), ovms::StatusCode::IMAGE_PARSING_FAILED);
 }
@@ -69,7 +69,7 @@ TEST_F(BinaryUtilsTest, tensorWithEmptyStringVal) {
     std::string invalidImage = "";
     stringValEmptyImage.add_string_val(invalidImage);
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 3, 1, 1}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 1, 1, 3}, InferenceEngine::Layout::NHWC);
 
     EXPECT_EQ(convertStringValToBlob(stringValEmptyImage, blob, tensorInfo, false), ovms::StatusCode::STRING_VAL_EMPTY);
 }
@@ -77,7 +77,7 @@ TEST_F(BinaryUtilsTest, tensorWithEmptyStringVal) {
 TEST_F(BinaryUtilsTest, tensorWithNonSupportedLayout) {
     InferenceEngine::Blob::Ptr blob;
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 3, 1, 1}, InferenceEngine::Layout::NCHW);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 1, 1, 3}, InferenceEngine::Layout::NCHW);
 
     EXPECT_EQ(convertStringValToBlob(stringVal, blob, tensorInfo, false), ovms::StatusCode::UNSUPPORTED_LAYOUT);
 }
@@ -85,7 +85,7 @@ TEST_F(BinaryUtilsTest, tensorWithNonSupportedLayout) {
 TEST_F(BinaryUtilsTest, tensorWithNonSupportedPrecision) {
     InferenceEngine::Blob::Ptr blob;
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::MIXED, shape_t{1, 3, 1, 1}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::MIXED, shape_t{1, 1, 1, 3}, InferenceEngine::Layout::NHWC);
 
     EXPECT_EQ(convertStringValToBlob(stringVal, blob, tensorInfo, false), ovms::StatusCode::INVALID_PRECISION);
 }
@@ -111,7 +111,7 @@ TEST_F(BinaryUtilsTest, positive_rgb) {
 
     InferenceEngine::Blob::Ptr blob;
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 3, 1, 1}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 1, 1, 3}, InferenceEngine::Layout::NHWC);
 
     ASSERT_EQ(convertStringValToBlob(stringVal, blob, tensorInfo, false), ovms::StatusCode::OK);
     ASSERT_EQ(blob->size(), 3);
@@ -149,7 +149,7 @@ TEST_F(BinaryUtilsTest, positive_batch_size_2) {
     InferenceEngine::Blob::Ptr blob;
     stringVal.add_string_val(image_bytes.get(), filesize);
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{2, 3, 1, 1}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{2, 1, 1, 3}, InferenceEngine::Layout::NHWC);
 
     ASSERT_EQ(convertStringValToBlob(stringVal, blob, tensorInfo, false), ovms::StatusCode::OK);
     ASSERT_EQ(blob->size(), 6);
@@ -162,7 +162,7 @@ TEST_F(BinaryUtilsTest, positive_precision_changed) {
 
     InferenceEngine::Blob::Ptr blob;
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::I32, shape_t{1, 3, 1, 1}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::I32, shape_t{1, 1, 1, 3}, InferenceEngine::Layout::NHWC);
 
     ASSERT_EQ(convertStringValToBlob(stringVal, blob, tensorInfo, false), ovms::StatusCode::OK);
     ASSERT_EQ(blob->size(), 3);
@@ -176,7 +176,7 @@ TEST_F(BinaryUtilsTest, positive_nhwc_layout) {
 
     InferenceEngine::Blob::Ptr blob;
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 3, 1, 1}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 1, 1, 3}, InferenceEngine::Layout::NHWC);
 
     ASSERT_EQ(convertStringValToBlob(stringVal, blob, tensorInfo, false), ovms::StatusCode::OK);
     ASSERT_EQ(blob->size(), 3);
@@ -190,7 +190,7 @@ TEST_F(BinaryUtilsTest, positive_resizing) {
 
     InferenceEngine::Blob::Ptr blob;
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 3, 2, 2}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", InferenceEngine::Precision::U8, shape_t{1, 2, 2, 3}, InferenceEngine::Layout::NHWC);
 
     ASSERT_EQ(convertStringValToBlob(stringVal, blob, tensorInfo, false), ovms::StatusCode::OK);
     ASSERT_EQ(blob->size(), 12);

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -326,7 +326,7 @@ public:
     void deserialize(const std::vector<float>& input, ov::runtime::InferRequest& inferRequest, std::shared_ptr<ovms::ModelInstance> modelInstance) {
         ov::runtime::Tensor tensor(
             modelInstance->getInputsInfo().at(DUMMY_MODEL_INPUT_NAME)->getOvPrecision(),
-            modelInstance->getInputsInfo().at(DUMMY_MODEL_INPUT_NAME)->getShape_2(),
+            modelInstance->getInputsInfo().at(DUMMY_MODEL_INPUT_NAME)->getShape(),
             const_cast<float*>(reinterpret_cast<const float*>(input.data())));
         inferRequest.set_tensor(DUMMY_MODEL_INPUT_NAME, tensor);
     }

--- a/src/test/ovtestutils.hpp
+++ b/src/test/ovtestutils.hpp
@@ -107,14 +107,14 @@ private:
 class MockBlob_2 : public ov::runtime::Tensor {
 public:
     MockBlob_2(const std::shared_ptr<ovms::TensorInfo>& info) :
-        ov::runtime::Tensor(info->getOvPrecision(), info->getShape_2()) {
+        ov::runtime::Tensor(info->getOvPrecision(), info->getShape()) {
         to = const_cast<char*>("12345678");
     }
 
     // TODO: Those are not virtual methods, therefore mocks do not work.
-    MOCK_METHOD(ov::Shape, get_shape, (), (const));
-    MOCK_METHOD(size_t, get_byte_size, (), (const));
-    MOCK_METHOD(ov::element::Type, get_element_type, (), (const));
+    // MOCK_METHOD(ov::Shape, get_shape, (), (const));
+    // MOCK_METHOD(size_t, get_byte_size, (), (const));
+    // MOCK_METHOD(ov::element::Type, get_element_type, (), (const));
 
 private:
     char* to;

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -57,7 +57,7 @@ protected:
 
         networkInputs = ovms::tensor_map_t({
             {"Input_FP32_1_3_224_224_NHWC",
-                std::make_shared<ovms::TensorInfo>("Input_FP32_1_3_224_224_NHWC", ovms::Precision::FP32, ovms::shape_t{1, 3, 224, 224}, InferenceEngine::Layout::NHWC)},
+                std::make_shared<ovms::TensorInfo>("Input_FP32_1_3_224_224_NHWC", ovms::Precision::FP32, ovms::shape_t{1, 224, 224, 3}, InferenceEngine::Layout::NHWC)},
             {"Input_U8_1_3_62_62_NCHW",
                 std::make_shared<ovms::TensorInfo>("Input_U8_1_3_62_62_NCHW", ovms::Precision::U8, ovms::shape_t{1, 3, 62, 62}, InferenceEngine::Layout::NCHW)},
             {"Input_I64_1_6_128_128_16_NCDHW",

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -459,7 +459,7 @@ TEST_F(TestPredict, SuccesfullReloadForMultipleThreadsDifferentBS) {
 }
 
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, LAYOUT_2_0_SuccesfullReshapeViaRequestOnDummyModel) {
+TEST_F(TestPredict, SuccesfullReshapeViaRequestOnDummyModel) {
     // Prepare model manager with dynamic shaped dummy model, originally loaded with 1x10 shape
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("0");
@@ -501,7 +501,7 @@ TEST_F(TestPredict, LAYOUT_2_0_SuccesfullReshapeViaRequestOnDummyModel) {
  * 7. Do the inference with (1,12) shape - expect status OK and result (1,12)
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, LAYOUT_2_0_ReshapeViaRequestAndConfigChange) {
+TEST_F(TestPredict, ReshapeViaRequestAndConfigChange) {
     using namespace ovms;
 
     // Prepare model with shape=auto (initially (1,10) shape)
@@ -550,7 +550,7 @@ TEST_F(TestPredict, LAYOUT_2_0_ReshapeViaRequestAndConfigChange) {
  * 7. Do the inference with (3,10) shape - expect status OK and result (3,10)
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, LAYOUT_2_0_ChangeBatchSizeViaRequestAndConfigChange) {
+TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChange) {
     using namespace ovms;
 
     // Prepare model with shape=auto (initially (1,10) shape)
@@ -598,7 +598,7 @@ TEST_F(TestPredict, LAYOUT_2_0_ChangeBatchSizeViaRequestAndConfigChange) {
  * 9. Do the inference with (1,4,5,3) shape - expect INVALID_SHAPE
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelInputLayout) {
+TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -620,6 +620,7 @@ TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelInputLayout) {
 
     // TODO: Functionality gap. How to remove preprocessing (transposition?)
     // Reload model with layout setting removed
+    ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
@@ -655,7 +656,7 @@ TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelInputLayout) {
  * 6. Do the inference with (1,3,4,5) shape - expect status OK and result in NCHW layout
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelOutputLayout) {
+TEST_F(TestPredict, PerformInferenceChangeModelOutputLayout) {
     using namespace ovms;
 
     // Prepare model with changed output layout to nhwc (internal layout=nchw)
@@ -667,27 +668,29 @@ TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelOutputLayout) {
 
     tensorflow::serving::PredictResponse response;
 
+    std::cout << "1111" << std::endl;
     // Perform inference with NCHW layout, ensure status OK and results in NHWC order
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
     checkOutputShape(response, {1, 1, 2, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
     checkOutputValues(response, {2.0, 4.0, 6.0, 3.0, 5.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-
+    std::cout << "22222" << std::endl;
     // Reload model with layout setting removed
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
-
+    std::cout << "33333" << std::endl;
     // Perform inference with NCHW layout, ensure status OK and results still in NHWC order
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
     checkOutputShape(response, {1, 1, 2, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
     checkOutputValues(response, {2.0, 4.0, 6.0, 3.0, 5.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-
+    std::cout << "44444" << std::endl;
     // Change output layout back to original nchw.
     ASSERT_EQ(config.parseLayoutParameter(std::string("{\"") + INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME + std::string("\":\"nchw\"}")), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
-
+    std::cout << "5555555" << std::endl;
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
     checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
     checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    std::cout << "6666666" << std::endl;
 }
 
 TEST_F(TestPredict, ErrorWhenLayoutSetForMissingTensor) {
@@ -714,7 +717,7 @@ TEST_F(TestPredict, NetworkNotLoadedWhenLayoutAndDimsInconsistent) {
  * 6. Do the inference with single binary image tensor - expect status OK and result in NCHW layout
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceWithBinaryInputChangeModelInputLayout) {
+TEST_F(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -755,7 +758,7 @@ TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceWithBinaryInputChangeModelInputLa
  * 2. Do the inference with batch=5 binary image tensor - expect status OK and result in NCHW layout
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceWithBinaryInputBatchSizeAuto) {
+TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAuto) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -610,7 +610,7 @@ TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
     checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Perform inference with NCHW layout, ensure error
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::INVALID_SHAPE);
 
     // Reload model with layout setting removed, model is still NHWC
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -458,7 +458,6 @@ TEST_F(TestPredict, SuccesfullReloadForMultipleThreadsDifferentBS) {
     testConcurrentBsChanges(initialBatchSize, numberOfThreads);
 }
 
-// TODO: Enable once Layout Change becomes available using OV 2.0.
 TEST_F(TestPredict, SuccesfullReshapeViaRequestOnDummyModel) {
     // Prepare model manager with dynamic shaped dummy model, originally loaded with 1x10 shape
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
@@ -500,7 +499,6 @@ TEST_F(TestPredict, SuccesfullReshapeViaRequestOnDummyModel) {
  * 6. Reshape model back to shape=auto, initial internal shape (1,10)
  * 7. Do the inference with (1,12) shape - expect status OK and result (1,12)
  */
-// TODO: Enable once Layout Change becomes available using OV 2.0.
 TEST_F(TestPredict, ReshapeViaRequestAndConfigChange) {
     using namespace ovms;
 
@@ -549,7 +547,6 @@ TEST_F(TestPredict, ReshapeViaRequestAndConfigChange) {
  * 6. Reshape model back to batchsize=auto, initial internal shape (1,10)
  * 7. Do the inference with (3,10) shape - expect status OK and result (3,10)
  */
-// TODO: Enable once Layout Change becomes available using OV 2.0.
 TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChange) {
     using namespace ovms;
 
@@ -587,24 +584,78 @@ TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChange) {
 /**
  * Scenario - perform inference with NHWC input layout changed via config.json.
  * 
- * 1. Load model with layout=nhwc, initial internal layout: nchw
+ * 1. Load model with layout=nhwc, initial internal layout: nchw, initial shape=(1,3,4,5)
  * 2. Do the inference with (1,4,5,3) shape - expect status OK and result (1,3,4,5)
  * 3. Do the inference with (1,3,4,5) shape - expect INVALID_SHAPE
  * 4. Remove layout setting
- * 5. Do the inference with (1,4,5,3) shape - expect status OK and result (1,3,4,5): model keeps old nhwc setting
+ * 5. Do the inference with (1,4,5,3) shape - expect status OK and result (1,3,4,5)
  * 6. Do the inference with (1,3,4,5) shape - expect INVALID_SHAPE
- * 7. Add layout setting to nchw
- * 8. Do the inference with (1,3,4,5) shape - expect status OK and result (1,3,4,5):
+ * 7. Adding layout setting to nchw
+ * 8. Do the inference with (1,3,4,5) shape - expect status OK and result (1,3,4,5)
  * 9. Do the inference with (1,4,5,3) shape - expect INVALID_SHAPE
  */
-// TODO: Enable once Layout Change becomes available using OV 2.0.
 TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
     ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     config.setBatchingParams("0");
-    ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseLayoutParameter("nhwc"), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    tensorflow::serving::PredictResponse response;
+
+    // Perform inference with NHWC layout, ensure status OK and correct results
+    ASSERT_EQ(performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::OK);
+    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+
+    // Perform inference with NCHW layout, ensure error
+    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}), ovms::StatusCode::INVALID_SHAPE);
+
+    // Reload model with layout setting removed, model is still NHWC
+    ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    // Perform inference with NHWC layout, ensure status OK and correct results
+    ASSERT_EQ(performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::OK);
+    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+
+    // Perform inference with NCHW layout, ensure error
+    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::INVALID_SHAPE);
+
+    // Prepare model with layout changed back to nchw
+    ASSERT_EQ(config.parseLayoutParameter("nchw"), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    // Perform inference with NCHW layout, ensure OK
+    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::OK);
+    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+
+    // Perform inference with NHWC layout, ensure error
+    ASSERT_EQ(performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::INVALID_SHAPE);
+}
+
+/**
+ * Scenario - perform inference with NHWC input layout changed and shape changed via config.json.
+ * 
+ * 1. Load model with layout=nhwc and shape=(1,1,2,3), initial internal layout: nchw, initial shape=(1,3,4,5)
+ * 2. Do the inference with (1,1,2,3) shape - expect status OK and result (1,3,1,2)
+ * 3. Do the inference with (1,3,1,2) shape - expect INVALID_SHAPE
+ * 4. Remove layout setting
+ * 5. Do the inference with (1,1,2,3) shape - expect status OK and result (1,3,1,2)
+ * 6. Do the inference with (1,3,1,2) shape - expect INVALID_SHAPE
+ * 7. Adding layout setting to nchw
+ * 8. Do the inference with (1,3,1,2) shape - expect status OK and result (1,3,1,2)
+ * 9. Do the inference with (1,1,2,3) shape - expect INVALID_SHAPE
+ */
+
+TEST_F(TestPredict, PerformInferenceChangeModelInputLayoutAndShape) {
+    using namespace ovms;
+
+    // Prepare model with changed layout to nhwc (internal layout=nchw)
+    ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc"), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
@@ -618,8 +669,7 @@ TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
     // Perform inference with NCHW layout, ensure error
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
 
-    // TODO: Functionality gap. How to remove preprocessing (transposition?)
-    // Reload model with layout setting removed
+    // Reload model with layout setting removed, model is still NHWC
     ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
@@ -633,10 +683,11 @@ TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
 
     // Prepare model with layout changed back to nchw
+    ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nchw"), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    // Perform inference with NCHW layout, ensure status OK and correct results
+    // Perform inference with NCHW layout, ensure OK
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
     checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
     checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
@@ -655,7 +706,6 @@ TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
  * 5. Roll back layout setting to internal nchw
  * 6. Do the inference with (1,3,4,5) shape - expect status OK and result in NCHW layout
  */
-// TODO: Enable once Layout Change becomes available using OV 2.0.
 TEST_F(TestPredict, PerformInferenceChangeModelOutputLayout) {
     using namespace ovms;
 
@@ -668,29 +718,27 @@ TEST_F(TestPredict, PerformInferenceChangeModelOutputLayout) {
 
     tensorflow::serving::PredictResponse response;
 
-    std::cout << "1111" << std::endl;
     // Perform inference with NCHW layout, ensure status OK and results in NHWC order
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
     checkOutputShape(response, {1, 1, 2, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
     checkOutputValues(response, {2.0, 4.0, 6.0, 3.0, 5.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    std::cout << "22222" << std::endl;
+
     // Reload model with layout setting removed
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
-    std::cout << "33333" << std::endl;
+
     // Perform inference with NCHW layout, ensure status OK and results still in NHWC order
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
     checkOutputShape(response, {1, 1, 2, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
     checkOutputValues(response, {2.0, 4.0, 6.0, 3.0, 5.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    std::cout << "44444" << std::endl;
+
     // Change output layout back to original nchw.
     ASSERT_EQ(config.parseLayoutParameter(std::string("{\"") + INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME + std::string("\":\"nchw\"}")), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
-    std::cout << "5555555" << std::endl;
+
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
     checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
     checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    std::cout << "6666666" << std::endl;
 }
 
 TEST_F(TestPredict, ErrorWhenLayoutSetForMissingTensor) {
@@ -716,14 +764,13 @@ TEST_F(TestPredict, NetworkNotLoadedWhenLayoutAndDimsInconsistent) {
  * 5. Set back layout setting to nhwc
  * 6. Do the inference with single binary image tensor - expect status OK and result in NCHW layout
  */
-// TODO: Enable once Layout Change becomes available using OV 2.0.
 TEST_F(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
     ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     config.setBatchingParams("0");
-    ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc"), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
@@ -736,6 +783,7 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
 
     // Reload model with layout setting removed
     ASSERT_EQ(config.parseLayoutParameter("nchw"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with binary input, ensure validation rejects the request due to NCHW setting
@@ -743,6 +791,7 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
 
     // Switch back to nhwc
     ASSERT_EQ(config.parseLayoutParameter("nhwc"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with binary input, ensure status OK after switching layout and correct results
@@ -757,14 +806,13 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
  * 1. Load model with input layout=nhwc, batch_size=auto, initial internal layout: nchw, batch_size=1
  * 2. Do the inference with batch=5 binary image tensor - expect status OK and result in NCHW layout
  */
-// TODO: Enable once Layout Change becomes available using OV 2.0.
 TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAuto) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
     ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     config.setBatchingParams("auto");
-    ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc"), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
@@ -790,7 +838,7 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputNoInputShape) {
     // Prepare model with changed layout to nhwc (internal layout=nchw)
     ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     config.setBatchingParams("auto");
-    ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc"), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -618,6 +618,7 @@ TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelInputLayout) {
     // Perform inference with NCHW layout, ensure error
     ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
 
+    // TODO: Functionality gap. How to remove preprocessing (transposition?)
     // Reload model with layout setting removed
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
     ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -459,7 +459,7 @@ TEST_F(TestPredict, SuccesfullReloadForMultipleThreadsDifferentBS) {
 }
 
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, DISABLED_SuccesfullReshapeViaRequestOnDummyModel) {
+TEST_F(TestPredict, LAYOUT_2_0_SuccesfullReshapeViaRequestOnDummyModel) {
     // Prepare model manager with dynamic shaped dummy model, originally loaded with 1x10 shape
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("0");
@@ -501,7 +501,7 @@ TEST_F(TestPredict, DISABLED_SuccesfullReshapeViaRequestOnDummyModel) {
  * 7. Do the inference with (1,12) shape - expect status OK and result (1,12)
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, DISABLED_ReshapeViaRequestAndConfigChange) {
+TEST_F(TestPredict, LAYOUT_2_0_ReshapeViaRequestAndConfigChange) {
     using namespace ovms;
 
     // Prepare model with shape=auto (initially (1,10) shape)
@@ -550,7 +550,7 @@ TEST_F(TestPredict, DISABLED_ReshapeViaRequestAndConfigChange) {
  * 7. Do the inference with (3,10) shape - expect status OK and result (3,10)
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, DISABLED_ChangeBatchSizeViaRequestAndConfigChange) {
+TEST_F(TestPredict, LAYOUT_2_0_ChangeBatchSizeViaRequestAndConfigChange) {
     using namespace ovms;
 
     // Prepare model with shape=auto (initially (1,10) shape)
@@ -598,7 +598,7 @@ TEST_F(TestPredict, DISABLED_ChangeBatchSizeViaRequestAndConfigChange) {
  * 9. Do the inference with (1,4,5,3) shape - expect INVALID_SHAPE
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, DISABLED_PerformInferenceChangeModelInputLayout) {
+TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -654,7 +654,7 @@ TEST_F(TestPredict, DISABLED_PerformInferenceChangeModelInputLayout) {
  * 6. Do the inference with (1,3,4,5) shape - expect status OK and result in NCHW layout
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, DISABLED_PerformInferenceChangeModelOutputLayout) {
+TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceChangeModelOutputLayout) {
     using namespace ovms;
 
     // Prepare model with changed output layout to nhwc (internal layout=nchw)
@@ -713,7 +713,7 @@ TEST_F(TestPredict, NetworkNotLoadedWhenLayoutAndDimsInconsistent) {
  * 6. Do the inference with single binary image tensor - expect status OK and result in NCHW layout
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, DISABLED_PerformInferenceWithBinaryInputChangeModelInputLayout) {
+TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceWithBinaryInputChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -754,7 +754,7 @@ TEST_F(TestPredict, DISABLED_PerformInferenceWithBinaryInputChangeModelInputLayo
  * 2. Do the inference with batch=5 binary image tensor - expect status OK and result in NCHW layout
  */
 // TODO: Enable once Layout Change becomes available using OV 2.0.
-TEST_F(TestPredict, DISABLED_PerformInferenceWithBinaryInputBatchSizeAuto) {
+TEST_F(TestPredict, LAYOUT_2_0_PerformInferenceWithBinaryInputBatchSizeAuto) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)

--- a/src/test/serialization_tests.cpp
+++ b/src/test/serialization_tests.cpp
@@ -199,7 +199,7 @@ TEST(SerializeTFGRPCPredictResponse, ShouldSuccessForSupportedPrecision) {
         shape_t{1, 10},
         InferenceEngine::Layout::NC);
     tenMap[DUMMY_MODEL_OUTPUT_NAME] = tensorInfo;
-    ov::runtime::Tensor tensor(tensorInfo->getOvPrecision(), tensorInfo->getShape_2());
+    ov::runtime::Tensor tensor(tensorInfo->getOvPrecision(), tensorInfo->getShape());
     inferRequest.set_tensor(DUMMY_MODEL_OUTPUT_NAME, tensor);
     auto status = serializePredictResponse_2(inferRequest, tenMap, &response);
     EXPECT_TRUE(status.ok());


### PR DESCRIPTION
This change allows changing expected input layout for requests on single model path.
The change is not compatible with previous behavior, which allowed changing input layout per se. Now, user defines additional pre/post processing step (transposition) with `--layout` parameter. Unit tests were adjusted accordingly to this change.