### PR TITLE
Ravikb config md5

### DIFF
--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -33,7 +33,6 @@
 #include <rapidjson/prettywriter.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include "openssl/md5.h"
 
 #include "azurefilesystem.hpp"
 #include "config.hpp"
@@ -46,6 +45,7 @@
 #include "localfilesystem.hpp"
 #include "logging.hpp"
 #include "node_library.hpp"
+#include "openssl/md5.h"
 #include "pipeline.hpp"
 #include "pipeline_factory.hpp"
 #include "pipelinedefinition.hpp"

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -784,8 +784,7 @@ std::string ModelManager::getConfigFileMD5() {
 
     unsigned char result[MD5_DIGEST_LENGTH];
     MD5((unsigned char*)str.c_str(), str.size(), result);
-    std::string md5sum(reinterpret_cast<char*>(result),MD5_DIGEST_LENGTH);
-
+    std::string md5sum(reinterpret_cast<char*>(result), MD5_DIGEST_LENGTH);
     return (md5sum);
 }
 

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -86,6 +86,7 @@ private:
 
     Status lastLoadConfigStatus = StatusCode::OK;
 
+    std::string getConfigFileMD5();
     Status cleanupModelTmpFiles(ModelConfig& config);
     Status reloadModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToReload, std::shared_ptr<model_versions_t> versionsFailed);
     Status addModelVersions(std::shared_ptr<ovms::Model>& model, std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t>& versionsToStart, std::shared_ptr<model_versions_t> versionsFailed);
@@ -149,9 +150,9 @@ private:
     uint32_t sequenceCleanerIntervalMinutes = 5;
 
     /**
-     * @brief Time of last config change
-     */
-    timespec lastConfigChangeTime;
+      * @brief last md5sum of configfile
+      */
+    std::string lastConfigFileMD5;
 
     /**
      * @brief Directory for OpenVINO to store cache files.

--- a/src/test/http_rest_api_handler_test.cpp
+++ b/src/test/http_rest_api_handler_test.cpp
@@ -35,6 +35,19 @@ static const char* configWith1Dummy = R"(
     ]
 })";
 
+static const char* configWith1DummyNew = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+		"batch_size": "16"
+            }
+        }
+    ]
+})";
+
 class ModelManagerTest : public ovms::ModelManager {};
 
 class ConfigApi : public TestWithTempDir {
@@ -158,7 +171,7 @@ TEST_F(ConfigReload, startWith1DummyThenReload) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     LoadConfig(manager);
     RemoveConfig();
-    SetUpConfig(configWith1Dummy);
+    SetUpConfig(configWith1DummyNew);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     const char* expectedJson = R"({
@@ -495,6 +508,46 @@ static const char* configWith1DummyPipeline = R"(
     ]
 })";
 
+static const char* configWith1DummyPipelineNew = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "batch_size": "16"
+
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode",
+                    "model_name": "dummy",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                            "data_item": "custom_dummy_input"}}
+                    ], 
+                    "outputs": [
+                        {"data_item": "a",
+                        "alias": "new_dummy_output"}
+                    ] 
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode",
+                                        "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+
 TEST_F(ConfigReload, StartWith1DummyThenReloadToAddPipeline) {
     ModelManagerTest manager;
     SetUpConfig(configWith1Dummy);
@@ -782,7 +835,7 @@ TEST_F(ConfigReload, StartWith1DummyPipelineThenReloadToAddPipeline) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     LoadConfig(manager);
     RemoveConfig();
-    SetUpConfig(configWith1DummyPipeline);
+    SetUpConfig(configWith1DummyPipelineNew);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     const char* expectedJson_1 = R"({

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -63,6 +63,27 @@ const char* config_2_models = R"({
     }]
 })";
 
+const char* config_2_models_new = R"({
+   "model_config_list": [
+    {
+      "config": {
+        "name": "resnet",
+        "base_path": "/tmp/models/dummy1",
+        "target_device": "CPU",
+        "model_version_policy": {"all": {}}
+      }
+    },
+    {
+      "config": {
+        "name": "alpha",
+        "base_path": "/tmp/models/dummy2",
+        "target_device": "CPU",
+	"batch_size": "auto",
+        "model_version_policy": {"all": {}}
+      }
+    }]
+})";
+
 const std::string FIRST_MODEL_NAME = "resnet";
 const std::string SECOND_MODEL_NAME = "alpha";
 
@@ -265,7 +286,7 @@ TEST(ModelManager, configRelodNeededManyThreads) {
 
     manager.configFileReloadNeeded(isNeeded);
     EXPECT_EQ(isNeeded, false);
-    createConfigFileWithContent(config_2_models, configFile);
+    createConfigFileWithContent(config_2_models_new, configFile);
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     for (int i = 0; i < numberOfThreads; i++) {
@@ -293,7 +314,7 @@ TEST(ModelManager, configReloadNeededChange) {
     manager.configFileReloadNeeded(isNeeded);
     EXPECT_EQ(isNeeded, false);
 
-    createConfigFileWithContent(config_2_models, configFile);
+    createConfigFileWithContent(config_2_models_new, configFile);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     manager.configFileReloadNeeded(isNeeded);
     EXPECT_EQ(isNeeded, true);
@@ -345,7 +366,7 @@ TEST(ModelManager, configReloadNeededBeforeConfigLoad) {
     manager.configFileReloadNeeded(isNeeded);
     EXPECT_EQ(isNeeded, false);
 
-    createConfigFileWithContent(config_2_models, configFile);
+    createConfigFileWithContent(config_2_models_new, configFile);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     manager.configFileReloadNeeded(isNeeded);
     EXPECT_EQ(isNeeded, true);


### PR DESCRIPTION
While running modelserver inside SGX Encalve using gramine libOS, the stat system call is returning zeros for timestamp. This is because time stamp is not trusted in side enclave and hence not supported by Gramine. Because of this, model reloading due to config file change is failing as the config file change detection is based on time stamp. To make the config file change detection generic, have implemented it based on md5sum using openssl libraries. 

Had to modify few unit tests to load a config file with content change to trigger a file difference. Earlier tests were creating same config file again as time stamp change was considered as file change.