### PR TITLE
CVS-72906/CVS-75078 API 1.0 cleanup part2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ DIST_OS_TAG ?= $(BASE_OS_TAG)
 ifeq ($(BASE_OS),ubuntu)
   BASE_OS_TAG=$(BASE_OS_TAG_UBUNTU)
   BASE_IMAGE ?= ubuntu:$(BASE_OS_TAG_UBUNTU)
-  DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_2022.1.0.390_offline.sh
+  DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_p_2022.1.0.476_offline.sh
 endif
 ifeq ($(BASE_OS),centos)
   BASE_OS_TAG=$(BASE_OS_TAG_CENTOS)
@@ -84,7 +84,7 @@ ifeq ($(BASE_OS),redhat)
   BASE_IMAGE ?= registry.access.redhat.com/ubi8/ubi:$(BASE_OS_TAG_REDHAT)
   DIST_OS=redhat
   DIST_OS_TAG=$(BASE_OS_TAG_REDHAT)
-  DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_runtime_rhel8_p_2022.1.0.390.tgz
+  DLDT_PACKAGE_URL ?= http://s3.toolbox.iotg.sclab.intel.com/ov-packages/l_openvino_toolkit_runtime_rhel8_p_2022.1.0.476.tgz
 endif
 
 OVMS_CPP_DOCKER_IMAGE ?= openvino/model_server

--- a/src/custom_node_output_allocator.hpp
+++ b/src/custom_node_output_allocator.hpp
@@ -15,39 +15,12 @@
 //*****************************************************************************
 #pragma once
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 
 #include "custom_node_interface.h"  // NOLINT
 #include "node_library.hpp"
 
 namespace ovms {
-
-class CustomNodeOutputAllocator : public InferenceEngine::IAllocator {
-    struct CustomNodeTensor tensor;
-    NodeLibrary nodeLibrary;
-    void* customNodeLibraryInternalManager;
-
-public:
-    CustomNodeOutputAllocator(struct CustomNodeTensor tensor, NodeLibrary nodeLibrary, void* customNodeLibraryInternalManager) :
-        tensor(tensor),
-        nodeLibrary(nodeLibrary),
-        customNodeLibraryInternalManager(customNodeLibraryInternalManager) {}
-
-    void* lock(void* handle, InferenceEngine::LockOp = InferenceEngine::LOCK_FOR_WRITE) noexcept override {
-        return handle;
-    }
-
-    void unlock(void* a) noexcept override {}
-
-    void* alloc(size_t size) noexcept override {
-        return (void*)tensor.data;
-    }
-
-    bool free(void* handle) noexcept override {
-        return nodeLibrary.release(tensor.data, customNodeLibraryInternalManager) == 0;
-    }
-};
 
 bool operator==(const CustomNodeTensor& t1, const CustomNodeTensor& t2);
 

--- a/src/customnodesession.cpp
+++ b/src/customnodesession.cpp
@@ -20,8 +20,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include <openvino/openvino.hpp>
-
 #include "custom_node_output_allocator.hpp"
 #include "logging.hpp"
 #include "node.hpp"
@@ -190,7 +188,7 @@ Status CustomNodeSession::createBlob(const struct CustomNodeTensor* tensor, std:
             error);
         return StatusCode::NODE_LIBRARY_INVALID_SHAPE;
     }
-    InferenceEngine::SizeVector shape(tensor->dims, tensor->dims + tensor->dimsCount);
+    shape_t shape(tensor->dims, tensor->dims + tensor->dimsCount);
 
     size_t expectedElementsCount = std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<size_t>());
     size_t expectedDataLength = expectedElementsCount *= ov::element::Type(precision).size();

--- a/src/customnodesession.hpp
+++ b/src/customnodesession.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <string>
 
+#include <openvino/openvino.hpp>
+
 #include "custom_node_interface.h"  // NOLINT
 #include "nodesession.hpp"
 #include "pipelineeventqueue.hpp"

--- a/src/deserialization.cpp
+++ b/src/deserialization.cpp
@@ -22,7 +22,7 @@ Status InputSink_2<ov::runtime::InferRequest&>::give(const std::string& name, ov
     Status status;
     try {
         requester.set_tensor(name, blob);
-        // OV implementation the InferenceEngine::Exception is not
+        // OV implementation the ov::Exception is not
         // a base class for all other exceptions thrown from OV.
         // OV can throw exceptions derived from std::logic_error.
     } catch (const ov::Exception& e) {
@@ -39,9 +39,8 @@ Status InputSink_2<ov::runtime::InferRequest&>::give(const std::string& name, ov
 }
 
 ov::runtime::Tensor makeBlob_2(const tensorflow::TensorProto& requestInput,
-    const std::shared_ptr<TensorInfo>& tensorInfo, bool isPipeline) {
+    const std::shared_ptr<TensorInfo>& tensorInfo) {
     ov::Shape shape;
-    // TODO: Use isPipeline when DAG are switched to OV 2.0.
     for (size_t i = 0; i < requestInput.tensor_shape().dim_size(); i++) {
         shape.push_back(requestInput.tensor_shape().dim(i).size());
     }

--- a/src/deserialization.hpp
+++ b/src/deserialization.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <string>
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 #include <spdlog/spdlog.h>
 
@@ -35,21 +34,21 @@
 namespace ovms {
 
 ov::runtime::Tensor makeBlob_2(const tensorflow::TensorProto& requestInput,
-    const std::shared_ptr<TensorInfo>& tensorInfo, bool isPipeline);
+    const std::shared_ptr<TensorInfo>& tensorInfo);
 
 class ConcreteTensorProtoDeserializator_2 {
 public:
     static ov::runtime::Tensor deserializeTensorProto_2(
         const tensorflow::TensorProto& requestInput,
-        const std::shared_ptr<TensorInfo>& tensorInfo, bool isPipeline) {
+        const std::shared_ptr<TensorInfo>& tensorInfo) {
         switch (tensorInfo->getPrecision_2()) {
         case ovms::Precision::FP32:
         case ovms::Precision::I32:
         case ovms::Precision::U8:
         case ovms::Precision::I16:
-            return makeBlob_2(requestInput, tensorInfo, isPipeline);
+            return makeBlob_2(requestInput, tensorInfo);
         case ovms::Precision::I8: {
-            return makeBlob_2(requestInput, tensorInfo, isPipeline);
+            return makeBlob_2(requestInput, tensorInfo);
         }
         case ovms::Precision::FP16: {
             ov::Shape shape;
@@ -90,8 +89,8 @@ public:
 template <class TensorProtoDeserializator>
 ov::runtime::Tensor deserializeTensorProto_2(
     const tensorflow::TensorProto& requestInput,
-    const std::shared_ptr<TensorInfo>& tensorInfo, bool isPipeline) {
-    return TensorProtoDeserializator::deserializeTensorProto_2(requestInput, tensorInfo, isPipeline);
+    const std::shared_ptr<TensorInfo>& tensorInfo) {
+    return TensorProtoDeserializator::deserializeTensorProto_2(requestInput, tensorInfo);
 }
 
 template <class Requester>
@@ -132,7 +131,7 @@ Status deserializePredictRequest_2(
                 }
             } else {
                 blob = deserializeTensorProto_2<TensorProtoDeserializator>(
-                    requestInput, tensorInfo, isPipeline);
+                    requestInput, tensorInfo);
             }
 
             if (!blob) {
@@ -146,7 +145,7 @@ Status deserializePredictRequest_2(
                 SPDLOG_DEBUG("Feeding input:{} to inference performer failed:{}", ovBlobName, status.string());
                 return status;
             }
-            // OV implementation the InferenceEngine::Exception is not
+            // OV implementation the ov::Exception is not
             // a base class for all other exceptions thrown from OV.
             // OV can throw exceptions derived from std::logic_error.
         } catch (const ov::Exception& e) {

--- a/src/dl_node.cpp
+++ b/src/dl_node.cpp
@@ -18,8 +18,6 @@
 #include <map>
 #include <utility>
 
-#include <openvino/openvino.hpp>
-
 #include "dlnodesession.hpp"
 #include "logging.hpp"
 #include "modelmanager.hpp"

--- a/src/dl_node.hpp
+++ b/src/dl_node.hpp
@@ -21,6 +21,8 @@
 #include <string>
 #include <unordered_map>
 
+#include <openvino/openvino.hpp>
+
 #include "executingstreamidguard.hpp"
 #include "model_version_policy.hpp"  // for model_version_t typename
 #include "modelinstance.hpp"

--- a/src/dlnodesession.cpp
+++ b/src/dlnodesession.cpp
@@ -249,7 +249,7 @@ Status DLNodeSession::setInputsForInference(ov::runtime::InferRequest& inferRequ
             }
             inferRequest.set_tensor(realModelInputName, *tensor);
         }
-        // OV implementation the InferenceEngine::Exception is not
+        // OV implementation the ov::Exception is not
         // a base class for all other exceptions thrown from OV.
         // OV can throw exceptions derived from std::logic_error.
     } catch (const ov::Exception& e) {

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -21,8 +21,6 @@
 #include <string>
 #include <utility>
 
-#include <inference_engine.hpp>
-
 #include "binaryutils.hpp"
 #include "deserialization.hpp"
 #include "logging.hpp"

--- a/src/entry_node.hpp
+++ b/src/entry_node.hpp
@@ -18,6 +18,8 @@
 #include <optional>
 #include <string>
 
+#include <openvino/openvino.hpp>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -110,20 +110,20 @@ const std::shared_ptr<ModelInstance> Model::getDefaultModelInstance() const {
     return modelInstanceIt->second;
 }
 
-std::shared_ptr<ovms::ModelInstance> Model::modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) {
+std::shared_ptr<ovms::ModelInstance> Model::modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion, ov::runtime::Core& ieCore_2) {
     if (isStateful()) {
         SPDLOG_DEBUG("Creating new stateful model instance - model name: {}; model version: {};", modelName, modelVersion);
         return std::move(std::static_pointer_cast<ModelInstance>(
-            std::make_shared<StatefulModelInstance>(modelName, modelVersion, ieCore, ieCore_2, this->globalSequencesViewer)));
+            std::make_shared<StatefulModelInstance>(modelName, modelVersion, ieCore_2, this->globalSequencesViewer)));
     } else {
         SPDLOG_DEBUG("Creating new model instance - model name: {}; model version: {};", modelName, modelVersion);
-        return std::move(std::make_shared<ModelInstance>(modelName, modelVersion, ieCore, ieCore_2));
+        return std::move(std::make_shared<ModelInstance>(modelName, modelVersion, ieCore_2));
     }
 }
 
-Status Model::addVersion(const ModelConfig& config, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) {
+Status Model::addVersion(const ModelConfig& config, ov::runtime::Core& ieCore_2) {
     const auto& version = config.getVersion();
-    std::shared_ptr<ModelInstance> modelInstance = modelInstanceFactory(config.getName(), version, ieCore, ieCore_2);
+    std::shared_ptr<ModelInstance> modelInstance = modelInstanceFactory(config.getName(), version, ieCore_2);
 
     std::unique_lock lock(modelVersionsMtx);
     modelVersions.emplace(version, modelInstance);
@@ -137,7 +137,7 @@ Status Model::addVersion(const ModelConfig& config, InferenceEngine::Core& ieCor
     return StatusCode::OK;
 }
 
-Status Model::addVersions(std::shared_ptr<model_versions_t> versionsToStart, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed) {
+Status Model::addVersions(std::shared_ptr<model_versions_t> versionsToStart, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed) {
     Status result = StatusCode::OK;
     downloadModels(fs, config, versionsToStart);
     versionsFailed->clear();
@@ -145,7 +145,7 @@ Status Model::addVersions(std::shared_ptr<model_versions_t> versionsToStart, ovm
         SPDLOG_INFO("Will add model: {}; version: {} ...", getName(), version);
         config.setVersion(version);
         config.parseModelMapping();
-        auto status = addVersion(config, ieCore, ieCore_2);
+        auto status = addVersion(config, ieCore_2);
         if (!status.ok()) {
             SPDLOG_ERROR("Error occurred while loading model: {}; version: {}; error: {}",
                 getName(),
@@ -243,7 +243,7 @@ void Model::cleanupAllVersions() {
     subscriptionManager.notifySubscribers();
 }
 
-Status Model::reloadVersions(std::shared_ptr<model_versions_t> versionsToReload, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed) {
+Status Model::reloadVersions(std::shared_ptr<model_versions_t> versionsToReload, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed) {
     Status result = StatusCode::OK;
     for (const auto version : *versionsToReload) {
         SPDLOG_INFO("Will reload model: {}; version: {} ...", getName(), version);

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -87,14 +87,14 @@ protected:
          *
          * @return status
          */
-    virtual Status addVersion(const ModelConfig& config, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2);
+    virtual Status addVersion(const ModelConfig& config, ov::runtime::Core& ieCore_2);
 
     /**
          * @brief ModelInstances factory
          *
          * @return modelInstance
          */
-    virtual std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2);
+    virtual std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const model_version_t modelVersion, ov::runtime::Core& ieCore_2);
 
     ModelChangeSubscription subscriptionManager;
 
@@ -175,7 +175,7 @@ public:
          *
          * @return status
          */
-    Status addVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed);
+    Status addVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed);
 
     /**
          * @brief Retires versions of Model
@@ -212,7 +212,7 @@ public:
          *
          * @return status
          */
-    Status reloadVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed);
+    Status reloadVersions(std::shared_ptr<model_versions_t> versions, ovms::ModelConfig& config, std::shared_ptr<FileSystem>& fs, ov::runtime::Core& ieCore_2, std::shared_ptr<model_versions_t> versionsFailed);
 
     void subscribe(PipelineDefinition& pd);
     void unsubscribe(PipelineDefinition& pd);

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 
 #pragma GCC diagnostic push
@@ -87,19 +86,17 @@ protected:
     /**
          * @brief Inference Engine core object
          */
-    InferenceEngine::Core& ieCore;
     ov::runtime::Core& ieCore_2;
 
     /**
          * @brief Inference Engine CNNNetwork object
          */
-    std::unique_ptr<InferenceEngine::CNNNetwork> network;
-    std::shared_ptr<ov::Function> network_2;
+    std::shared_ptr<ov::Model> network_2;
 
     /**
          * @brief Inference Engine device network
          */
-    std::shared_ptr<ov::runtime::ExecutableNetwork> execNetwork_2;
+    std::shared_ptr<ov::runtime::CompiledModel> execNetwork_2;
 
     /**
          * @brief Model name
@@ -162,7 +159,7 @@ protected:
          *
          * @return CNNNetwork ptr
          */
-    virtual std::unique_ptr<InferenceEngine::CNNNetwork> loadOVCNNNetworkPtr(const std::string& modelFile);
+    virtual std::shared_ptr<ov::Model> loadOVCNNNetworkPtr(const std::string& modelFile);
 
     /**
          * @brief Lock to disable concurrent modelinstance load/unload/reload
@@ -240,7 +237,6 @@ private:
     /**
          * @brief OpenVINO inference execution stream pool
          */
-    std::unique_ptr<OVInferRequestsQueue> inferRequestsQueue;
     std::unique_ptr<OVInferRequestsQueue_2> inferRequestsQueue_2;
 
     /**
@@ -255,7 +251,7 @@ private:
          *
          * @param config
          */
-    Status loadTensors(const ModelConfig& config, const DynamicModelParameter& parameter = DynamicModelParameter());
+    Status loadTensors(const ModelConfig& config, bool needsToApplyLayoutConfiguration, const DynamicModelParameter& parameter = DynamicModelParameter());
 
     /**
          * @brief Internal method for loading inputs
@@ -307,8 +303,7 @@ public:
     /**
          * @brief A default constructor
          */
-    ModelInstance(const std::string& name, model_version_t version, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) :
-        ieCore(ieCore),
+    ModelInstance(const std::string& name, model_version_t version, ov::runtime::Core& ieCore_2) :
         ieCore_2(ieCore_2),
         name(name),
         version(version),
@@ -391,7 +386,7 @@ public:
          * @return batch size
          */
     virtual Dimension getBatchSize() const {
-        return Dimension(ov::get_batch(network_2));  // TODO: Use layout info
+        return Dimension(ov::get_batch(network_2));
     }
 
     /**
@@ -519,7 +514,6 @@ public:
 
     const ModelChangeSubscription& getSubscribtionManager() const { return subscriptionManager; }
 
-    Status performInference(InferenceEngine::InferRequest& inferRequest);
     Status performInference_2(ov::runtime::InferRequest& inferRequest);
 
     virtual Status infer(const tensorflow::serving::PredictRequest* requestProto,

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -25,7 +25,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 #include <rapidjson/document.h>
 #include <spdlog/spdlog.h>
@@ -68,7 +67,6 @@ protected:
      * 
      */
     std::map<std::string, std::shared_ptr<Model>> models;
-    std::unique_ptr<InferenceEngine::Core> ieCore;
     std::unique_ptr<ov::runtime::Core> ieCore_2;
 
     PipelineFactory pipelineFactory;

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include <inference_engine.hpp>
+#include <openvino/openvino.hpp>
 
 #include "aliases.hpp"
 #include "nodesession.hpp"

--- a/src/node_library.hpp
+++ b/src/node_library.hpp
@@ -17,8 +17,6 @@
 
 #include <string>
 
-#include <inference_engine.hpp>
-
 #include "custom_node_interface.h"  // NOLINT
 
 namespace ovms {

--- a/src/node_library_utils.hpp
+++ b/src/node_library_utils.hpp
@@ -20,8 +20,6 @@
 #include <string>
 #include <unordered_map>
 
-#include <inference_engine.hpp>
-
 #include "custom_node_interface.h"  // NOLINT
 #include "node_library.hpp"
 #include "precision.hpp"

--- a/src/nodeoutputhandler.cpp
+++ b/src/nodeoutputhandler.cpp
@@ -15,10 +15,6 @@
 //*****************************************************************************
 #include "nodeoutputhandler.hpp"
 
-#include <inference_engine.hpp>
-
-#include "logging.hpp"
-
 namespace ovms {
-void NodeOutputHandler::setInput(const std::string& name, InferenceEngine::Blob::Ptr& ptr) {}
+void NodeOutputHandler::setInput(const std::string& name, std::shared_ptr<ov::runtime::Tensor>& blobPtr) {}
 }  // namespace ovms

--- a/src/nodeoutputhandler.hpp
+++ b/src/nodeoutputhandler.hpp
@@ -17,13 +17,12 @@
 
 #include <memory>
 #include <string>
-#include <utility>
 
-#include <inference_engine.hpp>
+#include <openvino/openvino.hpp>
 
 namespace ovms {
 class NodeOutputHandler {
 public:
-    void setInput(const std::string& inputName, InferenceEngine::Blob::Ptr& blobPtr);
+    void setInput(const std::string& inputName, std::shared_ptr<ov::runtime::Tensor>& blobPtr);
 };
 }  // namespace ovms

--- a/src/nodesession.hpp
+++ b/src/nodesession.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <utility>
 
-#include <inference_engine.hpp>
+#include <openvino/openvino.hpp>
 
 #include "nodesessionmetadata.hpp"
 #include "status.hpp"

--- a/src/ov_utils.cpp
+++ b/src/ov_utils.cpp
@@ -19,7 +19,6 @@
 #include <memory>
 #include <sstream>
 
-#include <inference_engine.hpp>
 #include <spdlog/spdlog.h>
 
 #include "tensorinfo.hpp"
@@ -33,51 +32,6 @@ std::shared_ptr<ov::runtime::Tensor> createSharedTensor(ov::element::Type_t prec
 
 Status createSharedTensor(std::shared_ptr<ov::runtime::Tensor>& destinationBlob, ov::element::Type_t precision, const ov::Shape& shape) {
     destinationBlob = std::make_shared<ov::runtime::Tensor>(precision, shape);
-    return StatusCode::OK;
-}
-Status createSharedBlob(InferenceEngine::Blob::Ptr& destinationBlob, InferenceEngine::TensorDesc tensorDesc) {
-    try {
-        switch (tensorDesc.getPrecision()) {
-        case InferenceEngine::Precision::FP32:
-            destinationBlob = InferenceEngine::make_shared_blob<float>(tensorDesc);
-            break;
-        case InferenceEngine::Precision::I32:
-            destinationBlob = InferenceEngine::make_shared_blob<int32_t>(tensorDesc);
-            break;
-        case InferenceEngine::Precision::I8:
-            destinationBlob = InferenceEngine::make_shared_blob<int8_t>(tensorDesc);
-            break;
-        case InferenceEngine::Precision::U8:
-            destinationBlob = InferenceEngine::make_shared_blob<uint8_t>(tensorDesc);
-            break;
-        case InferenceEngine::Precision::FP16:
-            destinationBlob = InferenceEngine::make_shared_blob<uint16_t>(tensorDesc);
-            break;
-        case InferenceEngine::Precision::I16:
-            destinationBlob = InferenceEngine::make_shared_blob<int16_t>(tensorDesc);
-            break;
-        case InferenceEngine::Precision::U16:
-            destinationBlob = InferenceEngine::make_shared_blob<uint16_t>(tensorDesc);
-            break;
-        case InferenceEngine::Precision::I64:
-        case InferenceEngine::Precision::MIXED:
-        case InferenceEngine::Precision::Q78:
-        case InferenceEngine::Precision::BIN:
-        case InferenceEngine::Precision::BOOL:
-        case InferenceEngine::Precision::CUSTOM:
-        default: {
-            SPDLOG_ERROR("Blob clone failed, unsupported precision");
-            return StatusCode::INVALID_PRECISION;
-        }
-        }
-    } catch (const InferenceEngine::Exception& e) {
-        SPDLOG_DEBUG("Blob clone failed; exception message: {}", e.what());
-        return StatusCode::OV_CLONE_BLOB_ERROR;
-    } catch (std::logic_error& e) {
-        SPDLOG_DEBUG("Blob clone failed; exception message: {}", e.what());
-        return StatusCode::OV_CLONE_BLOB_ERROR;
-    }
-    destinationBlob->allocate();
     return StatusCode::OK;
 }
 
@@ -104,9 +58,11 @@ Status tensorClone(std::shared_ptr<ov::runtime::Tensor>& destinationTensor, cons
 
     if (destinationTensor->get_byte_size() != sourceTensor.get_byte_size()) {
         destinationTensor = nullptr;
+        SPDLOG_ERROR("tensorClone byte size mismatch destination:{}; source:{}",
+            destinationTensor->get_byte_size(),
+            sourceTensor.get_byte_size());
         return StatusCode::OV_CLONE_TENSOR_ERROR;
     }
-    SPDLOG_ERROR("tensorClone byte_size:{}", sourceTensor.get_byte_size());
     std::memcpy(destinationTensor->data(), sourceTensor.data(), sourceTensor.get_byte_size());
     return StatusCode::OK;
 }

--- a/src/ov_utils.hpp
+++ b/src/ov_utils.hpp
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string>
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 #include <spdlog/spdlog.h>
 
@@ -30,7 +29,6 @@ namespace ovms {
 
 class TensorInfo;
 
-Status createSharedBlob(InferenceEngine::Blob::Ptr& destinationBlob, InferenceEngine::TensorDesc tensorDesc);
 Status createSharedTensor(std::shared_ptr<ov::runtime::Tensor>& destinationBlob, ov::element::Type_t precision, const ov::Shape& shape);
 /**
  *  Creates new tensor that copies data and owns the copy
@@ -38,22 +36,6 @@ Status createSharedTensor(std::shared_ptr<ov::runtime::Tensor>& destinationBlob,
 std::shared_ptr<ov::runtime::Tensor> createSharedTensor(ov::element::Type_t precision, const shape_t& shape, void* data);
 
 std::string getTensorMapString(const std::map<std::string, std::shared_ptr<TensorInfo>>& tensorMap);
-
-template <typename T>
-Status blobClone(InferenceEngine::Blob::Ptr& destinationBlob, const T sourceBlob) {
-    auto& description = sourceBlob->getTensorDesc();
-    auto status = createSharedBlob(destinationBlob, description);
-    if (!status.ok()) {
-        return status;
-    }
-
-    if (destinationBlob->byteSize() != sourceBlob->byteSize()) {
-        destinationBlob = nullptr;
-        return StatusCode::OV_CLONE_BLOB_ERROR;
-    }
-    std::memcpy(InferenceEngine::as<InferenceEngine::MemoryBlob>(destinationBlob)->wmap().as<void*>(), (const void*)InferenceEngine::as<InferenceEngine::MemoryBlob>(sourceBlob)->rmap(), sourceBlob->byteSize());
-    return StatusCode::OK;
-}
 
 Status tensorClone(std::shared_ptr<ov::runtime::Tensor>& destinationTensor, const ov::runtime::Tensor& sourceTensor);
 }  // namespace ovms

--- a/src/ovinferrequestsqueue.hpp
+++ b/src/ovinferrequestsqueue.hpp
@@ -24,7 +24,6 @@
 #include <thread>
 #include <vector>
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 #include <spdlog/spdlog.h>
 
@@ -32,20 +31,9 @@
 
 namespace ovms {
 
-class OVInferRequestsQueue : public Queue<InferenceEngine::InferRequest> {
-public:
-    OVInferRequestsQueue(InferenceEngine::ExecutableNetwork& network, int streamsLength) :
-        Queue(streamsLength) {
-        for (int i = 0; i < streamsLength; ++i) {
-            streams[i] = i;
-            inferRequests.push_back(network.CreateInferRequest());
-        }
-    }
-};
-
 class OVInferRequestsQueue_2 : public Queue<ov::runtime::InferRequest> {
 public:
-    OVInferRequestsQueue_2(ov::runtime::ExecutableNetwork& network, int streamsLength) :
+    OVInferRequestsQueue_2(ov::runtime::CompiledModel& network, int streamsLength) :
         Queue(streamsLength) {
         for (int i = 0; i < streamsLength; ++i) {
             streams[i] = i;

--- a/src/precision.hpp
+++ b/src/precision.hpp
@@ -15,11 +15,9 @@
 //*****************************************************************************
 #pragma once
 
-#include <map>  // TODO remove
 #include <string>
 #include <unordered_map>
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 
 namespace ovms {
@@ -109,32 +107,6 @@ inline static Precision fromString(const std::string& s) {
     return it->second;
 }
 
-inline static InferenceEngine::Precision ovmsPrecisionToIE1Precision(Precision precision) {
-    static std::unordered_map<Precision, InferenceEngine::Precision> precisionMap{
-        {Precision::BF16, InferenceEngine::Precision::BF16},
-        {Precision::FP64, InferenceEngine::Precision::FP64},
-        {Precision::FP32, InferenceEngine::Precision::FP32},
-        {Precision::FP16, InferenceEngine::Precision::FP16},
-        {Precision::I64, InferenceEngine::Precision::I64},
-        {Precision::I32, InferenceEngine::Precision::I32},
-        {Precision::I16, InferenceEngine::Precision::I16},
-        {Precision::I8, InferenceEngine::Precision::I8},
-        {Precision::U64, InferenceEngine::Precision::U64},
-        {Precision::U16, InferenceEngine::Precision::U16},
-        {Precision::U8, InferenceEngine::Precision::U8},
-        {Precision::BOOL, InferenceEngine::Precision::BOOL},
-        {Precision::MIXED, InferenceEngine::Precision::MIXED},
-        {Precision::Q78, InferenceEngine::Precision::Q78},
-        {Precision::BIN, InferenceEngine::Precision::BIN},
-        {Precision::UNDEFINED, InferenceEngine::Precision::UNSPECIFIED},
-        {Precision::CUSTOM, InferenceEngine::Precision::CUSTOM}};
-    auto it = precisionMap.find(precision);
-    if (it == precisionMap.end()) {
-        return InferenceEngine::Precision::CUSTOM;  // TODO other way?
-    }
-    return it->second;
-}
-
 inline static ov::element::Type_t ovmsPrecisionToIE2Precision(Precision precision) {
     static std::unordered_map<Precision, ov::element::Type_t> precisionMap{
         {Precision::FP32, ov::element::Type_t::f32},
@@ -208,31 +180,6 @@ inline static Precision ovElementTypeToOvmsPrecision(ov::element::Type_t type) {
 */
     };
     auto it = precisionMap.find(type);
-    if (it == precisionMap.end()) {
-        return Precision::UNDEFINED;  // TODO other way?
-    }
-    return it->second;
-}
-inline static Precision IE1PrecisionToOvmsPrecision(InferenceEngine::Precision precision) {
-    static std::map<InferenceEngine::Precision, Precision> precisionMap{
-        {InferenceEngine::Precision::BF16, Precision::BF16},
-        {InferenceEngine::Precision::FP64, Precision::FP64},
-        {InferenceEngine::Precision::FP32, Precision::FP32},
-        {InferenceEngine::Precision::FP16, Precision::FP16},
-        {InferenceEngine::Precision::I64, Precision::I64},
-        {InferenceEngine::Precision::I32, Precision::I32},
-        {InferenceEngine::Precision::I16, Precision::I16},
-        {InferenceEngine::Precision::I8, Precision::I8},
-        {InferenceEngine::Precision::U64, Precision::U64},
-        {InferenceEngine::Precision::U16, Precision::U16},
-        {InferenceEngine::Precision::U8, Precision::U8},
-        {InferenceEngine::Precision::BOOL, Precision::BOOL},
-        {InferenceEngine::Precision::MIXED, Precision::MIXED},
-        {InferenceEngine::Precision::Q78, Precision::Q78},
-        {InferenceEngine::Precision::BIN, Precision::BIN},
-        {InferenceEngine::Precision::UNSPECIFIED, Precision::UNDEFINED},
-        {InferenceEngine::Precision::CUSTOM, Precision::CUSTOM}};
-    auto it = precisionMap.find(precision);
     if (it == precisionMap.end()) {
         return Precision::UNDEFINED;  // TODO other way?
     }

--- a/src/prediction_service.cpp
+++ b/src/prediction_service.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <utility>
 
-#include <inference_engine.hpp>
 #include <spdlog/spdlog.h>
 
 #pragma GCC diagnostic push
@@ -37,8 +36,6 @@
 #include "timer.hpp"
 
 using grpc::ServerContext;
-
-using namespace InferenceEngine;
 
 using tensorflow::TensorProto;
 

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -25,7 +25,7 @@ Status serializeBlobToTensorProto_2(
     ov::runtime::Tensor& blob) {
     responseOutput.Clear();
     if (networkOutput->getOvPrecision() != blob.get_element_type()) {
-        SPDLOG_ERROR("Failed to serialize blob: {}. There is difference in precision expected:{} vs actual:{}",  // TODO: Convert OvType to readable string.
+        SPDLOG_ERROR("Failed to serialize blob: {}. There is difference in precision expected:{} vs actual:{}",
             networkOutput->getName(),
             TensorInfo::getPrecisionAsString(networkOutput->getPrecision_2()),
             blob.get_element_type().get_type_name());

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <string>
 
-#include <inference_engine.hpp>
 #include <openvino/openvino.hpp>
 #include <spdlog/spdlog.h>
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -23,7 +23,6 @@
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
-#include <inference_engine.hpp>
 #include <netinet/in.h>
 #include <signal.h>
 #include <stdlib.h>

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -76,10 +76,6 @@ ov::Dimension Dimension::createPartialDimension() const {
     return ov::Dimension(this->minimum, this->maximum);
 }
 
-dimension_value_t Dimension::getAnyValue() const {
-    return this->maximum;
-}
-
 dimension_value_t Dimension::getStaticValue() const {
     if (this->isDynamic())
         throw std::invalid_argument("getStaticValue but dimension dynamic");
@@ -89,12 +85,16 @@ dimension_value_t Dimension::getStaticValue() const {
 dimension_value_t Dimension::getMinValue() const {
     if (this->isStatic())
         throw std::invalid_argument("getMinValue but dimension static");
+    if (this->isAny())
+        throw std::invalid_argument("getMinValue but dimension any");
     return this->minimum;
 }
 
 dimension_value_t Dimension::getMaxValue() const {
     if (this->isStatic())
         throw std::invalid_argument("getMaxValue but dimension static");
+    if (this->isAny())
+        throw std::invalid_argument("getMinValue but dimension any");
     return this->maximum;
 }
 
@@ -304,20 +304,6 @@ ov::PartialShape Shape::createPartialShape() const {
         } else {
             shape.push_back(ov::Dimension{dim.getMinValue(), dim.getMaxValue()});
         }
-    }
-
-    return shape;
-}
-
-shape_t Shape::getFlatShape() const {
-    shape_t shape;
-    shape.reserve(this->size());
-
-    for (const Dimension& dim : *this) {
-        if (dim.getAnyValue() <= 0)
-            shape.emplace_back(0);
-        else
-            shape.emplace_back(dim.getAnyValue());
     }
 
     return shape;

--- a/src/shape.hpp
+++ b/src/shape.hpp
@@ -50,9 +50,6 @@ public:
 
     ov::Dimension createPartialDimension() const;
 
-    // TODO: Remove. For OV API 1.0 compatibility purposes only.
-    dimension_value_t getAnyValue() const;
-
     dimension_value_t getStaticValue() const;
     dimension_value_t getMinValue() const;
     dimension_value_t getMaxValue() const;
@@ -90,9 +87,6 @@ public:
     bool isDynamic() const;
 
     ov::PartialShape createPartialShape() const;
-
-    // TODO: Remove. For OV API 1.0 compatibility purposes only.
-    shape_t getFlatShape() const;
 
     bool operator==(const Shape& rhs) const;
     bool operator!=(const Shape& rhs) const;

--- a/src/statefulmodelinstance.hpp
+++ b/src/statefulmodelinstance.hpp
@@ -33,8 +33,8 @@ public:
     /**
          * @brief A default constructor
          */
-    StatefulModelInstance(const std::string& name, model_version_t version, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2, GlobalSequencesViewer* globalSequencesViewer) :
-        ModelInstance(name, version, ieCore, ieCore_2),
+    StatefulModelInstance(const std::string& name, model_version_t version, ov::runtime::Core& ieCore_2, GlobalSequencesViewer* globalSequencesViewer) :
+        ModelInstance(name, version, ieCore_2),
         globalSequencesViewer(globalSequencesViewer) {
         sequenceManager = std::make_shared<SequenceManager>(config.getMaxSequenceNumber(), name, version);
     }

--- a/src/tensorinfo.cpp
+++ b/src/tensorinfo.cpp
@@ -19,9 +19,6 @@
 #include <string>
 #include <unordered_map>
 
-#include <inference_engine.hpp>
-#include <openvino/openvino.hpp>
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
 #include "tensorflow/core/framework/tensor.h"

--- a/src/tensorinfo.hpp
+++ b/src/tensorinfo.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <inference_engine.hpp>
+#include <openvino/openvino.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"

--- a/src/test/binaryutils_test.cpp
+++ b/src/test/binaryutils_test.cpp
@@ -323,7 +323,7 @@ TEST_F(BinaryUtilsTest, positive_resizing_with_any_shape) {
 
     ov::runtime::Tensor tensor;
 
-    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", ovms::Precision::U8, ovms::Shape{1, -1, -1, 3}, InferenceEngine::Layout::NHWC);
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", ovms::Precision::U8, ovms::Shape{1, ovms::Dimension::any(), ovms::Dimension::any(), 3}, InferenceEngine::Layout::NHWC);
 
     ASSERT_EQ(convertStringValToBlob_2(stringVal, tensor, tensorInfo, false), ovms::StatusCode::OK);
     shape_t tensorDims = tensor.get_shape();
@@ -334,5 +334,19 @@ TEST_F(BinaryUtilsTest, positive_resizing_with_any_shape) {
     ASSERT_EQ(tensor.get_size(), 3);
     uint8_t* ptr = static_cast<uint8_t*>(tensor.data());
     EXPECT_EQ(std::equal(ptr, ptr + tensor.get_size(), rgb_expected_blob), true);
+}
+
+TEST_F(BinaryUtilsTest, positive_resizing_with_one_any_one_static_shape) {
+    ov::runtime::Tensor tensor;
+
+    std::shared_ptr<TensorInfo> tensorInfo = std::make_shared<TensorInfo>("", ovms::Precision::U8, ovms::Shape{1, ovms::Dimension::any(), 4, 3}, InferenceEngine::Layout::NHWC);
+
+    ASSERT_EQ(convertStringValToBlob_2(stringVal, tensor, tensorInfo, false), ovms::StatusCode::OK);
+    shape_t tensorDims = tensor.get_shape();
+    size_t expectedRowsNumber = 1;
+    EXPECT_EQ(tensorDims[1], expectedRowsNumber);
+    size_t expectedColsNumber = 4;
+    EXPECT_EQ(tensorDims[2], expectedColsNumber);
+    ASSERT_EQ(tensor.get_size(), 12);
 }
 }  // namespace

--- a/src/test/deserialization_tests.cpp
+++ b/src/test/deserialization_tests.cpp
@@ -148,7 +148,7 @@ public:
     MOCK_METHOD(ov::runtime::Tensor,
         deserializeTensorProto_2,
         (const tensorflow::TensorProto&,
-            const std::shared_ptr<ovms::TensorInfo>&, bool));
+            const std::shared_ptr<ovms::TensorInfo>&));
 };
 
 // Enables static method mock
@@ -157,8 +157,8 @@ public:
     static MockTensorProtoDeserializatorThrowingInferenceEngine_2* mock;
     static ov::runtime::Tensor deserializeTensorProto_2(
         const tensorflow::TensorProto& requestInput,
-        const std::shared_ptr<ovms::TensorInfo>& tensorInfo, bool isPipeline) {
-        return mock->deserializeTensorProto_2(requestInput, tensorInfo, isPipeline);
+        const std::shared_ptr<ovms::TensorInfo>& tensorInfo) {
+        return mock->deserializeTensorProto_2(requestInput, tensorInfo);
     }
 };
 
@@ -166,12 +166,12 @@ MockTensorProtoDeserializatorThrowingInferenceEngine_2* MockTensorProtoDeseriali
 
 TEST_F(GRPCPredictRequestNegative_2, ShouldReturnDeserializationErrorForSetBlobException2) {
     ov::runtime::Core ieCore;
-    std::shared_ptr<ov::Function> network = ieCore.read_model(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
-    ov::runtime::ExecutableNetwork execNetwork = ieCore.compile_model(network, "CPU");
+    std::shared_ptr<ov::Model> network = ieCore.read_model(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
+    ov::runtime::CompiledModel execNetwork = ieCore.compile_model(network, "CPU");
     ov::runtime::InferRequest inferRequest = execNetwork.create_infer_request();
     MockTensorProtoDeserializatorThrowingInferenceEngine_2 mockTPobject;
     MockTensorProtoDeserializator_2::mock = &mockTPobject;
-    EXPECT_CALL(mockTPobject, deserializeTensorProto_2(_, _, _))
+    EXPECT_CALL(mockTPobject, deserializeTensorProto_2(_, _))
         .Times(1)
         .WillRepeatedly(
             Throw(ov::Exception("")));
@@ -184,8 +184,8 @@ TEST_F(GRPCPredictRequestNegative_2, ShouldReturnDeserializationErrorForSetBlobE
 
 TEST_F(GRPCPredictRequest_2, ShouldSuccessForSupportedPrecision) {
     ov::runtime::Core ieCore;
-    std::shared_ptr<ov::Function> network = ieCore.read_model(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
-    ov::runtime::ExecutableNetwork execNetwork = ieCore.compile_model(network, "CPU");
+    std::shared_ptr<ov::Model> network = ieCore.read_model(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
+    ov::runtime::CompiledModel execNetwork = ieCore.compile_model(network, "CPU");
     ov::runtime::InferRequest inferRequest = execNetwork.create_infer_request();
     InputSink_2<ov::runtime::InferRequest&> inputSink(inferRequest);
     auto status = deserializePredictRequest_2<ConcreteTensorProtoDeserializator_2>(request, tensorMap, inputSink, isPipeline);
@@ -195,7 +195,7 @@ TEST_F(GRPCPredictRequest_2, ShouldSuccessForSupportedPrecision) {
 TEST_P(DeserializeTFTensorProtoNegative_2, ShouldReturnNullptrForPrecision) {
     ovms::Precision testedPrecision = GetParam();
     tensorMap[tensorName]->setPrecision(testedPrecision);
-    ov::runtime::Tensor tensor = deserializeTensorProto_2<ConcreteTensorProtoDeserializator_2>(tensorProto, tensorMap[tensorName], isPipeline);
+    ov::runtime::Tensor tensor = deserializeTensorProto_2<ConcreteTensorProtoDeserializator_2>(tensorProto, tensorMap[tensorName]);
     EXPECT_FALSE((bool)tensor) << "Unsupported OVMS precision:"
                                << toString(testedPrecision)
                                << " should return nullptr";
@@ -205,7 +205,7 @@ TEST_P(DeserializeTFTensorProto_2, ShouldReturnValidBlob) {
     ovms::Precision testedPrecision = GetParam();
     SetUpTensorProto(TensorInfo::getPrecisionAsDataType(testedPrecision));
     tensorMap[tensorName]->setPrecision(testedPrecision);
-    ov::runtime::Tensor tensor = deserializeTensorProto_2<ConcreteTensorProtoDeserializator_2>(tensorProto, tensorMap[tensorName], isPipeline);
+    ov::runtime::Tensor tensor = deserializeTensorProto_2<ConcreteTensorProtoDeserializator_2>(tensorProto, tensorMap[tensorName]);
     EXPECT_TRUE((bool)tensor) << "Supported OVMS precision:"
                               << toString(testedPrecision)
                               << " should return valid blob ptr";

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -3260,8 +3260,8 @@ class DummyModelWithMockedMetadata : public ovms::ModelInstance {
     ovms::tensor_map_t mockedInputsInfo, mockedOutputsInfo;
 
 public:
-    DummyModelWithMockedMetadata(InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2, const ovms::tensor_map_t& inputsInfo, const ovms::tensor_map_t& outputsInfo) :
-        ovms::ModelInstance("dummy", 1, ieCore, ieCore_2),
+    DummyModelWithMockedMetadata(ov::runtime::Core& ieCore_2, const ovms::tensor_map_t& inputsInfo, const ovms::tensor_map_t& outputsInfo) :
+        ovms::ModelInstance("dummy", 1, ieCore_2),
         mockedInputsInfo(inputsInfo),
         mockedOutputsInfo(outputsInfo) {}
 
@@ -3289,7 +3289,7 @@ public:
     ModelWithDummyModelWithMockedMetadata(const std::string& name, std::shared_ptr<DummyModelWithMockedMetadata> modelInstance) :
         Model(name, false, nullptr),
         modelInstance(modelInstance) {}
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) override {
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t, ov::runtime::Core& ieCore_2) override {
         return modelInstance;
     }
 };
@@ -3399,10 +3399,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, CustomNodeWithDemultipl
     connections[EXIT_NODE_NAME] = {
         {"dummy_node", {{DUMMY_MODEL_OUTPUT_NAME, pipelineOutputName}}}};
 
-    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto ieCore2 = std::make_unique<ov::runtime::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
-        *ieCore,
         *ieCore2,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
@@ -3421,8 +3419,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, CustomNodeWithDemultipl
     std::unique_ptr<PipelineDefinition> pipelineDefinition = std::make_unique<PipelineDefinition>("my_new_pipeline", info, connections);
     ASSERT_EQ(pipelineDefinition->validate(manager), StatusCode::OK);
 }
-// TODO enable when batch size is working
-TEST_F(EnsembleFlowCustomNodePipelineExecutionTest, DISABLED_CustomNodeWithDemultiplexerAndBatchSizeGreaterThan1ThenDummy) {
+
+TEST_F(EnsembleFlowCustomNodePipelineExecutionTest, CustomNodeWithDemultiplexerAndBatchSizeGreaterThan1ThenDummy) {
     // Prepare request
     std::vector<float> input(7 * 5 * DUMMY_MODEL_INPUT_SIZE);
     std::iota(input.begin(), input.end(), 42);
@@ -3509,10 +3507,8 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, ShapesNotMatchBetweenDL
 
     connections[EXIT_NODE_NAME] = {
         {"custom_node", {{"out", pipelineOutputName}}}};
-    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto ieCore_2 = std::make_unique<ov::runtime::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
-        *ieCore,
         *ieCore_2,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
@@ -3735,10 +3731,8 @@ TEST_F(EnsembleConfigurationValidationWithGather, SuccessfulConfigurationWithDLN
     connections[EXIT_NODE_NAME] = {
         {"custom_node_2", {{"out", pipelineOutputName}}}};
 
-    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto ieCore_2 = std::make_unique<ov::runtime::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
-        *ieCore,
         *ieCore_2,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
@@ -3790,10 +3784,8 @@ TEST_F(EnsembleConfigurationValidationWithGather, SuccessfulConfigurationWithDLN
     connections[EXIT_NODE_NAME] = {
         {"dummy_node", {{DUMMY_MODEL_OUTPUT_NAME, pipelineOutputName}}}};
 
-    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto ieCore_2 = std::make_unique<ov::runtime::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
-        *ieCore,
         *ieCore_2,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
@@ -3888,10 +3880,8 @@ TEST_F(EnsembleConfigurationValidationWithGather, ShapesNotMatchBetweenDLModelAn
     connections[EXIT_NODE_NAME] = {
         {"custom_node_2", {{"out", pipelineOutputName}}}};
 
-    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto ieCore_2 = std::make_unique<ov::runtime::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
-        *ieCore,
         *ieCore_2,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(
@@ -3943,10 +3933,8 @@ TEST_F(EnsembleConfigurationValidationWithGather, ShapesNotMatchBetweenCustomNod
     connections[EXIT_NODE_NAME] = {
         {"dummy_node", {{DUMMY_MODEL_OUTPUT_NAME, pipelineOutputName}}}};
 
-    auto ieCore = std::make_unique<InferenceEngine::Core>();
     auto ieCore_2 = std::make_unique<ov::runtime::Core>();
     auto dummyModelInstance = std::make_shared<DummyModelWithMockedMetadata>(
-        *ieCore,
         *ieCore_2,
         tensor_map_t{
             {DUMMY_MODEL_INPUT_NAME, std::make_shared<ovms::TensorInfo>(

--- a/src/test/get_model_metadata_response_test.cpp
+++ b/src/test/get_model_metadata_response_test.cpp
@@ -39,8 +39,8 @@ class GetModelMetadataResponse : public ::testing::Test {
 
     class MockModelInstance : public MockModelInstanceChangingStates {
     public:
-        MockModelInstance(InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) :
-            MockModelInstanceChangingStates("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore, ieCore_2) {
+        MockModelInstance(ov::runtime::Core& ieCore_2) :
+            MockModelInstanceChangingStates("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore_2) {
             status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_MODEL_VERSION, ovms::ModelVersionState::AVAILABLE);
         }
 
@@ -67,11 +67,10 @@ protected:
 
     std::shared_ptr<NiceMock<MockModelInstance>> instance;
     tensorflow::serving::GetModelMetadataResponse response;
-    std::unique_ptr<InferenceEngine::Core> ieCore;
     std::unique_ptr<ov::runtime::Core> ieCore_2;
 
     virtual void prepare() {
-        instance = std::make_shared<NiceMock<MockModelInstance>>(*ieCore, *ieCore_2);
+        instance = std::make_shared<NiceMock<MockModelInstance>>(*ieCore_2);
 
         inputTensors = tensor_desc_map_t({
             {"Input_FP32_1_3_224_224", {
@@ -119,12 +118,10 @@ protected:
     }
 
     void SetUp() override {
-        ieCore = std::make_unique<InferenceEngine::Core>();
         ieCore_2 = std::make_unique<ov::runtime::Core>();
         this->prepare();
     }
     void TearDown() override {
-        ieCore.reset();
         ieCore_2.reset();
     }
 };

--- a/src/test/mockmodelinstancechangingstates.hpp
+++ b/src/test/mockmodelinstancechangingstates.hpp
@@ -26,8 +26,8 @@
 
 class MockModelInstanceChangingStates : public ovms::ModelInstance {
 public:
-    MockModelInstanceChangingStates(const std::string& modelName, const ovms::model_version_t modelVersion, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) :
-        ModelInstance(modelName, modelVersion, ieCore, ieCore_2) {
+    MockModelInstanceChangingStates(const std::string& modelName, const ovms::model_version_t modelVersion, ov::runtime::Core& ieCore_2) :
+        ModelInstance(modelName, modelVersion, ieCore_2) {
         status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_MODEL_VERSION, ovms::ModelVersionState::START);
     }
     virtual ~MockModelInstanceChangingStates() {}
@@ -62,8 +62,8 @@ public:
     virtual ~MockModelWithInstancesJustChangingStates() {}
 
 protected:
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) { return modelInstanceFactory("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore, ieCore_2); }
-    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t version, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) override {
-        return std::move(std::make_shared<MockModelInstanceChangingStates>(modelName, version, ieCore, ieCore_2));
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(ov::runtime::Core& ieCore_2) { return modelInstanceFactory("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore_2); }
+    std::shared_ptr<ovms::ModelInstance> modelInstanceFactory(const std::string& modelName, const ovms::model_version_t version, ov::runtime::Core& ieCore_2) override {
+        return std::move(std::make_shared<MockModelInstanceChangingStates>(modelName, version, ieCore_2));
     }
 };

--- a/src/test/model_test.cpp
+++ b/src/test/model_test.cpp
@@ -26,14 +26,11 @@
 
 class ModelDefaultVersions : public ::testing::Test {
 protected:
-    std::unique_ptr<InferenceEngine::Core> ieCore;
     std::unique_ptr<ov::runtime::Core> ieCore_2;
     void SetUp() {
-        ieCore = std::make_unique<InferenceEngine::Core>();
         ieCore_2 = std::make_unique<ov::runtime::Core>();
     }
     void TearDown() {
-        ieCore.reset();
         ieCore_2.reset();
     }
 };
@@ -52,7 +49,7 @@ TEST_F(ModelDefaultVersions, DefaultVersionNullWhenVersionRetired) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed);
+    mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed);
     mockModel.retireVersions(versionsToChange);
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;
@@ -67,7 +64,7 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnValidWhen1Added) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;
     defaultInstance = mockModel.getDefaultModelInstance();
@@ -82,11 +79,11 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighest) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;
     defaultInstance = mockModel.getDefaultModelInstance();
@@ -101,12 +98,12 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighestNonRetired) {
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
@@ -126,12 +123,12 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighestWhenVersionReloade
     versionsToChange->push_back(1);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto fs = ovms::ModelManager::getFilesystem(config.getBasePath());
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.addVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     versionsToChange->push_back(2);
@@ -140,7 +137,7 @@ TEST_F(ModelDefaultVersions, DefaultVersionShouldReturnHighestWhenVersionReloade
 
     versionsToChange->push_back(2);
     config.setVersion(2);
-    ASSERT_EQ(mockModel.reloadVersions(versionsToChange, config, fs, *ieCore, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
+    ASSERT_EQ(mockModel.reloadVersions(versionsToChange, config, fs, *ieCore_2, versionsFailed), ovms::StatusCode::OK);
     versionsToChange->clear();
 
     std::shared_ptr<ovms::ModelInstance> defaultInstance;

--- a/src/test/ovinferrequestqueue_test.cpp
+++ b/src/test/ovinferrequestqueue_test.cpp
@@ -33,7 +33,7 @@ const std::string DUMMY_MODEL_PATH = std::filesystem::current_path().u8string() 
 TEST(OVInferRequestQueue, ShortQueue) {
     ov::runtime::Core ieCore;
     auto network = ieCore.read_model(DUMMY_MODEL_PATH);
-    ov::runtime::ExecutableNetwork execNetwork = ieCore.compile_model(network, "CPU");
+    ov::runtime::CompiledModel execNetwork = ieCore.compile_model(network, "CPU");
     ovms::OVInferRequestsQueue_2 inferRequestsQueue(execNetwork, 3);
     int reqid;
     reqid = inferRequestsQueue.getIdleStream().get();
@@ -56,7 +56,7 @@ TEST(OVInferRequestQueue, FullQueue) {
     ovms::Timer timer;
     ov::runtime::Core ieCore;
     auto network = ieCore.read_model(DUMMY_MODEL_PATH);
-    ov::runtime::ExecutableNetwork execNetwork = ieCore.compile_model(network, "CPU");
+    ov::runtime::CompiledModel execNetwork = ieCore.compile_model(network, "CPU");
     ovms::OVInferRequestsQueue_2 inferRequestsQueue(execNetwork, 50);
     int reqid;
     for (int i = 0; i < 50; i++) {
@@ -92,7 +92,7 @@ TEST(OVInferRequestQueue, MultiThread) {
     int number_clients = 100;  // represent number of serving clients
     ov::runtime::Core ieCore;
     auto network = ieCore.read_model(DUMMY_MODEL_PATH);
-    ov::runtime::ExecutableNetwork execNetwork = ieCore.compile_model(network, "CPU");
+    ov::runtime::CompiledModel execNetwork = ieCore.compile_model(network, "CPU");
 
     ovms::OVInferRequestsQueue_2 inferRequestsQueue(execNetwork, nireq);
 
@@ -110,7 +110,7 @@ TEST(OVInferRequestQueue, MultiThread) {
 TEST(OVInferRequestQueue, AsyncGetInferRequest) {
     ov::runtime::Core ieCore;
     auto network = ieCore.read_model(DUMMY_MODEL_PATH);
-    ov::runtime::ExecutableNetwork execNetwork = ieCore.compile_model(network, "CPU");
+    ov::runtime::CompiledModel execNetwork = ieCore.compile_model(network, "CPU");
     const int nireq = 1;
     ovms::OVInferRequestsQueue_2 inferRequestsQueue(execNetwork, nireq);
 

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -32,8 +32,8 @@ using ::testing::ReturnRef;
 class PredictValidation : public ::testing::Test {
     class MockModelInstance : public ovms::ModelInstance {
     public:
-        MockModelInstance(InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) :
-            ModelInstance("UNUSED_NAME", 42, ieCore, ieCore_2) {}
+        MockModelInstance(ov::runtime::Core& ieCore_2) :
+            ModelInstance("UNUSED_NAME", 42, ieCore_2) {}
         MOCK_METHOD(const ovms::tensor_map_t&, getInputsInfo, (), (const, override));
         MOCK_METHOD(ovms::Dimension, getBatchSize, (), (const, override));
         MOCK_METHOD(const ovms::ModelConfig&, getModelConfig, (), (const, override));
@@ -43,7 +43,6 @@ class PredictValidation : public ::testing::Test {
     };
 
 protected:
-    std::unique_ptr<InferenceEngine::Core> ieCore;
     std::unique_ptr<ov::runtime::Core> ieCore_2;
     std::unique_ptr<NiceMock<MockModelInstance>> instance;
     tensorflow::serving::PredictRequest request;
@@ -51,9 +50,8 @@ protected:
     ovms::tensor_map_t networkInputs;
 
     void SetUp() override {
-        ieCore = std::make_unique<InferenceEngine::Core>();
         ieCore_2 = std::make_unique<ov::runtime::Core>();
-        instance = std::make_unique<NiceMock<MockModelInstance>>(*ieCore, *ieCore_2);
+        instance = std::make_unique<NiceMock<MockModelInstance>>(*ieCore_2);
 
         networkInputs = ovms::tensor_map_t({
             {"Input_FP32_1_3_224_224_NHWC",

--- a/src/test/serialization_tests.cpp
+++ b/src/test/serialization_tests.cpp
@@ -39,7 +39,6 @@ using tensorflow::serving::PredictRequest;
 using tensorflow::serving::PredictResponse;
 
 using namespace ovms;
-using namespace InferenceEngine;
 
 using testing::_;
 using testing::NiceMock;
@@ -130,7 +129,7 @@ public:
 TEST(SerializeTFTensorProtoSingle_2, NegativeMismatchBetweenTensorInfoAndBlobPrecision) {
     ovms::Precision tensorInfoPrecision = ovms::Precision::FP32;
     shape_t tensorInfoShape{1, 3, 224, 224};
-    auto layout = Layout::NCHW;
+    auto layout = InferenceEngine::Layout::NCHW;
     const std::string name = "NOT_IMPORTANT";
     auto tensorInfo = std::make_shared<ovms::TensorInfo>(name, tensorInfoPrecision, tensorInfoShape, layout);
     ov::runtime::Tensor tensor(ov::element::i32, tensorInfoShape);
@@ -145,7 +144,7 @@ TEST(SerializeTFTensorProtoSingle_2, NegativeMismatchBetweenTensorInfoAndBlobSha
     ovms::Precision tensorInfoPrecision = ovms::Precision::FP32;
     shape_t tensorInfoShape{1, 3, 224, 224};
     shape_t blobShape{1, 3, 225, 225};
-    auto layout = Layout::NCHW;
+    auto layout = InferenceEngine::Layout::NCHW;
     const std::string name = "NOT_IMPORTANT";
     auto tensorInfo = std::make_shared<ovms::TensorInfo>(name, tensorInfoPrecision, tensorInfoShape, layout);
     ov::runtime::Tensor tensor(tensorInfo->getOvPrecision(), blobShape);
@@ -189,8 +188,8 @@ TEST_P(SerializeTFTensorProtoNegative_2, SerializeTensorProtoShouldSucceedForPre
 TEST(SerializeTFGRPCPredictResponse, ShouldSuccessForSupportedPrecision) {
     PredictResponse response;
     ov::runtime::Core ieCore;
-    std::shared_ptr<ov::Function> network = ieCore.read_model(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
-    ov::runtime::ExecutableNetwork execNetwork = ieCore.compile_model(network, "CPU");
+    std::shared_ptr<ov::Model> network = ieCore.read_model(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml");
+    ov::runtime::CompiledModel execNetwork = ieCore.compile_model(network, "CPU");
     ov::runtime::InferRequest inferRequest = execNetwork.create_infer_request();
     ovms::tensor_map_t tenMap;
     std::shared_ptr<ovms::TensorInfo> tensorInfo = std::make_shared<ovms::TensorInfo>(

--- a/src/test/shape_test.cpp
+++ b/src/test/shape_test.cpp
@@ -51,8 +51,11 @@ TEST(Dimension, PartiallyFitsInto) {
 }
 
 TEST(Shape, OvShapeMatch) {
+    EXPECT_FALSE(ovms::Shape({1, 6, 8}).match(ov::Shape({1, 6})));
     EXPECT_TRUE(ovms::Shape({1, 6, 8}).match(ov::Shape({1, 6, 8})));
     EXPECT_TRUE(ovms::Shape({{1, 2}, {6, 12}, Dimension::any()}).match(ov::Shape({1, 8, 100})));
     size_t startingPosition = 2;
     EXPECT_TRUE(ovms::Shape({{3, 5}, {7, 10}, {11, 19}}).match(ov::Shape({1000, 1000, 12}), startingPosition));
+    startingPosition = 200;
+    EXPECT_TRUE(ovms::Shape({{3, 5}, {7, 10}, {11, 19}}).match(ov::Shape({1000, 1000, 12000}), startingPosition));
 }

--- a/src/test/stateful_modelinstance_test.cpp
+++ b/src/test/stateful_modelinstance_test.cpp
@@ -95,7 +95,6 @@ public:
     inputs_info_t modelInput;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
-    std::unique_ptr<InferenceEngine::Core> ieCore;
     std::unique_ptr<ov::runtime::Core> ieCore_2;
 
     void SetUpConfig(const std::string& configContent) {
@@ -107,7 +106,6 @@ public:
     }
     void SetUp() override {
         TestWithTempDir::SetUp();
-        ieCore = std::make_unique<InferenceEngine::Core>();
         ieCore_2 = std::make_unique<ov::runtime::Core>();
         modelVersion = 1;
         // Prepare manager
@@ -129,18 +127,15 @@ public:
     inputs_info_t modelInput;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
-    std::unique_ptr<InferenceEngine::Core> ieCore;
     std::unique_ptr<ov::runtime::Core> ieCore_2;
 
     void SetUp() override {
         modelInput = {};
-        ieCore = std::make_unique<InferenceEngine::Core>();
         ieCore_2 = std::make_unique<ov::runtime::Core>();
     }
 
     void TearDown() override {
         modelInput.clear();
-        ieCore.reset();
         ieCore_2.reset();
     }
 };
@@ -148,8 +143,8 @@ public:
 class MockedValidateStatefulModelInstance : public ovms::StatefulModelInstance {
 public:
     ovms::GlobalSequencesViewer sequencesViewer;
-    MockedValidateStatefulModelInstance(const std::string& name, ovms::model_version_t version, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) :
-        StatefulModelInstance(name, version, ieCore, ieCore_2, &sequencesViewer) {}
+    MockedValidateStatefulModelInstance(const std::string& name, ovms::model_version_t version, ov::runtime::Core& ieCore_2) :
+        StatefulModelInstance(name, version, ieCore_2, &sequencesViewer) {}
 
     const ovms::Status mockValidate(const tensorflow::serving::PredictRequest* request, ovms::SequenceProcessingSpec& processingSpec) {
         return validate(request, processingSpec);
@@ -168,8 +163,8 @@ public:
     ovms::GlobalSequencesViewer sequencesViewer;
     std::unique_ptr<MockedSequenceManager> mockedSequenceManager = std::make_unique<MockedSequenceManager>(60, "dummy", 1);
 
-    MockedStatefulModelInstance(const std::string& name, ovms::model_version_t version, InferenceEngine::Core& ieCore, ov::runtime::Core& ieCore_2) :
-        StatefulModelInstance(name, version, ieCore, ieCore_2, &sequencesViewer) {}
+    MockedStatefulModelInstance(const std::string& name, ovms::model_version_t version, ov::runtime::Core& ieCore_2) :
+        StatefulModelInstance(name, version, ieCore_2, &sequencesViewer) {}
 
     const std::unique_ptr<MockedSequenceManager>& getMockedSequenceManager() const {
         return this->mockedSequenceManager;
@@ -284,10 +279,6 @@ public:
     DummyStatefulModel realModel;
     std::shared_ptr<MockedStatefulModelInstance> modelInstance;
     std::vector<size_t> shape;
-    Blob::Ptr defaultBlob;
-    Blob::Ptr currentBlob;
-    Blob::Ptr newBlob;
-    std::unique_ptr<InferenceEngine::Core> ieCore;
     std::unique_ptr<ov::runtime::Core> ieCore_2;
 
     std::vector<float> defaultState{0};
@@ -297,15 +288,11 @@ public:
     size_t elementsCount;
 
     void SetUp() override {
-        ieCore = std::make_unique<InferenceEngine::Core>();
         ieCore_2 = std::make_unique<ov::runtime::Core>();
-        modelInstance = std::make_shared<MockedStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+        modelInstance = std::make_shared<MockedStatefulModelInstance>("model", 1, *ieCore_2);
         // Prepare states blob desc
         shape = std::vector<size_t>{1, 1};
         elementsCount = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
-        const Precision precision{Precision::FP32};
-        const Layout layout{Layout::NC};
-        const TensorDesc desc{precision, shape, layout};
     }
 };
 
@@ -1053,7 +1040,7 @@ TEST_F(StatefulModelInstanceTempDir, statefulInferStandardFlow) {
 
 TEST_F(StatefulModelInstanceTempDir, loadModel) {
     ovms::GlobalSequencesViewer sequencesViewer;
-    ovms::StatefulModelInstance modelInstance(dummyModelName, modelVersion, *ieCore, *ieCore_2, &sequencesViewer);
+    ovms::StatefulModelInstance modelInstance(dummyModelName, modelVersion, *ieCore_2, &sequencesViewer);
 
     const ovms::ModelConfig config1{
         dummyModelName,
@@ -1097,7 +1084,7 @@ TEST_F(StatefulModelInstanceTempDir, loadModel) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, positiveValidate) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore_2);
     uint64_t seqId = 1;
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, seqId);
 
@@ -1124,7 +1111,7 @@ TEST_F(StatefulModelInstanceInputValidation, positiveValidate) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, missingSeqId) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore_2);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     setRequestSequenceControl(&request, ovms::SEQUENCE_END);
@@ -1134,7 +1121,7 @@ TEST_F(StatefulModelInstanceInputValidation, missingSeqId) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdEnd) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore_2);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     setRequestSequenceControl(&request, ovms::SEQUENCE_END);
@@ -1146,7 +1133,7 @@ TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdEnd) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdNoControl) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore_2);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     setRequestSequenceControl(&request, ovms::NO_CONTROL_INPUT);
@@ -1158,7 +1145,7 @@ TEST_F(StatefulModelInstanceInputValidation, wrongSeqIdNoControl) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, wrongProtoKeywords) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore_2);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     auto& input = (*request.mutable_inputs())["sequenceid"];
@@ -1170,7 +1157,7 @@ TEST_F(StatefulModelInstanceInputValidation, wrongProtoKeywords) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, badControlInput) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore_2);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);
     request = preparePredictRequest(modelInput);
@@ -1183,7 +1170,7 @@ TEST_F(StatefulModelInstanceInputValidation, badControlInput) {
 }
 
 TEST_F(StatefulModelInstanceInputValidation, invalidProtoTypes) {
-    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore, *ieCore_2);
+    std::shared_ptr<MockedValidateStatefulModelInstance> modelInstance = std::make_shared<MockedValidateStatefulModelInstance>("model", 1, *ieCore_2);
     ovms::SequenceProcessingSpec spec(ovms::SEQUENCE_START, 1);
     {
         tensorflow::serving::PredictRequest request = preparePredictRequest(modelInput);

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -26,7 +26,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <inference_engine.hpp>
 #include <spdlog/spdlog.h>
 
 #pragma GCC diagnostic push

--- a/third_party/openvino/BUILD
+++ b/third_party/openvino/BUILD
@@ -19,7 +19,16 @@ package(
 )
 
 cc_library(
-    name = "openvino_deprecated",
+    name = "openvino_old_headers",
+    hdrs = glob([
+        "include/ie/**/*.*"
+    ]),
+    strip_include_prefix = "include/ie",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "openvino_new_headers",
     hdrs = glob([
         "include/openvino/**/*.*"
     ]),
@@ -35,25 +44,20 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
-        "@openvino//:openvino_deprecated",
+        "@openvino//:openvino_old_headers",
     ],
 )
 
 cc_library(
     name = "openvino",
     srcs = glob([
-        "lib/intel64/libinference_engine_legacy.so",
-        "lib/intel64/libinference_engine.so",
-        "lib/intel64/libinference_engine_c_api.so",
-        "lib/intel64/libngraph.so",
-    ]),
-    hdrs = glob([
-        "include/ie/**/*.*"
+        "lib/intel64/libov_runtime.so"
     ]),
     data = [ "lib/intel64/plugins.xml" ],
     strip_include_prefix = "include/ie",
     visibility = ["//visibility:public"],
     deps = [
         "@openvino//:ngraph",
+        "@openvino//:openvino_new_headers",
     ],
 )


### PR DESCRIPTION
- CVS-75078 Fix stateful low accurracy issue
- bump OV package to 2022.1.0.476
- adjust ov::Function to ov::Model and ov::runtime::ExecutableNetwork to ov::runtime::CompiledModel
- adjust bazel BUILD file to support new openvino artifact names (libov_runtime.so)
- fix issue with binary inputs when uncaught exception was thrown if one of resolution parameters was -1 (any); added unit test for that
- removal of 1.0 api dependend OVMS code
- removal of inference_engine.hpp includes
- removal of getAnyValue and getFlatShape
- API 1.0 model loading removed (IE::Core/IE::CNNNetwork/IE::ExecutableNetwork) meaning API 1.0 loaded model is no longer in memory
- fix issue with changing shape but not modyfing layout
- cpu extension uses API 2.0 now
- metrics are read from API 2.0 now
- fixed tensorClone error log
- 

Not included
- tensorinfo layout enum still uses 1.0 api
- batch size in certain parts of OVMS is still considered on 1st position