### PR TITLE
CVS-74525 Dynamic shape unit tests

### DIFF
--- a/src/dlnodesession.cpp
+++ b/src/dlnodesession.cpp
@@ -172,7 +172,7 @@ Status DLNodeSession::validate(const std::shared_ptr<ov::runtime::Tensor>& tenso
     if (!tensorInfo.getShape()[batchIndex.value()].match(dims[batchIndex.value()])) {
         // If remaining dimensions are equal, it is invalid batch size
         std::stringstream ss;
-        if (!tensorInfo.getShape().match(dims, batchIndex.value())) {
+        if (tensorInfo.getShape().match(dims, batchIndex.value())) {
             ss << "Node: " << getName() << " input: " << tensorInfo.getName()
                << " Invalid batch size -"
                << " Expected: " << tensorInfo.getShape()[batchIndex.value()].toString()

--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -1109,7 +1109,9 @@ Status PipelineDefinition::updateInputsInfo(const ModelManager& manager) {
                         }
                         if (!it->second->isTensorSpecEqual(*tensorInfo) &&
                             !it->second->isTensorUnspecified()) {
-                            return StatusCode::PIPELINE_INPUTS_AMBIGUOUS_METADATA;
+                            Status status = StatusCode::PIPELINE_INPUTS_AMBIGUOUS_METADATA;
+                            SPDLOG_ERROR("Error validating pipeline: {}", status.string());
+                            return status;
                         }
                     }
                     inputsInfo[alias] = tensorInfo;

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -301,6 +301,8 @@ ov::PartialShape Shape::createPartialShape() const {
     for (const Dimension& dim : *this) {
         if (dim.isStatic()) {
             shape.push_back(ov::Dimension(dim.getStaticValue()));
+        } else if (dim.isAny()) {
+            shape.push_back(ov::Dimension::dynamic());
         } else {
             shape.push_back(ov::Dimension{dim.getMinValue(), dim.getMaxValue()});
         }

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -919,8 +919,8 @@ TEST_F(EnsembleFlowTest, ExecutePipelineWithShapeRange) {
     managerWithDynamicShapeDummyModel.reloadModelWithVersions(config);
 
     // Configure pipeline
-    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName, ovms::Precision::FP32, ovms::Shape{1, ovms::Dimension::any()}, Layout{"NC"});
-    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName, ovms::Precision::FP32, ovms::Shape{1, ovms::Dimension::any()}, Layout{"NC"});
+    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName, ovms::Precision::FP32, ovms::Shape{1, {1, 5}}, Layout{"NC"});
+    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName, ovms::Precision::FP32, ovms::Shape{1, {1, 5}}, Layout{"NC"});
     {
         const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
         auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -175,9 +175,168 @@ TEST_F(EnsembleFlowTest, DummyModel) {
     pipeline.push(std::move(model_node));
     pipeline.push(std::move(output_node));
 
-    pipeline.execute();
+    ASSERT_EQ(pipeline.execute(), StatusCode::OK);
     const int dummySeriallyConnectedCount = 1;
     checkDummyResponse(dummySeriallyConnectedCount);
+}
+
+TEST_F(EnsembleFlowTest, TwoInnerNodesConnectedShapeRangePartiallyMatching) {
+    ConstructorEnabledModelManager managerWithDummyModel;
+
+    config = DUMMY_MODEL_CONFIG;
+    config.setName("dummy_A");
+    config.setBatchSize(std::nullopt);
+    config.parseShapeParameter("(-1,1:3)");
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    config = DUMMY_MODEL_CONFIG;
+    config.setName("dummy_B");
+    config.setBatchSize(std::nullopt);
+    config.parseShapeParameter("(-1,2:4)");
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
+        ovms::Precision::FP32,
+        ovms::Shape{Dimension::any(), {1, 3}},
+        Layout{"NC"});
+    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
+        ovms::Precision::FP32,
+        ovms::Shape{Dimension::any(), {2, 4}},
+        Layout{"NC"});
+
+    // 2x2 passing
+    {
+        prepareRequest(std::vector<float>{5.0, 6.0, 15.0, 16.0}, request, customPipelineInputName, {2, 2});
+        response.Clear();
+
+        const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node_A = std::make_unique<DLNode>("dummy_node_A", "dummy_A", requestedModelVersion, managerWithDummyModel);
+        auto model_node_B = std::make_unique<DLNode>("dummy_node_B", "dummy_B", requestedModelVersion, managerWithDummyModel);
+        const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+        Pipeline pipeline(*input_node, *output_node);
+        pipeline.connect(*input_node, *model_node_A, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node_A, *model_node_B, {{DUMMY_MODEL_OUTPUT_NAME, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node_B, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node_A));
+        pipeline.push(std::move(model_node_B));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), StatusCode::OK);
+        ASSERT_EQ(response.outputs().count(customPipelineOutputName), 1);
+        const auto& output_proto = response.outputs().at(customPipelineOutputName);
+
+        ASSERT_EQ(output_proto.tensor_content().size(), 2 * 2 * sizeof(float));
+        ASSERT_EQ(output_proto.tensor_shape().dim_size(), 2);
+        ASSERT_EQ(output_proto.tensor_shape().dim(0).size(), 2);
+        ASSERT_EQ(output_proto.tensor_shape().dim(1).size(), 2);
+
+        std::vector<float> responseData = {7.0, 8.0, 17.0, 18.0};
+        float* actual_output = (float*)output_proto.tensor_content().data();
+        float* expected_output = responseData.data();
+        EXPECT_EQ(0, std::memcmp(actual_output, expected_output, 2 * 2 * sizeof(float)));
+    }
+
+    // 2x4 not passing due to not matched dummy_A (but matching dummy_B)
+    {
+        prepareRequest(std::vector<float>{5.0, 6.0, 15.0, 16.0, 5.0, 6.0, 15.0, 16.0}, request, customPipelineInputName, {2, 4});
+        response.Clear();
+
+        const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node_A = std::make_unique<DLNode>("dummy_node_A", "dummy_A", requestedModelVersion, managerWithDummyModel);
+        auto model_node_B = std::make_unique<DLNode>("dummy_node_B", "dummy_B", requestedModelVersion, managerWithDummyModel);
+        const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+        Pipeline pipeline(*input_node, *output_node);
+        pipeline.connect(*input_node, *model_node_A, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node_A, *model_node_B, {{DUMMY_MODEL_OUTPUT_NAME, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node_B, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node_A));
+        pipeline.push(std::move(model_node_B));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), StatusCode::INVALID_SHAPE);
+    }
+
+    // 2x1 not passing due to not matched dummy_B (but matching dummy_A)
+    {
+        prepareRequest(std::vector<float>{5.0, 6.0}, request, customPipelineInputName, {2, 1});
+        response.Clear();
+
+        const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node_A = std::make_unique<DLNode>("dummy_node_A", "dummy_A", requestedModelVersion, managerWithDummyModel);
+        auto model_node_B = std::make_unique<DLNode>("dummy_node_B", "dummy_B", requestedModelVersion, managerWithDummyModel);
+        const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+        Pipeline pipeline(*input_node, *output_node);
+        pipeline.connect(*input_node, *model_node_A, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node_A, *model_node_B, {{DUMMY_MODEL_OUTPUT_NAME, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node_B, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node_A));
+        pipeline.push(std::move(model_node_B));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), StatusCode::INVALID_SHAPE);
+    }
+}
+
+// This test is only theoretical scenario, since pipeline validation should not allow such pipelines.
+TEST_F(EnsembleFlowTest, TwoInnerNodesConnectedShapeRangeNotMatching) {
+    ConstructorEnabledModelManager managerWithDummyModel;
+
+    config = DUMMY_MODEL_CONFIG;
+    config.setName("dummy_A");
+    config.setBatchSize(std::nullopt);
+    config.parseShapeParameter("(-1,1:3)");
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    config = DUMMY_MODEL_CONFIG;
+    config.setName("dummy_B");
+    config.setBatchSize(std::nullopt);
+    config.parseShapeParameter("(-1,4:6)");
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
+        ovms::Precision::FP32,
+        ovms::Shape{Dimension::any(), {1, 3}},
+        Layout{"NC"});
+    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
+        ovms::Precision::FP32,
+        ovms::Shape{Dimension::any(), {4, 6}},
+        Layout{"NC"});
+
+    // 2x2 not matching dummy_B at execution time
+    prepareRequest(std::vector<float>{5.0, 6.0, 15.0, 16.0}, request, customPipelineInputName, {2, 2});
+    response.Clear();
+
+    const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+    auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+    auto model_node_A = std::make_unique<DLNode>("dummy_node_A", "dummy_A", requestedModelVersion, managerWithDummyModel);
+    auto model_node_B = std::make_unique<DLNode>("dummy_node_B", "dummy_B", requestedModelVersion, managerWithDummyModel);
+    const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+    auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+    Pipeline pipeline(*input_node, *output_node);
+    pipeline.connect(*input_node, *model_node_A, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+    pipeline.connect(*model_node_A, *model_node_B, {{DUMMY_MODEL_OUTPUT_NAME, DUMMY_MODEL_INPUT_NAME}});
+    pipeline.connect(*model_node_B, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+    pipeline.push(std::move(input_node));
+    pipeline.push(std::move(model_node_A));
+    pipeline.push(std::move(model_node_B));
+    pipeline.push(std::move(output_node));
+
+    ASSERT_EQ(pipeline.execute(), StatusCode::INVALID_SHAPE);
 }
 
 class EnsembleFlowValidationTest : public EnsembleFlowTest {
@@ -198,6 +357,14 @@ public:
         return pipeline;
     }
 };
+
+TEST_F(EnsembleFlowValidationTest, DummyModelValid) {
+    ConstructorEnabledModelManager managerWithDummyModel;
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    auto pipeline = createDummyPipeline(managerWithDummyModel);
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+}
 
 TEST_F(EnsembleFlowValidationTest, DummyModelProtoValidationErrorNumberOfInputs) {
     ConstructorEnabledModelManager managerWithDummyModel;
@@ -338,6 +505,90 @@ TEST_F(EnsembleFlowValidationTest, DummyModelProtoValidationErrorInvalidTensorCo
     ASSERT_EQ(pipeline->execute(), StatusCode::INVALID_CONTENT_SIZE);
 }
 
+class EnsembleFlowValidationShapeRangeTest : public EnsembleFlowValidationTest {
+protected:
+    void SetUp() {
+        EnsembleFlowValidationTest::SetUp();
+
+        dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
+            ovms::Precision::FP32,
+            ovms::Shape{{1, 10}, {2, 11}},
+            Layout{"NC"});
+        dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
+            ovms::Precision::FP32,
+            ovms::Shape{{1, 10}, {2, 11}},
+            Layout{"NC"});
+
+        config = DUMMY_MODEL_CONFIG;
+        config.setBatchingParams("0");
+        config.parseShapeParameter("(1:10,2:11)");
+    }
+};
+
+TEST_F(EnsembleFlowValidationShapeRangeTest, DummyModelValid) {
+    ConstructorEnabledModelManager managerWithDummyModel;
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    auto pipeline = createDummyPipeline(managerWithDummyModel);
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+}
+
+TEST_F(EnsembleFlowValidationShapeRangeTest, DummyModelProtoValidationErrorInvalidBatchSize) {
+    ConstructorEnabledModelManager managerWithDummyModel;
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    request.Clear();
+    auto& proto1 = (*request.mutable_inputs())[customPipelineInputName];
+    proto1.mutable_tensor_shape()->add_dim()->set_size(11);
+    proto1.mutable_tensor_shape()->add_dim()->set_size(10);
+    proto1.set_dtype(tensorflow::DataType::DT_FLOAT);
+
+    auto pipeline = createDummyPipeline(managerWithDummyModel);
+    ASSERT_EQ(pipeline->execute(), StatusCode::INVALID_BATCH_SIZE);
+}
+
+TEST_F(EnsembleFlowValidationShapeRangeTest, DummyModelProtoValidationErrorInvalidShape) {
+    ConstructorEnabledModelManager managerWithDummyModel;
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    request.Clear();
+    auto& proto1 = (*request.mutable_inputs())[customPipelineInputName];
+    proto1.mutable_tensor_shape()->add_dim()->set_size(6);
+    proto1.mutable_tensor_shape()->add_dim()->set_size(1);
+    proto1.set_dtype(tensorflow::DataType::DT_FLOAT);
+
+    auto pipeline = createDummyPipeline(managerWithDummyModel);
+    ASSERT_EQ(pipeline->execute(), StatusCode::INVALID_SHAPE);
+}
+
+class EnsembleFlowValidationShapeAnyTest : public EnsembleFlowValidationTest {
+protected:
+    void SetUp() {
+        EnsembleFlowValidationTest::SetUp();
+
+        dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
+            ovms::Precision::FP32,
+            ovms::Shape{ovms::Dimension::any(), ovms::Dimension::any()},
+            Layout{"NC"});
+        dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
+            ovms::Precision::FP32,
+            ovms::Shape{ovms::Dimension::any(), ovms::Dimension::any()},
+            Layout{"NC"});
+
+        config = DUMMY_MODEL_CONFIG;
+        config.setBatchingParams("0");
+        config.parseShapeParameter("(-1,-1)");
+    }
+};
+
+TEST_F(EnsembleFlowValidationShapeAnyTest, DummyModelValid) {
+    ConstructorEnabledModelManager managerWithDummyModel;
+    managerWithDummyModel.reloadModelWithVersions(config);
+
+    auto pipeline = createDummyPipeline(managerWithDummyModel);
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+}
+
 TEST_F(EnsembleFlowTest, DummyModelDirectAndPipelineInference) {
     ConstructorEnabledModelManager managerWithDummyModel;
     config.setNireq(1);
@@ -391,7 +642,7 @@ TEST_F(EnsembleFlowTest, DummyModelDirectAndPipelineInference) {
     pipeline.push(std::move(model_node));
     pipeline.push(std::move(output_node));
 
-    pipeline.execute();
+    ASSERT_EQ(pipeline.execute(), StatusCode::OK);
     const int dummySeriallyConnectedCount = 1;
     checkDummyResponse(dummySeriallyConnectedCount);
 
@@ -449,7 +700,7 @@ TEST_F(EnsembleFlowTest, SeriesOfDummyModels) {
 
     timer.stop("prepare pipeline");
     timer.start("pipeline::execute");
-    pipeline.execute();
+    ASSERT_EQ(pipeline.execute(), StatusCode::OK);
     timer.stop("pipeline::execute");
 
     timer.start("compare results");
@@ -459,6 +710,456 @@ TEST_F(EnsembleFlowTest, SeriesOfDummyModels) {
     std::cout << "prepare pipeline: " << timer.elapsed<std::chrono::microseconds>("prepare pipeline") / 1000 << "ms\n";
     std::cout << "pipeline::execute: " << timer.elapsed<std::chrono::microseconds>("pipeline::execute") / 1000 << "ms\n";
     std::cout << "compare results: " << timer.elapsed<std::chrono::microseconds>("compare results") / 1000 << "ms\n";
+}
+
+TEST_F(EnsembleFlowTest, ExecutePipelineWithBatchSizeAny) {
+    // Scenario
+
+    // input(3x10)   dummy(1x10), change batch size to any    output(3x10)
+    //  O-------------------------->O----------------------------->O
+
+    // input 3x10
+    // dummy is natively 1x10, batch size change to -1 (any)
+    // process dummy
+    // check if output is 3x10
+
+    tensorflow::TensorProto& proto = (*request.mutable_inputs())[customPipelineInputName];
+    const int batchSize = 3;
+    proto.mutable_tensor_shape()->mutable_dim(0)->set_size(batchSize);
+    requestData = {
+        -5, -4, -3, -2, -1, 1, 2, 3, 4, 5,            // batch 1
+        -15, -14, -13, -12, -11, 11, 12, 13, 14, 15,  // batch 2
+        -25, -24, -23, -22, -21, 21, 22, 23, 24, 25,  // batch 3
+    };
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+
+    config.setBatchingParams("-1");
+    ConstructorEnabledModelManager managerWithDynamicBatchDummyModel;
+    managerWithDynamicBatchDummyModel.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName, ovms::Precision::FP32, ovms::Shape{ovms::Dimension::any(), 10}, Layout{"NC"});
+    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName, ovms::Precision::FP32, ovms::Shape{ovms::Dimension::any(), 10}, Layout{"NC"});
+    const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+    auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+    auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, managerWithDynamicBatchDummyModel);
+    const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+    auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+    Pipeline pipeline(*input_node, *output_node);
+
+    pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+    pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+    pipeline.push(std::move(input_node));
+    pipeline.push(std::move(model_node));
+    pipeline.push(std::move(output_node));
+
+    ASSERT_EQ(pipeline.execute(), StatusCode::OK);
+    const int seriallyConnectedDummyModels = 1;
+    checkDummyResponse(seriallyConnectedDummyModels, batchSize);
+}
+
+TEST_F(EnsembleFlowTest, ExecutePipelineWithBatchSizeRange) {
+    // Scenario
+
+    // input(3x10)   dummy(1x10), change batch size to (1:5x10)    output(3x10)
+    //  O-------------------------->O------------------------------->O
+
+    // input 3x10
+    // dummy is natively 1x10, batch size change to 1:5 (range)
+    // process dummy
+    // check if output is 3x10
+    // check if execution fails for batch higher than 5
+
+    tensorflow::TensorProto& proto = (*request.mutable_inputs())[customPipelineInputName];
+    int batchSize = 3;
+    proto.mutable_tensor_shape()->mutable_dim(0)->set_size(batchSize);
+    requestData = {
+        -5, -4, -3, -2, -1, 1, 2, 3, 4, 5,            // batch 1
+        -15, -14, -13, -12, -11, 11, 12, 13, 14, 15,  // batch 2
+        -25, -24, -23, -22, -21, 21, 22, 23, 24, 25,  // batch 3
+    };
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+
+    config.setBatchingParams("1:5");
+    ConstructorEnabledModelManager managerWithDynamicBatchDummyModel;
+    managerWithDynamicBatchDummyModel.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName, ovms::Precision::FP32, ovms::Shape{{1, 5}, 10}, Layout{"NC"});
+    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName, ovms::Precision::FP32, ovms::Shape{{1, 5}, 10}, Layout{"NC"});
+    {
+        const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, managerWithDynamicBatchDummyModel);
+        const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+        Pipeline pipeline(*input_node, *output_node);
+
+        pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), StatusCode::OK);
+        const int seriallyConnectedDummyModels = 1;
+        checkDummyResponse(seriallyConnectedDummyModels, batchSize);
+    }
+    // Prepare invalid data
+    batchSize = 6;
+    proto.mutable_tensor_shape()->mutable_dim(0)->set_size(batchSize);
+    requestData = std::vector<float>(batchSize * 10, 1.234);
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+    {
+        const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, managerWithDynamicBatchDummyModel);
+        const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+        Pipeline pipeline(*input_node, *output_node);
+
+        pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), StatusCode::INVALID_BATCH_SIZE);
+    }
+}
+
+TEST_F(EnsembleFlowTest, ExecutePipelineWithShapeAny) {
+    // Scenario
+
+    // input(1x5)      dummy(1x10) second dimension set to any             output(1x5)
+    //  O---------------------->O----------------------------------------------->O
+
+    // input 1x5
+    // dummy is natively 1x10, but second dimension set to any (-1)
+    // process dummy
+    // check if output is 1x5
+
+    tensorflow::TensorProto& proto = (*request.mutable_inputs())[customPipelineInputName];
+    proto.mutable_tensor_shape()->mutable_dim(1)->set_size(5);
+    std::vector<float> requestData = {
+        -5, -4, -3, -2, -1,  // batch 1
+    };
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+
+    config.setBatchSize(std::nullopt);  // = not specified in --batch_size parameter
+    config.parseShapeParameter("(1,-1)");
+    ConstructorEnabledModelManager managerWithDynamicShapeDummyModel;
+    managerWithDynamicShapeDummyModel.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName, ovms::Precision::FP32, ovms::Shape{1, ovms::Dimension::any()}, Layout{"NC"});
+    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName, ovms::Precision::FP32, ovms::Shape{1, ovms::Dimension::any()}, Layout{"NC"});
+    const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+    auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+    auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, managerWithDynamicShapeDummyModel);
+    const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+    auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+    Pipeline pipeline(*input_node, *output_node);
+
+    pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+    pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+    pipeline.push(std::move(input_node));
+    pipeline.push(std::move(model_node));
+    pipeline.push(std::move(output_node));
+
+    ASSERT_EQ(pipeline.execute(), StatusCode::OK);
+
+    ASSERT_EQ(response.outputs().count(customPipelineOutputName), 1);
+    const auto& output_proto = response.outputs().at(customPipelineOutputName);
+
+    ASSERT_EQ(output_proto.tensor_content().size(), 1 * 5 * sizeof(float));
+    ASSERT_EQ(output_proto.tensor_shape().dim_size(), 2);
+    ASSERT_EQ(output_proto.tensor_shape().dim(0).size(), 1);
+    ASSERT_EQ(output_proto.tensor_shape().dim(1).size(), 5);
+
+    std::vector<float> responseData = requestData;
+    std::for_each(responseData.begin(), responseData.end(), [](float& v) { v += 1.0; });
+
+    float* actual_output = (float*)output_proto.tensor_content().data();
+    float* expected_output = responseData.data();
+
+    EXPECT_EQ(0, std::memcmp(actual_output, expected_output, 1 * 5 * sizeof(float)));
+}
+
+TEST_F(EnsembleFlowTest, ExecutePipelineWithShapeRange) {
+    // Scenario
+
+    // input(1x5)      dummy(1x10) second dimension set to range (1:5)             output(1x5)
+    //  O---------------------->O----------------------------------------------->O
+
+    // input 1x5
+    // dummy is natively 1x10, but second dimension set to (1:5) range
+    // process dummy
+    // check if output is 1x5
+    // check if there is an error for input dimension higher than 5
+
+    tensorflow::TensorProto& proto = (*request.mutable_inputs())[customPipelineInputName];
+    proto.mutable_tensor_shape()->mutable_dim(1)->set_size(5);
+    std::vector<float> requestData = {
+        -5, -4, -3, -2, -1,  // batch 1
+    };
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+
+    config.setBatchSize(std::nullopt);  // = not specified in --batch_size parameter
+    config.parseShapeParameter("(1,1:5)");
+    ConstructorEnabledModelManager managerWithDynamicShapeDummyModel;
+    managerWithDynamicShapeDummyModel.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName, ovms::Precision::FP32, ovms::Shape{1, ovms::Dimension::any()}, Layout{"NC"});
+    dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName, ovms::Precision::FP32, ovms::Shape{1, ovms::Dimension::any()}, Layout{"NC"});
+    {
+        const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, managerWithDynamicShapeDummyModel);
+        const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+        Pipeline pipeline(*input_node, *output_node);
+
+        pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), StatusCode::OK);
+
+        ASSERT_EQ(response.outputs().count(customPipelineOutputName), 1);
+        const auto& output_proto = response.outputs().at(customPipelineOutputName);
+
+        ASSERT_EQ(output_proto.tensor_content().size(), 1 * 5 * sizeof(float));
+        ASSERT_EQ(output_proto.tensor_shape().dim_size(), 2);
+        ASSERT_EQ(output_proto.tensor_shape().dim(0).size(), 1);
+        ASSERT_EQ(output_proto.tensor_shape().dim(1).size(), 5);
+
+        std::vector<float> responseData = requestData;
+        std::for_each(responseData.begin(), responseData.end(), [](float& v) { v += 1.0; });
+
+        float* actual_output = (float*)output_proto.tensor_content().data();
+        float* expected_output = responseData.data();
+
+        EXPECT_EQ(0, std::memcmp(actual_output, expected_output, 1 * 5 * sizeof(float)));
+    }
+    // Prepare invalid data
+    proto.mutable_tensor_shape()->mutable_dim(1)->set_size(6);
+    requestData = std::vector<float>(6, 1.234);
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+    {
+        const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, managerWithDynamicShapeDummyModel);
+        const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+        Pipeline pipeline(*input_node, *output_node);
+
+        pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), StatusCode::INVALID_SHAPE);
+    }
+}
+
+TEST_F(EnsembleFlowTest, ExecutePipelineWithBatchAndShapeSetToAny) {
+    // Scenario
+
+    // input(3x500)   dummy(1x10), all dimensions set to any    output(3x500)
+    //  O------------------------------>O----------------------------->O
+
+    // input 3x500
+    // dummy is natively 1x10, but all dimensions set to any
+    // process dummy
+    // check if output is 3x500
+
+    const int BATCH_SIZE = 3;
+    const int WIDTH = 500;
+
+    tensorflow::TensorProto& proto = (*request.mutable_inputs())[customPipelineInputName];
+    proto.mutable_tensor_shape()->mutable_dim(0)->set_size(BATCH_SIZE);
+    proto.mutable_tensor_shape()->mutable_dim(1)->set_size(WIDTH);
+    std::vector<float> requestData;
+    for (int i = 0; i < BATCH_SIZE; i++) {
+        for (int j = 0; j < WIDTH; j++) {
+            requestData.push_back((i + 1) * (j + 1));
+            /*
+            1.0, 2.0, 3.0, ..., 500.0,
+            2.0, 4.0, 6.0, ..., 1000.0,
+            3.0, 6.0, 9.0, ..., 1500.0
+            */
+        }
+    }
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+
+    config.setBatchSize(std::nullopt);  // simulate --batch_size parameter not set
+    config.parseShapeParameter("(-1,-1)");
+    ConstructorEnabledModelManager manager;
+    manager.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    auto inputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
+        ovms::Precision::FP32,
+        ovms::Shape{ovms::Dimension::any(), ovms::Dimension::any()},
+        Layout{"NC"});
+    const tensor_map_t inputsInfo{{customPipelineInputName, inputTensorInfo}};
+    auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+    auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, manager);
+    auto tensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
+        ovms::Precision::FP32,
+        ovms::Shape{ovms::Dimension::any(), ovms::Dimension::any()},
+        Layout{"NC"});
+    const tensor_map_t outputsInfo{{customPipelineOutputName, tensorInfo}};
+    auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+    Pipeline pipeline(*input_node, *output_node);
+
+    pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+    pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+    pipeline.push(std::move(input_node));
+    pipeline.push(std::move(model_node));
+    pipeline.push(std::move(output_node));
+
+    ASSERT_EQ(pipeline.execute(), ovms::StatusCode::OK);
+
+    ASSERT_EQ(response.outputs().count(customPipelineOutputName), 1);
+    const auto& output_proto = response.outputs().at(customPipelineOutputName);
+
+    ASSERT_EQ(output_proto.tensor_content().size(), BATCH_SIZE * WIDTH * sizeof(float));
+    ASSERT_EQ(output_proto.tensor_shape().dim_size(), 2);
+    ASSERT_EQ(output_proto.tensor_shape().dim(0).size(), BATCH_SIZE);
+    ASSERT_EQ(output_proto.tensor_shape().dim(1).size(), WIDTH);
+
+    std::vector<float> responseData = requestData;
+    std::for_each(responseData.begin(), responseData.end(), [](float& v) { v += 1.0; });
+
+    float* actual_output = (float*)output_proto.tensor_content().data();
+    float* expected_output = responseData.data();
+
+    EXPECT_EQ(0, std::memcmp(actual_output, expected_output, BATCH_SIZE * WIDTH * sizeof(float)));
+}
+
+TEST_F(EnsembleFlowTest, ExecutePipelineWithBatchAndShapeSetToRange) {
+    // Scenario
+
+    // input(3x500)   dummy(1x10), all dimensions set to range (1:1000)    output(3x500)
+    //  O------------------------------>O----------------------------->O
+
+    // input 3x500
+    // dummy is natively 1x10, but all dimensions are reset to support range (1:1000)
+    // process dummy
+    // check if output is 3x500
+    // check if for input dimension higher than 1000 there is an error
+
+    const int BATCH_SIZE = 3;
+    const int WIDTH = 500;
+
+    tensorflow::TensorProto& proto = (*request.mutable_inputs())[customPipelineInputName];
+    proto.mutable_tensor_shape()->mutable_dim(0)->set_size(BATCH_SIZE);
+    proto.mutable_tensor_shape()->mutable_dim(1)->set_size(WIDTH);
+    std::vector<float> requestData;
+    for (int i = 0; i < BATCH_SIZE; i++) {
+        for (int j = 0; j < WIDTH; j++) {
+            requestData.push_back((i + 1) * (j + 1));
+            /*
+            1.0, 2.0, 3.0, ..., 500.0,
+            2.0, 4.0, 6.0, ..., 1000.0,
+            3.0, 6.0, 9.0, ..., 1500.0
+            */
+        }
+    }
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+
+    config.setBatchSize(std::nullopt);  // simulate --batch_size parameter not set
+    config.parseShapeParameter("(1:1000,1:1000)");
+    ConstructorEnabledModelManager manager;
+    manager.reloadModelWithVersions(config);
+
+    // Configure pipeline
+    auto inputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
+        ovms::Precision::FP32,
+        ovms::Shape{{1, 1000}, {1, 1000}},
+        Layout{"NC"});
+    auto tensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
+        ovms::Precision::FP32,
+        ovms::Shape{{1, 1000}, {1, 1000}},
+        Layout{"NC"});
+    {
+        const tensor_map_t inputsInfo{{customPipelineInputName, inputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, manager);
+
+        const tensor_map_t outputsInfo{{customPipelineOutputName, tensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+        Pipeline pipeline(*input_node, *output_node);
+
+        pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), ovms::StatusCode::OK);
+
+        ASSERT_EQ(response.outputs().count(customPipelineOutputName), 1);
+        const auto& output_proto = response.outputs().at(customPipelineOutputName);
+
+        ASSERT_EQ(output_proto.tensor_content().size(), BATCH_SIZE * WIDTH * sizeof(float));
+        ASSERT_EQ(output_proto.tensor_shape().dim_size(), 2);
+        ASSERT_EQ(output_proto.tensor_shape().dim(0).size(), BATCH_SIZE);
+        ASSERT_EQ(output_proto.tensor_shape().dim(1).size(), WIDTH);
+
+        std::vector<float> responseData = requestData;
+        std::for_each(responseData.begin(), responseData.end(), [](float& v) { v += 1.0; });
+
+        float* actual_output = (float*)output_proto.tensor_content().data();
+        float* expected_output = responseData.data();
+
+        EXPECT_EQ(0, std::memcmp(actual_output, expected_output, BATCH_SIZE * WIDTH * sizeof(float)));
+    }
+    // Prepare invalid data
+    proto.mutable_tensor_shape()->mutable_dim(1)->set_size(1001);
+    requestData = std::vector<float>(BATCH_SIZE * 1001, 1.234);
+    proto.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
+    {
+        const tensor_map_t inputsInfo{{customPipelineInputName, inputTensorInfo}};
+        auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
+        auto model_node = std::make_unique<DLNode>("dummy_node", dummyModelName, requestedModelVersion, manager);
+
+        const tensor_map_t outputsInfo{{customPipelineOutputName, tensorInfo}};
+        auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
+
+        Pipeline pipeline(*input_node, *output_node);
+
+        pipeline.connect(*input_node, *model_node, {{customPipelineInputName, DUMMY_MODEL_INPUT_NAME}});
+        pipeline.connect(*model_node, *output_node, {{DUMMY_MODEL_OUTPUT_NAME, customPipelineOutputName}});
+
+        pipeline.push(std::move(input_node));
+        pipeline.push(std::move(model_node));
+        pipeline.push(std::move(output_node));
+
+        ASSERT_EQ(pipeline.execute(), ovms::StatusCode::INVALID_SHAPE);
+    }
 }
 
 // Disabled with deserialization unification. For this use case to work we would have to additionally rely on "isPipeline" in getFinalShapedTensorInfo() to not use shape from tensor info but to rely on tensorProto
@@ -507,7 +1208,7 @@ TEST_F(EnsembleFlowTest, DISABLED_ExecutePipelineWithDynamicBatchSize) {
     pipeline.push(std::move(model_node));
     pipeline.push(std::move(output_node));
 
-    pipeline.execute();
+    ASSERT_EQ(pipeline.execute(), StatusCode::OK);
     const int seriallyConnectedDummyModels = 1;
     checkDummyResponse(seriallyConnectedDummyModels, batchSize);
 }
@@ -556,7 +1257,7 @@ TEST_F(EnsembleFlowTest, DISABLED_ExecutePipelineWithDynamicShape) {
     pipeline.push(std::move(model_node));
     pipeline.push(std::move(output_node));
 
-    pipeline.execute();
+    ASSERT_EQ(pipeline.execute(), StatusCode::OK);
 
     ASSERT_EQ(response.outputs().count(customPipelineOutputName), 1);
     const auto& output_proto = response.outputs().at(customPipelineOutputName);
@@ -575,7 +1276,7 @@ TEST_F(EnsembleFlowTest, DISABLED_ExecutePipelineWithDynamicShape) {
     EXPECT_EQ(0, std::memcmp(actual_output, expected_output, 1 * 5 * sizeof(float)));
 }
 
-TEST_F(EnsembleFlowTest, ExecutePipelineWithDynamicBatchAndShape) {
+TEST_F(EnsembleFlowTest, DISABLED_ExecutePipelineWithDynamicBatchAndShape) {
     // Scenario
 
     // input(3x500)   dummy(1x10), reshape, change batch size    output(3x500)
@@ -653,7 +1354,7 @@ TEST_F(EnsembleFlowTest, ExecutePipelineWithDynamicBatchAndShape) {
     EXPECT_EQ(0, std::memcmp(actual_output, expected_output, BATCH_SIZE * WIDTH * sizeof(float)));
 }
 
-TEST_F(EnsembleFlowTest, ExecutePipelineWithDynamicShape_RequestHasDifferentDim0) {
+TEST_F(EnsembleFlowTest, DISABLED_ExecutePipelineWithDynamicShape_RequestHasDifferentDim0) {
     // Scenario
     // Shape is set to auto but only first dimension differs - change batch size via reshape
 
@@ -2447,23 +3148,25 @@ TEST_F(EnsembleFlowTest, RuntimeWrongBatchSizeArbitraryPosition) {
 
     ModelConfig configCN = DUMMY_MODEL_CONFIG;
     configCN.setName("dummy_C1_N10");
+    configCN.setBatchingParams("0");
     configCN.parseShapeParameter("(1,10)");
     ASSERT_EQ(configCN.parseLayoutParameter("cn"), StatusCode::OK);
     managerWithDummyModel.reloadModelWithVersions(configCN);
 
     configCN = DUMMY_MODEL_CONFIG;
     configCN.setName("dummy_C1_N15");
+    configCN.setBatchingParams("0");
     configCN.parseShapeParameter("(1,15)");
     ASSERT_EQ(configCN.parseLayoutParameter("cn"), StatusCode::OK);
     managerWithDummyModel.reloadModelWithVersions(configCN);
 
     dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
         ovms::Precision::FP32,
-        Shape{1, 10},
+        Shape{1, 15},
         Layout{"CN"});
     dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
         ovms::Precision::FP32,
-        Shape{1, 15},
+        Shape{1, 10},
         Layout{"CN"});
 
     // Configure pipeline
@@ -2491,30 +3194,32 @@ TEST_F(EnsembleFlowTest, RuntimeWrongShapeArbitraryBatchPosition) {
 
     ModelConfig configCN = DUMMY_MODEL_CONFIG;
     configCN.setName("dummy_C1_N10");
+    configCN.setBatchingParams("0");
     configCN.parseShapeParameter("(1,10)");
     ASSERT_EQ(configCN.parseLayoutParameter("cn"), StatusCode::OK);
     managerWithDummyModel.reloadModelWithVersions(configCN);
 
     configCN = DUMMY_MODEL_CONFIG;
     configCN.setName("dummy_C2_N10");
+    configCN.setBatchingParams("0");
     configCN.parseShapeParameter("(2,10)");
     ASSERT_EQ(configCN.parseLayoutParameter("cn"), StatusCode::OK);
     managerWithDummyModel.reloadModelWithVersions(configCN);
 
     dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
         ovms::Precision::FP32,
-        Shape{1, 10},
+        Shape{2, 10},
         Layout{"CN"});
     dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
         ovms::Precision::FP32,
-        Shape{2, 10},
+        Shape{1, 10},
         Layout{"CN"});
 
     // Configure pipeline
     const tensor_map_t inputsInfo{{customPipelineInputName, dagDummyModelInputTensorInfo}};
     auto input_node = std::make_unique<EntryNode>(&request, inputsInfo);
     auto model_node_1 = std::make_unique<DLNode>("dummy_node_1", "dummy_C1_N10", requestedModelVersion, managerWithDummyModel);
-    auto model_node_2 = std::make_unique<DLNode>("dummy_node_2", "dummy_C1_N15", requestedModelVersion, managerWithDummyModel);
+    auto model_node_2 = std::make_unique<DLNode>("dummy_node_2", "dummy_C2_N10", requestedModelVersion, managerWithDummyModel);
     const tensor_map_t outputsInfo{{customPipelineOutputName, dagDummyModelOutputTensorInfo}};
     auto output_node = std::make_unique<ExitNode>(&response, outputsInfo);
     Pipeline pipeline(*input_node, *output_node);
@@ -3406,6 +4111,153 @@ TEST_F(EnsembleFlowTest, DemultiplexerMultipleBatchSizeWithShapeNotEqualToDemult
         PipelineDefinitionStateCode::LOADING_PRECONDITION_FAILED);
 }
 
+static const char* pipelineInnerNodeConnectionShapeRangeNotMatch = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy_A",
+                "base_path": "/ovms/src/test/dummy",
+                "shape": "(-1,30:40) ",
+                "nireq": 1
+            }
+        },
+        {
+            "config": {
+                "name": "dummy_B",
+                "base_path": "/ovms/src/test/dummy",
+                "shape": "(-1,41:60) ",
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode_A",
+                    "model_name": "dummy_A",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                },
+                {
+                    "name": "dummyNode_B",
+                    "model_name": "dummy_B",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "dummyNode_A",
+                               "data_item": "new_dummy_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode_B",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+
+// TODO: Enable once implementation is ready.
+TEST_F(EnsembleFlowTest, DISABLED_InnerNodeConnectionShapeRangeNotMatch) {
+    std::string fileToReload = directoryPath + "/config.json";
+    createConfigFileWithContent(pipelineInnerNodeConnectionShapeRangeNotMatch, fileToReload);
+    ConstructorEnabledModelManager manager;
+
+    auto status = manager.loadConfig(fileToReload);
+    ASSERT_EQ(status, StatusCode::UNKNOWN_ERROR);  // TODO: Fill with proper error once implemented
+
+    ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_1_DUMMY_NAME)->getStateCode(),
+        PipelineDefinitionStateCode::LOADING_PRECONDITION_FAILED);
+}
+
+static const char* pipelineInnerNodeConnectionShapeRangePartiallyMatch = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy_A",
+                "base_path": "/ovms/src/test/dummy",
+                "shape": "(-1,30:40) ",
+                "nireq": 1
+            }
+        },
+        {
+            "config": {
+                "name": "dummy_B",
+                "base_path": "/ovms/src/test/dummy",
+                "shape": "(-1,40:60) ",
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "pipeline1Dummy",
+            "inputs": ["custom_dummy_input"],
+            "nodes": [
+                {
+                    "name": "dummyNode_A",
+                    "model_name": "dummy_A",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "request",
+                               "data_item": "custom_dummy_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                },
+                {
+                    "name": "dummyNode_B",
+                    "model_name": "dummy_B",
+                    "type": "DL model",
+                    "inputs": [
+                        {"b": {"node_name": "dummyNode_A",
+                               "data_item": "new_dummy_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "a",
+                         "alias": "new_dummy_output"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"custom_dummy_output": {"node_name": "dummyNode_B",
+                                         "data_item": "new_dummy_output"}
+                }
+            ]
+        }
+    ]
+})";
+
+TEST_F(EnsembleFlowTest, InnerNodeConnectionShapeRangePartiallyMatch) {
+    std::string fileToReload = directoryPath + "/config.json";
+    createConfigFileWithContent(pipelineInnerNodeConnectionShapeRangePartiallyMatch, fileToReload);
+    ConstructorEnabledModelManager manager;
+
+    auto status = manager.loadConfig(fileToReload);
+    ASSERT_EQ(status, StatusCode::OK);
+
+    ASSERT_EQ(manager.getPipelineFactory().findDefinitionByName(PIPELINE_1_DUMMY_NAME)->getStateCode(),
+        PipelineDefinitionStateCode::AVAILABLE);
+}
+
 static const char* pipelineDemultiplexerShapeEqualToDemultiplyCount = R"(
 {
     "model_config_list": [
@@ -3860,6 +4712,7 @@ class EnsembleFlowTestBinaryInput : public EnsembleFlowTest {
 public:
     const std::string imagePath = "/ovms/src/test/binaryutils/rgb.jpg";
     const std::string imagePath2x2 = "/ovms/src/test/binaryutils/rgb2x2.jpg";
+    const std::string imagePath4x4 = "/ovms/src/test/binaryutils/rgb4x4.jpg";
     const std::string graycaleImagePath = "/ovms/src/test/binaryutils/grayscale.jpg";
 };
 
@@ -3919,6 +4772,65 @@ TEST_F(EnsembleFlowTestBinaryInput, BatchSize1) {
 
     ASSERT_EQ(pipeline->execute(), StatusCode::OK);
     checkIncrement4DimResponse("pipeline_output", {37.0, 28.0, 238.0}, request, response, {1, 3, 1, 1});
+}
+
+static const char* pipelineSingleIncrement4DimOutputNHWC1x1BatchAny = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "increment",
+                "base_path": "/ovms/src/test/increment_1x3x4x5",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "shape": "(-1,1,1,3) ",
+                "layout": "nhwc:nchw",
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "increment_pipeline",
+            "inputs": ["pipeline_input"],
+            "nodes": [
+                {
+                    "name": "increment_node",
+                    "model_name": "increment",
+                    "type": "DL model",
+                    "inputs": [
+                        {"input": {"node_name": "request",
+                                   "data_item": "pipeline_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "output",
+                         "alias": "out"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"pipeline_output": {"node_name": "increment_node",
+                                     "data_item": "out"}
+                }
+            ]
+        }
+    ]
+})";
+
+TEST_F(EnsembleFlowTestBinaryInput, BatchSizeAny) {
+    std::string fileToReload = directoryPath + "/config.json";
+    createConfigFileWithContent(pipelineSingleIncrement4DimOutputNHWC1x1BatchAny, fileToReload);
+    ConstructorEnabledModelManager manager;
+    std::unique_ptr<Pipeline> pipeline;
+
+    const size_t batchSize = 100;
+    prepareBinaryRequest(imagePath, request, "pipeline_input", batchSize);
+
+    ASSERT_EQ(manager.loadConfig(fileToReload), StatusCode::OK);
+    ASSERT_EQ(manager.getPipelineFactory().create(pipeline, "increment_pipeline", &request, &response, manager), StatusCode::OK);
+
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+    checkIncrement4DimShape("pipeline_output", response, {batchSize, 3, 1, 1});
 }
 
 static const char* pipelineSingleIncrement4DimOutputNCHW1x1 = R"(
@@ -4347,6 +5259,82 @@ TEST_F(EnsembleFlowTestBinaryInput, EntryDemultiplexer) {
     checkIncrement4DimResponse("pipeline_output", {37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0}, request, response, {5, 1, 3, 1, 1});
 }
 
+static const char* pipelineSingleIncrement4DimOutputNHWCRangeResolutionEntryDemultiplexer = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "increment",
+                "base_path": "/ovms/src/test/increment_1x3x4x5",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "shape": "(1,1:3,1:3,3) ",
+                "layout": "nhwc:nchw",
+                "nireq": 1
+            }
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "increment_pipeline",
+            "inputs": ["pipeline_input"],
+            "demultiply_count": 0,
+            "nodes": [
+                {
+                    "name": "increment_node",
+                    "model_name": "increment",
+                    "type": "DL model",
+                    "inputs": [
+                        {"input": {"node_name": "request",
+                                   "data_item": "pipeline_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "output",
+                         "alias": "out"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"pipeline_output": {"node_name": "increment_node",
+                                     "data_item": "out"}
+                }
+            ]
+        }
+    ]
+})";
+
+TEST_F(EnsembleFlowTestBinaryInput, EntryDemultiplexerResolutionMatches) {
+    std::string fileToReload = directoryPath + "/config.json";
+    createConfigFileWithContent(pipelineSingleIncrement4DimOutputNHWCRangeResolutionEntryDemultiplexer, fileToReload);
+    ConstructorEnabledModelManager manager;
+    std::unique_ptr<Pipeline> pipeline;
+
+    int batchSize = 5;
+    prepareBinaryRequest(imagePath, request, "pipeline_input", batchSize);
+
+    ASSERT_EQ(manager.loadConfig(fileToReload), StatusCode::OK);
+    ASSERT_EQ(manager.getPipelineFactory().create(pipeline, "increment_pipeline", &request, &response, manager), StatusCode::OK);
+
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+    checkIncrement4DimResponse("pipeline_output", {37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0}, request, response, {5, 1, 3, 1, 1});
+}
+
+TEST_F(EnsembleFlowTestBinaryInput, EntryDemultiplexerResolutionAutoAlign) {
+    std::string fileToReload = directoryPath + "/config.json";
+    createConfigFileWithContent(pipelineSingleIncrement4DimOutputNHWCRangeResolutionEntryDemultiplexer, fileToReload);
+    ConstructorEnabledModelManager manager;
+    std::unique_ptr<Pipeline> pipeline;
+
+    int batchSize = 5;
+    prepareBinaryRequest(imagePath4x4, request, "pipeline_input", batchSize);
+
+    ASSERT_EQ(manager.loadConfig(fileToReload), StatusCode::OK);
+    ASSERT_EQ(manager.getPipelineFactory().create(pipeline, "increment_pipeline", &request, &response, manager), StatusCode::OK);
+
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+    checkIncrement4DimShape("pipeline_output", response, {5, 1, 3, 3, 3});
+}
+
 static const char* pipelineWithOnlyDynamicCustomNode = R"(
 {
     "model_config_list": [],
@@ -4531,4 +5519,172 @@ TEST_F(EnsembleFlowTestBinaryInput, BinaryInputWithPipelineInputLayoutANYAndDemu
     ASSERT_EQ(manager.loadConfig(fileToReload), StatusCode::OK);
     ASSERT_EQ(manager.getPipelineFactory().create(pipeline, "my_pipeline", &request, &response, manager), StatusCode::OK);
     ASSERT_EQ(pipeline->execute(), StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS);
+}
+
+static const char* pipelineWithDynamicCustomNodeDemultiplexerAndDynamicResolutionModel = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "increment",
+                "base_path": "/ovms/src/test/increment_1x3x4x5",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "shape": "(1,-1,-1,3) ",
+                "layout": "nhwc:nchw",
+                "nireq": 1
+            }
+        }
+    ],
+    "custom_node_library_config_list": [
+        {
+            "name": "lib_dynamic_image",
+            "base_path": "/ovms/bazel-bin/src/lib_node_dynamic_image.so"
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "my_pipeline",
+            "inputs": ["pipeline_input"],
+            "demultiply_count": 0,
+            "nodes": [
+                {
+                    "name": "custom_node",
+                    "library_name": "lib_dynamic_image",
+                    "type": "custom",
+                    "inputs": [
+                        {"input_numbers": {"node_name": "request",
+                                           "data_item": "pipeline_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "output_numbers",
+                         "alias": "custom_node_output"}
+                    ]
+                },
+                {
+                    "name": "increment_node",
+                    "model_name": "increment",
+                    "type": "DL model",
+                    "inputs": [
+                        {"input": {"node_name": "custom_node",
+                                   "data_item": "custom_node_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "output",
+                         "alias": "out"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"pipeline_output": {"node_name": "increment_node",
+                                     "data_item": "out"}
+                }
+            ]
+        }
+    ]
+})";
+
+TEST_F(EnsembleFlowTestBinaryInput, BinaryInputWithPipelineInputLayoutANYCustomNodeDemultiplexerAndDynamicResolutionModel) {
+    std::string fileToReload = directoryPath + "/config.json";
+    createConfigFileWithContent(pipelineWithDynamicCustomNodeDemultiplexerAndDynamicResolutionModel, fileToReload);
+    ConstructorEnabledModelManager manager;
+    std::unique_ptr<Pipeline> pipeline;
+
+    int batchSize = 1;
+    prepareBinaryRequest(imagePath, request, "pipeline_input", batchSize);
+
+    ASSERT_EQ(manager.loadConfig(fileToReload), StatusCode::OK);
+    ASSERT_EQ(manager.getPipelineFactory().create(pipeline, "my_pipeline", &request, &response, manager), StatusCode::OK);
+
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+    checkIncrement4DimResponse("pipeline_output", {45.0, 36.0, 246.0}, request, response, {1, 1, 3, 1, 1});
+}
+
+static const char* pipelineWithDynamicCustomNodeDemultiplexerAndRangeOfResolutionModel = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "increment",
+                "base_path": "/ovms/src/test/increment_1x3x4x5",
+                "target_device": "CPU",
+                "model_version_policy": {"all": {}},
+                "shape": "(1,1:2,1:2,3) ",
+                "layout": "nhwc:nchw",
+                "nireq": 1
+            }
+        }
+    ],
+    "custom_node_library_config_list": [
+        {
+            "name": "lib_dynamic_image",
+            "base_path": "/ovms/bazel-bin/src/lib_node_dynamic_image.so"
+        }
+    ],
+    "pipeline_config_list": [
+        {
+            "name": "my_pipeline",
+            "inputs": ["pipeline_input"],
+            "demultiply_count": 0,
+            "nodes": [
+                {
+                    "name": "custom_node",
+                    "library_name": "lib_dynamic_image",
+                    "type": "custom",
+                    "inputs": [
+                        {"input_numbers": {"node_name": "request",
+                                           "data_item": "pipeline_input"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "output_numbers",
+                         "alias": "custom_node_output"}
+                    ]
+                },
+                {
+                    "name": "increment_node",
+                    "model_name": "increment",
+                    "type": "DL model",
+                    "inputs": [
+                        {"input": {"node_name": "custom_node",
+                                   "data_item": "custom_node_output"}}
+                    ],
+                    "outputs": [
+                        {"data_item": "output",
+                         "alias": "out"}
+                    ]
+                }
+            ],
+            "outputs": [
+                {"pipeline_output": {"node_name": "increment_node",
+                                     "data_item": "out"}
+                }
+            ]
+        }
+    ]
+})";
+
+TEST_F(EnsembleFlowTestBinaryInput, BinaryInputWithPipelineInputLayoutANYCustomNodeDemultiplexerAndRangeOfResolutionModel) {
+    std::string fileToReload = directoryPath + "/config.json";
+    createConfigFileWithContent(pipelineWithDynamicCustomNodeDemultiplexerAndRangeOfResolutionModel, fileToReload);
+    ConstructorEnabledModelManager manager;
+    std::unique_ptr<Pipeline> pipeline;
+
+    // Try with resolution out of shape range, expect INVALID_SHAPE
+    int batchSize = 1;
+    prepareBinaryRequest(imagePath4x4, request, "pipeline_input", batchSize);
+
+    ASSERT_EQ(manager.loadConfig(fileToReload), StatusCode::OK);
+    ASSERT_EQ(manager.getPipelineFactory().create(pipeline, "my_pipeline", &request, &response, manager), StatusCode::OK);
+
+    ASSERT_EQ(pipeline->execute(), StatusCode::INVALID_SHAPE);
+
+    request.Clear();
+    response.Clear();
+
+    // Try with resolution matching the shape, expect OK
+    ASSERT_EQ(manager.getPipelineFactory().create(pipeline, "my_pipeline", &request, &response, manager), StatusCode::OK);
+    prepareBinaryRequest(imagePath, request, "pipeline_input", batchSize);
+
+    ASSERT_EQ(pipeline->execute(), StatusCode::OK);
+    checkIncrement4DimResponse("pipeline_output", {45.0, 36.0, 246.0}, request, response, {1, 1, 3, 1, 1});
 }

--- a/src/test/modelinstance_test.cpp
+++ b/src/test/modelinstance_test.cpp
@@ -297,6 +297,30 @@ TEST_F(TestLoadModel, UnSuccessfulLoadWhenLayoutIncorrect) {
     EXPECT_EQ(ovms::ModelVersionState::LOADING, modelInstance.getStatus().getState()) << modelInstance.getStatus().getStateString();
 }
 
+TEST_F(TestLoadModel, SuccessfulLoadDummyAllDimensionsAny) {
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
+    ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(-1,-1)"), ovms::StatusCode::OK);
+    ASSERT_EQ(modelInstance.loadModel(config), ovms::StatusCode::OK);
+    ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance.getStatus().getState());
+    ASSERT_NE(modelInstance.getInputsInfo().begin(), modelInstance.getInputsInfo().end());
+    ASSERT_EQ(modelInstance.getInputsInfo().begin()->second->getShape(), ovms::Shape(
+                                                                             {ovms::Dimension::any(), ovms::Dimension::any()}));
+}
+
+TEST_F(TestLoadModel, SuccessfulLoadDummyDimensionRanges) {
+    ovms::ModelInstance modelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, *ieCore);
+    ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(20:30,40:50)"), ovms::StatusCode::OK);
+    ASSERT_EQ(modelInstance.loadModel(config), ovms::StatusCode::OK);
+    ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance.getStatus().getState());
+    ASSERT_NE(modelInstance.getInputsInfo().begin(), modelInstance.getInputsInfo().end());
+    ASSERT_EQ(modelInstance.getInputsInfo().begin()->second->getShape(), ovms::Shape(
+                                                                             {{20, 30}, {40, 50}}));
+}
+
 class TestLoadModelWithMapping : public TestLoadModel {
 protected:
     void SetUp() override {

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -1014,4 +1014,178 @@ TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChangeArbitraryPosition) {
     ASSERT_EQ(performInferenceWithBatchSize(response, 30, tensorflow::DataType::DT_FLOAT, batchSizePosition), ovms::StatusCode::INVALID_SHAPE);
 }
 
+/**
+ * Scenario - inference with different shapes with dynamic dummy, both dimensions reshaped to any.
+ * No model reload performed between requests.
+ *
+ * 1. Load model with input shape (-1, -1)
+ * 2. Do the inference with (3, 2) shape, expect correct output shape
+ * 3. Do the inference with (1, 4) shape, expect correct output shape
+ */
+
+TEST_F(TestPredict, PerformInferenceDummyAllDimensionsAny) {
+    using namespace ovms;
+
+    // Prepare model with changed layout to nhwc (internal layout=nchw)
+    ModelConfig config = DUMMY_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(-1,-1)"), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    tensorflow::serving::PredictResponse response;
+
+    // Do the inference with (3, 2)
+    ASSERT_EQ(performInferenceWithShape(response, {3, 2}), ovms::StatusCode::OK);
+    checkOutputShape(response, {3, 2}, DUMMY_MODEL_OUTPUT_NAME);
+
+    // Do the inference with (1, 4)
+    ASSERT_EQ(performInferenceWithShape(response, {1, 4}), ovms::StatusCode::OK);
+    checkOutputShape(response, {1, 4}, DUMMY_MODEL_OUTPUT_NAME);
+}
+
+/**
+ * Scenario - inference with different batch sizes for dynamic batch dummy.
+ * No model reload performed between requests.
+ *
+ * 1. Load model with input shape (-1, 10)
+ * 2. Do the X inferences with (x, 10) shape, expect correct output shapes. x=(0; 100]
+ */
+
+TEST_F(TestPredict, PerformInferenceDummyBatchSizeAny) {
+    using namespace ovms;
+
+    // Prepare model with changed layout to nhwc (internal layout=nchw)
+    ModelConfig config = DUMMY_MODEL_CONFIG;
+    config.setBatchingParams("-1");
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    tensorflow::serving::PredictResponse response;
+
+    for (int i = 1; i <= 100; i++) {
+        ASSERT_EQ(performInferenceWithShape(response, {i, 10}), ovms::StatusCode::OK);
+        checkOutputShape(response, {i, 10}, DUMMY_MODEL_OUTPUT_NAME);
+    }
+}
+
+/**
+ * Scenario - inference with different shapes with dynamic dummy, both dimensions reshaped to range.
+ * No model reload performed between requests.
+ *
+ * 1. Load model with input shape (2:4, 1:5)
+ * 2. Do the inference with (1, 1) shape, expect not in range
+ * 3. Do the inference with (2, 1) shape, expect success and correct output shape
+ * 4. Do the inference with (3, 2) shape, expect success and correct output shape
+ * 5. Do the inference with (3, 5) shape, expect success and correct output shape
+ * 6. Do the inference with (3, 6) shape, expect not in range
+ * 7. Do the inference with (5, 5) shape, expect not in range
+ */
+
+TEST_F(TestPredict, PerformInferenceDummyAllDimensionsHaveRange) {
+    using namespace ovms;
+
+    // Prepare model with changed layout to nhwc (internal layout=nchw)
+    ModelConfig config = DUMMY_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(2:4,1:5)"), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    tensorflow::serving::PredictResponse response;
+
+    ASSERT_EQ(performInferenceWithShape(response, {1, 1}), ovms::StatusCode::INVALID_BATCH_SIZE);
+
+    ASSERT_EQ(performInferenceWithShape(response, {2, 1}), ovms::StatusCode::OK);
+    checkOutputShape(response, {2, 1}, DUMMY_MODEL_OUTPUT_NAME);
+
+    ASSERT_EQ(performInferenceWithShape(response, {3, 2}), ovms::StatusCode::OK);
+    checkOutputShape(response, {3, 2}, DUMMY_MODEL_OUTPUT_NAME);
+
+    ASSERT_EQ(performInferenceWithShape(response, {3, 5}), ovms::StatusCode::OK);
+    checkOutputShape(response, {3, 5}, DUMMY_MODEL_OUTPUT_NAME);
+
+    ASSERT_EQ(performInferenceWithShape(response, {3, 6}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(performInferenceWithShape(response, {5, 5}), ovms::StatusCode::INVALID_BATCH_SIZE);
+}
+
+/**
+ * Scenario - send binary input request to model accepting dynamic batch size.
+ *
+ * 1. Load model with input layout=nhwc, batch_size=-1, initial internal layout: nchw, batch_size=1
+ * 2. Do the inference with batch=5 binary image tensor - expect status OK and result in NCHW layout
+ */
+TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAny) {
+    using namespace ovms;
+
+    // Prepare model with changed layout to nhwc (internal layout=nchw)
+    ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(-1,1,2,3)"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    tensorflow::serving::PredictResponse response;
+
+    const int batchSize = 5;
+    // Perform inference with binary input, ensure status OK and correct results
+    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5", batchSize), ovms::StatusCode::OK);
+    checkOutputShape(response, {5, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+}
+
+/**
+ * Scenario - send binary input request to model accepting dynamic resolution.
+ *
+ * 1. Load model with input layout=nhwc, shape 1,-1,-1,3, initial internal layout: nchw, batch_size=1
+ * 2. Do the inference with resolution 1x1 binary image tensor - expect status OK and result in NCHW layout
+ */
+TEST_F(TestPredict, PerformInferenceWithBinaryInputResolutionAny) {
+    using namespace ovms;
+
+    // Prepare model with changed layout to nhwc (internal layout=nchw)
+    ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(1,-1,-1,3)"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    tensorflow::serving::PredictResponse response;
+
+    // Perform inference with binary input, ensure status OK and correct results
+    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
+    checkOutputShape(response, {1, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    checkOutputValues(response, {37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+}
+
+/**
+ * Scenario - send binary input request to model accepting range of resolution.
+ *
+ * 1. Load model with input layout=nhwc, shape 1,1:2,1:2,3, initial internal layout: nchw, batch_size=1
+ * 2. Do the inference with resolution 4x4 binary image tensor - expect status OK and reshaped to 2x2
+ * 3. Do the inference with resolution 1x1 binary image tensor - expect status OK and result in NCHW layout
+ */
+TEST_F(TestPredict, PerformInferenceWithBinaryInputResolutionRange) {
+    using namespace ovms;
+
+    // Prepare model with changed layout to nhwc (internal layout=nchw)
+    ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
+    config.setBatchingParams("0");
+    ASSERT_EQ(config.parseShapeParameter("(1,1:2,1:2,3)"), ovms::StatusCode::OK);
+    ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
+    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+
+    tensorflow::serving::PredictResponse response;
+
+    ASSERT_EQ(
+        performInferenceWithRequest(
+            prepareBinary4x4PredictRequest(INCREMENT_1x3x4x5_MODEL_INPUT_NAME), response, "increment_1x3x4x5"),
+        ovms::StatusCode::OK);
+    checkOutputShape(response, {1, 3, 2, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+
+    response.Clear();
+
+    // Perform inference with binary input, ensure status OK and correct results
+    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
+    checkOutputShape(response, {1, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    checkOutputValues(response, {37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+}
+
 #pragma GCC diagnostic pop

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -1061,7 +1061,7 @@ TEST_F(TestPredict, PerformInferenceDummyBatchSizeAny) {
 
     tensorflow::serving::PredictResponse response;
 
-    for (int i = 1; i <= 100; i++) {
+    for (size_t i : {1, 3, 5, 7, 11, 17, 21, 57, 99}) {
         ASSERT_EQ(performInferenceWithShape(response, {i, 10}), ovms::StatusCode::OK);
         checkOutputShape(response, {i, 10}, DUMMY_MODEL_OUTPUT_NAME);
     }

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -100,6 +100,18 @@ void checkIncrement4DimResponse(const std::string outputName,
         << readableError(expected_output, actual_output, dataLengthToCheck / sizeof(float));
 }
 
+void checkIncrement4DimShape(const std::string outputName,
+    PredictResponse& response,
+    const std::vector<size_t>& expectedShape) {
+    ASSERT_EQ(response.outputs().count(outputName), 1) << "Did not find:" << outputName;
+    const auto& output_proto = response.outputs().at(outputName);
+
+    ASSERT_EQ(output_proto.tensor_shape().dim_size(), expectedShape.size());
+    for (size_t i = 0; i < expectedShape.size(); i++) {
+        ASSERT_EQ(output_proto.tensor_shape().dim(i).size(), expectedShape[i]);
+    }
+}
+
 bool isShapeTheSame(const tensorflow::TensorShapeProto& actual, const std::vector<int64_t>&& expected) {
     bool same = true;
     if (static_cast<unsigned int>(actual.dim_size()) != expected.size()) {
@@ -140,12 +152,31 @@ void readRgbJpg(size_t& filesize, std::unique_ptr<char[]>& image_bytes) {
     return readImage("/ovms/src/test/binaryutils/rgb.jpg", filesize, image_bytes);
 }
 
+void read4x4RgbJpg(size_t& filesize, std::unique_ptr<char[]>& image_bytes) {
+    return readImage("/ovms/src/test/binaryutils/rgb4x4.jpg", filesize, image_bytes);
+}
+
 tensorflow::serving::PredictRequest prepareBinaryPredictRequest(const std::string& inputName, const int batchSize) {
     tensorflow::serving::PredictRequest request;
     auto& tensor = (*request.mutable_inputs())[inputName];
     size_t filesize = 0;
     std::unique_ptr<char[]> image_bytes = nullptr;
     readRgbJpg(filesize, image_bytes);
+
+    for (int i = 0; i < batchSize; i++) {
+        tensor.add_string_val(image_bytes.get(), filesize);
+    }
+    tensor.set_dtype(tensorflow::DataType::DT_STRING);
+    tensor.mutable_tensor_shape()->add_dim()->set_size(batchSize);
+    return request;
+}
+
+tensorflow::serving::PredictRequest prepareBinary4x4PredictRequest(const std::string& inputName, const int batchSize) {
+    tensorflow::serving::PredictRequest request;
+    auto& tensor = (*request.mutable_inputs())[inputName];
+    size_t filesize = 0;
+    std::unique_ptr<char[]> image_bytes = nullptr;
+    read4x4RgbJpg(filesize, image_bytes);
 
     for (int i = 0; i < batchSize; i++) {
         tensor.add_string_val(image_bytes.get(), filesize);

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -139,6 +139,7 @@ static tensorflow::serving::PredictRequest preparePredictRequest(inputs_info_t r
 }
 
 tensorflow::serving::PredictRequest prepareBinaryPredictRequest(const std::string& inputName, const int batchSize = 1);
+tensorflow::serving::PredictRequest prepareBinary4x4PredictRequest(const std::string& inputName, const int batchSize = 1);
 
 void checkDummyResponse(const std::string outputName,
     const std::vector<float>& requestData,
@@ -147,6 +148,10 @@ void checkDummyResponse(const std::string outputName,
 void checkIncrement4DimResponse(const std::string outputName,
     const std::vector<float>& expectedData,
     tensorflow::serving::PredictRequest& request,
+    tensorflow::serving::PredictResponse& response,
+    const std::vector<size_t>& expectedShape);
+
+void checkIncrement4DimShape(const std::string outputName,
     tensorflow::serving::PredictResponse& response,
     const std::vector<size_t>& expectedShape);
 


### PR DESCRIPTION
```
EnsembleMetadata.
  OneModelNodeWithShapeRange
  DISABLED_TwoParallelModelsShapeRangeIntersection
  DISABLED_TwoParallelModelsOneShapeRangeOneStaticIntersection
  DISABLED_TwoParallelModelsOneShapeAnyOneStaticIntersection
EnsembleFlowValidationShapeRangeTest.
  DummyModelValid
  DummyModelProtoValidationErrorInvalidBatchSize
  DummyModelProtoValidationErrorInvalidShape
EnsembleFlowValidationShapeAnyTest.
  DummyModelValid
EnsembleFlowTest.
  DISABLED_InnerNodeConnectionShapeRangeNotMatch
  InnerNodeConnectionShapeRangePartiallyMatch
  TwoInnerNodesConnectedShapeRangePartiallyMatching
  TwoInnerNodesConnectedShapeRangeNotMatching
  ExecutePipelineWithBatchSizeAny
  ExecutePipelineWithBatchSizeRange
  ExecutePipelineWithShapeAny
  ExecutePipelineWithShapeRange
  ExecutePipelineWithBatchAndShapeSetToAny
  ExecutePipelineWithBatchAndShapeSetToRange
  ExecutePipelineWithInnerNhwcConnection
EnsembleFlowTestBinaryInput.
  BatchSizeAny
  EntryDemultiplexerResolutionMatches
  EntryDemultiplexerResolutionAutoAlign
  BinaryInputWithPipelineInputLayoutANYCustomNodeDemultiplexerAndDynamicResolutionModel
  BinaryInputWithPipelineInputLayoutANYCustomNodeDemultiplexerAndRangeOfResolutionModel
TestLoadModel.
  SuccessfulLoadDummyAllDimensionsAny
  SuccessfulLoadDummyDimensionRanges
PredictValidationDynamicModel.
  ValidRequest
  RequestBatchNotInRangeFirstPosition
  RequestBatchNotInRangeSecondPosition
  RequestDimensionNotInRangeSecondPosition
  RequestDimensionInRangeWrongTensorContent
TestPredict.
  PerformInferenceDummyAllDimensionsAny
  PerformInferenceDummyBatchSizeAny
  PerformInferenceDummyAllDimensionsHaveRange
  PerformInferenceWithBinaryInputBatchSizeAny
  PerformInferenceWithBinaryInputResolutionAny
  PerformInferenceWithBinaryInputResolutionRange

Disabled remaining dynamic (shape=auto) unit tests
Fixed arbitrary batch size position DAG tests
```