### PR TITLE
CVS-75094 Disallow layout setting incompatible with shape 

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -118,4 +118,19 @@ Layout Layout::fromOvLayout(const ov::Layout& layout) {
     return Layout(strCopy);
 }
 
+bool Layout::containsEtc() const {
+    return (*this).find(ETC_LAYOUT_DELIMETER) != std::string::npos;
+}
+
+std::string::size_type Layout::getNumberOfKnownDimensions() const {
+    return std::count_if((*this).begin(), (*this).end(), [](char c) { return ALLOWED_DIMENSION_LETTERS.find(c) != std::string::npos || c == UNDEFINED_DIMENSION_CHAR; });
+}
+
+bool Layout::isCompatible(const Shape& shape) const {
+    if (this->containsEtc()) {
+        return this->getNumberOfKnownDimensions() <= shape.size();
+    }
+    return this->getNumberOfKnownDimensions() == shape.size();
+}
+
 }  // namespace ovms

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -20,6 +20,7 @@
 
 #include <openvino/openvino.hpp>
 
+#include "shape.hpp"
 #include "status.hpp"
 
 namespace ovms {
@@ -37,6 +38,8 @@ class Layout : public std::string {
     std::optional<size_t> retrieveBatchIndex() const;
     bool containsEtc() const;
 
+    std::string::size_type getNumberOfKnownDimensions() const;
+
 public:
     Layout() = default;
     Layout(const std::string& str);
@@ -48,6 +51,8 @@ public:
     std::optional<Layout> createIntersection(const Layout& other) const;
     static const Layout& getDefaultLayout();
     static const Layout& getUnspecifiedLayout();
+
+    bool isCompatible(const Shape& shape) const;
 };
 
 }  // namespace ovms

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -397,6 +397,11 @@ Status ModelInstance::loadInputTensors(const ModelConfig& config, const DynamicM
             std::string mappingName = config.getMappingInputByKey(name);
             const Layout layout = getReportedTensorLayout(config, name, true);
 
+            if (!layout.isCompatible(shape)) {
+                SPDLOG_LOGGER_ERROR(modelmanager_logger, "Layout: {}; incompatible with shape: {}; for input name: {}", layout, shape.toString(), name);
+                return StatusCode::LAYOUT_INCOMPATIBLE_WITH_SHAPE;
+            }
+
             std::shared_ptr<TensorInfo> info = std::make_shared<TensorInfo>(
                 name,
                 mappingName,
@@ -442,6 +447,11 @@ Status ModelInstance::loadOutputTensors(const ModelConfig& config) {
             Shape shape(output.get_partial_shape());
             std::string mappingName = config.getMappingOutputByKey(name);
             const Layout layout = getReportedTensorLayout(config, name, false);
+
+            if (!layout.isCompatible(shape)) {
+                SPDLOG_LOGGER_ERROR(modelmanager_logger, "Layout: {}; incompatible with shape: {}; for output name: {}", layout, shape.toString(), name);
+                return StatusCode::LAYOUT_INCOMPATIBLE_WITH_SHAPE;
+            }
 
             std::shared_ptr<TensorInfo> info = std::make_shared<TensorInfo>(
                 name,

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -71,6 +71,7 @@ const std::unordered_map<const StatusCode, const std::string> Status::statusMess
     {StatusCode::INVALID_MAX_SEQUENCE_NUMBER, "Sequence max number parameter too high"},
     {StatusCode::CANNOT_CONVERT_FLAT_SHAPE, "Cannot convert flat shape to Shape object"},
     {StatusCode::INVALID_BATCH_DIMENSION, "Invalid batch dimension in shape"},
+    {StatusCode::LAYOUT_INCOMPATIBLE_WITH_SHAPE, "Layout incompatible with given shape"},
     {StatusCode::UNKNOWN_ERROR, "Unknown error"},
 
     // Sequence management

--- a/src/status.hpp
+++ b/src/status.hpp
@@ -66,6 +66,7 @@ enum class StatusCode {
     REQUESTED_DYNAMIC_PARAMETERS_ON_SUBSCRIBED_MODEL,
     CANNOT_CONVERT_FLAT_SHAPE,
     INVALID_BATCH_DIMENSION, /*!< Invalid batch dimension in shape */
+    LAYOUT_INCOMPATIBLE_WITH_SHAPE,
 
     // Model management
     MODEL_MISSING,                                     /*!< Model with such name and/or version does not exist */

--- a/src/test/layout_test.cpp
+++ b/src/test/layout_test.cpp
@@ -108,3 +108,22 @@ TEST(Layout, ConversionBetweenOvLayout) {
             << "error converting layout: " << layoutStr;
     }
 }
+
+TEST(Layout, IsCompatibleWithShape) {
+    EXPECT_TRUE(Layout("NCHW").isCompatible(Shape{1, 3, 224, 224}));
+    EXPECT_TRUE(Layout("NCHW...").isCompatible(Shape{1, 3, 224, 224}));
+    EXPECT_TRUE(Layout("N?HW...").isCompatible(Shape{1, 3, 224, 224}));
+    EXPECT_TRUE(Layout("N...").isCompatible(Shape{1}));
+    EXPECT_TRUE(Layout("N...").isCompatible(Shape{1, 5, 9, 100}));
+    EXPECT_TRUE(Layout("...").isCompatible(Shape{1, 5, 9, 100}));
+    EXPECT_TRUE(Layout("NC...H").isCompatible(Shape{1, 5, 9}));
+    EXPECT_TRUE(Layout("NC...H").isCompatible(Shape{1, 5, 9, 100}));
+}
+
+TEST(Layout, IsIncompatibleWithShape) {
+    EXPECT_FALSE(Layout("NCHW").isCompatible(Shape{1, 3, 224, 224, 10}));  // to many dims in shape
+    EXPECT_FALSE(Layout("NCHW").isCompatible(Shape{1, 224, 224}));         // too few dims in shape
+    EXPECT_FALSE(Layout("N...H").isCompatible(Shape{1}));                  // too few dims in shape
+    EXPECT_FALSE(Layout("N?HW").isCompatible(Shape{1, 224, 224}));         // too few dims in shape
+    EXPECT_FALSE(Layout("N?HW").isCompatible(Shape{1, 224, 224, 3, 1}));   // too many dims in shape
+}


### PR DESCRIPTION
Incompatible layout with shape meaning different number of dimensions inside layout and shape.
Example of incompatible pairs:
- NCHW & (1,10)
- NC & (1,3,224,224)