### PR TITLE
Model optimizer 2022.1 adjustments

### DIFF
--- a/demos/optical_character_recognition/python/README.md
+++ b/demos/optical_character_recognition/python/README.md
@@ -73,8 +73,8 @@ docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw -w /EAST openvino/ubuntu18_d
 
 Convert the TensorFlow frozen model to Intermediate Representation format using the model_optimizer tool:
 ```bash
-docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw openvino/ubuntu18_dev:2021.3 deployment_tools/model_optimizer/mo.py \
---framework=tf --input_shape=[1,1024,1920,3] --input=input_images --output=feature_fusion/Conv_7/Sigmoid,feature_fusion/concat_3  \
+docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw nncv-harbor.inn.intel.com/openvino/ubuntu20_dev:2022.1.0.579 python3 /usr/local/lib/python3.8/dist-packages/openvino/tools/mo/mo.py \
+--framework=tf --input_shape=[1,1024,1920,3] --input=input_images --output=feature_fusion/Conv_7/Sigmoid,feature_fusion/concat_3 \
 --input_model /EAST/model.pb --output_dir /EAST/IR/1/
 ```
 It will create model files in `${PWD}/IR/1/` folder.
@@ -84,9 +84,9 @@ model.mapping
 model.xml
 ```
 Converted east-reasnet50 model will have the following interface:
-- Input name: `input_images` ; shape: `[1 3 1024 1920]` ; precision: `FP32`, layout: `N...`
-- Output name: `feature_fusion/Conv_7/Sigmoid` ; shape: `[1 1 256 480]` ; precision: `FP32`
-- Output name: `feature_fusion/concat_3` ; shape: `[1 5 256 480]` ; precision: `FP32`
+- Input name: `input_images` ; shape: `[1 1024 1920 3]` ; precision: `FP32`, layout: `N...`
+- Output name: `feature_fusion/Conv_7/Sigmoid` ; shape: `[1 256 480 1]` ; precision: `FP32`
+- Output name: `feature_fusion/concat_3` ; shape: `[1 256 480 5]` ; precision: `FP32`
 
 ### Text-recognition model
 Download [text-recognition](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/intel/text-recognition-0014) model and store it in `${PWD}/text-recognition/1` folder.

--- a/demos/optical_character_recognition/python/README.md
+++ b/demos/optical_character_recognition/python/README.md
@@ -68,7 +68,7 @@ export_model('./east_icdar2015_resnet_v1_50_rbox/model.ckpt-49491','./model.pb')
 Freeze the model in checkpoint format and save it in proto buffer format in `model.pb`:
 
 ```bash
-docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw -w /EAST openvino/ubuntu18_dev:2021.3 python3 freeze_east_model.py
+docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw -w /EAST tensorflow/tensorflow:1.15.5 python3 freeze_east_model.py
 ```
 
 Convert the TensorFlow frozen model to Intermediate Representation format using the model_optimizer tool:

--- a/demos/optical_character_recognition/python/README.md
+++ b/demos/optical_character_recognition/python/README.md
@@ -84,9 +84,9 @@ model.mapping
 model.xml
 ```
 Converted east-reasnet50 model will have the following interface:
-- Input name: `input_images` ; shape: `[1 1024 1920 3]` ; precision: `FP32`, layout: `N...`
-- Output name: `feature_fusion/Conv_7/Sigmoid` ; shape: `[1 256 480 1]` ; precision: `FP32`
-- Output name: `feature_fusion/concat_3` ; shape: `[1 256 480 5]` ; precision: `FP32`
+- Input name: `input_images` ; shape: `[1 1024 1920 3]` ; precision: `FP32` ; layout: `N...`
+- Output name: `feature_fusion/Conv_7/Sigmoid` ; shape: `[1 256 480 1]` ; precision: `FP32` ; layout: `N...`
+- Output name: `feature_fusion/concat_3` ; shape: `[1 256 480 5]` ; precision: `FP32`; layout: `N...`
 
 ### Text-recognition model
 Download [text-recognition](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/intel/text-recognition-0014) model and store it in `${PWD}/text-recognition/1` folder.

--- a/demos/optical_character_recognition/python/README.md
+++ b/demos/optical_character_recognition/python/README.md
@@ -73,7 +73,7 @@ docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw -w /EAST tensorflow/tensorfl
 
 Convert the TensorFlow frozen model to Intermediate Representation format using the model_optimizer tool:
 ```bash
-docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw nncv-harbor.inn.intel.com/openvino/ubuntu20_dev:2022.1.0.579 python3 /usr/local/lib/python3.8/dist-packages/openvino/tools/mo/mo.py \
+docker run -u $(id -u):$(id -g) -v ${PWD}/:/EAST:rw openvino/ubuntu20_dev:2022.1 python3 /usr/local/lib/python3.8/dist-packages/openvino/tools/mo/mo.py \
 --framework=tf --input_shape=[1,1024,1920,3] --input=input_images --output=feature_fusion/Conv_7/Sigmoid,feature_fusion/concat_3 \
 --input_model /EAST/model.pb --output_dir /EAST/IR/1/
 ```
@@ -129,6 +129,9 @@ OCR
 └── lib
     └── libcustom_node_east_ocr.so
 ```
+
+**NOTE:** east_fp32 model created before 2022.1 requires additional parameters in config.json:
+- `layout: {"input_images": "NHWC:NCHW", "feature_fusion/Conv_7/Sigmoid": "NHWC:NCHW", "feature_fusion/concat_3": "NHWC:NCHW"}`
 
 ## Deploying OVMS
 

--- a/demos/optical_character_recognition/python/config.json
+++ b/demos/optical_character_recognition/python/config.json
@@ -4,7 +4,6 @@
             "config": {
                 "name": "east",
                 "base_path": "/OCR/east_fp32",
-                "layout": "NHWC:NCHW",
                 "plugin_config": {
                     "CPU_THROUGHPUT_STREAMS":  "1"
                 }

--- a/docs/tf_model_binary_input.md
+++ b/docs/tf_model_binary_input.md
@@ -22,14 +22,9 @@ rmdir resnet_v2_fp32_savedmodel_NHWC/
 ```
 *Note:* Directories operations are not necessary for the preparation, but in this guide the directories are simplified.
 
-Pull the latest openvino ubuntu_dev image from dockerhub
-```Bash
-docker pull openvino/ubuntu18_dev:latest
-```
-
 Convert the TensorFlow model to Intermediate Representation format using model_optimizer tool:
 ```Bash
-docker run -u $(id -u):$(id -g) -v ${PWD}/resnet_v2/:/resnet openvino/ubuntu18_dev:latest deployment_tools/model_optimizer/mo.py --saved_model_dir /resnet/ --output_dir /resnet/models/resnet/1/ --input_shape=[1,224,224,3] --mean_values=[123.68,116.78,103.94] --reverse_input_channels
+docker run -u $(id -u):$(id -g) -v ${PWD}/resnet_v2/:/resnet nncv-harbor.inn.intel.com/openvino/ubuntu20_dev:2022.1.0.579 python3 /usr/local/lib/python3.8/dist-packages/openvino/tools/mo/mo.py --saved_model_dir /resnet/ --output_dir /resnet/models/resnet/1/ --input_shape=[1,224,224,3] --mean_values=[123.68,116.78,103.94] --reverse_input_channels
 ```
 
 *Note:* Some models might require other parameters such as `--scale` parameter.
@@ -54,13 +49,13 @@ docker pull openvino/model_server:latest
 
 Deploy OVMS using the following command:
 ```Bash
-docker run -d -p 9000:9000 -v ${PWD}/resnet_v2/models:/models openvino/model_server:latest --model_path /models/resnet --model_name resnet --port 9000 --layout NHWC:NCHW
+docker run -d -p 9000:9000 -v ${PWD}/resnet_v2/models:/models openvino/model_server:latest --model_path /models/resnet --model_name resnet --port 9000
 ```
 
 ### Running the inference requests from the client
 
 ```Bash
-cd client/python/ovmsclient/samples
+cd ../client/python/ovmsclient/samples
 virtualenv .venv
 . .venv/bin/activate
 pip install -r requirements.txt

--- a/docs/tf_model_binary_input.md
+++ b/docs/tf_model_binary_input.md
@@ -55,7 +55,7 @@ docker run -d -p 9000:9000 -v ${PWD}/resnet_v2/models:/models openvino/model_ser
 ### Running the inference requests from the client
 
 ```Bash
-cd ../client/python/ovmsclient/samples
+cd client/python/ovmsclient/samples
 virtualenv .venv
 . .venv/bin/activate
 pip install -r requirements.txt

--- a/docs/tf_model_binary_input.md
+++ b/docs/tf_model_binary_input.md
@@ -24,7 +24,7 @@ rmdir resnet_v2_fp32_savedmodel_NHWC/
 
 Convert the TensorFlow model to Intermediate Representation format using model_optimizer tool:
 ```Bash
-docker run -u $(id -u):$(id -g) -v ${PWD}/resnet_v2/:/resnet nncv-harbor.inn.intel.com/openvino/ubuntu20_dev:2022.1.0.579 python3 /usr/local/lib/python3.8/dist-packages/openvino/tools/mo/mo.py --saved_model_dir /resnet/ --output_dir /resnet/models/resnet/1/ --input_shape=[1,224,224,3] --mean_values=[123.68,116.78,103.94] --reverse_input_channels
+docker run -u $(id -u):$(id -g) -v ${PWD}/resnet_v2/:/resnet openvino/ubuntu20_dev:2022.1 python3 /usr/local/lib/python3.8/dist-packages/openvino/tools/mo/mo.py --saved_model_dir /resnet/ --output_dir /resnet/models/resnet/1/ --input_shape=[1,224,224,3] --mean_values=[123.68,116.78,103.94] --reverse_input_channels
 ```
 
 *Note:* Some models might require other parameters such as `--scale` parameter.

--- a/src/custom_nodes/east_ocr/README.md
+++ b/src/custom_nodes/east_ocr/README.md
@@ -25,8 +25,8 @@ make BASE_OS=redhat
 | Input name       | Description           | Shape  | Precision |
 | ------------- |:-------------:| -----:| ------:|
 | image      | Input image in an array format. Only batch size 1 is supported and images must have 3 channels. Resolution is configurable via parameters original_image_width and original_image_height. | `1,3,H,W` | FP32 |
-| scores      | east-resnet50 model output `feature_fusion/Conv_7/Sigmoid` | `1,1,256,480` | FP32 |
-| geometry | east-resnet50 model output `feature_fusion/concat_3` | `1,5,256,480` | FP32 |
+| scores      | east-resnet50 model output `feature_fusion/Conv_7/Sigmoid` | `1,256,480,1` | FP32 |
+| geometry | east-resnet50 model output `feature_fusion/concat_3` | `1,256,480,5` | FP32 |
 
 
 # Custom node outputs

--- a/src/custom_nodes/east_ocr/config.json
+++ b/src/custom_nodes/east_ocr/config.json
@@ -4,7 +4,6 @@
             "config": {
                 "name": "east",
                 "base_path": "/OCR/east_fp32",
-                "layout": "NHWC:NCHW",
                 "plugin_config": {
                     "CPU_THROUGHPUT_STREAMS":  "1"
                 }

--- a/src/custom_nodes/east_ocr/east_ocr.cpp
+++ b/src/custom_nodes/east_ocr/east_ocr.cpp
@@ -264,7 +264,8 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
             int offsetY = y * 4;
 
             // Extract the rotation angle for the prediction and then compute the sin and cosine
-            float angle = geometryData[(x * 5) + 4];
+            int dataOffset = (x * 5);
+            float angle = geometryData[dataOffset + 4];
 
             if (debugMode)
                 std::cout << "Angle: " << angle << std::endl;
@@ -272,12 +273,12 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
             float sin = std::sin(angle);
 
             // Use the geometry volume to derive the width and height of the bounding box
-            float h = geometryData[(x * 5) + 0] + geometryData[(x * 5) + 2];
-            float w = geometryData[(x * 5) + 1] + geometryData[(x * 5) + 3];
+            float h = geometryData[dataOffset + 0] + geometryData[dataOffset + 2];
+            float w = geometryData[dataOffset + 1] + geometryData[dataOffset + 3];
 
             cv::Point2i p2{
-                offsetX + static_cast<int>(cos * geometryData[(x * 5) + 1] + sin * geometryData[(x * 5) + 2]),
-                offsetY + static_cast<int>(-sin * geometryData[(x * 5) + 1] + cos * geometryData[(x * 5) + 2])};
+                offsetX + static_cast<int>(cos * geometryData[dataOffset + 1] + sin * geometryData[dataOffset + 2]),
+                offsetY + static_cast<int>(-sin * geometryData[dataOffset + 1] + cos * geometryData[dataOffset + 2])};
             cv::Point2i p1{
                 static_cast<int>(-sin * h) + p2.x,
                 static_cast<int>(-cos * h) + p2.y};

--- a/src/custom_nodes/east_ocr/east_ocr.cpp
+++ b/src/custom_nodes/east_ocr/east_ocr.cpp
@@ -225,17 +225,17 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     NODE_ASSERT(image.cols == imageWidth, "Mat generation failed");
     NODE_ASSERT(image.rows == imageHeight, "Mat generation failed");
 
-    uint64_t _numRows = scoresTensor->dims[2];
-    uint64_t _numCols = scoresTensor->dims[3];
+    uint64_t _numRows = scoresTensor->dims[1];
+    uint64_t _numCols = scoresTensor->dims[2];
     NODE_ASSERT(_numRows <= std::numeric_limits<int>::max(), "score  rows is too large");
     NODE_ASSERT(_numCols <= std::numeric_limits<int>::max(), "score columns is too large");
     int numRows = static_cast<int>(_numRows);
     int numCols = static_cast<int>(_numCols);
 
-    NODE_ASSERT(scoresTensor->dims[1] == 1, "scores has dim 1 not equal to 1");
-    NODE_ASSERT(geometryTensor->dims[1] == 5, "geometry has dim 1 not equal to 5");
-    NODE_ASSERT(scoresTensor->dims[2] == geometryTensor->dims[2], "scores and geometry has not equal dim 2");
-    NODE_ASSERT(scoresTensor->dims[3] == geometryTensor->dims[3], "scores and geometry has not equal dim 3");
+    NODE_ASSERT(scoresTensor->dims[3] == 1, "scores has dim 3 not equal to 1");
+    NODE_ASSERT(geometryTensor->dims[3] == 5, "geometry has dim 3 not equal to 5");
+    NODE_ASSERT(scoresTensor->dims[1] == geometryTensor->dims[1], "scores and geometry has not equal dim 2");
+    NODE_ASSERT(scoresTensor->dims[2] == geometryTensor->dims[2], "scores and geometry has not equal dim 3");
 
     NODE_ASSERT((numRows * 4) == imageHeight, "image is not x4 larger than score/geometry data");
     NODE_ASSERT((numCols * 4) == imageWidth, "image is not x4 larger than score/geometry data");
@@ -247,11 +247,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
     // Extract the scores (probabilities), followed by the geometrical data used to derive potential bounding box coordinates that surround text
     for (int y = 0; y < numRows; y++) {
         float* scoresData = (float*)scoresTensor->data + (y * numCols);
-        float* xData0 = (float*)geometryTensor->data + ((0 * numRows * numCols) + (y * numCols));
-        float* xData1 = (float*)geometryTensor->data + ((1 * numRows * numCols) + (y * numCols));
-        float* xData2 = (float*)geometryTensor->data + ((2 * numRows * numCols) + (y * numCols));
-        float* xData3 = (float*)geometryTensor->data + ((3 * numRows * numCols) + (y * numCols));
-        float* anglesData = (float*)geometryTensor->data + ((4 * numRows * numCols) + (y * numCols));
+        float* geometryData = (float*)geometryTensor->data + (y * numCols * 5);
 
         for (int x = 0; x < numCols; x++) {
             float score = scoresData[x];
@@ -268,7 +264,7 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
             int offsetY = y * 4;
 
             // Extract the rotation angle for the prediction and then compute the sin and cosine
-            float angle = anglesData[x];
+            float angle = geometryData[(x * 5) + 4];
 
             if (debugMode)
                 std::cout << "Angle: " << angle << std::endl;
@@ -276,12 +272,12 @@ int execute(const struct CustomNodeTensor* inputs, int inputsCount, struct Custo
             float sin = std::sin(angle);
 
             // Use the geometry volume to derive the width and height of the bounding box
-            float h = xData0[x] + xData2[x];
-            float w = xData1[x] + xData3[x];
+            float h = geometryData[(x * 5) + 0] + geometryData[(x * 5) + 2];
+            float w = geometryData[(x * 5) + 1] + geometryData[(x * 5) + 3];
 
             cv::Point2i p2{
-                offsetX + static_cast<int>(cos * xData1[x] + sin * xData2[x]),
-                offsetY + static_cast<int>(-sin * xData1[x] + cos * xData2[x])};
+                offsetX + static_cast<int>(cos * geometryData[(x * 5) + 1] + sin * geometryData[(x * 5) + 2]),
+                offsetY + static_cast<int>(-sin * geometryData[(x * 5) + 1] + cos * geometryData[(x * 5) + 2])};
             cv::Point2i p1{
                 static_cast<int>(-sin * h) + p2.x,
                 static_cast<int>(-cos * h) + p2.y};
@@ -407,9 +403,9 @@ int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const stru
     (*info)[1].dims = (uint64_t*)malloc((*info)->dimsCount * sizeof(uint64_t));
     NODE_ASSERT(((*info)[1].dims) != nullptr, "malloc has failed");
     (*info)[1].dims[0] = 1;
-    (*info)[1].dims[1] = 1;
-    (*info)[1].dims[2] = originalImageHeight / 4;
-    (*info)[1].dims[3] = originalImageWidth / 4;
+    (*info)[1].dims[1] = originalImageHeight / 4;
+    (*info)[1].dims[2] = originalImageWidth / 4;
+    (*info)[1].dims[3] = 1;
     (*info)[1].precision = FP32;
 
     (*info)[2].name = GEOMETRY_TENSOR_NAME;
@@ -417,9 +413,9 @@ int getInputsInfo(struct CustomNodeTensorInfo** info, int* infoCount, const stru
     (*info)[2].dims = (uint64_t*)malloc((*info)->dimsCount * sizeof(uint64_t));
     NODE_ASSERT(((*info)[2].dims) != nullptr, "malloc has failed");
     (*info)[2].dims[0] = 1;
-    (*info)[2].dims[1] = 5;
-    (*info)[2].dims[2] = originalImageHeight / 4;
-    (*info)[2].dims[3] = originalImageWidth / 4;
+    (*info)[2].dims[1] = originalImageHeight / 4;
+    (*info)[2].dims[2] = originalImageWidth / 4;
+    (*info)[2].dims[3] = 5;
     (*info)[2].precision = FP32;
     return 0;
 }


### PR DESCRIPTION
In previous versions of model optimizer east_fp32 model's input and outputs had NCHW layout after optimizing. Since 2022.1 model optimizer does not change the layout. Therefore east_ocr custom node was adjusted to expect all inputs in NHWC layout. If you intend to use east_fp32 model optimized with pre 2022.1 model optimizer it is necessary to force NHWC layout on both inputs and outputs of east_fp32 model.