### PR TITLE
Fix model instance construction

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -116,6 +116,7 @@ cc_library(
         "modelinstanceunloadguard.cpp",
         "modelinstanceunloadguard.hpp",
         "modelversion.hpp",
+        "modelversionstatus.cpp",
         "modelversionstatus.hpp",
         "model_service.hpp",
         "model_service.cpp",

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -314,7 +314,8 @@ public:
         ieCore(ieCore),
         name(name),
         version(version),
-        subscriptionManager(std::string("model: ") + name + std::string(" version: ") + std::to_string(version)) { isCustomLoaderConfigChanged = false; }
+        subscriptionManager(std::string("model: ") + name + std::string(" version: ") + std::to_string(version)),
+        status(name, version) { isCustomLoaderConfigChanged = false; }
 
     /**
          * @brief Destroy the Model Instance object

--- a/src/modelversionstatus.cpp
+++ b/src/modelversionstatus.cpp
@@ -1,0 +1,115 @@
+//*****************************************************************************
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include "modelversionstatus.hpp"
+
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#include <spdlog/spdlog.h>
+
+// note: think about using https://github.com/Neargye/magic_enum when compatible compiler is supported.
+
+namespace ovms {
+
+// those values have to match tensorflow-serving state:
+static const std::unordered_map<ModelVersionState, std::string> versionStatesStrings = {
+    {ModelVersionState::START, "START"},
+    {ModelVersionState::LOADING, "LOADING"},
+    {ModelVersionState::AVAILABLE, "AVAILABLE"},
+    {ModelVersionState::UNLOADING, "UNLOADING"},
+    {ModelVersionState::END, "END"}};
+const std::string& ModelVersionStateToString(ModelVersionState state) {
+    return versionStatesStrings.at(state);
+}
+
+static const std::unordered_map<ModelVersionStatusErrorCode, std::string> versionsStatesErrors = {
+    {ModelVersionStatusErrorCode::OK, "OK"},
+    {ModelVersionStatusErrorCode::UNKNOWN, "UNKNOWN"},
+    {ModelVersionStatusErrorCode::FAILED_PRECONDITION, "FAILED_PRECONDITION"}};
+
+const std::string& ModelVersionStatusErrorCodeToString(ModelVersionStatusErrorCode code) {
+    return versionsStatesErrors.at(code);
+}
+
+ModelVersionStatus::ModelVersionStatus(const std::string& model_name, model_version_t version, ModelVersionState state) :
+    modelName(model_name),
+    version(version),
+    state(state),
+    errorCode(ModelVersionStatusErrorCode::OK) {
+    logStatus();
+}
+
+ModelVersionState ModelVersionStatus::getState() const {
+    return this->state;
+}
+
+const std::string& ModelVersionStatus::getStateString() const {
+    return ModelVersionStateToString(this->state);
+}
+
+ModelVersionStatusErrorCode ModelVersionStatus::getErrorCode() const {
+    return this->errorCode;
+}
+
+const std::string& ModelVersionStatus::getErrorMsg() const {
+    return ModelVersionStatusErrorCodeToString(this->errorCode);
+}
+
+bool ModelVersionStatus::willEndUnloaded() const {
+    return ovms::ModelVersionState::UNLOADING <= this->state;
+}
+
+bool ModelVersionStatus::isFailedLoading() const {
+    return this->state == ovms::ModelVersionState::LOADING && this->errorCode == ovms::ModelVersionStatusErrorCode::UNKNOWN;
+}
+
+void ModelVersionStatus::setLoading(ModelVersionStatusErrorCode error_code) {
+    SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
+    state = ModelVersionState::LOADING;
+    errorCode = error_code;
+    logStatus();
+}
+
+void ModelVersionStatus::setAvailable(ModelVersionStatusErrorCode error_code) {
+    SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
+    state = ModelVersionState::AVAILABLE;
+    errorCode = error_code;
+    logStatus();
+}
+
+void ModelVersionStatus::setUnloading(ModelVersionStatusErrorCode error_code) {
+    SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
+    state = ModelVersionState::UNLOADING;
+    errorCode = error_code;
+    logStatus();
+}
+
+void ModelVersionStatus::setEnd(ModelVersionStatusErrorCode error_code) {
+    SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
+    state = ModelVersionState::END;
+    errorCode = error_code;
+    logStatus();
+}
+
+void ModelVersionStatus::logStatus() {
+    SPDLOG_INFO("STATUS CHANGE: Version {} of model {} status change. New status: ( \"state\": \"{}\", \"error_code\": \"{}\" )",
+        this->version,
+        this->modelName,
+        ModelVersionStateToString(state),
+        ModelVersionStatusErrorCodeToString(errorCode));
+}
+}  // namespace ovms

--- a/src/modelversionstatus.hpp
+++ b/src/modelversionstatus.hpp
@@ -36,15 +36,7 @@ enum class ModelVersionState : int {
     END = 50
 };
 
-inline const std::string& ModelVersionStateToString(ModelVersionState state) {
-    static const std::unordered_map<ModelVersionState, std::string> errors = {
-        {ModelVersionState::START, "START"},
-        {ModelVersionState::LOADING, "LOADING"},
-        {ModelVersionState::AVAILABLE, "AVAILABLE"},
-        {ModelVersionState::UNLOADING, "UNLOADING"},
-        {ModelVersionState::END, "END"}};
-    return errors.at(state);
-}
+const std::string& ModelVersionStateToString(ModelVersionState state);
 
 enum class ModelVersionStatusErrorCode : int {
     OK = 0,
@@ -68,13 +60,7 @@ enum class ModelVersionStatusErrorCode : int {
     //    = 20
 };
 
-inline const std::string& ModelVersionStatusErrorCodeToString(ModelVersionStatusErrorCode code) {
-    static const std::unordered_map<ModelVersionStatusErrorCode, std::string> errors = {
-        {ModelVersionStatusErrorCode::OK, "OK"},
-        {ModelVersionStatusErrorCode::UNKNOWN, "UNKNOWN"},
-        {ModelVersionStatusErrorCode::FAILED_PRECONDITION, "FAILED_PRECONDITION"}};
-    return errors.at(code);
-}
+const std::string& ModelVersionStatusErrorCodeToString(ModelVersionStatusErrorCode code);
 
 class ModelVersionStatus {
     std::string modelName;
@@ -83,81 +69,36 @@ class ModelVersionStatus {
     ModelVersionStatusErrorCode errorCode;
 
 public:
-    ModelVersionStatus() = default;
+    ModelVersionStatus() = delete;
 
-    ModelVersionStatus(const std::string& model_name, model_version_t version, ModelVersionState state = ModelVersionState::START) :
-        modelName(model_name),
-        version(version),
-        state(state),
-        errorCode(ModelVersionStatusErrorCode::OK) {
-        logStatus();
-    }
+    ModelVersionStatus(const std::string& model_name, model_version_t version, ModelVersionState state = ModelVersionState::START);
 
-    ModelVersionState getState() const {
-        return this->state;
-    }
+    ModelVersionState getState() const;
 
-    const std::string& getStateString() const {
-        return ModelVersionStateToString(this->state);
-    }
+    const std::string& getStateString() const;
 
-    ModelVersionStatusErrorCode getErrorCode() const {
-        return this->errorCode;
-    }
+    ModelVersionStatusErrorCode getErrorCode() const;
 
-    const std::string& getErrorMsg() const {
-        return ModelVersionStatusErrorCodeToString(this->errorCode);
-    }
+    const std::string& getErrorMsg() const;
 
     /**
      * @brief Check if current state is state that is either transforming to END or already in that state.
      *
      * @return
      */
-    bool willEndUnloaded() const {
-        return ovms::ModelVersionState::UNLOADING <= this->state;
-    }
+    bool willEndUnloaded() const;
 
-    bool isFailedLoading() const {
-        return this->state == ovms::ModelVersionState::LOADING && this->errorCode == ovms::ModelVersionStatusErrorCode::UNKNOWN;
-    }
+    bool isFailedLoading() const;
+    void setLoading(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK);
 
-    void setLoading(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK) {
-        SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
-        state = ModelVersionState::LOADING;
-        errorCode = error_code;
-        logStatus();
-    }
+    void setAvailable(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK);
 
-    void setAvailable(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK) {
-        SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
-        state = ModelVersionState::AVAILABLE;
-        errorCode = error_code;
-        logStatus();
-    }
+    void setUnloading(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK);
 
-    void setUnloading(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK) {
-        SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
-        state = ModelVersionState::UNLOADING;
-        errorCode = error_code;
-        logStatus();
-    }
-
-    void setEnd(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK) {
-        SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
-        state = ModelVersionState::END;
-        errorCode = error_code;
-        logStatus();
-    }
+    void setEnd(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK);
 
 private:
-    void logStatus() {
-        SPDLOG_INFO("STATUS CHANGE: Version {} of model {} status change. New status: ( \"state\": \"{}\", \"error_code\": \"{}\" )",
-            this->version,
-            this->modelName,
-            ModelVersionStateToString(state),
-            ModelVersionStatusErrorCodeToString(errorCode));
-    }
+    void logStatus();
 };
 
 }  // namespace ovms

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -20,6 +20,7 @@
 #include "../get_model_metadata_impl.hpp"
 #include "../localfilesystem.hpp"
 #include "../logging.hpp"
+#include "../model_service.hpp"
 #include "../modelconfig.hpp"
 #include "../modelinstance.hpp"
 #include "../pipeline.hpp"
@@ -961,6 +962,22 @@ static const char* stressPipelineCustomNodeAddOneThenDummyIncreasedQueueSize = R
     ]
 })";
 
+static const char* stressTestOneDummyConfig = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "(1,10) "}
+            }
+        }
+    ]
+})";
+
 class StressPipelineConfigChanges : public TestWithTempDir {
 protected:
     const uint loadThreadCount = 20;
@@ -980,6 +997,9 @@ protected:
     const std::vector<float> requestData{1.1, 2., 3., 7., 5., 6., 4., 9., 10., 8.};
 
 public:
+    virtual std::string getServableName() {
+        return pipelineName;
+    }
     void SetUpConfig(const std::string& configContent) {
         ovmsConfig = configContent;
         const std::string modelPathToReplace{"/ovms/src/test/dummy"};
@@ -1004,6 +1024,12 @@ public:
     void defaultVersionAdd() {
         SPDLOG_INFO("{} start", __FUNCTION__);
         std::filesystem::copy("/ovms/src/test/dummy/1", modelPath + "/2", std::filesystem::copy_options::recursive);
+        SPDLOG_INFO("{} end", __FUNCTION__);
+    }
+    void addFirstModel() {
+        SPDLOG_INFO("{} start", __FUNCTION__);
+        SetUpConfig(stressTestOneDummyConfig);
+        createConfigFileWithContent(ovmsConfig, configFilePath);
         SPDLOG_INFO("{} end", __FUNCTION__);
     }
     void changeToAutoShape() {
@@ -1271,6 +1297,41 @@ public:
             }
         }
     }
+    void triggerGetPipelineStatusInALoop(
+        std::future<void>& startSignal,
+        std::future<void>& stopSignal,
+        ModelManager& manager,
+        const std::set<StatusCode>& requiredLoadResults,
+        const std::set<StatusCode>& allowedLoadResults,
+        std::unordered_map<StatusCode, std::atomic<uint64_t>>& createPipelineRetCodesCounters) {
+        tensorflow::serving::GetModelStatusRequest request;
+        tensorflow::serving::GetModelStatusResponse response;
+        startSignal.get();
+        // stressIterationsCounter is additional safety measure
+        // for getModelStatus requests it must be much higher since the response time is much lower
+        // as in contrast to predict/metadata requests
+        auto stressIterationsCounter = stressIterationsLimit * 100000;
+        while (stressIterationsCounter-- > 0) {
+            auto futureWaitResult = stopSignal.wait_for(std::chrono::milliseconds(0));
+            if (futureWaitResult == std::future_status::ready) {
+                SPDLOG_INFO("Got stop signal. Ending Load");
+                break;
+            }
+            auto status = ovms::GetModelStatusImpl::createGrpcRequest(getServableName(), 1, &request);
+            status = ovms::GetModelStatusImpl::getModelStatus(&request, &response, manager);
+            createPipelineRetCodesCounters[status.getCode()]++;
+            EXPECT_TRUE((requiredLoadResults.find(status.getCode()) != requiredLoadResults.end()) ||
+                        (allowedLoadResults.find(status.getCode()) != allowedLoadResults.end()))
+                << status.string() << "\n";
+            if (!status.ok()) {
+                continue;
+            }
+            if (::testing::Test::HasFailure()) {
+                SPDLOG_INFO("Earlier fail detected. Stopping execution");
+                break;
+            }
+        }
+    }
     virtual inputs_info_t getExpectedInputsInfo() {
         return {{pipelineInputName,
             std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}};
@@ -1342,6 +1403,29 @@ public:
         std::stringstream ss;
         ss << "Executed: " << stressIterationsLimit - stressIterationsCounter << " inferences by thread id: " << std::this_thread::get_id() << std::endl;
         SPDLOG_INFO(ss.str());
+    }
+};
+
+static const char* initialClearConfig = R"(
+{
+    "model_config_list": [
+    ]
+})";
+
+class StressModelConfigChanges : public StressPipelineConfigChanges {
+    const std::string modelName = "dummy";
+    const std::string modelInputName = "b";
+    const std::string modelOutputName = "a";
+
+public:
+    std::string getServableName() override {
+        return modelName;
+    }
+    void SetUp() override {
+        TestWithTempDir::SetUp();
+        modelPath = directoryPath + "/dummy/";
+        SetUpConfig(initialClearConfig);
+        std::filesystem::copy("/ovms/src/test/dummy", modelPath, std::filesystem::copy_options::recursive);
     }
 };
 
@@ -1740,6 +1824,20 @@ TEST_F(StressPipelineCustomNodesConfigChanges, ChangeCustomLibraryParamDuringGet
     performStressTest(
         &StressPipelineConfigChanges::triggerGetPipelineMetadataInALoop,
         &StressPipelineConfigChanges::changeCustomLibraryParam,
+        performWholeConfigReload,
+        requiredLoadResults,
+        allowedLoadResults);
+}
+TEST_F(StressModelConfigChanges, AddModelDuringGetModelStatusLoad) {
+    bool performWholeConfigReload = true;  // we just need to have all model versions rechecked
+    std::set<StatusCode> requiredLoadResults = {
+        StatusCode::MODEL_NAME_MISSING,     // until first model is loaded
+        StatusCode::MODEL_VERSION_MISSING,  // this should be hit if test is stressing enough, pottentially to be moved to allowed
+        StatusCode::OK};                    // we expect full continuouity of operation
+    std::set<StatusCode> allowedLoadResults = {};
+    performStressTest(
+        &StressPipelineConfigChanges::triggerGetPipelineStatusInALoop,
+        &StressPipelineConfigChanges::addFirstModel,
         performWholeConfigReload,
         requiredLoadResults,
         allowedLoadResults);


### PR DESCRIPTION
This fixes problem uncovered with:
https://github.com/openvinotoolkit/model_server/pull/719

It uncovered issue in model instance construction. When creating model instance it initially had illegal ModelVersionStatus with uninitialized ModelVersionState. Before that change it was not an issue since we only exposed model instance to end user after it was loaded. But MR above pushed exposing the model instance before it was loaded thus uncovering this issue.

Uninitialized ModelVersionState field could have value non existing in state string mapping so it could lead to throwing out of range.

JIRA:CVS-80036