### PR TITLE
CVS-80264 Updated CPU_THROUGHTPUT_AUTO/PERFORMANCE auto configuration logic

### DIFF
--- a/demos/real_time_stream_analysis/python/README.md
+++ b/demos/real_time_stream_analysis/python/README.md
@@ -5,7 +5,7 @@ For object classification, detection and segmentation we use CV (Computer Vision
 
 In this demo you'll see how to analyze RTSP (Real Time Streaming Protocol) stream using OpenVINO Model Server for inference.
 
-<img src="https://github.com/openvinotoolkit/model_server/blob/develop/demos/real_time_stream_analysis/python/assets/concept.jpg">
+![concept](assets/concept.jpg)
 
 The stream analysis app is started with `real_time_stream_analysis.py` script. It reads frames from the provided stream URL, runs pre and post processing and requests inference on specified model served by OVMS.
 
@@ -98,8 +98,7 @@ python3 real_time_stream_analysis.py --stream_url rtsp://localhost:8554/mystream
 
 __Console output:__
 
-<img src="https://github.com/openvinotoolkit/model_server/blob/develop/demos/real_time_stream_analysis/python/assets/minimal_example.jpg">
-
+![minimal example](assets/minimal_example.jpg)
 
 ### Running with visualizer
 
@@ -116,11 +115,11 @@ python3 real_time_stream_analysis.py --stream_url rtsp://localhost:8554/mystream
 
 __Console output:__
 
-<img src="https://github.com/openvinotoolkit/model_server/blob/develop/demos/real_time_stream_analysis/python/assets/visualizer_example_console.jpg">
+![visualizer example console](assets/visualizer_example_console.jpg)
 
 __Browser preview:__
 
-<img src="https://github.com/openvinotoolkit/model_server/blob/develop/demos/real_time_stream_analysis/python/assets/visualizer_example_browser.gif">
+![visualizer example browser](assets/visualizer_example_browser.gif)
 
 > Note: Visualizer does not use effecient streaming techniques to display results. It's main goal is to help during development and provide simple solution for quick health/accuracy checks.
 

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -40,11 +40,28 @@ This mode prioritizes low latency, providing short response time for each infere
 Note that currently the `PERFORMANCE_HINT` property is supported by CPU and GPU devices only. [More information](https://github.com/openvinotoolkit/openvino/blob/928076ed319fcf172d24d1af4c6844e39c1bc100/docs/OV_Runtime_UG/auto_device_selection.md).
 
 To enable Performance Hints for your application, use the following command:
-```
-docker run --rm -d -v <model_path>:/opt/model -p 9001:9001 openvino/model_server:latest \
---model_path /opt/model --model_name my_model --port 9001 \
---plugin_config '{"PERFORMANCE_HINT": "THROUGHTPUT"}'
-```
+@sphinxdirective
+
+.. tab:: CPU  
+
+   .. code-block:: sh
+
+        docker run --rm -d -v <model_path>:/opt/model -p 9001:9001 openvino/model_server:latest \
+            --model_path /opt/model --model_name my_model --port 9001 \
+            --plugin_config '{"PERFORMANCE_HINT": "THROUGHTPUT"}' \
+            --target_device CPU
+
+.. tab:: GPU
+
+   .. code-block:: sh  
+   
+        docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
+            -v <model_path>:/opt/model -p 9001:9001 openvino/model_server:latest \
+            --model_path /opt/model --model_name my_model --port 9001 \
+            --plugin_config '{"PERFORMANCE_HINT": "THROUGHTPUT"}' \
+            --target_device GPU
+
+@endsphinxdirective
 
 > NOTE: CPU_THROUGHPUT_STREAMS and PERFORMANCE_HINT should not be used together.
 

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -10,7 +10,7 @@ OpenVINO&trade; Model Server can be tuned to a single client use case or a high 
 execution streams. They split the available resources to perform parallel execution of multiple requests.
 It is particularly efficient for models which can not consume effectively all CPU cores or for CPUs with high number of cores.
 
-By default, OpenVINO Model Server sets the value CPU_THROUGHPUT_AUTO. It calculates the number of streams based on number of
+By default, for `CPU` target device, OpenVINO Model Server sets the value CPU_THROUGHPUT_AUTO and GPU_THROUGHTPUT_AUTO for `GPU` target device. It calculates the number of streams based on number of
 available vCPUs. It gives a compromise between the single client scenario and the high concurrency.
 
 If this default configuration is not suitable, adjust it with the parameter `CPU_THROUGHPUT_STREAMS` defined as part 
@@ -28,6 +28,25 @@ For example with ~50 clients sending the requests to the server with 48 cores, s
 
 `--plugin_config '{"CPU_THROUGHPUT_STREAMS": "24"}'`
 
+
+## Performance Hints
+The `PERFORMANCE_HINT` plugin config property enables you to specify a performance mode for the plugin to be more efficient for particular use cases.
+
+#### THROUGHPUT
+This mode prioritizes high throughput, balancing between latency and power. It is best suited for tasks involving multiple jobs, like inference of video feeds or large numbers of images.
+
+#### LATENCY
+This mode prioritizes low latency, providing short response time for each inference job. It performs best for tasks where inference is required for a single input image, like a medical analysis of an ultrasound scan image. It also fits the tasks of real-time or nearly real-time applications, such as an industrial robot's response to actions in its environment or obstacle avoidance for autonomous vehicles.
+Note that currently the `PERFORMANCE_HINT` property is supported by CPU and GPU devices only. [More information](https://github.com/openvinotoolkit/openvino/blob/928076ed319fcf172d24d1af4c6844e39c1bc100/docs/OV_Runtime_UG/auto_device_selection.md).
+
+To enable Performance Hints for your application, use the following command:
+```
+docker run --rm -d -v <model_path>:/opt/model -p 9001:9001 openvino/model_server:latest \
+--model_path /opt/model --model_name my_model --port 9001 \
+--plugin_config '{"PERFORMANCE_HINT": "THROUGHTPUT"}'
+```
+
+> NOTE: CPU_THROUGHPUT_STREAMS and PERFORMANCE_HINT should not be used together.
 
 ## Input data in REST API calls
 
@@ -69,6 +88,12 @@ docker run --rm -d --cpuset-cpus 0,1,2,3 -v <model_path>:/opt/model -p 9001:9001
 --model_path /opt/model --model_name my_model --port 9001 \
 --plugin_config '{"CPU_THROUGHPUT_STREAMS": "1"}'
 
+```
+
+## CPU Power Management Settings
+In order to save power, the OS can decrease the CPU frequency and increase a volatility of the latency values. Similarly the Intel® Turbo Boost Technolog may also affect the stability of results. For best reproducibility, consider locking the frequency to the processor base frequency (refer to the https://ark.intel.com/ for your specific CPU). For example, in Linux setting the releveant values for the /sys/devices/system/cpu/cpu* entries does the trick. [Read more](https://docs.openvino.ai/nightly/openvino_docs_optimization_guide_dldt_optimization_guide.html). High-level commands like cpupower also exists:
+```
+$ cpupower frequency-set --min 3.1GHz
 ```
 
 ## Tuning Model Server configuration parameters           

--- a/src/modelconfig.hpp
+++ b/src/modelconfig.hpp
@@ -396,21 +396,12 @@ public:
     }
 
     /**
-         * @brief Checks if target device is heterogeneous and contains specific device
+         * @brief Checks if given device is used as single target device.
          * 
          * @param bool
          */
-    bool isHeteroTargetDevice(const std::string& device) const {
-        return this->targetDevice.find("HETERO") != std::string::npos && this->targetDevice.find(device) != std::string::npos;
-    }
-
-    /**
-         * @brief Checks if given device name is used alone or as a part of multi device configuration
-         * 
-         * @param bool
-         */
-    bool isDeviceUsed(const std::string& device) const {
-        return this->targetDevice == device || this->isHeteroTargetDevice(device);
+    bool isSingleDeviceUsed(const std::string& device) const {
+        return this->targetDevice == device;
     }
 
     /**

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -643,13 +643,18 @@ void ModelInstance::loadCompiledModelPtr(const plugin_config_t& pluginConfig) {
 
 plugin_config_t ModelInstance::prepareDefaultPluginConfig(const ModelConfig& config) {
     plugin_config_t pluginConfig = config.getPluginConfig();
+    // Do not add CPU_THROUGHPUT_AUTO when performance hint is specified.
+    bool isPerformanceHintSpecified = pluginConfig.count("PERFORMANCE_HINT") > 0;
+    if (isPerformanceHintSpecified) {
+        return pluginConfig;
+    }
     // For CPU and GPU, if user did not specify, calculate CPU_THROUGHPUT_STREAMS automatically
-    if (config.isDeviceUsed("CPU")) {
+    if (config.isSingleDeviceUsed("CPU")) {
         if (pluginConfig.count("CPU_THROUGHPUT_STREAMS") == 0) {
             pluginConfig["CPU_THROUGHPUT_STREAMS"] = "CPU_THROUGHPUT_AUTO";
         }
     }
-    if (config.isDeviceUsed("GPU")) {
+    if (config.isSingleDeviceUsed("GPU")) {
         if (pluginConfig.count("GPU_THROUGHPUT_STREAMS") == 0) {
             pluginConfig["GPU_THROUGHPUT_STREAMS"] = "GPU_THROUGHPUT_AUTO";
         }

--- a/src/test/modelconfig_test.cpp
+++ b/src/test/modelconfig_test.cpp
@@ -554,16 +554,16 @@ TEST(ModelConfig, mappingRealOutputs) {
     EXPECT_EQ(empty, "");
 }
 
-TEST(ModelConfig, isDeviceUsed) {
+TEST(ModelConfig, isSingleDeviceUsed) {
     ovms::ModelConfig config;
     config.setTargetDevice("GPU");
-    EXPECT_FALSE(config.isDeviceUsed("CPU"));
+    EXPECT_FALSE(config.isSingleDeviceUsed("CPU"));
     config.setTargetDevice("CPU");
-    EXPECT_TRUE(config.isDeviceUsed("CPU"));
+    EXPECT_TRUE(config.isSingleDeviceUsed("CPU"));
     config.setTargetDevice("HETERO:MYRIAD,CPU");
-    EXPECT_TRUE(config.isDeviceUsed("CPU"));
+    EXPECT_FALSE(config.isSingleDeviceUsed("CPU"));
     config.setTargetDevice("HETERO:MYRIAD,GPU");
-    EXPECT_FALSE(config.isDeviceUsed("CPU"));
+    EXPECT_FALSE(config.isSingleDeviceUsed("CPU"));
 }
 
 TEST(ModelConfig, shapeConfigurationEqual_SingleInput) {

--- a/src/test/modelinstance_test.cpp
+++ b/src/test/modelinstance_test.cpp
@@ -802,12 +802,12 @@ TEST(CpuThroughputStreamsNotSpecified, DefaultIsSetForCPU) {
     EXPECT_EQ(pluginConfig.count("CPU_THROUGHPUT_STREAMS"), 1);
 }
 
-TEST(CpuThroughputStreamsNotSpecified, DefaultIsSetForHeteroCPU) {
+TEST(CpuThroughputStreamsNotSpecified, NotSetForHeteroCPU) {
     ovms::ModelConfig config;
     config.setTargetDevice("HETERO:MYRIAD,CPU");
     config.setPluginConfig({});
     ovms::plugin_config_t pluginConfig = ovms::ModelInstance::prepareDefaultPluginConfig(config);
-    EXPECT_EQ(pluginConfig.count("CPU_THROUGHPUT_STREAMS"), 1);
+    EXPECT_EQ(pluginConfig.count("CPU_THROUGHPUT_STREAMS"), 0);
 }
 
 TEST(CpuThroughputStreamsNotSpecified, NotSetForNonCpuDevices) {
@@ -820,6 +820,17 @@ TEST(CpuThroughputStreamsNotSpecified, NotSetForNonCpuDevices) {
     pluginConfig = ovms::ModelInstance::prepareDefaultPluginConfig(config);
     EXPECT_EQ(pluginConfig.count("CPU_THROUGHPUT_STREAMS"), 0);
     config.setTargetDevice("GPU");
+    pluginConfig = ovms::ModelInstance::prepareDefaultPluginConfig(config);
+    EXPECT_EQ(pluginConfig.count("CPU_THROUGHPUT_STREAMS"), 0);
+}
+
+TEST(CpuThroughputStreamsNotSpecified, NotSetWhenPerfHintSpecified) {
+    ovms::ModelConfig config;
+    config.setPluginConfig({{"PERFORMANCE_HINT", "LATENCY"}});
+    config.setTargetDevice("CPU");
+    ovms::plugin_config_t pluginConfig = ovms::ModelInstance::prepareDefaultPluginConfig(config);
+    EXPECT_EQ(pluginConfig.count("CPU_THROUGHPUT_STREAMS"), 0);
+    config.setPluginConfig({{"PERFORMANCE_HINT", "THROUGHTPUT"}});
     pluginConfig = ovms::ModelInstance::prepareDefaultPluginConfig(config);
     EXPECT_EQ(pluginConfig.count("CPU_THROUGHPUT_STREAMS"), 0);
 }


### PR DESCRIPTION
Implementation:
- `CPU_THROUGHTPUT_STREAMS` is *not* set automatically anymore when `PERFORMANCE_HINT` is used manually
-  `CPU_THROUGHTPUT_STREAMS` is *not* set automatically anymore for HETERO devices (only for single CPU and GPU)

Documentation:
- Fixed Realtime Video Stream demo on sphinx: http://openvino-docs.inn.intel.com/ovms-test-develop_18/ovms_demo_real_time_stream_analysis.html
- Added PERFORMANCE_HINT note in Performance Tuning doc: http://openvino-docs.inn.intel.com/ovms-test-develop_18/ovms_docs_performance_tuning.html