### PR TITLE
venv and sdl-check targets update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,9 @@ venv:$(ACTIVATE)
 $(ACTIVATE):
 	@echo "Updating virtualenv dependencies in: $(VIRTUALENV_DIR)..."
 	@test -d $(VIRTUALENV_DIR) || $(VIRTUALENV_EXE) $(VIRTUALENV_DIR)
-	@. $(ACTIVATE); pip$(PY_VERSION) install --upgrade pip
-	@. $(ACTIVATE); pip$(PY_VERSION) install -vUqq setuptools
-	@. $(ACTIVATE); pip$(PY_VERSION) install -qq -r tests/requirements.txt --use-deprecated=legacy-resolver
+	@. $(ACTIVATE); pip3 install --upgrade pip
+	@. $(ACTIVATE); pip3 install -vUqq setuptools
+	@. $(ACTIVATE); pip3 install -qq -r tests/requirements.txt --use-deprecated=legacy-resolver
 	@touch $(ACTIVATE)
 
 style: venv clang-format

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -18,7 +18,7 @@ This document gives information and steps to run and debug tests. It gives infor
 
 ## Set up the Development Environment <a name="set-env"></a>
 
-The tests in this guide are written in Python. Therefore, to complete the functional tests, Python 3.6 - 3.8 must be installed. 
+The tests in this guide are written in Python. Therefore, to complete the functional tests, Python 3.8 must be installed. 
 
 In-case of problems, see <a href="#debug">Debugging</a>.
 
@@ -79,7 +79,7 @@ In-case of problems, see <a href="#debug">Debugging</a>.
 
 ### Step 2: Install software
 
-1. Install Python release 3.6 through 3.8.
+1. Install Python release 3.8.
  
 > **NOTE**: Python is only necessary to complete the functional tests in this guide.
 


### PR DESCRIPTION
- Removal of PY_VERSION parameter since pip3 should be enough given creating venv with python3 link
- COPYRIGHT check in lib_search.py(sdl-check runs this script) changed. We should check for the word "Copyright", followed by the year of the first publication of the work and the name of the copyright holder. Several years may be noted if the work has gone through substantial revisions.
New check should check the following:
Copyright (single year|range|years devided by ',') (license holder)