### PR TITLE
Simplify PortManager used in functional tests.

### DIFF
--- a/tests/functional/utils/grpc.py
+++ b/tests/functional/utils/grpc.py
@@ -20,8 +20,7 @@ from tensorflow_serving.apis import prediction_service_pb2_grpc, model_service_p
     get_model_metadata_pb2, get_model_status_pb2
 
 from config import infer_timeout
-from config import grpc_ovms_starting_port, ports_pool_size
-from utils.port_manager import PortManager
+from utils.port_manager import SimplePortManager
 from constants import MODEL_SERVICE, PREDICTION_SERVICE
 import logging
 
@@ -30,7 +29,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_GRPC_PORT = str(grpc_ovms_starting_port)
 DEFAULT_ADDRESS = 'localhost'
 
-port_manager_grpc = PortManager("gRPC", starting_port=grpc_ovms_starting_port, pool_size=ports_pool_size)
+port_manager_grpc = SimplePortManager("gRPC")
 
 
 def create_channel(address: str = DEFAULT_ADDRESS, port: str = DEFAULT_GRPC_PORT, service: int = PREDICTION_SERVICE):

--- a/tests/functional/utils/grpc.py
+++ b/tests/functional/utils/grpc.py
@@ -21,7 +21,7 @@ from tensorflow_serving.apis import prediction_service_pb2_grpc, model_service_p
 
 from config import infer_timeout
 from config import grpc_ovms_starting_port, ports_pool_size
-from utils.port_manager import PortManager
+from utils.port_manager import SimplePortManager
 from constants import MODEL_SERVICE, PREDICTION_SERVICE
 import logging
 

--- a/tests/functional/utils/grpc.py
+++ b/tests/functional/utils/grpc.py
@@ -20,7 +20,8 @@ from tensorflow_serving.apis import prediction_service_pb2_grpc, model_service_p
     get_model_metadata_pb2, get_model_status_pb2
 
 from config import infer_timeout
-from utils.port_manager import SimplePortManager
+from config import grpc_ovms_starting_port, ports_pool_size
+from utils.port_manager import PortManager
 from constants import MODEL_SERVICE, PREDICTION_SERVICE
 import logging
 

--- a/tests/functional/utils/port_manager.py
+++ b/tests/functional/utils/port_manager.py
@@ -1,29 +1,25 @@
 #
-# INTEL CONFIDENTIAL
 # Copyright (c) 2022 Intel Corporation
 #
-# The source code contained or described herein and all documents related to
-# the source code ("Material") are owned by Intel Corporation or its suppliers
-# or licensors. Title to the Material remains with Intel Corporation or its
-# suppliers and licensors. The Material contains trade secrets and proprietary
-# and confidential information of Intel or its suppliers and licensors. The
-# Material is protected by worldwide copyright and trade secret laws and treaty
-# provisions. No part of the Material may be used, copied, reproduced, modified,
-# published, uploaded, posted, transmitted, distributed, or disclosed in any way
-# without Intel's prior express written permission.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# No license under any patent, copyright, trade secret or other intellectual
-# property right is granted to or conferred upon you by disclosure or delivery
-# of the Materials, either expressly, by implication, inducement, estoppel or
-# otherwise. Any license under such intellectual property rights must be express
-# and approved by Intel in writing.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
 import socket
 import errno
 
-from common_libs.logger import get_logger
+from utils.helpers import get_xdist_worker_count, get_xdist_worker_nr
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 class SimplePortManager:
     def __init__(self, name: str):

--- a/tests/functional/utils/rest.py
+++ b/tests/functional/utils/rest.py
@@ -23,7 +23,7 @@ from tensorflow_serving.apis import get_model_metadata_pb2, \
 import logging
 
 from config import infer_timeout
-from utils.port_manager import PortManager
+from utils.port_manager import SimplePortManager
 from config import rest_ovms_starting_port, ports_pool_size
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ DEFAULT_REST_PORT = "{}".format(rest_ovms_starting_port)
 PREDICT = ':predict'
 METADATA = '/metadata'
 
-port_manager_rest = PortManager("rest", starting_port=rest_ovms_starting_port, pool_size=ports_pool_size)
+port_manager_rest = SimplePortManager("rest", starting_port=rest_ovms_starting_port, pool_size=ports_pool_size)
 
 
 def get_url(model: str, address: str = DEFAULT_ADDRESS, port: str = DEFAULT_REST_PORT,

--- a/tests/functional/utils/rest.py
+++ b/tests/functional/utils/rest.py
@@ -33,7 +33,7 @@ DEFAULT_REST_PORT = "{}".format(rest_ovms_starting_port)
 PREDICT = ':predict'
 METADATA = '/metadata'
 
-port_manager_rest = SimplePortManager("rest", starting_port=rest_ovms_starting_port, pool_size=ports_pool_size)
+port_manager_rest = SimplePortManager("rest")
 
 
 def get_url(model: str, address: str = DEFAULT_ADDRESS, port: str = DEFAULT_REST_PORT,


### PR DESCRIPTION
Changes were inspired by StackOverflow article:

 https://unix.stackexchange.com/questions/55913/whats-the-easiest-way-to-find-an-unused-local-port