### PR TITLE
CVS-83453 Integrate minitrace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 version
 __pycache__/
 report.json
+trace.json
 bazel-bin
 bazel-out
 bazel-ovms

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -30,6 +30,7 @@ ARG JOBS
 # build_type=[ opt, dbg ]
 ARG build_type=dbg
 ARG debug_bazel_flags=--strip=never\ --copt="-g"\ -c\ dbg
+ARG minitrace_flags
 ENV TF_SYSTEM_LIBS="curl"
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && yum update -d6 -y && yum install -d6 -y \
@@ -168,7 +169,7 @@ RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/runtime/lib/intel64/:/opt/intel/openvino/extras/opencv/lib/:/opt/intel/openvino/runtime/3rdparty/tbb/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN bazel build ${debug_bazel_flags} ${minitrace_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/example/SampleCpuExtension/ && make

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -31,6 +31,7 @@ ARG APT_OVCV_PACKAGE=openvino-opencv-2022.1.0
 # build_type=[ opt, dbg ]
 ARG build_type=dbg
 ARG debug_bazel_flags=--strip=never\ --copt="-g"\ -c\ dbg
+ARG minitrace_flags
 ENV HDDL_INSTALL_DIR=/opt/intel/openvino/deployment_tools/inference_engine/external/hddl
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TF_SYSTEM_LIBS="curl"
@@ -204,7 +205,7 @@ RUN if [ "$ov_use_binary" == "1" ] ; then true ; else exit 0 ; fi ; sed -i -e "s
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; sed -i -e "s#REPLACE_OPENVINO_NAME#`git --git-dir /openvino/.git log -n 1 | head -n 1 | cut -d' ' -f2 | head -c 12`#g" /ovms/src/version.hpp
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/runtime/lib/intel64/:/opt/intel/openvino/extras/opencv/lib/:/opt/intel/openvino/runtime/3rdparty/tbb/lib/
 
-RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:ovms
+RUN bazel build ${debug_bazel_flags} ${minitrace_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 
 RUN cd /ovms/src/example/SampleCpuExtension/ && make

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,18 @@ APT_OV_PACKAGE ?= openvino-2022.1.0
 APT_OVCV_PACKAGE ?= openvino-opencv-2022.1.0
 # opt, dbg:
 BAZEL_BUILD_TYPE ?= opt
+MINITRACE ?= OFF
 
 ifeq ($(BAZEL_BUILD_TYPE),dbg)
   BAZEL_DEBUG_FLAGS=" --strip=never --copt=-g -c dbg "
 else
   BAZEL_DEBUG_FLAGS=" --strip=never "
+endif
+
+ifeq ($(MINITRACE),ON)
+  MINITRACE_FLAGS="--copt=-DMTR_ENABLED"
+else
+  MINITRACE_FLAGS=""
 endif
 
 # Option to Override release image.
@@ -172,6 +179,7 @@ endif
 		--build-arg APT_OV_PACKAGE=$(APT_OV_PACKAGE) \
 		--build-arg APT_OVCV_PACKAGE=$(APT_OVCV_PACKAGE) \
 		--build-arg build_type=$(BAZEL_BUILD_TYPE) --build-arg debug_bazel_flags=$(BAZEL_DEBUG_FLAGS) \
+		--build-arg minitrace_flags=$(MINITRACE_FLAGS) \
 		--build-arg PROJECT_NAME=${PROJECT_NAME} \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg OPENVINO_OPENCV_DOWNLOAD_SERVER=$(OPENVINO_OPENCV_DOWNLOAD_SERVER) \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,7 @@
 workspace(name = "ovms")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # overriding tensorflow serving bazel dependency
@@ -65,6 +66,23 @@ git_repository(
     patches = ["net_http.patch", "listen.patch"]
     #                             ^^^^^^^^^^^^
     #                       make bind address configurable
+)
+
+# minitrace
+new_git_repository(
+    name = "minitrace",
+    remote = "https://github.com/hrydgard/minitrace.git",
+    commit = "020f42b189e8d6ad50e4d8f45d69edee0a6b3f23",
+    build_file_content = """
+cc_library(
+    name = "trace",
+    hdrs = ["minitrace.h"],
+    srcs = ["minitrace.c"],
+    visibility = ["//visibility:public"],
+    local_defines = [
+    ],
+)
+""",
 )
 
 load("@tensorflow_serving//tensorflow_serving:repo.bzl", "tensorflow_http_archive")

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -73,7 +73,7 @@ In-case of problems, see <a href="#debug">Debugging</a>.
 	* Without a Docker cache :
 
 	```bash
-	make NO_DOCKER_CACHE=true
+	make docker_build NO_DOCKER_CACHE=true
 	```
 
 
@@ -253,7 +253,7 @@ os.environ["LD_LIBRARY_PATH"] = "<path to ovms libraries>"
 
 ## Debugging <a name="debug"></a>
 
-Two debugging options are available. Click on the required option :
+Debugging options are available. Click on the required option :
 
 
 <details><summary>Use gdb to debug in Docker</summary>
@@ -285,6 +285,48 @@ Two debugging options are available. Click on the required option :
 	# (in gdb cli) set follow-fork-mode child
 	```
 </details>
+
+<details><summary>Use minitrace to display flame graph</summary>
+
+### Option 1. Use OpenVINO Model Server build image.
+This is convenient way during development in case it is needed to add new or remove already existing traces.
+
+1. Build OVMS build image locally.
+```
+$ make docker_build
+```
+
+2. Start the container.
+```
+$ docker run -it -v ${PWD}:/ovms --entrypoint bash -p 9178:9178 openvino/model_server-build:latest 
+```
+
+3. Build OVMS with minitrace enabled.
+```
+$ bazel build --copts="-DMTR_ENABLED" //src:ovms
+```
+
+4. Run OVMS with `--trace_path` specifying where to save flame graph JSON file.
+```
+$ bazel-bin/src/ovms --model_name resnet --model_path models/resnet --trace_path trace.json
+```
+
+5. During app exit, the trace info will be saved into `trace.json`.
+
+6. Use Chrome web browser `chrome://tracing` tool to display the graph.
+
+### Option 2. Build OVMS image with minitrace enabled
+This is convenient when final image has to be used on different machine and no changes to existing traces do not need to be modified for debugging.
+
+1. Build OVMS with minitrace enabled locally.
+```
+$ make docker_build MINITRACE=ON
+```
+
+2. Run OVMS with minitrace enabled and `--trace_path` and follow Option 1 to open trace file in Chrome web browser.
+
+</details>
+
 <details><summary>Debug functional tests</summary>
 
 Use OpenVINO Model Server build image because it installs the necessary tools.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -337,10 +337,10 @@ $ docker run -it -v ${PWD}:/workspace:rw -p 9178:9178 openvino/model_server --mo
 |---|---|---|
 | OVMS_PROFILER_FUNCTION | Add this macro at the very beginning of a function. This will automatically add function name to trace marker. | `OVMS_PROFILER_FUNCTION();`  |
 | OVMS_PROFILER_SCOPE | Add this macro at the beginning of a code scope and add marker name. This will automatically add ending marker at the end of code scope.  | `OVMS_PROFILER_SCOPE("My Code Scope Marker");`  |
-| OVMS_PROFILER_SYNC_BEGIN | For custom start and end markers, use this macro to mark beginning of synchronous event. Remember to use the same marker name for beginning and end. | `OVMS_PROFILER_SYNC_BEGIN("My Synchronous Event")` |
-| OVMS_PROFILER_SYNC_END | For custom start and end markers, use this macro to mark ending of synchronous event. Remember to use the same marker name for beginning and end. | `OVMS_PROFILER_SYNC_END("My Synchronous Event")` |
-| OVMS_PROFILER_ASYNC_BEGIN | For custom start and end markers, use this macro to mark beginning of asynchronous event. Remember to use the same marker name and id for beginning and end. Asynchronous markers need an identifier to correctly match events. | `OVMS_PROFILER_ASYNC_BEGIN("My Asynchronous Event", unique_id)` |
-| OVMS_PROFILER_ASYNC_END | For custom start and end markers, use this macro to mark end of asynchronous event. Remember to use the same marker name and id for beginning and end. Asynchronous markers need an identifier to correctly match events. | `OVMS_PROFILER_ASYNC_END("My Asynchronous Event", unique_id)` |
+| OVMS_PROFILER_SYNC_BEGIN | For custom start and end markers, use this macro to mark beginning of synchronous event. Remember to use the same marker name for beginning and end. | `OVMS_PROFILER_SYNC_BEGIN("My Synchronous Event");` |
+| OVMS_PROFILER_SYNC_END | For custom start and end markers, use this macro to mark ending of synchronous event. Remember to use the same marker name for beginning and end. | `OVMS_PROFILER_SYNC_END("My Synchronous Event");` |
+| OVMS_PROFILER_ASYNC_BEGIN | For custom start and end markers, use this macro to mark beginning of asynchronous event. Remember to use the same marker name and id for beginning and end. Asynchronous markers need an identifier to correctly match events. | `OVMS_PROFILER_ASYNC_BEGIN("My Asynchronous Event", unique_id);` |
+| OVMS_PROFILER_ASYNC_END | For custom start and end markers, use this macro to mark end of asynchronous event. Remember to use the same marker name and id for beginning and end. Asynchronous markers need an identifier to correctly match events. | `OVMS_PROFILER_ASYNC_END("My Asynchronous Event", unique_id);` |
 
 More information can be found in [profiler.hpp](../src/profiler.hpp) file.
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -323,7 +323,26 @@ This is convenient when final image has to be used on different machine and no c
 $ make docker_build MINITRACE=ON
 ```
 
-2. Run OVMS with minitrace enabled and `--trace_path` and follow Option 1 to open trace file in Chrome web browser.
+2. Run OVMS with minitrace enabled and `--trace_path` to specify where to save trace JSON file. Since the file is flushed and saved at container shutdown, mount the host directory with write access to persist the file after container stops.
+```
+$ docker run -it -v ${PWD}:/workspace:rw -p 9178:9178 openvino/model_server --model_name resnet --model_path /workspace/models/resnet --trace_path /workspace/trace.json 
+```
+
+3. During app exit, the trace info will be saved into `${PWD}/trace.json`.
+
+4. Use Chrome web browser `chrome://tracing` tool to display the graph, similarly to Option 1.
+
+### Profiling macros
+| Macro | Description | Example Usage |
+|---|---|---|
+| OVMS_PROFILER_FUNCTION | Add this macro at the very beginning of a function. This will automatically add function name to trace marker. | `OVMS_PROFILER_FUNCTION();`  |
+| OVMS_PROFILER_SCOPE | Add this macro at the beginning of a code scope and add marker name. This will automatically add ending marker at the end of code scope.  | `OVMS_PROFILER_SCOPE("My Code Scope Marker");`  |
+| OVMS_PROFILER_SYNC_BEGIN | For custom start and end markers, use this macro to mark beginning of synchronous event. Remember to use the same marker name for beginning and end. | `OVMS_PROFILER_SYNC_BEGIN("My Synchronous Event")` |
+| OVMS_PROFILER_SYNC_END | For custom start and end markers, use this macro to mark ending of synchronous event. Remember to use the same marker name for beginning and end. | `OVMS_PROFILER_SYNC_END("My Synchronous Event")` |
+| OVMS_PROFILER_ASYNC_BEGIN | For custom start and end markers, use this macro to mark beginning of asynchronous event. Remember to use the same marker name and id for beginning and end. Asynchronous markers need an identifier to correctly match events. | `OVMS_PROFILER_ASYNC_BEGIN("My Asynchronous Event", unique_id)` |
+| OVMS_PROFILER_ASYNC_END | For custom start and end markers, use this macro to mark end of asynchronous event. Remember to use the same marker name and id for beginning and end. Asynchronous markers need an identifier to correctly match events. | `OVMS_PROFILER_ASYNC_END("My Asynchronous Event", unique_id)` |
+
+More information can be found in [profiler.hpp](../src/profiler.hpp) file.
 
 </details>
 

--- a/release_files/thirdparty-licenses/minitrace.LICENSE.txt
+++ b/release_files/thirdparty-licenses/minitrace.LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Henrik Rydgård
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/BUILD
+++ b/src/BUILD
@@ -161,6 +161,8 @@ cc_library(
         "prediction_service_utils.cpp",
         "predict_request_validation_utils.hpp",
         "predict_request_validation_utils.cpp",
+        "profiler.cpp",
+        "profiler.hpp",
         "rest_parser.cpp",
         "rest_parser.hpp",
         "rest_utils.cpp",
@@ -200,6 +202,7 @@ cc_library(
     deps = [
         "@tensorflow_serving//tensorflow_serving/apis:prediction_service_cc_proto",
         "@tensorflow_serving//tensorflow_serving/apis:model_service_cc_proto",
+        "@minitrace//:trace",
         "@com_github_grpc_grpc//:grpc++",
         "@org_tensorflow//tensorflow/core:framework",
         "@rapidjson//:rapidjson",
@@ -222,7 +225,7 @@ cc_library(
         "//src/kfserving_api:kfserving_api_cpp",
     ],
     local_defines = [
-        "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE"
+        "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE",
     ],
     copts = [
         "-Wall",

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -75,6 +75,11 @@ Config& Config::parse(int argc, char** argv) {
             ("log_path",
                 "Optional path to the log file",
                 cxxopts::value<std::string>(), "LOG_PATH")
+#ifdef MTR_ENABLED
+            ("trace_path",
+                "Path to the trace file",
+                cxxopts::value<std::string>(), "TRACE_PATH")
+#endif
             ("grpc_channel_arguments",
                 "A comma separated list of arguments to be passed to the grpc server. (e.g. grpc.max_connection_age_ms=2000)",
                 cxxopts::value<std::string>(), "GRPC_CHANNEL_ARGUMENTS")

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -328,6 +328,19 @@ public:
         return empty;
     }
 
+#ifdef MTR_ENABLED
+    /**
+        * @brief Get the log path
+         *
+        * @return const std::string&
+        */
+    const std::string& tracePath() {
+        if (result->count("trace_path"))
+            return result->operator[]("trace_path").as<std::string>();
+        return empty;
+    }
+#endif
+
     /**
         * @brief Get the plugin config
         *

--- a/src/deserialization.hpp
+++ b/src/deserialization.hpp
@@ -30,6 +30,7 @@
 #pragma GCC diagnostic pop
 
 #include "binaryutils.hpp"
+#include "profiler.hpp"
 #include "status.hpp"
 #include "tensorinfo.hpp"
 
@@ -147,6 +148,7 @@ Status deserializePredictRequest(
     const tensorflow::serving::PredictRequest& request,
     const tensor_map_t& inputMap,
     Sink& inputSink, bool isPipeline) {
+    OVMS_PROFILE_FUNCTION();
     Status status;
     for (const auto& pair : inputMap) {
         try {

--- a/src/dlnodesession.cpp
+++ b/src/dlnodesession.cpp
@@ -27,6 +27,7 @@
 #include "nodeoutputhandler.hpp"
 #include "nodestreamidguard.hpp"
 #include "ov_utils.hpp"
+#include "profiler.hpp"
 #include "shape.hpp"
 #include "tensorinfo.hpp"
 #include "timer.hpp"
@@ -65,6 +66,7 @@ ov::InferRequest& DLNodeSession::getInferRequest(const uint microseconds) {
 }
 
 Status DLNodeSession::requestExecuteRequiredResources() {
+    OVMS_PROFILE_FUNCTION();
     Status status = modelManager.getModelInstance(
         modelName,
         modelVersion,
@@ -85,6 +87,7 @@ Status DLNodeSession::requestExecuteRequiredResources() {
 }
 
 Status DLNodeSession::prepareInputsAndModelForInference() {
+    OVMS_PROFILE_FUNCTION();
     std::optional<Dimension> requestedBatchSize = std::nullopt;
     std::map<std::string, shape_t> requestedReshapes;
 
@@ -147,6 +150,7 @@ Status DLNodeSession::prepareInputsAndModelForInference() {
 }
 
 Status DLNodeSession::validate(const ov::Tensor& tensor, const TensorInfo& tensorInfo) {
+    OVMS_PROFILE_FUNCTION();
     if (ovmsPrecisionToIE2Precision(tensorInfo.getPrecision()) != tensor.get_element_type()) {
         std::stringstream ss;
         ss << "Node: " << getName() << " input: " << tensorInfo.getName()
@@ -207,6 +211,7 @@ Status DLNodeSession::validate(const ov::Tensor& tensor, const TensorInfo& tenso
 }
 
 Status DLNodeSession::execute(PipelineEventQueue& notifyEndQueue, uint waitForStreamIdTimeoutMicroseconds, Node& node) {
+    OVMS_PROFILE_FUNCTION();
     Status status;
     if (this->nodeStreamIdGuard == nullptr) {
         status = requestExecuteRequiredResources();
@@ -245,6 +250,7 @@ Status DLNodeSession::getRealInputName(const std::string& alias, std::string* re
 }
 
 Status DLNodeSession::setInputsForInference(ov::InferRequest& inferRequest) {
+    OVMS_PROFILE_FUNCTION();
     Status status = StatusCode::OK;
     try {
         // Prepare inference request, fill with input tensors
@@ -263,9 +269,12 @@ Status DLNodeSession::setInputsForInference(ov::InferRequest& inferRequest) {
                     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] tensor clone error: {}", getName(), status.string());
                     return status;
                 }
+                OVMS_PROFILE_SYNC_BEGIN("ov::InferRequest::set_tensor");
                 inferRequest.set_tensor(realModelInputName, clonedTensor);
+                OVMS_PROFILE_SYNC_END("ov::InferRequest::set_tensor");
                 SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] tensor name: {} cloned before GPU inference", getName(), name);
             } else {
+                OVMS_PROFILE_SCOPE("ov::InferRequest::set_tensor");
                 inferRequest.set_tensor(realModelInputName, tensor);
             }
         }
@@ -286,9 +295,11 @@ Status DLNodeSession::setInputsForInference(ov::InferRequest& inferRequest) {
 }
 
 Status DLNodeSession::executeInference(PipelineEventQueue& notifyEndQueue, ov::InferRequest& inferRequest, Node& node) {
+    OVMS_PROFILE_FUNCTION();
     try {
         SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Setting completion callback for node name: {}", this->getName());
         inferRequest.set_callback([this, &notifyEndQueue, &inferRequest, &node](std::exception_ptr exception_ptr) {
+            OVMS_PROFILE_ASYNC_END("async inference", this);
             this->timer->stop("inference");
             SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Completion callback received for node name: {}", this->getName());
             // After inference is completed, input tensors are not needed anymore
@@ -298,7 +309,10 @@ Status DLNodeSession::executeInference(PipelineEventQueue& notifyEndQueue, ov::I
         });
         SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Starting infer async for node name: {}", getName());
         this->timer->start("inference");
+        OVMS_PROFILE_SYNC_BEGIN("ov::InferRequest::start_async");
         inferRequest.start_async();
+        OVMS_PROFILE_SYNC_END("ov::InferRequest::start_async");
+        OVMS_PROFILE_ASYNC_BEGIN("async inference", this);
     } catch (const ov::Exception& e) {
         SPDLOG_LOGGER_DEBUG(dag_executor_logger, "[Node: {}] Exception occured when starting async inference or setting completion callback on model: {}, error: {}",
             getName(), getModelName(), e.what());

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -26,6 +26,7 @@
 #include "logging.hpp"
 #include "ov_utils.hpp"
 #include "predict_request_validation_utils.hpp"
+#include "profiler.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
@@ -37,6 +38,7 @@ namespace ovms {
 
 template <typename RequestType>
 Status EntryNode<RequestType>::execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) {
+    OVMS_PROFILE_FUNCTION();
     // this should be created in EntryNode::SetInputs, or special method for entry node called
     // in event loop can be done in future release while implementing dynamic demultiplexing at
     // entry node
@@ -52,6 +54,7 @@ Status EntryNode<RequestType>::execute(session_key_t sessionId, PipelineEventQue
 
 template <typename RequestType>
 Status EntryNode<RequestType>::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) {
+    OVMS_PROFILE_FUNCTION();
     TensorMap outputs;
     auto status = fetchResults(outputs);
     if (!status.ok()) {

--- a/src/exit_node.cpp
+++ b/src/exit_node.cpp
@@ -32,12 +32,14 @@
 namespace ovms {
 template <typename ResponseType>
 Status ExitNode<ResponseType>::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) {
+    OVMS_PROFILE_FUNCTION();
     auto& exitNodeSession = static_cast<ExitNodeSession&>(nodeSession);
     return this->fetchResults(exitNodeSession.getInputTensors());
 }
 
 template <typename ResponseType>
 Status ExitNode<ResponseType>::execute(session_key_t sessionId, PipelineEventQueue& notifyEndQueue) {
+    OVMS_PROFILE_FUNCTION();
     notifyEndQueue.push(NodeSessionKeyPair(*this, sessionId));
     return StatusCode::OK;
 }

--- a/src/nodestreamidguard.hpp
+++ b/src/nodestreamidguard.hpp
@@ -21,6 +21,7 @@
 #include <spdlog/spdlog.h>
 
 #include "ovinferrequestsqueue.hpp"
+#include "profiler.hpp"
 
 namespace ovms {
 
@@ -41,6 +42,7 @@ struct NodeStreamIdGuard {
     }
 
     std::optional<int> tryGetId(const uint microseconds = 1) {
+        OVMS_PROFILE_FUNCTION();
         if (!streamId) {
             if (std::future_status::ready == futureStreamId.wait_for(std::chrono::microseconds(microseconds))) {
                 streamId = futureStreamId.get();

--- a/src/ov_utils.cpp
+++ b/src/ov_utils.cpp
@@ -21,6 +21,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include "profiler.hpp"
 #include "tensorinfo.hpp"
 
 namespace ovms {
@@ -55,6 +56,7 @@ std::string getTensorMapString(const std::map<std::string, std::shared_ptr<Tenso
 }
 
 Status tensorClone(ov::Tensor& destinationTensor, const ov::Tensor& sourceTensor) {
+    OVMS_PROFILE_FUNCTION();
     destinationTensor = ov::Tensor(sourceTensor.get_element_type(), sourceTensor.get_shape());
 
     if (destinationTensor.get_byte_size() != sourceTensor.get_byte_size()) {

--- a/src/predict_request_validation_utils.cpp
+++ b/src/predict_request_validation_utils.cpp
@@ -26,6 +26,7 @@
 
 #include "kfs_grpc_inference_service.hpp"
 #include "modelconfig.hpp"
+#include "profiler.hpp"
 
 namespace ovms {
 namespace request_validation_utils {
@@ -374,11 +375,13 @@ Status RequestValidator::validate() {
 
 template <>
 Status validate(const tensorflow::serving::PredictRequest& request, const tensor_map_t& inputsInfo, const std::string& servableName, const model_version_t servableVersion, const std::set<const char*>& optionalAllowedInputNames, const Mode batchingMode, const shapes_info_map_t& shapeInfo) {
+    OVMS_PROFILE_FUNCTION();
     return RequestValidator(request, inputsInfo, servableName, servableVersion, optionalAllowedInputNames, batchingMode, shapeInfo).validate();
 }
 
 template <>
 Status validate(const ::inference::ModelInferRequest& request, const tensor_map_t& inputsInfo, const std::string& servableName, const model_version_t servableVersion, const std::set<const char*>& optionalAllowedInputNames, const Mode batchingMode, const shapes_info_map_t& shapeInfo) {
+    OVMS_PROFILE_FUNCTION();
     return StatusCode::NOT_IMPLEMENTED;
 }
 

--- a/src/prediction_service.cpp
+++ b/src/prediction_service.cpp
@@ -32,6 +32,7 @@
 #include "modelmanager.hpp"
 #include "ovinferrequestsqueue.hpp"
 #include "prediction_service_utils.hpp"
+#include "profiler.hpp"
 #include "status.hpp"
 #include "timer.hpp"
 
@@ -48,6 +49,7 @@ namespace ovms {
 Status getModelInstance(const PredictRequest* request,
     std::shared_ptr<ovms::ModelInstance>& modelInstance,
     std::unique_ptr<ModelInstanceUnloadGuard>& modelInstanceUnloadGuardPtr) {
+    OVMS_PROFILE_FUNCTION();
     ModelManager& manager = ModelManager::getInstance();
     return manager.getModelInstance(request->model_spec().name(), request->model_spec().version().value(), modelInstance, modelInstanceUnloadGuardPtr);
 }
@@ -55,6 +57,7 @@ Status getModelInstance(const PredictRequest* request,
 Status getPipeline(const PredictRequest* request,
     PredictResponse* response,
     std::unique_ptr<ovms::Pipeline>& pipelinePtr) {
+    OVMS_PROFILE_FUNCTION();
     ModelManager& manager = ModelManager::getInstance();
     return manager.createPipeline(pipelinePtr, request->model_spec().name(), request, response);
 }
@@ -63,6 +66,7 @@ grpc::Status ovms::PredictionServiceImpl::Predict(
     ServerContext* context,
     const PredictRequest* request,
     PredictResponse* response) {
+    OVMS_PROFILE_FUNCTION();
     Timer timer;
     timer.start("total");
     using std::chrono::microseconds;
@@ -104,6 +108,7 @@ grpc::Status PredictionServiceImpl::GetModelMetadata(
     grpc::ServerContext* context,
     const tensorflow::serving::GetModelMetadataRequest* request,
     tensorflow::serving::GetModelMetadataResponse* response) {
+    OVMS_PROFILE_FUNCTION();
     return GetModelMetadataImpl::getModelStatus(request, response).grpc();
 }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -17,11 +17,13 @@
 
 #include <stdio.h>
 
-bool profiler_init(const char* file_name) {
+namespace ovms {
+
+bool profiler_init(const char* file_path) {
 #ifndef MTR_ENABLED
     return true;
 #endif
-    FILE* f = fopen(file_name, "wb");
+    FILE* f = fopen(file_path, "wb");
     if (f == nullptr) {
         return false;
     }
@@ -36,3 +38,19 @@ void profiler_shutdown() {
     mtr_flush();
     mtr_shutdown();
 }
+
+Profiler::Profiler(const std::string& file_path) {
+    this->initialized = profiler_init(file_path.c_str());
+}
+
+Profiler::~Profiler() {
+    if (this->isInitialized()) {
+        profiler_shutdown();
+    }
+}
+
+bool Profiler::isInitialized() const {
+    return this->initialized;
+}
+
+}  // namespace ovms

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1,0 +1,38 @@
+//*****************************************************************************
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include "profiler.hpp"
+
+#include <stdio.h>
+
+bool profiler_init(const char* file_name) {
+#ifndef MTR_ENABLED
+    return true;
+#endif
+    FILE* f = fopen(file_name, "wb");
+    if (f == nullptr) {
+        return false;
+    }
+    mtr_init_from_stream(f);
+    return true;
+}
+
+void profiler_shutdown() {
+#ifndef MTR_ENABLED
+    return;
+#endif
+    mtr_flush();
+    mtr_shutdown();
+}

--- a/src/profiler.hpp
+++ b/src/profiler.hpp
@@ -15,6 +15,8 @@
 //*****************************************************************************
 #pragma once
 
+#include <string>
+
 #include "minitrace.h"  // NOLINT
 
 #define OVMS_PROFILE_SCOPE(name) MTR_SCOPE("OVMS", name);
@@ -29,5 +31,19 @@
 #define OVMS_PROFILE_ASYNC_BEGIN(name, id) MTR_START("OVMS", name, id);
 #define OVMS_PROFILE_ASYNC_END(name, id) MTR_FINISH("OVMS", name, id);
 
-bool profiler_init(const char* file_name);
+namespace ovms {
+
+bool profiler_init(const char* file_path);
 void profiler_shutdown();
+
+class Profiler {
+public:
+    Profiler(const std::string& file_path);
+    ~Profiler();
+    bool isInitialized() const;
+
+private:
+    bool initialized = false;
+};
+
+}  // namespace ovms

--- a/src/profiler.hpp
+++ b/src/profiler.hpp
@@ -1,0 +1,33 @@
+//*****************************************************************************
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+
+#include "minitrace.h"  // NOLINT
+
+#define OVMS_PROFILE_SCOPE(name) MTR_SCOPE("OVMS", name);
+#define OVMS_PROFILE_SCOPE_S(name, vname, cstr) MTR_SCOPE_S("OVMS", name, vname, cstr);
+#define OVMS_PROFILE_FUNCTION() OVMS_PROFILE_SCOPE(__PRETTY_FUNCTION__)
+
+#define OVMS_PROFILE_SYNC_BEGIN(name) MTR_BEGIN("OVMS", name);
+#define OVMS_PROFILE_SYNC_END(name) MTR_END("OVMS", name);
+#define OVMS_PROFILE_SYNC_BEGIN_S(name, vname, cstr) MTR_BEGIN_S("OVMS", name, vname, cstr);
+#define OVMS_PROFILE_SYNC_END_S(name, vname, cstr) MTR_END_S("OVMS", name, vname, cstr);
+
+#define OVMS_PROFILE_ASYNC_BEGIN(name, id) MTR_START("OVMS", name, id);
+#define OVMS_PROFILE_ASYNC_END(name, id) MTR_FINISH("OVMS", name, id);
+
+bool profiler_init(const char* file_name);
+void profiler_shutdown();

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -28,6 +28,7 @@
 #pragma GCC diagnostic pop
 
 #include "kfs_grpc_inference_service.hpp"
+#include "profiler.hpp"
 #include "status.hpp"
 #include "tensorinfo.hpp"
 
@@ -82,6 +83,7 @@ Status serializePredictResponse(
     const tensor_map_t& outputMap,
     tensorflow::serving::PredictResponse* response,
     outputNameChooser_t outputNameChooser) {
+    OVMS_PROFILE_FUNCTION();
     Status status;
     ProtoGetter<tensorflow::serving::PredictResponse*, tensorflow::TensorProto&> protoGetter(response);
     for (const auto& [outputName, outputInfo] : outputMap) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -260,14 +260,12 @@ int server_main(int argc, char** argv) {
         configure_logger(config.logLevel(), config.logPath());
 
 #ifdef MTR_ENABLED
-        const char* traceFileName = config.tracePath().c_str();
-#else
-        const char* traceFileName = "";
-#endif
-        if (!profiler_init(traceFileName)) {
-            SPDLOG_ERROR("Cannot open file for profiler, --trace_path: {}", traceFileName);
+        auto profiler = Profiler(config.tracePath());
+        if (!profiler.isInitialized()) {
+            SPDLOG_ERROR("Cannot open file for profiler, --trace_path: {}", config.tracePath());
             return EXIT_FAILURE;
         }
+#endif
 
         PredictionServiceImpl predict_service;
         ModelServiceImpl model_service;
@@ -297,14 +295,11 @@ int server_main(int argc, char** argv) {
         ModelManager::getInstance().join();
     } catch (std::exception& e) {
         SPDLOG_ERROR("Exception catch: {} - will now terminate.", e.what());
-        profiler_shutdown();
         return EXIT_FAILURE;
     } catch (...) {
         SPDLOG_ERROR("Unknown exception catch - will now terminate.");
-        profiler_shutdown();
         return EXIT_FAILURE;
     }
 
-    profiler_shutdown();
     return EXIT_SUCCESS;
 }

--- a/src/statefulmodelinstance.cpp
+++ b/src/statefulmodelinstance.cpp
@@ -22,6 +22,7 @@
 #include "executingstreamidguard.hpp"
 #include "logging.hpp"
 #include "predict_request_validation_utils.hpp"
+#include "profiler.hpp"
 #include "serialization.hpp"
 #include "timer.hpp"
 
@@ -178,6 +179,7 @@ const Status StatefulModelInstance::validateSpecialKeys(const tensorflow::servin
 
 template <typename RequestType>
 const Status StatefulModelInstance::validate(const RequestType* request, SequenceProcessingSpec& sequenceProcessingSpec) {
+    OVMS_PROFILE_FUNCTION();
     auto status = validateSpecialKeys(request, sequenceProcessingSpec);
     if (!status.ok())
         return status;
@@ -195,6 +197,7 @@ const Status StatefulModelInstance::validate(const RequestType* request, Sequenc
 Status StatefulModelInstance::infer(const tensorflow::serving::PredictRequest* requestProto,
     tensorflow::serving::PredictResponse* responseProto,
     std::unique_ptr<ModelInstanceUnloadGuard>& modelUnloadGuardPtr) {
+    OVMS_PROFILE_FUNCTION();
     Timer timer;
     using std::chrono::microseconds;
     SequenceProcessingSpec sequenceProcessingSpec;


### PR DESCRIPTION
Integration with minitrace should have no overhead on performance and no effect for standard builds.
To build with minitrace enabled, add `MINITRACE=ON` param to docker_build target.
In such builds, `--trace_path` CLI param is enabled to configure where traces should be stored.

Added developer documentation how to use it.