### PR TITLE
benchmark_client: fix timing & Docker build

### DIFF
--- a/client/python/ovmsclient/Dockerfile.ubuntu
+++ b/client/python/ovmsclient/Dockerfile.ubuntu
@@ -32,7 +32,7 @@ RUN apt-get install -y python3-pip python3-venv make && \
     cd /ovmsclient/lib && make build
 
 RUN cd /ovmsclient/lib && python3 -m venv .client_venv && . .client_venv/bin/activate && \ 
-    pip3 install dist/ovmsclient-0.2-py3-none-any.whl && \
+    pip3 install dist/ovmsclient-*-py3-none-any.whl && \
     cd .client_venv/lib && ln -s python3* python3 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #


### PR DESCRIPTION
Replace all time.time() calls with time.perf_count(), since the former
is not very accurate, and more importantly not a monotonic counter.
That means that we can end up with negative time deltas, causing all
kinds of trouble.