### PR TITLE
POC: CVS-82882 Write data directly into gRPC response during exit node gathering in DAG

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -101,6 +101,7 @@ cc_library(
         "localfilesystem.hpp",
         "gathernodeinputhandler.cpp",
         "gathernodeinputhandler.hpp",
+        "gatherexitnodeinputhandler.hpp",
         "gcsfilesystem.cpp",
         "gcsfilesystem.hpp",
         "kfs_grpc_inference_service.cpp",

--- a/src/entry_node.cpp
+++ b/src/entry_node.cpp
@@ -115,7 +115,7 @@ Status EntryNode<::inference::ModelInferRequest>::isInputBinary(const std::strin
 }
 
 template <typename RequestType>
-Status EntryNode<RequestType>::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string tensorName) {
+Status EntryNode<RequestType>::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string& tensorName) {
     bool isBinary = false;
     auto status = this->isInputBinary(tensorName, isBinary);
     if (!status.ok()) {
@@ -173,8 +173,8 @@ template Status EntryNode<tensorflow::serving::PredictRequest>::fetchResults(Ten
 template Status EntryNode<::inference::ModelInferRequest>::fetchResults(TensorWithSourceMap& outputs);
 template Status EntryNode<tensorflow::serving::PredictRequest>::isInputBinary(const std::string& name, bool& isBinary) const;
 template Status EntryNode<::inference::ModelInferRequest>::isInputBinary(const std::string& name, bool& isBinary) const;
-template Status EntryNode<tensorflow::serving::PredictRequest>::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string tensorName);
-template Status EntryNode<::inference::ModelInferRequest>::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string tensorName);
+template Status EntryNode<tensorflow::serving::PredictRequest>::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string& tensorName);
+template Status EntryNode<::inference::ModelInferRequest>::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string& tensorName);
 template const Status EntryNode<tensorflow::serving::PredictRequest>::validate();
 template const Status EntryNode<::inference::ModelInferRequest>::validate();
 }  //  namespace ovms

--- a/src/entry_node.hpp
+++ b/src/entry_node.hpp
@@ -47,7 +47,7 @@ public:
 
 protected:
     Status fetchResults(TensorWithSourceMap& outputs);
-    Status createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string tensorName) override;
+    Status createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string& tensorName) override;
 
 public:
     // Entry nodes have no dependency

--- a/src/exit_node.cpp
+++ b/src/exit_node.cpp
@@ -33,7 +33,7 @@ namespace ovms {
 template <typename ResponseType>
 Status ExitNode<ResponseType>::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) {
     OVMS_PROFILE_FUNCTION();
-    auto& exitNodeSession = static_cast<ExitNodeSession&>(nodeSession);
+    auto& exitNodeSession = static_cast<ExitNodeSession<ResponseType>&>(nodeSession);
     return this->fetchResults(exitNodeSession.getInputTensors());
 }
 
@@ -63,7 +63,7 @@ Status ExitNode<ResponseType>::fetchResults(const TensorMap& inputTensors) {
 
 template <typename ResponseType>
 std::unique_ptr<NodeSession> ExitNode<ResponseType>::createNodeSession(const NodeSessionMetadata& metadata, const CollapseDetails& collapsingDetails) {
-    return std::make_unique<ExitNodeSession>(metadata, getName(), previous.size(), collapsingDetails);
+    return std::make_unique<ExitNodeSession<ResponseType>>(metadata, getName(), previous.size(), collapsingDetails, this->response);
 }
 
 template Status ExitNode<::inference::ModelInferResponse>::fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs);

--- a/src/exitnodesession.cpp
+++ b/src/exitnodesession.cpp
@@ -23,9 +23,6 @@ namespace ovms {
 ExitNodeSession::ExitNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails) :
     NodeSession(metadata, nodeName, inputsCount, collapsingDetails) {}
 
-ExitNodeSession::ExitNodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails) :
-    NodeSession(std::move(metadata), nodeName, inputsCount, collapsingDetails) {}
-
 ExitNodeSession::~ExitNodeSession() = default;
 
 void ExitNodeSession::release() {}

--- a/src/exitnodesession.hpp
+++ b/src/exitnodesession.hpp
@@ -24,6 +24,7 @@
 #include "nodeinputhandler.hpp"
 #include "nodesession.hpp"
 #include "nodesessionmetadata.hpp"
+#include "profiler.hpp"
 #include "status.hpp"
 #include "tensormap.hpp"
 
@@ -44,7 +45,10 @@ public:
             this->inputHandler = std::make_unique<GatherExitNodeInputHandler<ResponseType>>(inputsCount, collapsingDetails, response);
         }
     }
-    virtual ~ExitNodeSession() = default;
+    virtual ~ExitNodeSession() {
+        OVMS_PROFILE_SCOPE("~ExitNodeSession()");
+        SPDLOG_INFO("~ExitNodeSession()");
+    }
 
     const TensorMap& getInputTensors() const { return this->inputHandler->getInputs(); }
     void release() override {}

--- a/src/exitnodesession.hpp
+++ b/src/exitnodesession.hpp
@@ -15,10 +15,13 @@
 //*****************************************************************************
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include <openvino/openvino.hpp>
 
+#include "gatherexitnodeinputhandler.hpp"
+#include "nodeinputhandler.hpp"
 #include "nodesession.hpp"
 #include "nodesessionmetadata.hpp"
 #include "status.hpp"
@@ -29,12 +32,21 @@ namespace ovms {
 class Node;
 class TensorInfo;
 
+template <class ResponseType>
 class ExitNodeSession : public NodeSession {
-public:
-    ExitNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails);
-    virtual ~ExitNodeSession();
+    ResponseType* response;
 
-    const TensorMap& getInputTensors() const;
-    void release() override;
+public:
+    ExitNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails, ResponseType* response) :
+        NodeSession(metadata, nodeName, inputsCount, collapsingDetails),
+        response(response) {
+        if (collapsingDetails.collapsedSessionNames.size() > 0) {
+            this->inputHandler = std::make_unique<GatherExitNodeInputHandler<ResponseType>>(inputsCount, collapsingDetails, response);
+        }
+    }
+    virtual ~ExitNodeSession() = default;
+
+    const TensorMap& getInputTensors() const { return this->inputHandler->getInputs(); }
+    void release() override {}
 };
 }  // namespace ovms

--- a/src/gatherexitnodeinputhandler.cpp
+++ b/src/gatherexitnodeinputhandler.cpp
@@ -1,10 +1,11 @@
 //*****************************************************************************
-// Copyright 2021 Intel Corporation
+// Copyright 2022 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,22 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#include "exitnodesession.hpp"
-
-#include <utility>
+#include "gatherexitnodeinputhandler.hpp"
 
 #include "logging.hpp"
-#include "nodeinputhandler.hpp"
+#include "profiler.hpp"
 
 namespace ovms {
-// ExitNodeSession::ExitNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails) :
-//     NodeSession(metadata, nodeName, inputsCount, collapsingDetails) {}
 
-// ExitNodeSession::~ExitNodeSession() = default;
-
-// void ExitNodeSession::release() {}
-
-// const TensorMap& ExitNodeSession::getInputTensors() const {
-//     return this->inputHandler->getInputs();
-// }
 }  // namespace ovms

--- a/src/gatherexitnodeinputhandler.hpp
+++ b/src/gatherexitnodeinputhandler.hpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright 2021 Intel Corporation
+// Copyright 2022 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,26 +15,15 @@
 //*****************************************************************************
 #pragma once
 
-#include <string>
-
-#include <openvino/openvino.hpp>
-
-#include "nodesession.hpp"
-#include "nodesessionmetadata.hpp"
-#include "status.hpp"
-#include "tensormap.hpp"
+#include "gathernodeinputhandler.hpp"
 
 namespace ovms {
 
-class Node;
-class TensorInfo;
+class CollapseDetails;
 
-class ExitNodeSession : public NodeSession {
+class GatherExitNodeInputHandler : public GatherNodeInputHandler {
 public:
-    ExitNodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails);
-    virtual ~ExitNodeSession();
-
-    const TensorMap& getInputTensors() const;
-    void release() override;
+    GatherExitNodeInputHandler(uint32_t inputsMissingCount, const CollapseDetails& collapsingDetails) : GatherNodeInputHandler(inputsMissingCount, collapsingDetails) {};
+    //Status notifyFinishedDependency() override;
 };
 }  // namespace ovms

--- a/src/gatherexitnodeinputhandler.hpp
+++ b/src/gatherexitnodeinputhandler.hpp
@@ -55,6 +55,9 @@ public:
     //    return GatherNodeInputHandler::notifyFinishedDependency();
     //  }
 
+    ~GatherExitNodeInputHandler() {
+    }
+
     ov::Tensor makeTensorForWrite(const std::string& name, ov::element::Type_t precision, const ov::Shape& shape) override {
         OVMS_PROFILE_FUNCTION();
         size_t size = 1;
@@ -63,7 +66,6 @@ public:
         }
         size *= ov::element::Type(precision).size();
         auto* buf = prepareBuffer(response, name, size);
-        std::cout << buf << std::endl;
         return ov::Tensor(precision, shape, buf);
     }
 };

--- a/src/gatherexitnodeinputhandler.hpp
+++ b/src/gatherexitnodeinputhandler.hpp
@@ -15,15 +15,57 @@
 //*****************************************************************************
 #pragma once
 
+#include <string>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
+#pragma GCC diagnostic pop
+
 #include "gathernodeinputhandler.hpp"
+#include "kfs_grpc_inference_service.hpp"
+#include "logging.hpp"
 
 namespace ovms {
 
 class CollapseDetails;
 
+char* prepareBuffer(tensorflow::serving::PredictResponse* response, const std::string& name, size_t size) {
+    OVMS_PROFILE_FUNCTION();
+    tensorflow::TensorProto& tensorProto = (*response->mutable_outputs())[name];
+    tensorProto.mutable_tensor_content()->resize(size);
+    return tensorProto.mutable_tensor_content()->data();
+}
+
+char* prepareBuffer(::inference::ModelInferResponse* response, const std::string& name, size_t size) {
+    return 0;
+}
+
+template <class ResponseType>
 class GatherExitNodeInputHandler : public GatherNodeInputHandler {
+    ResponseType* response;
+
 public:
-    GatherExitNodeInputHandler(uint32_t inputsMissingCount, const CollapseDetails& collapsingDetails) : GatherNodeInputHandler(inputsMissingCount, collapsingDetails) {};
-    //Status notifyFinishedDependency() override;
+    GatherExitNodeInputHandler(uint32_t inputsMissingCount, const CollapseDetails& collapsingDetails, ResponseType* response) :
+        GatherNodeInputHandler(inputsMissingCount, collapsingDetails),
+        response(response) {}
+    //  Status notifyFinishedDependency() override {
+    //    SPDLOG_INFO("GatherExitNodeInputHandler XXXXXXXXXXXXXXX");
+    //    return GatherNodeInputHandler::notifyFinishedDependency();
+    //  }
+
+    ov::Tensor makeTensorForWrite(const std::string& name, ov::element::Type_t precision, const ov::Shape& shape) override {
+        OVMS_PROFILE_FUNCTION();
+        size_t size = 1;
+        for (size_t i = 0; i < shape.size(); i++) {
+            size *= shape[i];
+        }
+        size *= ov::element::Type(precision).size();
+        auto* buf = prepareBuffer(response, name, size);
+        std::cout << buf << std::endl;
+        return ov::Tensor(precision, shape, buf);
+    }
 };
+
 }  // namespace ovms

--- a/src/gathernodeinputhandler.cpp
+++ b/src/gathernodeinputhandler.cpp
@@ -105,6 +105,9 @@ Status GatherNodeInputHandler::notifyFinishedDependency() {
                 tensor.data(),
                 memstep);
         }
+        OVMS_PROFILE_SYNC_BEGIN("Remove used shards");
+        shardMap.clear();
+        OVMS_PROFILE_SYNC_END("Remove used shards");
         inputTensors.insert({inputName, consolidatedTensor});
     }
     return StatusCode::OK;

--- a/src/gathernodeinputhandler.cpp
+++ b/src/gathernodeinputhandler.cpp
@@ -76,11 +76,12 @@ Status GatherNodeInputHandler::notifyFinishedDependency() {
         newDims.insert(newDims.begin(),
             collapsingDetails->collapsedSessionSizes.begin(),
             collapsingDetails->collapsedSessionSizes.end());
-        ov::Tensor consolidatedTensor;
-        auto status = createSharedTensor(consolidatedTensor, precision, newDims);
-        if (!status.ok()) {
-            return status;
-        }
+        ov::Tensor consolidatedTensor = makeTensorForWrite(inputName, precision, newDims);
+        // ov::Tensor consolidatedTensor;
+        // auto status = createSharedTensor(consolidatedTensor, precision, newDims);
+        // if (!status.ok()) {
+        //     return status;
+        // }
         for (auto& [shardId, tensor] : shardMap) {
             OVMS_PROFILE_SCOPE("Copy Shard");
             if ((tensor.get_element_type() != precision) ||

--- a/src/gathernodeinputhandler.hpp
+++ b/src/gathernodeinputhandler.hpp
@@ -39,6 +39,24 @@ class GatherNodeInputHandler : public NodeInputHandler {
 
 public:
     GatherNodeInputHandler(uint32_t inputsMissingCount, const CollapseDetails& collapsingDetails);
+    ~GatherNodeInputHandler() {
+        {
+            OVMS_PROFILE_SCOPE("shardsStorage.clear");
+            shardsStorage.clear();
+        }
+        {
+            OVMS_PROFILE_SCOPE("collapsingDetails.reset");
+            collapsingDetails.reset();
+        }
+        {
+            OVMS_PROFILE_SCOPE("inputTensors.clear");
+            inputTensors.clear();
+        }
+        {
+            OVMS_PROFILE_SCOPE("sourceTensorRefs.clear");
+            sourceTensorRefs.clear();
+        }
+    }
     Status setInput(const std::string& inputName, TensorWithSource& tensor, session_id_t shardId) override;
     Status notifyFinishedDependency() override;
 

--- a/src/gathernodeinputhandler.hpp
+++ b/src/gathernodeinputhandler.hpp
@@ -23,6 +23,8 @@
 #include <openvino/openvino.hpp>
 
 #include "nodeinputhandler.hpp"
+#include "ov_utils.hpp"
+#include "profiler.hpp"
 #include "session_id.hpp"
 
 namespace ovms {
@@ -39,5 +41,15 @@ public:
     GatherNodeInputHandler(uint32_t inputsMissingCount, const CollapseDetails& collapsingDetails);
     Status setInput(const std::string& inputName, TensorWithSource& tensor, session_id_t shardId) override;
     Status notifyFinishedDependency() override;
+
+    virtual ov::Tensor makeTensorForWrite(
+        const std::string& name,
+        ov::element::Type_t precision,
+        const ov::Shape& shape) {
+        OVMS_PROFILE_FUNCTION();
+        ov::Tensor result;
+        createSharedTensor(result, precision, shape);
+        return result;
+    }
 };
 }  // namespace ovms

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -265,7 +265,7 @@ Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
     return StatusCode::OK;
 }
 
-Status Node::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string tensorName) {
+Status Node::createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string& tensorName) {
     dividedTensor = createSharedTensor(tensor.get_element_type(), shape, (char*)(tensor.data()) + i * step);
     return StatusCode::OK;
 }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -71,7 +71,10 @@ Status Node::fetchResults(session_key_t sessionId, SessionResults& nodeSessionOu
         status = demultiplyOutputs(nodeSessionOutputs);
     }
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Will remove node: {} session: {}", getName(), sessionId);
-    nodeSessions.erase(sessionId);
+    {
+        OVMS_PROFILE_SCOPE("Erase Exit Node Session");
+        nodeSessions.erase(it);
+    }
     return status;
 }
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -248,10 +248,6 @@ Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
             OVMS_PROFILE_SCOPE("Create Shard");
             ov::Tensor dividedTensor;
             this->createShardedTensor(dividedTensor, ovElementTypeToOvmsPrecision(tensor.get_element_type()), newDims, tensor, i, step, metadata, tensorName);
-            std::stringstream ss;
-            ss << "Node: " << getName() << " input demultiplied: " << tensorName
-               << "; Actual: " << TensorInfo::shapeToString(dividedTensor.get_shape());
-            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "{}", ss.str());
             auto sessionKey = newSessionMetadatas[i].getSessionKey();
             auto it = nodeSessionOutputs.find(sessionKey);
             if (it == nodeSessionOutputs.end()) {

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -67,7 +67,7 @@ public:
 protected:
     virtual Status fetchResults(NodeSession& nodeSession, SessionResults& nodeSessionOutputs) = 0;
     Status demultiplyOutputs(SessionResults& nodeSessionOutputs);
-    virtual Status createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string tensorName);
+    virtual Status createShardedTensor(ov::Tensor& dividedTensor, Precision precision, const shape_t& shape, const ov::Tensor& tensor, size_t i, size_t step, const NodeSessionMetadata& metadata, const std::string& tensorName);
 
 public:
     Status setInputs(const Node& dependency, TensorWithSourceMap& inputs, NodeSessionMetadata& metadata);

--- a/src/nodesession.cpp
+++ b/src/nodesession.cpp
@@ -19,10 +19,26 @@
 #include "logging.hpp"
 #include "nodeinputhandler.hpp"
 #include "nodeoutputhandler.hpp"
+#include "profiler.hpp"
 #include "timer.hpp"
 
 namespace ovms {
-NodeSession::~NodeSession() = default;
+NodeSession::~NodeSession() {
+    OVMS_PROFILE_SCOPE("~NodeSession");
+    // 0.176ms
+    {
+        OVMS_PROFILE_SCOPE("timer.reset");
+        timer.reset();
+    }
+    {
+        OVMS_PROFILE_SCOPE("inputHandler.reset");
+        inputHandler.reset();
+    }
+    {
+        OVMS_PROFILE_SCOPE("outputHandler.reset");
+        outputHandler.reset();
+    }
+}
 
 const NodeSessionMetadata& NodeSession::getNodeSessionMetadata() const {
     return this->metadata;

--- a/src/nodesession.cpp
+++ b/src/nodesession.cpp
@@ -48,14 +48,6 @@ NodeSession::NodeSession(const NodeSessionMetadata& metadata, const std::string&
     inputHandler(createNodeInputHandler(inputsCount, collapsingDetails)),
     outputHandler(std::make_unique<NodeOutputHandler>()) {}
 
-NodeSession::NodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails) :
-    metadata(std::move(metadata)),
-    sessionKey(this->metadata.getSessionKey()),
-    nodeName(nodeName),
-    timer(std::make_unique<Timer>()),
-    inputHandler(std::make_unique<NodeInputHandler>(inputsCount)),
-    outputHandler(std::make_unique<NodeOutputHandler>()) {}
-
 bool NodeSession::isReady() const {
     bool isReady = inputHandler->isReady();
     SPDLOG_LOGGER_DEBUG(dag_executor_logger, "node: {} session: {} isReady: {}", getName(), getSessionKey(), isReady);

--- a/src/nodesession.hpp
+++ b/src/nodesession.hpp
@@ -42,7 +42,6 @@ protected:
 
 public:
     NodeSession(const NodeSessionMetadata& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails);
-    NodeSession(const NodeSessionMetadata&& metadata, const std::string& nodeName, uint32_t inputsCount, const CollapseDetails& collapsingDetails);
     virtual ~NodeSession();
     const std::string& getName() const { return nodeName; }
     Status setInput(const std::string& inputName, TensorWithSource& tensor, session_id_t shardId);

--- a/src/nodesessionmetadata.hpp
+++ b/src/nodesessionmetadata.hpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "profiler.hpp"
 #include "session_id.hpp"
 
 namespace ovms {
@@ -39,6 +40,12 @@ class NodeSessionMetadata {
     std::vector<std::string> sessionsLevels;
 
 public:
+    ~NodeSessionMetadata() {
+        OVMS_PROFILE_SCOPE("~NodeSessionMetadata");
+        details.clear();
+        sessionsLevels.clear();
+    }
+
     std::vector<NodeSessionMetadata> generateSubsessions(const std::string& nodeName, session_id_t subsessionSize) const;
     std::string getSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
     std::pair<NodeSessionMetadata, CollapseDetails> getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const;

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -23,6 +23,8 @@ Status serializeTensorToTensorProto(
     tensorflow::TensorProto& responseOutput,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
+    OVMS_PROFILE_SYNC_BEGIN("Serialize Precision");
     if (servableOutput->getOvPrecision() != tensor.get_element_type()) {
         SPDLOG_ERROR("Failed to serialize tensor: {}. There is difference in precision expected:{} vs actual:{}",
             servableOutput->getName(),
@@ -54,6 +56,8 @@ Status serializeTensorToTensorProto(
         return status;
     }
     }
+    OVMS_PROFILE_SYNC_END("Serialize Precision");
+    OVMS_PROFILE_SYNC_BEGIN("Serialize Shape");
     responseOutput.mutable_tensor_shape()->Clear();
     auto& effectiveNetworkOutputShape = servableOutput->getShape();
     ov::Shape actualTensorShape = tensor.get_shape();
@@ -71,10 +75,13 @@ Status serializeTensorToTensorProto(
         }
         responseOutput.mutable_tensor_shape()->add_dim()->set_size(dim);
     }
+    OVMS_PROFILE_SYNC_END("Serialize Shape");
+    OVMS_PROFILE_SYNC_BEGIN("Serialize Buffer");
     // Output may already be filled during gathering
     if (responseOutput.mutable_tensor_content()->size() == 0) {
         responseOutput.mutable_tensor_content()->assign((char*)tensor.data(), tensor.get_byte_size());
     }
+    OVMS_PROFILE_SYNC_END("Serialize Buffer");
     return StatusCode::OK;
 }
 

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -23,7 +23,6 @@ Status serializeTensorToTensorProto(
     tensorflow::TensorProto& responseOutput,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
-    responseOutput.Clear();
     if (servableOutput->getOvPrecision() != tensor.get_element_type()) {
         SPDLOG_ERROR("Failed to serialize tensor: {}. There is difference in precision expected:{} vs actual:{}",
             servableOutput->getName(),
@@ -72,7 +71,10 @@ Status serializeTensorToTensorProto(
         }
         responseOutput.mutable_tensor_shape()->add_dim()->set_size(dim);
     }
-    responseOutput.mutable_tensor_content()->assign((char*)tensor.data(), tensor.get_byte_size());
+    // Output may already be filled during gathering
+    if (responseOutput.mutable_tensor_content()->size() == 0) {
+        responseOutput.mutable_tensor_content()->assign((char*)tensor.data(), tensor.get_byte_size());
+    }
     return StatusCode::OK;
 }
 


### PR DESCRIPTION
Currently gathering step consolidates all shads into one tensor. If the gather step appears in the last node, the consolidated tensor is then copied into gRPC response buffer. This causes the process to copy data twice. Depending on the size of tensor, it might add significant overhead.

This POC shows working patch that makes the exit node write data directly into gRPC response buffer instead of consolidating data into intermediate buffer.

Gathering and consolidating shards in other parts of DAG (non exit) remain unchanged.