### PR TITLE
Refactor prediction tests to support KFS

### DIFF
--- a/src/precision.cpp
+++ b/src/precision.cpp
@@ -17,6 +17,7 @@
 #include "precision.hpp"
 
 #include <unordered_map>
+
 #include <spdlog/spdlog.h>
 
 namespace ovms {
@@ -104,7 +105,6 @@ Precision KFSPrecisionToOvmsPrecision(const KFSDataType& datatype) {
 }
 
 Precision TFSPrecisionToOvmsPrecision(const TFSDataType& datatype) {
-        SPDLOG_ERROR("ER");
     static std::unordered_map<TFSDataType, Precision> precisionMap{
         {TFSDataType::DT_FLOAT, Precision::FP32},
         {TFSDataType::DT_DOUBLE, Precision::FP64},
@@ -116,15 +116,12 @@ Precision TFSPrecisionToOvmsPrecision(const TFSDataType& datatype) {
         {TFSDataType::DT_UINT64, Precision::U64},
         {TFSDataType::DT_UINT16, Precision::U16},
         {TFSDataType::DT_UINT8, Precision::U8},
-        {TFSDataType::DT_BOOL, Precision::BOOL}
-    };
+        {TFSDataType::DT_BOOL, Precision::BOOL}};
     auto it = precisionMap.find(datatype);
-        SPDLOG_ERROR("ER");
     if (it == precisionMap.end()) {
         // TODO missing precisions
         return Precision::UNDEFINED;
     }
-        SPDLOG_ERROR("ER");
     return it->second;
 }
 

--- a/src/precision.cpp
+++ b/src/precision.cpp
@@ -18,8 +18,6 @@
 
 #include <unordered_map>
 
-#include <spdlog/spdlog.h>
-
 namespace ovms {
 
 std::string toString(Precision precision) {

--- a/src/precision.cpp
+++ b/src/precision.cpp
@@ -17,6 +17,7 @@
 #include "precision.hpp"
 
 #include <unordered_map>
+#include <spdlog/spdlog.h>
 
 namespace ovms {
 
@@ -80,8 +81,8 @@ Precision fromString(const std::string& s) {
     return it->second;
 }
 
-Precision KFSPrecisionToOvmsPrecision(const KFSDataType& s) {
-    static std::unordered_map<std::string, Precision> precisionMap{
+Precision KFSPrecisionToOvmsPrecision(const KFSDataType& datatype) {
+    static std::unordered_map<KFSDataType, Precision> precisionMap{
         {"BOOL", Precision::BOOL},
         {"FP64", Precision::FP64},
         {"FP32", Precision::FP32},
@@ -95,10 +96,35 @@ Precision KFSPrecisionToOvmsPrecision(const KFSDataType& s) {
         {"UINT16", Precision::U16},
         // {"BYTES", Precision::??}, // TODO decide what to do with BYTES
         {"UINT8", Precision::U8}};
-    auto it = precisionMap.find(s);
+    auto it = precisionMap.find(datatype);
     if (it == precisionMap.end()) {
         return Precision::UNDEFINED;
     }
+    return it->second;
+}
+
+Precision TFSPrecisionToOvmsPrecision(const TFSDataType& datatype) {
+        SPDLOG_ERROR("ER");
+    static std::unordered_map<TFSDataType, Precision> precisionMap{
+        {TFSDataType::DT_FLOAT, Precision::FP32},
+        {TFSDataType::DT_DOUBLE, Precision::FP64},
+        {TFSDataType::DT_HALF, Precision::FP16},
+        {TFSDataType::DT_INT64, Precision::I64},
+        {TFSDataType::DT_INT32, Precision::I32},
+        {TFSDataType::DT_INT16, Precision::I16},
+        {TFSDataType::DT_INT8, Precision::I8},
+        {TFSDataType::DT_UINT64, Precision::U64},
+        {TFSDataType::DT_UINT16, Precision::U16},
+        {TFSDataType::DT_UINT8, Precision::U8},
+        {TFSDataType::DT_BOOL, Precision::BOOL}
+    };
+    auto it = precisionMap.find(datatype);
+        SPDLOG_ERROR("ER");
+    if (it == precisionMap.end()) {
+        // TODO missing precisions
+        return Precision::UNDEFINED;
+    }
+        SPDLOG_ERROR("ER");
     return it->second;
 }
 

--- a/src/precision.hpp
+++ b/src/precision.hpp
@@ -18,10 +18,16 @@
 #include <string>
 
 #include <openvino/openvino.hpp>
+// TODO remove from here
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
+#pragma GCC diagnostic pop
 
 namespace ovms {
 
 using KFSDataType = std::string;
+using TFSDataType = tensorflow::DataType;
 
 enum class Precision {
     BF16,
@@ -53,6 +59,7 @@ std::string toString(Precision precision);
 Precision fromString(const std::string& s);
 
 Precision KFSPrecisionToOvmsPrecision(const KFSDataType& s);
+Precision TFSPrecisionToOvmsPrecision(const TFSDataType& s);
 
 size_t KFSDataTypeSize(const KFSDataType& datatype);
 

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -597,9 +597,10 @@ TEST_F(TestCustomLoader, CustomLoaderPrediction) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 }
 
@@ -645,9 +646,10 @@ TEST_F(TestCustomLoader, CustomLoaderPredictDeletePredict) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     tensorflow::serving::PredictResponse response;
     ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::OK);
 
@@ -671,9 +673,10 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewVersionPredict) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Copy version 1 to version 2
@@ -681,9 +684,9 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewVersionPredict) {
     std::filesystem::copy(cl_model_1_path + "1", cl_model_1_path + "2", std::filesystem::copy_options::recursive);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    request = preparePredictRequest(
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 2, request);
 }
 
@@ -700,9 +703,10 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewModelPredict) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Copy model1 to model2
@@ -717,9 +721,9 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewModelPredict) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    request = preparePredictRequest(
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
     performPredict("dummy-new", 1, request);
 }
@@ -737,9 +741,10 @@ TEST_F(TestCustomLoader, CustomLoaderPredictRemoveCustomLoaderOptionsPredict) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Replace model path in the config string
@@ -766,9 +771,10 @@ TEST_F(TestCustomLoader, PredictNormalModelAddCustomLoaderOptionsPredict) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Replace model path in the config string
@@ -796,9 +802,10 @@ TEST_F(TestCustomLoader, CustomLoaderOptionWithUnknownLibrary) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     tensorflow::serving::PredictResponse response;
     ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::MODEL_VERSION_MISSING);
 }
@@ -813,9 +820,10 @@ TEST_F(TestCustomLoader, CustomLoaderWithMissingModelFiles) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     tensorflow::serving::PredictResponse response;
     ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::MODEL_VERSION_MISSING);
 }
@@ -884,9 +892,10 @@ TEST_F(TestCustomLoader, CustomLoaderPredictionUsingManyCustomLoaders) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
 
     performPredict("dummy-a", 1, request);
     performPredict("dummy-b", 1, request);
@@ -1027,9 +1036,10 @@ TEST_F(TestCustomLoader, CustomLoaderMultipleLoaderWithSameLoaderName) {
     createConfigFileWithContent(configStr, fileToReload);
     ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
 
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 }
 

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -1332,13 +1332,14 @@ public:
             }
         }
     }
-    virtual inputs_info_t getExpectedInputsInfo() {
+    virtual inputs_info_t2 getExpectedInputsInfo() {
         return {{pipelineInputName,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}}};
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}}};
     }
 
     virtual tensorflow::serving::PredictRequest preparePipelinePredictRequest() {
-        tensorflow::serving::PredictRequest request = preparePredictRequest(getExpectedInputsInfo());
+        tensorflow::serving::PredictRequest request;
+        preparePredictRequest(request, getExpectedInputsInfo());
         auto& input = (*request.mutable_inputs())[pipelineInputName];
         input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
         return request;
@@ -1753,18 +1754,19 @@ class StressPipelineCustomNodesConfigChanges : public StressPipelineConfigChange
 
 public:
     tensorflow::serving::PredictRequest preparePipelinePredictRequest() override {
-        tensorflow::serving::PredictRequest request = preparePredictRequest(getExpectedInputsInfo());
+        tensorflow::serving::PredictRequest request;
+        preparePredictRequest(request, getExpectedInputsInfo());
         auto& input = (*request.mutable_inputs())[pipelineInputName];
         input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
         auto& factors = (*request.mutable_inputs())[pipelineFactorsInputName];
         factors.mutable_tensor_content()->assign((char*)factorsData.data(), factorsData.size() * sizeof(float));
         return request;
     }
-    inputs_info_t getExpectedInputsInfo() override {
+    inputs_info_t2 getExpectedInputsInfo() override {
         return {{pipelineInputName,
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, tensorflow::DataType::DT_FLOAT}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}},
             {pipelineFactorsInputName,
-                std::tuple<ovms::shape_t, tensorflow::DataType>{{1, differentOpsFactorsInputSize}, tensorflow::DataType::DT_FLOAT}}};
+                std::tuple<ovms::shape_t, ovms::Precision>{{1, differentOpsFactorsInputSize}, ovms::Precision::FP32}}};
     }
     void checkPipelineResponse(const std::string& pipelineOutputName,
         tensorflow::serving::PredictRequest& request,

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -1332,7 +1332,7 @@ public:
             }
         }
     }
-    virtual inputs_info_t2 getExpectedInputsInfo() {
+    virtual inputs_info_t getExpectedInputsInfo() {
         return {{pipelineInputName,
             std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}}};
     }
@@ -1762,7 +1762,7 @@ public:
         factors.mutable_tensor_content()->assign((char*)factorsData.data(), factorsData.size() * sizeof(float));
         return request;
     }
-    inputs_info_t2 getExpectedInputsInfo() override {
+    inputs_info_t getExpectedInputsInfo() override {
         return {{pipelineInputName,
                     std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}},
             {pipelineFactorsInputName,

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -603,9 +603,10 @@ TEST_F(EnsembleFlowTest, DummyModelDirectAndPipelineInference) {
     ASSERT_EQ(status, ovms::StatusCode::OK);
 
     // Prepare request for dummy model directly
-    tensorflow::serving::PredictRequest simpleModelRequest = preparePredictRequest(
+    tensorflow::serving::PredictRequest simpleModelRequest;
+    preparePredictRequest(simpleModelRequest,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     std::vector<float> requestData{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
     auto& input = (*simpleModelRequest.mutable_inputs())[DUMMY_MODEL_INPUT_NAME];
     input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -786,8 +786,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
     modelConfig.setBatchingParams("auto");
 
     // First is incorrect, second is correct
-    preparePredictRequest(request,{{"im_data", {{3, 3, 800, 1344}, ovms::Precision::FP32}},
-        {"im_info", {{1, 3}, ovms::Precision::FP32}}});
+    preparePredictRequest(request, {{"im_data", {{3, 3, 800, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{1, 3}, ovms::Precision::FP32}}});
 
     servableInputs.clear();
     servableInputs = ovms::tensor_map_t{
@@ -798,8 +798,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED);
 
-    preparePredictRequest(request,{{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
-        {"im_info", {{3, 3}, ovms::Precision::FP32}}});
+    preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{3, 3}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED) << status.string();
@@ -807,8 +807,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
 
 TEST_F(KFSPredictValidation, RequestWrongAndCorrectShapeAuto) {
     modelConfig.parseShapeParameter("auto");
-    preparePredictRequest(request,{{"im_data", {{1, 3, 900, 1344}, ovms::Precision::FP32}},
-        {"im_info", {{1, 3}, ovms::Precision::FP32}}});
+    preparePredictRequest(request, {{"im_data", {{1, 3, 900, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{1, 3}, ovms::Precision::FP32}}});
 
     // First is incorrect, second is correct
     servableInputs.clear();
@@ -821,8 +821,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectShapeAuto) {
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED) << status.string();
 
     // First is correct, second is incorrect
-    preparePredictRequest(request,{{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
-        {"im_info", {{1, 6}, ovms::Precision::FP32}}});
+    preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{1, 6}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED) << status.string();

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -1062,7 +1062,6 @@ TEST_P(KFSPredictValidationPrecision, ValidPrecisions) {
     preparePredictRequest(request,
         {
             {tensorName,
-                // TODO std::tuple<ovms::shape_t, ovms::KFSDataType>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::ovmsPrecisionToKFSPrecision(testedPrecision)}},
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
         });
     auto status = ovms::request_validation_utils::validate(request, mockedInputsInfo, "dummy", ovms::model_version_t{1});

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -74,14 +74,14 @@ protected:
         ON_CALL(*instance, getBatchSize()).WillByDefault(Return(1));
         ON_CALL(*instance, getModelConfig()).WillByDefault(ReturnRef(modelConfig));
 
-        request = preparePredictRequest(
+        preparePredictRequest(request,
             {
                 {"Input_FP32_1_224_224_3_NHWC",
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 224, 224, 3}, tensorflow::DataType::DT_FLOAT}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
                 {"Input_U8_1_3_62_62_NCHW",
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 3, 62, 62}, tensorflow::DataType::DT_UINT8}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
                 {"Input_I64_1_6_128_128_16_NCDHW",
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 6, 128, 128, 16}, tensorflow::DataType::DT_INT64}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             });
 
         // U16 uses int_val instead of tensor_content so it needs separate test
@@ -247,8 +247,8 @@ TEST_F(TfsPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
     modelConfig.setBatchingParams("auto");
 
     // First is incorrect, second is correct
-    request = preparePredictRequest({{"im_data", {{3, 3, 800, 1344}, tensorflow::DataType::DT_FLOAT}},
-        {"im_info", {{1, 3}, tensorflow::DataType::DT_FLOAT}}});
+    preparePredictRequest(request, {{"im_data", {{3, 3, 800, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{1, 3}, ovms::Precision::FP32}}});
 
     servableInputs.clear();
     servableInputs = ovms::tensor_map_t{
@@ -259,8 +259,8 @@ TEST_F(TfsPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED);
 
-    request = preparePredictRequest({{"im_data", {{1, 3, 800, 1344}, tensorflow::DataType::DT_FLOAT}},
-        {"im_info", {{3, 3}, tensorflow::DataType::DT_FLOAT}}});
+    preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{3, 3}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED);
@@ -268,8 +268,8 @@ TEST_F(TfsPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
 
 TEST_F(TfsPredictValidation, RequestWrongAndCorrectShapeAuto) {
     modelConfig.parseShapeParameter("auto");
-    request = preparePredictRequest({{"im_data", {{1, 3, 900, 1344}, tensorflow::DataType::DT_FLOAT}},
-        {"im_info", {{1, 3}, tensorflow::DataType::DT_FLOAT}}});
+    preparePredictRequest(request, {{"im_data", {{1, 3, 900, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{1, 3}, ovms::Precision::FP32}}});
 
     // First is incorrect, second is correct
     servableInputs.clear();
@@ -282,8 +282,8 @@ TEST_F(TfsPredictValidation, RequestWrongAndCorrectShapeAuto) {
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED);
 
     // First is correct, second is incorrect
-    request = preparePredictRequest({{"im_data", {{1, 3, 800, 1344}, tensorflow::DataType::DT_FLOAT}},
-        {"im_info", {{1, 6}, tensorflow::DataType::DT_FLOAT}}});
+    preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
+                                       {"im_info", {{1, 6}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED);
@@ -501,12 +501,12 @@ protected:
                 std::make_shared<ovms::TensorInfo>("Input_U8_3_1_128_CNH", ovms::Precision::U8, ovms::shape_t{3, 1, 128}, ovms::Layout{"CNH"})},
         });
 
-        request = preparePredictRequest(
+        preparePredictRequest(request,
             {
                 {"Input_FP32_224_224_3_1_HWCN",
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{224, 224, 3, 1}, tensorflow::DataType::DT_FLOAT}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
                 {"Input_U8_3_1_128_CNH",
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{3, 1, 128}, tensorflow::DataType::DT_UINT8}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
             });
     }
 };
@@ -577,12 +577,12 @@ protected:
         ON_CALL(*instance, getBatchSize()).WillByDefault(Return(ovms::Dimension::any()));
 
         const ovms::dimension_value_t requestBatchSize = 16;
-        request = preparePredictRequest(
+        preparePredictRequest(request,
             {
                 {"Input_FP32_any_224:512_224:512_3_NHWC",
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{requestBatchSize, 300, 320, 3}, tensorflow::DataType::DT_FLOAT}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
                 {"Input_U8_100:200_any_CN",
-                    std::tuple<ovms::shape_t, tensorflow::DataType>{{101, requestBatchSize}, tensorflow::DataType::DT_UINT8}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
             });
     }
 };
@@ -656,10 +656,10 @@ protected:
 TEST_P(TfsPredictValidationPrecision, ValidPrecisions) {
     ovms::Precision testedPrecision = GetParam();
     mockedInputsInfo[tensorName]->setPrecision(testedPrecision);
-    request = preparePredictRequest(
+    preparePredictRequest(request,
         {
             {tensorName,
-                std::tuple<ovms::shape_t, tensorflow::DataType>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::TensorInfo::getPrecisionAsDataType(testedPrecision)}},
+                std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
         });
     auto status = ovms::request_validation_utils::validate(request, mockedInputsInfo, "dummy", ovms::model_version_t{1});
     EXPECT_EQ(status, ovms::StatusCode::OK) << "Precision validation failed:"
@@ -702,15 +702,15 @@ protected:
         ON_CALL(*instance, getBatchSize()).WillByDefault(Return(1));
         ON_CALL(*instance, getModelConfig()).WillByDefault(ReturnRef(modelConfig));
 
-        request = prepareKFSPredictRequest(
+        preparePredictRequest(request,
             {{"Input_FP32_1_224_224_3_NHWC",
-                 std::tuple<ovms::shape_t, ovms::KFSDataType>{{1, 224, 224, 3}, "FP32"}},
+                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
                 {"Input_U8_1_3_62_62_NCHW",
-                    std::tuple<ovms::shape_t, ovms::KFSDataType>{{1, 3, 62, 62}, "UINT8"}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
                 {"Input_I64_1_6_128_128_16_NCDHW",
-                    std::tuple<ovms::shape_t, ovms::KFSDataType>{{1, 6, 128, 128, 16}, "INT64"}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
                 {"Input_U16_1_2_8_4_NCHW",
-                    std::tuple<ovms::shape_t, ovms::KFSDataType>{{1, 2, 8, 4}, "UINT16"}}});
+                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}});
     }
 };
 
@@ -786,8 +786,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
     modelConfig.setBatchingParams("auto");
 
     // First is incorrect, second is correct
-    request = prepareKFSPredictRequest({{"im_data", {{3, 3, 800, 1344}, "FP32"}},
-        {"im_info", {{1, 3}, "FP32"}}});
+    preparePredictRequest(request,{{"im_data", {{3, 3, 800, 1344}, ovms::Precision::FP32}},
+        {"im_info", {{1, 3}, ovms::Precision::FP32}}});
 
     servableInputs.clear();
     servableInputs = ovms::tensor_map_t{
@@ -798,8 +798,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED);
 
-    request = prepareKFSPredictRequest({{"im_data", {{1, 3, 800, 1344}, "FP32"}},
-        {"im_info", {{3, 3}, "FP32"}}});
+    preparePredictRequest(request,{{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
+        {"im_info", {{3, 3}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED) << status.string();
@@ -807,8 +807,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectBatchSizeAuto) {
 
 TEST_F(KFSPredictValidation, RequestWrongAndCorrectShapeAuto) {
     modelConfig.parseShapeParameter("auto");
-    request = prepareKFSPredictRequest({{"im_data", {{1, 3, 900, 1344}, "FP32"}},
-        {"im_info", {{1, 3}, "FP32"}}});
+    preparePredictRequest(request,{{"im_data", {{1, 3, 900, 1344}, ovms::Precision::FP32}},
+        {"im_info", {{1, 3}, ovms::Precision::FP32}}});
 
     // First is incorrect, second is correct
     servableInputs.clear();
@@ -821,8 +821,8 @@ TEST_F(KFSPredictValidation, RequestWrongAndCorrectShapeAuto) {
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED) << status.string();
 
     // First is correct, second is incorrect
-    request = prepareKFSPredictRequest({{"im_data", {{1, 3, 800, 1344}, "FP32"}},
-        {"im_info", {{1, 6}, "FP32"}}});
+    preparePredictRequest(request,{{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
+        {"im_info", {{1, 6}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED) << status.string();
@@ -938,12 +938,12 @@ protected:
                 std::make_shared<ovms::TensorInfo>("Input_U8_3_1_128_CNH", ovms::Precision::U8, ovms::shape_t{3, 1, 128}, ovms::Layout{"CNH"})},
         });
 
-        request = prepareKFSPredictRequest(
+        preparePredictRequest(request,
             {
                 {"Input_FP32_224_224_3_1_HWCN",
-                    std::tuple<ovms::shape_t, ovms::KFSDataType>{{224, 224, 3, 1}, "FP32"}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
                 {"Input_U8_3_1_128_CNH",
-                    std::tuple<ovms::shape_t, ovms::KFSDataType>{{3, 1, 128}, "UINT8"}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
             });
     }
 };
@@ -997,12 +997,12 @@ protected:
         ON_CALL(*instance, getBatchSize()).WillByDefault(Return(ovms::Dimension::any()));
 
         const ovms::dimension_value_t requestBatchSize = 16;
-        request = prepareKFSPredictRequest(
+        preparePredictRequest(request,
             {
                 {"Input_FP32_any_224:512_224:512_3_NHWC",
-                    std::tuple<ovms::shape_t, ovms::KFSDataType>{{requestBatchSize, 300, 320, 3}, "FP32"}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
                 {"Input_U8_100:200_any_CN",
-                    std::tuple<ovms::shape_t, ovms::KFSDataType>{{101, requestBatchSize}, "UINT8"}},
+                    std::tuple<ovms::shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
             });
     }
 };
@@ -1059,10 +1059,11 @@ protected:
 TEST_P(KFSPredictValidationPrecision, ValidPrecisions) {
     ovms::Precision testedPrecision = GetParam();
     mockedInputsInfo[tensorName]->setPrecision(testedPrecision);
-    request = prepareKFSPredictRequest(
+    preparePredictRequest(request,
         {
             {tensorName,
-                std::tuple<ovms::shape_t, ovms::KFSDataType>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::ovmsPrecisionToKFSPrecision(testedPrecision)}},
+                // TODO std::tuple<ovms::shape_t, ovms::KFSDataType>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::ovmsPrecisionToKFSPrecision(testedPrecision)}},
+                std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
         });
     auto status = ovms::request_validation_utils::validate(request, mockedInputsInfo, "dummy", ovms::model_version_t{1});
     EXPECT_EQ(status, ovms::StatusCode::OK) << "Precision validation failed:"

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -425,7 +425,6 @@ public:
         })",
             mappingConfigPath);
     }
-    RequestType hack;
 };
 
 TYPED_TEST_SUITE(TestPredictWithMapping, MyTypes);

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -36,6 +36,25 @@
 
 using testing::Each;
 using testing::Eq;
+
+using ovms::StatusCode;
+
+using KFSRequestType = ::inference::ModelInferRequest;
+using KFSResponseType = ::inference::ModelInferResponse;
+using KFSInputTensorType = ::inference::ModelInferRequest_InferInputTensor;
+using KFSShapeType = google::protobuf::RepeatedField<int64_t>;
+using KFSInputTensorIteratorType = google::protobuf::internal::RepeatedPtrIterator<const ::inference::ModelInferRequest_InferInputTensor>;
+using KFSOutputTensorIteratorType = google::protobuf::internal::RepeatedPtrIterator<const ::inference::ModelInferResponse_InferOutputTensor>;
+using TFSRequestType = tensorflow::serving::PredictRequest;
+using TFSResponseType = tensorflow::serving::PredictResponse;
+using TFSInputTensorType = tensorflow::TensorProto;
+using TFSOutputTensorType = tensorflow::TensorProto;
+using TFSShapeType = tensorflow::TensorShapeProto;
+using TFSInputTensorIteratorType = google::protobuf::Map<std::string, TFSInputTensorType>::const_iterator;
+using TFSOutputTensorIteratorType = google::protobuf::Map<std::string, TFSOutputTensorType>::const_iterator;
+using TFSInterface = std::pair<TFSRequestType, TFSResponseType>;
+using KFSInterface = std::pair<KFSRequestType, KFSResponseType>;
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 void serializeAndCheck(int outputSize, ov::InferRequest& inferRequest, const std::string& outputName, const ovms::tensor_map_t& outputsInfo) {
@@ -48,6 +67,34 @@ void serializeAndCheck(int outputSize, ov::InferRequest& inferRequest, const std
     std::memcpy(output.data(), (float*)response.outputs().at(outputName).tensor_content().data(), DUMMY_MODEL_OUTPUT_SIZE * sizeof(float));
     EXPECT_THAT(output, Each(Eq(1.)));
 }
+
+ovms::Status getOutput(const KFSResponseType& response, const std::string&  name, KFSOutputTensorIteratorType& it, size_t& bufferId) { // TODO FIXME
+    it = response.outputs().begin();
+    bufferId = 0;
+    while (it != response.outputs().end()) {
+        if (it->name() == name) {
+            break;
+        }
+        ++it;
+        ++bufferId;
+    }
+    if (it != response.outputs().end()) {
+        return StatusCode::OK;
+    }
+    return StatusCode::INVALID_MISSING_INPUT;
+}
+
+ovms::Status getOutput(const TFSResponseType& response, const std::string&  name, TFSOutputTensorIteratorType& it, size_t& bufferId) {
+    it = response.outputs().find(name);
+    if (it != response.outputs().end()) {
+        return StatusCode::OK;
+    }
+    return StatusCode::INVALID_MISSING_INPUT;
+}
+
+template <typename Pair,
+          typename RequestType = typename Pair::first_type,
+          typename ResponseType = typename Pair::second_type>
 class TestPredict : public ::testing::Test {
 public:
     void SetUp() {
@@ -61,7 +108,7 @@ public:
      */
     void performPredict(const std::string modelName,
         const ovms::model_version_t modelVersion,
-        const tensorflow::serving::PredictRequest& request,
+        const RequestType& request,
         std::unique_ptr<std::future<void>> waitBeforeGettingModelInstance = nullptr,
         std::unique_ptr<std::future<void>> waitBeforePerformInference = nullptr);
 
@@ -79,9 +126,10 @@ public:
             predictsWaitingBeforeGettingModelInstance.emplace_back(
                 std::thread(
                     [this, initialBatchSize, &releaseWaitBeforeGettingModelInstance, i]() {
-                        tensorflow::serving::PredictRequest request = preparePredictRequest(
+                        RequestType request;
+                        preparePredictRequest(request,
                             {{DUMMY_MODEL_INPUT_NAME,
-                                std::tuple<ovms::shape_t, tensorflow::DataType>{{(initialBatchSize + (i % 3)), 10}, tensorflow::DataType::DT_FLOAT}}});
+                                std::tuple<ovms::shape_t, ovms::Precision>{{(initialBatchSize + (i % 3)), 10}, ovms::Precision::FP32}}});
 
                         performPredict(config.getName(), config.getVersion(), request,
                             std::move(std::make_unique<std::future<void>>(releaseWaitBeforeGettingModelInstance[i].get_future())));
@@ -91,16 +139,17 @@ public:
             predictsWaitingBeforeInference.emplace_back(
                 std::thread(
                     [this, initialBatchSize, &releaseWaitBeforePerformInference, i]() {
-                        tensorflow::serving::PredictRequest request = preparePredictRequest(
+                        RequestType request;
+                        preparePredictRequest(request,
                             {{DUMMY_MODEL_INPUT_NAME,
-                                std::tuple<ovms::shape_t, tensorflow::DataType>{{initialBatchSize, 10}, tensorflow::DataType::DT_FLOAT}}});
+                                std::tuple<ovms::shape_t, ovms::Precision>{{initialBatchSize, 10}, ovms::Precision::FP32}}});
 
                         performPredict(config.getName(), config.getVersion(), request, nullptr,
                             std::move(std::make_unique<std::future<void>>(releaseWaitBeforePerformInference[i].get_future())));
                     }));
         }
         // sleep to allow all threads to initialize
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
         for (auto& promise : releaseWaitBeforeGettingModelInstance) {
             promise.set_value();
         }
@@ -126,15 +175,16 @@ public:
             predictThreads.emplace_back(
                 std::thread(
                     [this, initialBatchSize, &releaseWaitBeforeGettingModelInstance, i]() {
-                        tensorflow::serving::PredictRequest request = preparePredictRequest(
+                        RequestType request;
+                        preparePredictRequest(request,
                             {{DUMMY_MODEL_INPUT_NAME,
-                                std::tuple<ovms::shape_t, tensorflow::DataType>{{(initialBatchSize + i), 10}, tensorflow::DataType::DT_FLOAT}}});
+                                std::tuple<ovms::shape_t, ovms::Precision>{{(initialBatchSize + i), 10}, ovms::Precision::FP32}}});
                         performPredict(config.getName(), config.getVersion(), request,
                             std::move(std::make_unique<std::future<void>>(releaseWaitBeforeGettingModelInstance[i].get_future())));
                     }));
         }
         // sleep to allow all threads to initialize
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
         for (auto& promise : releaseWaitBeforeGettingModelInstance) {
             promise.set_value();
         }
@@ -144,14 +194,7 @@ public:
         }
     }
 
-    static void checkOutputShape(const tensorflow::serving::PredictResponse& response, const ovms::shape_t& shape, const std::string& outputName = "a") {
-        ASSERT_EQ(response.outputs().count(outputName), 1);
-        const auto& output_tensor = response.outputs().at(outputName);
-        ASSERT_EQ(output_tensor.tensor_shape().dim_size(), shape.size());
-        for (unsigned int i = 0; i < shape.size(); i++) {
-            EXPECT_EQ(output_tensor.tensor_shape().dim(i).size(), shape[i]);
-        }
-    }
+    void checkOutputShape(const ResponseType& response, const ovms::shape_t& shape, const std::string& outputName = "a");
 
     static void checkOutputValues(const tensorflow::serving::PredictResponse& response, const std::vector<float>& expectedValues, const std::string& outputName = INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME) {
         ASSERT_EQ(response.outputs().count(outputName), 1);
@@ -161,8 +204,17 @@ public:
         ASSERT_EQ(0, std::memcmp(actualValues.data(), expectedValues.data(), expectedValues.size() * sizeof(float)))
             << readableError(expectedValues.data(), actualValues.data(), expectedValues.size() * sizeof(float));
     }
+    static void checkOutputValues(const KFSResponseType& response, const std::vector<float>& expectedValues, const std::string& outputName = INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME) {
+        KFSOutputTensorIteratorType it;
+        size_t bufferId;
+        auto status = getOutput(response, outputName, it, bufferId);
+        ASSERT_TRUE(status.ok());
+        float* buffer = (float*)&(response.raw_output_contents(bufferId));
+        ASSERT_EQ(0, std::memcmp(buffer, expectedValues.data(), expectedValues.size() * sizeof(float)))
+            << readableError(expectedValues.data(), buffer, expectedValues.size() * sizeof(float));
+    }
 
-    ovms::Status performInferenceWithRequest(const tensorflow::serving::PredictRequest& request, tensorflow::serving::PredictResponse& response, const std::string& servableName = "dummy") {
+    ovms::Status performInferenceWithRequest(const RequestType& request, ResponseType& response, const std::string& servableName = "dummy") {
         std::shared_ptr<ovms::ModelInstance> model;
         std::unique_ptr<ovms::ModelInstanceUnloadGuard> unload_guard;
         auto status = manager.getModelInstance(servableName, 0, model, unload_guard);
@@ -174,29 +226,37 @@ public:
         return model->infer(&request, &response, unload_guard);
     }
 
-    ovms::Status performInferenceWithShape(tensorflow::serving::PredictResponse& response, const ovms::shape_t& shape = {1, 10}, const tensorflow::DataType precision = tensorflow::DataType::DT_FLOAT) {
-        auto request = preparePredictRequest(
-            {{DUMMY_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, tensorflow::DataType>{shape, precision}}});
+    ovms::Status performInferenceWithShape(ResponseType& response, const ovms::shape_t& shape = {1, 10}, const ovms::Precision precision = ovms::Precision::FP32) {
+        RequestType request;
+        preparePredictRequest(request,
+            {{DUMMY_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, ovms::Precision>{shape, precision}}});
         return performInferenceWithRequest(request, response);
     }
 
-    ovms::Status performInferenceWithBatchSize(tensorflow::serving::PredictResponse& response, int batchSize = 1, const tensorflow::DataType precision = tensorflow::DataType::DT_FLOAT, const size_t batchSizePosition = 0) {
+    ovms::Status performInferenceWithBatchSize(ResponseType& response, int batchSize = 1, const ovms::Precision precision = ovms::Precision::FP32, const size_t batchSizePosition = 0) {
         ovms::shape_t shape = {1, 10};
         shape[batchSizePosition] = batchSize;
-        auto request = preparePredictRequest(
-            {{DUMMY_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, tensorflow::DataType>{shape, precision}}});
+        RequestType request;
+        preparePredictRequest(request,
+            {{DUMMY_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, ovms::Precision>{shape, precision}}});
         return performInferenceWithRequest(request, response);
     }
 
-    ovms::Status performInferenceWithImageInput(tensorflow::serving::PredictResponse& response, const std::vector<size_t>& shape, const std::vector<float>& data = {}, const std::string& servableName = "increment_1x3x4x5", int batchSize = 1, const tensorflow::DataType precision = tensorflow::DataType::DT_FLOAT) {
-        auto request = preparePredictRequest(
-            {{INCREMENT_1x3x4x5_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, tensorflow::DataType>{shape, precision}}}, data);
+    ovms::Status performInferenceWithImageInput(ResponseType& response, const std::vector<size_t>& shape, const std::vector<float>& data = {}, const std::string& servableName = "increment_1x3x4x5", int batchSize = 1, const ovms::Precision precision = ovms::Precision::FP32) {
+        RequestType request;
+        preparePredictRequest(request,
+            {{INCREMENT_1x3x4x5_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, ovms::Precision>{shape, precision}}}, data);
         return performInferenceWithRequest(request, response, servableName);
     }
 
     ovms::Status performInferenceWithBinaryImageInput(tensorflow::serving::PredictResponse& response, const std::string& inputName, const std::string& servableName = "increment_1x3x4x5", int batchSize = 1) {
         auto request = prepareBinaryPredictRequest(inputName, batchSize);
         return performInferenceWithRequest(request, response, servableName);
+    }
+    ovms::Status performInferenceWithBinaryImageInput(KFSResponseType& response, const std::string& inputName, const std::string& servableName = "increment_1x3x4x5", int batchSize = 1) {
+            return StatusCode::OK; // TODO FIXME
+   //     auto request = prepareBinaryPredictRequest(inputName, batchSize);
+ //       return performInferenceWithRequest(request, response, servableName);
     }
 
 public:
@@ -207,18 +267,47 @@ public:
     }
 };
 
+
+template<>
+void TestPredict<TFSInterface>::checkOutputShape(const TFSResponseType& response, const ovms::shape_t& shape, const std::string& outputName) {
+    ASSERT_EQ(response.outputs().count(outputName), 1);
+    const auto& output_tensor = response.outputs().at(outputName);
+    ASSERT_EQ(output_tensor.tensor_shape().dim_size(), shape.size());
+    for (unsigned int i = 0; i < shape.size(); i++) {
+        EXPECT_EQ(output_tensor.tensor_shape().dim(i).size(), shape[i]);
+    }
+}
+
+
+
+template<>
+void TestPredict<KFSInterface>::checkOutputShape(const KFSResponseType& response, const ovms::shape_t& shape, const std::string& outputName) {
+    auto it = response.outputs().begin();
+    size_t bufferId;
+    auto status = getOutput(response, outputName, it, bufferId);
+    ASSERT_EQ(status, StatusCode::OK);
+    ASSERT_EQ(it->shape().size(), shape.size());
+    for (unsigned int i = 0; i < shape.size(); i++) {
+        EXPECT_EQ(it->shape()[i], shape[i]);
+    }
+}
+
 class MockModelInstance : public ovms::ModelInstance {
 public:
     MockModelInstance(ov::Core& ieCore) :
         ModelInstance("UNUSED_NAME", 42, ieCore) {}
-    const ovms::Status mockValidate(const tensorflow::serving::PredictRequest* request) {
+    template <typename RequestType>
+    //const ovms::Status mockValidate(const tensorflow::serving::PredictRequest* request) {
+    const ovms::Status mockValidate(const RequestType* request) {
         return validate(request);
     }
 };
 
+template <typename RequestType>
 void performPrediction(const std::string modelName,
     const ovms::model_version_t modelVersion,
-    const tensorflow::serving::PredictRequest& request,
+    //const tensorflow::serving::PredictRequest& request,
+    const RequestType& request,
     std::unique_ptr<std::future<void>> waitBeforeGettingModelInstance,
     std::unique_ptr<std::future<void>> waitBeforePerformInference,
     ovms::ModelManager& manager,
@@ -228,15 +317,14 @@ void performPrediction(const std::string modelName,
     std::shared_ptr<ovms::ModelInstance> modelInstance;
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> modelInstanceUnloadGuard;
 
-    auto& tensorProto = request.inputs().at(inputName);
-    size_t batchSize = tensorProto.tensor_shape().dim(0).size();
-    size_t inputSize = 1;
-    for (int i = 0; i < tensorProto.tensor_shape().dim_size(); i++) {
-        inputSize *= tensorProto.tensor_shape().dim(i).size();
-    }
+    auto bsPositionIndex = 0;
+    auto requestBatchSizeOpt = ovms::getRequestBatchSize(&request, bsPositionIndex);
+    ASSERT_TRUE(requestBatchSizeOpt);
+    ASSERT_TRUE(requestBatchSizeOpt.value().isStatic());
+    auto requestBatchSize = requestBatchSizeOpt.value().getStaticValue();
 
     if (waitBeforeGettingModelInstance) {
-        std::cout << "Waiting before getModelInstance. Batch size: " << batchSize << std::endl;
+        std::cout << "Waiting before getModelInstance. Batch size: " << requestBatchSize << std::endl;
         waitBeforeGettingModelInstance->get();
     }
     ASSERT_EQ(manager.getModelInstance(modelName, modelVersion, modelInstance, modelInstanceUnloadGuard), ovms::StatusCode::OK);
@@ -249,8 +337,6 @@ void performPrediction(const std::string modelName,
     ASSERT_TRUE(validationStatus == ovms::StatusCode::OK ||
                 validationStatus == ovms::StatusCode::RESHAPE_REQUIRED ||
                 validationStatus == ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED);
-    auto bsPositionIndex = 0;
-    auto requestBatchSize = ovms::getRequestBatchSize(&request, bsPositionIndex);
     auto requestShapes = ovms::getRequestShapes(&request);
     ASSERT_EQ(modelInstance->reloadModelIfRequired(validationStatus, requestBatchSize, requestShapes, modelInstanceUnloadGuard), ovms::StatusCode::OK);
 
@@ -262,12 +348,15 @@ void performPrediction(const std::string modelName,
     auto status = ovms::deserializePredictRequest<ovms::ConcreteTensorProtoDeserializator>(request, modelInstance->getInputsInfo(), inputSink, isPipeline);
     status = modelInstance->performInference(inferRequest);
     ASSERT_EQ(status, ovms::StatusCode::OK);
-    size_t outputSize = batchSize * DUMMY_MODEL_OUTPUT_SIZE;
+    size_t outputSize = requestBatchSize * DUMMY_MODEL_OUTPUT_SIZE;
     serializeAndCheck(outputSize, inferRequest, outputName, modelInstance->getOutputsInfo());
 }
-void TestPredict::performPredict(const std::string modelName,
+template <typename Pair,
+          typename RequestType,
+          typename ResponseType>
+void TestPredict<Pair, RequestType, ResponseType>::performPredict(const std::string modelName,
     const ovms::model_version_t modelVersion,
-    const tensorflow::serving::PredictRequest& request,
+    const RequestType& request,
     std::unique_ptr<std::future<void>> waitBeforeGettingModelInstance,
     std::unique_ptr<std::future<void>> waitBeforePerformInference) {
     performPrediction(modelName,
@@ -280,15 +369,23 @@ void TestPredict::performPredict(const std::string modelName,
         DUMMY_MODEL_OUTPUT_NAME);
 }
 
-TEST_F(TestPredict, SuccesfullOnDummyModel) {
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+using TestPredictTFS = TestPredict<TFSInterface>;
+
+//using MyTypes= ::testing::Types<TFSInterface, KFSInterface>;
+using MyTypes= ::testing::Types<TFSInterface>;
+//using MyTypes= ::testing::Types<KFSInterface>;
+TYPED_TEST_SUITE(TestPredict, MyTypes);
+
+TYPED_TEST(TestPredict, SuccesfullOnDummyModel) {
+    typename TypeParam::first_type request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchSize(1);
 
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
-    performPredict(config.getName(), config.getVersion(), request);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    this->performPredict(config.getName(), config.getVersion(), request);
 }
 
 static const char* oneDummyWithMappedInputConfig = R"(
@@ -307,8 +404,9 @@ static const char* oneDummyWithMappedInputConfig = R"(
     ]
 })";
 
+template<typename RequestType>
 class TestPredictWithMapping : public TestWithTempDir {
-protected:
+public:
     std::string ovmsConfig;
     std::string modelPath;
     std::string configFilePath;
@@ -316,7 +414,6 @@ protected:
     const std::string dummyModelInputMapping = "input_tensor";
     const std::string dummyModelOutputMapping = "output_tensor";
 
-public:
     void SetUpConfig(const std::string& configContent) {
         ovmsConfig = configContent;
         const std::string modelPathToReplace{"/ovms/src/test/dummy"};
@@ -339,52 +436,59 @@ public:
         })",
             mappingConfigPath);
     }
+    RequestType hack;
 };
 
-TEST_F(TestPredictWithMapping, SuccesfullOnDummyModelWithMapping) {
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
-        {{dummyModelInputMapping,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+TYPED_TEST_SUITE(TestPredictWithMapping, MyTypes);
+
+TYPED_TEST(TestPredictWithMapping, SuccesfullOnDummyModelWithMapping) {
+    typename TypeParam::first_type request;
+    preparePredictRequest(request,
+        {{this->dummyModelInputMapping,
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     ConstructorEnabledModelManager manager;
-    auto status = manager.loadConfig(configFilePath);
+    auto status = manager.loadConfig(this->configFilePath);
     ASSERT_EQ(status, ovms::StatusCode::OK) << status.string();
-    performPrediction(config.getName(), config.getVersion(), request, nullptr, nullptr, manager, dummyModelInputMapping, dummyModelOutputMapping);
+    performPrediction(config.getName(), config.getVersion(), request, nullptr, nullptr, manager, this->dummyModelInputMapping, this->dummyModelOutputMapping);
 }
 
-TEST_F(TestPredict, SuccesfullReloadFromAlreadyLoadedWithNewBatchSize) {
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+TYPED_TEST(TestPredict, SuccesfullReloadFromAlreadyLoadedWithNewBatchSize) {
+    typename TypeParam::first_type request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     const auto initialBatchSize = config.getBatchSize();
     config.setBatchSize(initialBatchSize);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
-    performPredict(config.getName(), config.getVersion(), request);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    this->performPredict(config.getName(), config.getVersion(), request);
 }
 
-TEST_F(TestPredict, SuccesfullReloadWhen1InferenceInProgress) {
+TYPED_TEST(TestPredict, SuccesfullReloadWhen1InferenceInProgress) {
     //  FIRST LOAD MODEL WITH BS=1
-    tensorflow::serving::PredictRequest requestBs1 = preparePredictRequest(
+    typename TypeParam::first_type requestBs1;
+    preparePredictRequest(requestBs1,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
-    tensorflow::serving::PredictRequest requestBs2 = preparePredictRequest(
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+    typename TypeParam::first_type requestBs2;
+    preparePredictRequest(requestBs2,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{2, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{2, 10}, ovms::Precision::FP32}}});
 
-    config.setBatchingParams("auto");
-    config.setNireq(2);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    this->config.setBatchingParams("auto");
+    this->config.setNireq(2);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(this->config), ovms::StatusCode::OK_RELOADED);
 
     std::promise<void> releaseWaitBeforePerformInferenceBs1, releaseWaitBeforeGetModelInstanceBs2;
     std::thread t1(
         [this, &requestBs1, &releaseWaitBeforePerformInferenceBs1]() {
-            performPredict(config.getName(), config.getVersion(), requestBs1, nullptr,
+            this->performPredict(this->config.getName(), this->config.getVersion(), requestBs1, nullptr,
                 std::move(std::make_unique<std::future<void>>(releaseWaitBeforePerformInferenceBs1.get_future())));
         });
     std::thread t2(
         [this, &requestBs2, &releaseWaitBeforeGetModelInstanceBs2]() {
-            performPredict(config.getName(), config.getVersion(), requestBs2,
+            this->performPredict(this->config.getName(), this->config.getVersion(), requestBs2,
                 std::move(std::make_unique<std::future<void>>(releaseWaitBeforeGetModelInstanceBs2.get_future())),
                 nullptr);
         });
@@ -395,29 +499,31 @@ TEST_F(TestPredict, SuccesfullReloadWhen1InferenceInProgress) {
     t2.join();
 }
 
-TEST_F(TestPredict, SuccesfullReloadWhen1InferenceAboutToStart) {
+TYPED_TEST(TestPredict, SuccesfullReloadWhen1InferenceAboutToStart) {
     //  FIRST LOAD MODEL WITH BS=1
-    tensorflow::serving::PredictRequest requestBs1 = preparePredictRequest(
+    typename TypeParam::first_type requestBs1;
+    preparePredictRequest(requestBs1,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 10}, tensorflow::DataType::DT_FLOAT}}});
-    tensorflow::serving::PredictRequest requestBs2 = preparePredictRequest(
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+    typename TypeParam::first_type requestBs2;
+    preparePredictRequest(requestBs2,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{2, 10}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{2, 10}, ovms::Precision::FP32}}});
 
-    config.setBatchingParams("auto");
-    config.setNireq(2);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    this->config.setBatchingParams("auto");
+    this->config.setNireq(2);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(this->config), ovms::StatusCode::OK_RELOADED);
 
     std::promise<void> releaseWaitBeforeGetModelInstanceBs1, releaseWaitBeforePerformInferenceBs2;
     std::thread t1(
         [this, &requestBs1, &releaseWaitBeforeGetModelInstanceBs1]() {
-            performPredict(config.getName(), config.getVersion(), requestBs1,
+            this->performPredict(this->config.getName(), this->config.getVersion(), requestBs1,
                 std::move(std::make_unique<std::future<void>>(releaseWaitBeforeGetModelInstanceBs1.get_future())),
                 nullptr);
         });
     std::thread t2(
         [this, &requestBs2, &releaseWaitBeforePerformInferenceBs2]() {
-            performPredict(config.getName(), config.getVersion(), requestBs2, nullptr,
+            this->performPredict(this->config.getName(), this->config.getVersion(), requestBs2, nullptr,
                 std::move(std::make_unique<std::future<void>>(releaseWaitBeforePerformInferenceBs2.get_future())));
         });
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -427,166 +533,162 @@ TEST_F(TestPredict, SuccesfullReloadWhen1InferenceAboutToStart) {
     t2.join();
 }
 
-TEST_F(TestPredict, SuccesfullReloadWhenSeveralInferRequestJustBeforeGettingModelInstance) {
+TYPED_TEST(TestPredict, SuccesfullReloadWhenSeveralInferRequestJustBeforeGettingModelInstance) {
     const int initialBatchSize = 1;
-    config.setBatchingParams("auto");
+    this->config.setBatchingParams("auto");
 
     const uint waitingBeforePerformInferenceCount = 0;
     const uint waitingBeforeGettingModelCount = 9;
-    testConcurrentPredicts(initialBatchSize, waitingBeforePerformInferenceCount, waitingBeforeGettingModelCount);
+    this->testConcurrentPredicts(initialBatchSize, waitingBeforePerformInferenceCount, waitingBeforeGettingModelCount);
 }
 
-TEST_F(TestPredict, SuccesfullReloadWhenSeveralInferRequestJustBeforeInference) {
+TYPED_TEST(TestPredict, SuccesfullReloadWhenSeveralInferRequestJustBeforeInference) {
     const int initialBatchSize = 1;
-    config.setBatchingParams("auto");
+    this->config.setBatchingParams("auto");
 
     const uint waitingBeforePerformInferenceCount = 9;
     const uint waitingBeforeGettingModelCount = 0;
-    testConcurrentPredicts(initialBatchSize, waitingBeforePerformInferenceCount, waitingBeforeGettingModelCount);
+    this->testConcurrentPredicts(initialBatchSize, waitingBeforePerformInferenceCount, waitingBeforeGettingModelCount);
 }
 
-TEST_F(TestPredict, SuccesfullReloadWhenSeveralInferRequestAtDifferentStages) {
+TYPED_TEST(TestPredict, SuccesfullReloadWhenSeveralInferRequestAtDifferentStages) {
     const int initialBatchSize = 1;
-    config.setBatchingParams("auto");
+    this->config.setBatchingParams("auto");
 
     const uint waitingBeforePerformInferenceCount = 9;
     const uint waitingBeforeGettingModelCount = 9;
-    testConcurrentPredicts(initialBatchSize, waitingBeforePerformInferenceCount, waitingBeforeGettingModelCount);
+    this->testConcurrentPredicts(initialBatchSize, waitingBeforePerformInferenceCount, waitingBeforeGettingModelCount);
 }
 
-TEST_F(TestPredict, SuccesfullReloadForMultipleThreadsDifferentBS) {
+TYPED_TEST(TestPredict, SuccesfullReloadForMultipleThreadsDifferentBS) {
     const int initialBatchSize = 2;
-    config.setBatchingParams("auto");
+    this->config.setBatchingParams("auto");
 
     const uint numberOfThreads = 5;
-    testConcurrentBsChanges(initialBatchSize, numberOfThreads);
+    this->testConcurrentBsChanges(initialBatchSize, numberOfThreads);
 }
-
-TEST_F(TestPredict, SuccesfullReshapeViaRequestOnDummyModel) {
-    // Prepare model manager with dynamic shaped dummy model, originally loaded with 1x10 shape
+TYPED_TEST(TestPredict, SuccesfullReshapeViaRequestOnDummyModel) {
+    // Prepare model this->manager with dynamic shaped dummy model, originally loaded with 1x10 shape
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("0");
     config.parseShapeParameter("auto");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Get dummy model instance
     std::shared_ptr<ovms::ModelInstance> model;
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> unload_guard;
-    auto status = manager.getModelInstance("dummy", 0, model, unload_guard);
+    auto status = this->manager.getModelInstance("dummy", 0, model, unload_guard);
 
     // Prepare request with 1x5 shape, expect reshape
-    tensorflow::serving::PredictRequest request = preparePredictRequest(
+    typename TypeParam::first_type request;
+    preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, tensorflow::DataType>{{1, 5}, tensorflow::DataType::DT_FLOAT}}});
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 5}, ovms::Precision::FP32}}});
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Do the inference
     ASSERT_EQ(model->infer(&request, &response, unload_guard), ovms::StatusCode::OK);
 
     // Expect reshape to 1x5
-    ASSERT_EQ(response.outputs().count("a"), 1);
-    auto& output_tensor = (*response.mutable_outputs())["a"];
-    ASSERT_EQ(output_tensor.tensor_shape().dim_size(), 2);
-    EXPECT_EQ(output_tensor.tensor_shape().dim(0).size(), 1);
-    EXPECT_EQ(output_tensor.tensor_shape().dim(1).size(), 5);
+    this->checkOutputShape(response, {1,5}, DUMMY_MODEL_OUTPUT_NAME);
 }
 
-/**
- * Scenario - perform inferences with different shapes and model reload via config.json change
+/* // TODO fix
+ * Scenario - perform inferences with different shapes and model reload via this->config.json change
  * 
  * 1. Load model with shape=auto, initial internal shape (1,10)
  * 2. Do the inference with (1,12) shape - expect status OK and result (1,12)
- * 3. Reshape model to fixed=(1,11) with config.json change
+ * 3. Reshape model to fixed=(1,11) with this->config.json change
  * 4. Do the inference with (1,12) shape - expect status INVALID_SHAPE
  * 5. Do the inference with (1,11) shape - expect status OK and result (1,11)
  * 6. Reshape model back to shape=auto, initial internal shape (1,10)
  * 7. Do the inference with (1,12) shape - expect status OK and result (1,12)
+ * // TODO fix
  */
-TEST_F(TestPredict, ReshapeViaRequestAndConfigChange) {
+TYPED_TEST(TestPredict, ReshapeViaRequestAndConfigChange) {
     using namespace ovms;
 
     // Prepare model with shape=auto (initially (1,10) shape)
     ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("0");
     config.parseShapeParameter("auto");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform reshape to (1,12) using request
-    ASSERT_EQ(performInferenceWithShape(response, {1, 12}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 12});
+    ASSERT_EQ(this->performInferenceWithShape(response, {1, 12}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 12});
 
     // Reshape with model reload to Fixed=(1,11)
     config.setBatchingParams("0");
     config.parseShapeParameter("(1,11)");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Cannot do the inference with (1,12)
-    ASSERT_EQ(performInferenceWithShape(response, {1, 12}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithShape(response, {1, 12}), ovms::StatusCode::INVALID_SHAPE);
 
     // Successfull inference with (1,11)
-    ASSERT_EQ(performInferenceWithShape(response, {1, 11}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 11});
+    ASSERT_EQ(this->performInferenceWithShape(response, {1, 11}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 11});
 
     // Reshape back to AUTO, internal shape is (1,10)
     config.setBatchingParams("0");
     config.parseShapeParameter("auto");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform reshape to (1,12) using request
-    ASSERT_EQ(performInferenceWithShape(response, {1, 12}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 12});
+    ASSERT_EQ(this->performInferenceWithShape(response, {1, 12}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 12});
 }
-
-/**
- * Scenario - perform inferences with different batch size and model reload via config.json change
+/*
+ * Scenario - perform inferences with different batch size and model reload via this->config.json change
  * 
  * 1. Load model with bs=auto, initial internal shape (1,10)
  * 2. Do the inference with (3,10) shape - expect status OK and result (3,10)
- * 3. Change model batch size to fixed=4 with config.json change
+ * 3. Change model batch size to fixed=4 with this->config.json change
  * 4. Do the inference with (3,10) shape - expect status INVALID_BATCH_SIZE
  * 5. Do the inference with (4,10) shape - expect status OK and result (4,10)
  * 6. Reshape model back to batchsize=auto, initial internal shape (1,10)
  * 7. Do the inference with (3,10) shape - expect status OK and result (3,10)
  */
-TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChange) {
+TYPED_TEST(TestPredict, ChangeBatchSizeViaRequestAndConfigChange) {
     using namespace ovms;
 
     // Prepare model with shape=auto (initially (1,10) shape)
     ModelConfig config = DUMMY_MODEL_CONFIG;
-    config.setBatchingParams("auto");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    this->config.setBatchingParams("auto");
+    ASSERT_EQ(this->manager.reloadModelWithVersions(this->config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform batch size change to 3 using request
-    ASSERT_EQ(performInferenceWithBatchSize(response, 3), ovms::StatusCode::OK);
-    checkOutputShape(response, {3, 10});
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 3), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {3, 10});
 
     // Change batch size with model reload to Fixed=4
-    config.setBatchingParams("4");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    this->config.setBatchingParams("4");
+    ASSERT_EQ(this->manager.reloadModelWithVersions(this->config), ovms::StatusCode::OK_RELOADED);
 
     // Cannot do the inference with (3,10)
-    ASSERT_EQ(performInferenceWithBatchSize(response, 3), ovms::StatusCode::INVALID_BATCH_SIZE);
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 3), ovms::StatusCode::INVALID_BATCH_SIZE);
 
     // Successfull inference with (4,10)
-    ASSERT_EQ(performInferenceWithBatchSize(response, 4), ovms::StatusCode::OK);
-    checkOutputShape(response, {4, 10});
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 4), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {4, 10});
 
     // Reshape back to AUTO, internal shape is (1,10)
-    config.setBatchingParams("auto");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    this->config.setBatchingParams("auto");
+    ASSERT_EQ(this->manager.reloadModelWithVersions(this->config), ovms::StatusCode::OK_RELOADED);
 
     // Perform batch change to 3 using request
-    ASSERT_EQ(performInferenceWithBatchSize(response, 3), ovms::StatusCode::OK);
-    checkOutputShape(response, {3, 10});
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 3), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {3, 10});
 }
 
-/**
- * Scenario - perform inference with NHWC input layout changed via config.json.
+/*
+ * Scenario - perform inference with NHWC input layout changed via this->config.json.
  * 
  * 1. Load model with layout=nhwc:nchw, initial internal layout: nchw, initial shape=(1,3,4,5)
  * 2. Do the inference with (1,4,5,3) shape - expect status OK and result (1,3,4,5)
@@ -598,49 +700,48 @@ TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChange) {
  * 8. Do the inference with (1,3,4,5) shape - expect status OK and result (1,3,4,5)
  * 9. Do the inference with (1,4,5,3) shape - expect INVALID_SHAPE
  */
-TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
+TYPED_TEST(TestPredict, PerformInferenceChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
     ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with NHWC layout, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Perform inference with NCHW layout, ensure error
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::INVALID_SHAPE);
 
     // Reload model with layout setting removed, model is back to NCHW
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NCHW layout, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Perform inference with NHWC layout, ensure error
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::INVALID_SHAPE);
 
     // Prepare model with layout changed back to nchw
     ASSERT_EQ(config.parseLayoutParameter("nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NCHW layout, ensure OK
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 4, 5}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Perform inference with NHWC layout, ensure error
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::INVALID_SHAPE);
 }
-
-/**
- * Scenario - perform inference with NHWC input layout changed and shape changed via config.json.
+/*
+ * Scenario - perform inference with NHWC input layout changed and shape changed via this->config.json.
  * 
  * 1. Load model with layout=nchw:nhwc and shape=(1,1,2,3), initial internal layout: nchw, initial shape=(1,3,4,5)
  * 2. Do the inference with (1,1,2,3) shape - expect status OK and result (1,3,1,2)
@@ -652,7 +753,7 @@ TEST_F(TestPredict, PerformInferenceChangeModelInputLayout) {
  * 8. Do the inference with (1,3,1,2) shape - expect status OK and result (1,3,1,2)
  * 9. Do the inference with (1,1,2,3) shape - expect INVALID_SHAPE
  */
-TEST_F(TestPredict, PerformInferenceChangeModelInputLayoutAndShape) {
+TYPED_TEST(TestPredict, PerformInferenceChangeModelInputLayoutAndShape) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -660,43 +761,43 @@ TEST_F(TestPredict, PerformInferenceChangeModelInputLayoutAndShape) {
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with NHWC layout, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 1, 2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {2.0, 5.0, 3.0, 6.0, 4.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 1, 2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {2.0, 5.0, 3.0, 6.0, 4.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Perform inference with NCHW layout, ensure error
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
 
     // Reload model with layout setting removed, model is back to NCHW
     ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NCHW layout, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Perform inference with NHWC layout, ensure error
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 1, 2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 1, 2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
 
     // Prepare model with layout changed back to nchw
     ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NCHW layout, ensure OK
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Perform inference with NHWC layout, ensure error
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 1, 2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 1, 2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::INVALID_SHAPE);
 }
 
 /**
@@ -709,38 +810,38 @@ TEST_F(TestPredict, PerformInferenceChangeModelInputLayoutAndShape) {
  * 5. Roll back layout setting to internal nchw
  * 6. Do the inference with (1,3,4,5) shape - expect status OK and result in NCHW layout
  */
-TEST_F(TestPredict, PerformInferenceChangeModelOutputLayout) {
+TYPED_TEST(TestPredict, PerformInferenceChangeModelOutputLayout) {
     using namespace ovms;
 
     // Prepare model with changed output layout to nhwc (internal layout=nchw)
     ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseLayoutParameter(std::string("{\"") + INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME + std::string("\":\"nhwc:nchw\"}")), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with NCHW layout, ensure status OK and results in NHWC order
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 4, 5, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 4, 5}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 4, 5, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Reload model with layout setting removed
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NCHW layout, ensure status OK and results still in NHWC order
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 4, 5}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Change output layout back to original nchw.
     ASSERT_EQ(config.parseLayoutParameter(std::string("{\"") + INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME + std::string("\":\"nchw\"}")), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 4, 5}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 4, 5}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
 
-/**
+/*
  * Scenario - change output layout of model, modify shape and perform inference. Check results if in correct order.
  *
  * 1. Load model with output layout=nhwc:nchw, shape (1,1,2,3) initial internal layout: nchw
@@ -750,7 +851,7 @@ TEST_F(TestPredict, PerformInferenceChangeModelOutputLayout) {
  * 5. Roll back layout setting to internal nchw
  * 6. Do the inference with (1,3,4,5) shape - expect status OK and result in NCHW layout
  */
-TEST_F(TestPredict, PerformInferenceChangeModelOutputLayoutAndShape) {
+TYPED_TEST(TestPredict, PerformInferenceChangeModelOutputLayoutAndShape) {
     using namespace ovms;
 
     // Prepare model with changed output layout to nhwc (internal layout=nchw)
@@ -758,35 +859,34 @@ TEST_F(TestPredict, PerformInferenceChangeModelOutputLayoutAndShape) {
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter(std::string("{\"") + INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME + std::string("\":\"nhwc:nchw\"}")), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with NCHW layout, ensure status OK and results in NHWC order
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 1, 2, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {2.0, 4.0, 6.0, 3.0, 5.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 1, 2, 3}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {2.0, 4.0, 6.0, 3.0, 5.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Reload model with layout setting removed
     ASSERT_EQ(config.parseLayoutParameter(""), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NCHW layout, ensure status OK and results still in NHWC order
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Change output layout back to original nchw.
     ASSERT_EQ(config.parseLayoutParameter(std::string("{\"") + INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME + std::string("\":\"nchw\"}")), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 3, 1, 2}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
 
-/**
- * Scenario - change input layout and changing batch size at runtime. Expect shape dimension order to stay the same.
+ /* Scenario - change input layout and changing batch size at runtime. Expect shape dimension order to stay the same.
  *
  * 1. Load model with output layout=nhwc:nchw, native unchanged shape (1,4,5,3) initial internal layout: nchw
  * 2. Do the inference with (1,4,5,3) shape - expect status OK and result in NCHW layout
@@ -794,54 +894,53 @@ TEST_F(TestPredict, PerformInferenceChangeModelOutputLayoutAndShape) {
  * 4. Do the inference with (10,4,5,3) shape - expect status OK and result in NCHW layout
  * 5. Change batch size setting to 15
  * 6. Do the inference with (15,4,5,3) shape - expect status OK and result in NCHW layout
- */
-TEST_F(TestPredict, PerformInferenceChangeModelLayoutAndKeepChangingBatchSize) {
+ * */
+TYPED_TEST(TestPredict, PerformInferenceChangeModelLayoutAndKeepChangingBatchSize) {
     using namespace ovms;
 
     // Prepare model with changed output layout to nhwc (internal layout=nchw)
     ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with NHWC layout, ensure status OK and results in NHWC order
-    ASSERT_EQ(performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {1, 4, 5, 3}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Reload model with batch size changed
     config.setBatchingParams("10");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NHWC layout batch=10, ensure status OK and results still in NCHW order
-    ASSERT_EQ(performInferenceWithImageInput(response, {10, 4, 5, 3}), ovms::StatusCode::OK);
-    checkOutputShape(response, {10, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {10, 4, 5, 3}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {10, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Change bs to 15
     config.setBatchingParams("15");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with NHWC layout batch=15, ensure status OK and input/output layout has not changed
-    ASSERT_EQ(performInferenceWithImageInput(response, {15, 4, 5, 3}), ovms::StatusCode::OK);
-    checkOutputShape(response, {15, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithImageInput(response, {15, 4, 5, 3}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {15, 3, 4, 5}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
 
-TEST_F(TestPredict, ErrorWhenLayoutSetForMissingTensor) {
+TYPED_TEST(TestPredict, ErrorWhenLayoutSetForMissingTensor) {
     ovms::ModelConfig config = INCREMENT_1x3x4x5_MODEL_CONFIG;
     ASSERT_EQ(config.parseLayoutParameter("{\"invalid_tensor_name\":\"nhwc\"}"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::CONFIG_LAYOUT_IS_NOT_IN_MODEL);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::CONFIG_LAYOUT_IS_NOT_IN_MODEL);
 }
 
-TEST_F(TestPredict, NetworkNotLoadedWhenLayoutAndDimsInconsistent) {
+TYPED_TEST(TestPredict, NetworkNotLoadedWhenLayoutAndDimsInconsistent) {
     // Dummy has 2 dimensions: (1,10), changing layout to NHWC should fail
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::MODEL_NOT_LOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::MODEL_NOT_LOADED);
 }
 
-/**
- * Scenario - change input layout of model and perform inference with binary input. Check results.
+/* Scenario - change input layout of model and perform inference with binary input. Check results.
  *
  * 1. Load model with input layout=nhwc, initial internal layout: nchw
  * 2. Do the inference with single binary image tensor - expect status OK and result in NCHW layout
@@ -849,8 +948,8 @@ TEST_F(TestPredict, NetworkNotLoadedWhenLayoutAndDimsInconsistent) {
  * 4. Do the inference with single binary image tensor - expect status UNSUPPORTED_LAYOUT
  * 5. Set back layout setting to nhwc
  * 6. Do the inference with single binary image tensor - expect status OK and result in NCHW layout
- */
-TEST_F(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
+ * */
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -858,41 +957,40 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputChangeModelInputLayout) {
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with binary input, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     // Reload model with layout setting removed
     ASSERT_EQ(config.parseLayoutParameter("nchw"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseShapeParameter("(1,3,1,2)"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with binary input, ensure validation rejects the request due to NCHW setting
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME), ovms::StatusCode::UNSUPPORTED_LAYOUT);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME), ovms::StatusCode::UNSUPPORTED_LAYOUT);
 
     // Switch back to nhwc
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform inference with binary input, ensure status OK after switching layout and correct results
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
 
-/**
- * Scenario - perform inference with binary input with witdth exceeding shape range when model shape is dynamic. Check results.
+/* Scenario - perform inference with binary input with witdth exceeding shape range when model shape is dynamic. Check results.
  *
  * 1. Load model with dynamic shape and input layout=nhwc, initial internal layout: nchw
  * 2. Do the inference with single binary image tensor with witdth exceeding shape range - expect status OK and reshaped output tensor
  */
-TEST_F(TestPredict, PerformInferenceWithBinaryInputAndShapeDynamic) {
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputAndShapeDynamic) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -901,23 +999,22 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputAndShapeDynamic) {
     // binary input shape is [1,1,1,3] so it should be resized to the nearest border which is in this case [1,1,2,3]
     ASSERT_EQ(config.parseShapeParameter("(1,1,2:5,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with binary input, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
-
-/**
+/*
  * Scenario - send binary input request to model accepting auto batch size.
  *
  * 1. Load model with input layout=nhwc, batch_size=auto, initial internal layout: nchw, batch_size=1
  * 2. Do the inference with batch=5 binary image tensor - expect status OK and result in NCHW layout
  */
-TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAuto) {
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputBatchSizeAuto) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -925,25 +1022,24 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAuto) {
     config.setBatchingParams("auto");
     ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     const int batchSize = 5;
     // Perform inference with binary input, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5", batchSize), ovms::StatusCode::OK);
-    checkOutputShape(response, {5, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5", batchSize), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {5, 3, 1, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0, 37.0, 37.0, 28.0, 28.0, 238.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
 
-/**
- * Scenario - send binary input request with no shape set.
+/* Scenario - send binary input request with no shape set.
  *
  * 1. Load model with input layout=nhwc, batch_size=auto, initial internal layout: nchw, batch_size=1
  * 2. Do the inference with binary image tensor with no shape set - expect status INVALID_NO_OF_SHAPE_DIMENSIONS
- */
-
-TEST_F(TestPredict, PerformInferenceWithBinaryInputNoInputShape) {
+*/
+/* TODO
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputNoInputShape) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -951,10 +1047,10 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputNoInputShape) {
     config.setBatchingParams("auto");
     ASSERT_EQ(config.parseShapeParameter("(1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
-    tensorflow::serving::PredictRequest request;
+    typename TypeParam::first_type request;
+    typename TypeParam::second_type response;
     auto& tensor = (*request.mutable_inputs())[INCREMENT_1x3x4x5_MODEL_INPUT_NAME];
     size_t filesize = 0;
     std::unique_ptr<char[]> image_bytes = nullptr;
@@ -963,10 +1059,9 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputNoInputShape) {
     tensor.set_dtype(tensorflow::DataType::DT_STRING);
 
     // Perform inference with binary input, ensure status INVALID_NO_OF_SHAPE_DIMENSIONS
-    ASSERT_EQ(performInferenceWithRequest(request, response, "increment_1x3x4x5"), ovms::StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS);
-}
-
-/**
+    ASSERT_EQ(this->performInferenceWithRequest(request, response, "increment_1x3x4x5"), ovms::StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS);
+}*/ //TODO FIXME
+/*
  * Scenario - perform inference with with batch size set to auto and batch size not matching on position other than first
  * 
  * 1. Load model with bs=auto, layout=b=>cn,a=>cn initial internal shape (1,10)
@@ -978,7 +1073,7 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputNoInputShape) {
  * 7. Do the inference with (1,30) shape - expect status OK and result (1,30)
  * 8. Do the inference with (30,10) shape - expect status INVALID_SHAPE
  */
-TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChangeArbitraryPosition) {
+TYPED_TEST(TestPredict, ChangeBatchSizeViaRequestAndConfigChangeArbitraryPosition) {
     using namespace ovms;
     size_t batchSizePosition = 1;  //  [0:C, 1:N]
 
@@ -986,113 +1081,124 @@ TEST_F(TestPredict, ChangeBatchSizeViaRequestAndConfigChangeArbitraryPosition) {
     ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("auto");
     ASSERT_EQ(config.parseLayoutParameter("{\"b\":\"cn\",\"a\":\"cn\"}"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform batch size change to 30 using request
-    ASSERT_EQ(performInferenceWithBatchSize(response, 30, tensorflow::DataType::DT_FLOAT, batchSizePosition), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 30});
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 30, ovms::Precision::FP32, batchSizePosition), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 30});
 
     // Change batch size with model reload to Fixed=4
     config.setBatchingParams("4");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Cannot do the inference with (1,30)
-    ASSERT_EQ(performInferenceWithBatchSize(response, 30, tensorflow::DataType::DT_FLOAT, batchSizePosition), ovms::StatusCode::INVALID_BATCH_SIZE);
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 30, ovms::Precision::FP32, batchSizePosition), ovms::StatusCode::INVALID_BATCH_SIZE);
 
     // Successfull inference with (1,4)
-    ASSERT_EQ(performInferenceWithBatchSize(response, 4, tensorflow::DataType::DT_FLOAT, batchSizePosition), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 4});
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 4, ovms::Precision::FP32, batchSizePosition), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 4});
 
     // Reshape back to AUTO, internal shape is (1,10)
     config.setBatchingParams("auto");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
     // Perform batch change to 30 using request
-    ASSERT_EQ(performInferenceWithBatchSize(response, 30, tensorflow::DataType::DT_FLOAT, batchSizePosition), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 30});
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 30, ovms::Precision::FP32, batchSizePosition), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 30});
 
     // Ensure cannot change batch size with first dimension
     batchSizePosition = 0;
-    ASSERT_EQ(performInferenceWithBatchSize(response, 30, tensorflow::DataType::DT_FLOAT, batchSizePosition), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithBatchSize(response, 30, ovms::Precision::FP32, batchSizePosition), ovms::StatusCode::INVALID_SHAPE);
 }
 
-/**
- * Scenario - inference with different shapes with dynamic dummy, both dimensions reshaped to any.
+/* Scenario - inference with different shapes with dynamic dummy, both dimensions reshaped to any.
  * No model reload performed between requests.
  *
  * 1. Load model with input shape (-1, -1)
  * 2. Do the inference with (3, 2) shape, expect correct output shape
  * 3. Do the inference with (1, 4) shape, expect correct output shape
- */
-
-TEST_F(TestPredict, PerformInferenceDummyAllDimensionsAny) {
+*/
+TYPED_TEST(TestPredict, PerformInferenceDummyAllDimensionsAny) {
     using namespace ovms;
 
     ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(-1,-1)"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Do the inference with (3, 2)
-    ASSERT_EQ(performInferenceWithShape(response, {3, 2}), ovms::StatusCode::OK);
-    checkOutputShape(response, {3, 2}, DUMMY_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithShape(response, {3, 2}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {3, 2}, DUMMY_MODEL_OUTPUT_NAME);
 
     // Do the inference with (1, 4)
-    ASSERT_EQ(performInferenceWithShape(response, {1, 4}), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 4}, DUMMY_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithShape(response, {1, 4}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 4}, DUMMY_MODEL_OUTPUT_NAME);
 }
 
-/**
- * Scenario - inference with different batch sizes for dynamic batch dummy.
+/* Scenario - inference with different batch sizes for dynamic batch dummy.
  * No model reload performed between requests.
  *
  * 1. Load model with input shape (-1, 10)
  * 2. Do the X inferences with (x, 10) shape, expect correct output shapes. x=[1, 3, 5, 7, 11, 17, 21, 57, 99]
- */
-
-TEST_F(TestPredict, PerformInferenceDummyBatchSizeAny) {
+*/
+TYPED_TEST(TestPredict, PerformInferenceDummyBatchSizeAny) {
     using namespace ovms;
 
     ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("-1");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     for (size_t i : {1, 3, 5, 7, 11, 17, 21, 57, 99}) {
-        ASSERT_EQ(performInferenceWithShape(response, {i, 10}), ovms::StatusCode::OK);
-        checkOutputShape(response, {i, 10}, DUMMY_MODEL_OUTPUT_NAME);
+        ASSERT_EQ(this->performInferenceWithShape(response, {i, 10}), ovms::StatusCode::OK);
+        this->checkOutputShape(response, {i, 10}, DUMMY_MODEL_OUTPUT_NAME);
     }
 }
 
-/**
- * Scenario - inference with dummy precision fp32.
+/* Scenario - inference with dummy precision fp32.
  *
  * 1. Load model with input shape (-1, 10)
  * 2. Do the inferences with (3, 10) shape, expect correct output shapes and precision
- */
+*/
 
-TEST_F(TestPredict, PerformInferenceDummyFp32) {
+ovms::Precision getPrecisionFromResponse(KFSResponseType& response, const std::string& name) {
+    KFSOutputTensorIteratorType it;;
+    size_t bufferId;
+    auto status = getOutput(response, name, it, bufferId);
+    EXPECT_TRUE(status.ok());
+    return ovms::KFSPrecisionToOvmsPrecision(it->datatype());
+}
+ovms::Precision getPrecisionFromResponse(TFSResponseType& response, const std::string& name) {
+    TFSOutputTensorIteratorType it;
+    size_t bufferId;
+    auto status = getOutput(response, name, it, bufferId);
+    EXPECT_TRUE(status.ok());
+    if (!status.ok())
+       return ovms::Precision::UNDEFINED;
+    return ovms::TFSPrecisionToOvmsPrecision(it->second.dtype());
+}
+TYPED_TEST(TestPredict, PerformInferenceDummyFp64) {
     using namespace ovms;
 
     ModelConfig config = DUMMY_FP64_MODEL_CONFIG;
     config.setBatchingParams("3");
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::first_type request;
+    typename TypeParam::second_type response;
 
-    auto request = preparePredictRequest({{"input:0", std::tuple<ovms::shape_t, tensorflow::DataType>{{3, 10}, tensorflow::DataType::DT_DOUBLE}}});
-    ASSERT_EQ(performInferenceWithRequest(request, response, "dummy_fp64"), ovms::StatusCode::OK);
-    checkOutputShape(response, {3, 10}, "output:0");
-    ASSERT_EQ(response.outputs().at("output:0").dtype(), tensorflow::DataType::DT_DOUBLE);
+    preparePredictRequest(request,{{"input:0", std::tuple<ovms::shape_t, ovms::Precision>{{3, 10}, ovms::Precision::FP64}}});
+    ASSERT_EQ(this->performInferenceWithRequest(request, response, "dummy_fp64"), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {3, 10}, "output:0");
+    ASSERT_EQ(getPrecisionFromResponse(response,"output:0"), ovms::Precision::FP64);
 }
 
-/**
- * Scenario - inference with different shapes with dynamic dummy, both dimensions reshaped to range.
+/* Scenario - inference with different shapes with dynamic dummy, both dimensions reshaped to range.
  * No model reload performed between requests.
  *
  * 1. Load model with input shape (2:4, 1:5)
@@ -1102,40 +1208,38 @@ TEST_F(TestPredict, PerformInferenceDummyFp32) {
  * 5. Do the inference with (3, 5) shape, expect success and correct output shape
  * 6. Do the inference with (3, 6) shape, expect not in range
  * 7. Do the inference with (5, 5) shape, expect not in range
- */
-
-TEST_F(TestPredict, PerformInferenceDummyAllDimensionsHaveRange) {
+*/
+TYPED_TEST(TestPredict, PerformInferenceDummyAllDimensionsHaveRange) {
     using namespace ovms;
 
     ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(2:4,1:5)"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
-    ASSERT_EQ(performInferenceWithShape(response, {1, 1}), ovms::StatusCode::INVALID_BATCH_SIZE);
+    ASSERT_EQ(this->performInferenceWithShape(response, {1, 1}), ovms::StatusCode::INVALID_BATCH_SIZE);
 
-    ASSERT_EQ(performInferenceWithShape(response, {2, 1}), ovms::StatusCode::OK);
-    checkOutputShape(response, {2, 1}, DUMMY_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithShape(response, {2, 1}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {2, 1}, DUMMY_MODEL_OUTPUT_NAME);
 
-    ASSERT_EQ(performInferenceWithShape(response, {3, 2}), ovms::StatusCode::OK);
-    checkOutputShape(response, {3, 2}, DUMMY_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithShape(response, {3, 2}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {3, 2}, DUMMY_MODEL_OUTPUT_NAME);
 
-    ASSERT_EQ(performInferenceWithShape(response, {3, 5}), ovms::StatusCode::OK);
-    checkOutputShape(response, {3, 5}, DUMMY_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithShape(response, {3, 5}), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {3, 5}, DUMMY_MODEL_OUTPUT_NAME);
 
-    ASSERT_EQ(performInferenceWithShape(response, {3, 6}), ovms::StatusCode::INVALID_SHAPE);
-    ASSERT_EQ(performInferenceWithShape(response, {5, 5}), ovms::StatusCode::INVALID_BATCH_SIZE);
+    ASSERT_EQ(this->performInferenceWithShape(response, {3, 6}), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithShape(response, {5, 5}), ovms::StatusCode::INVALID_BATCH_SIZE);
 }
 
-/**
- * Scenario - send binary input request to model accepting dynamic batch size.
+/* Scenario - send binary input request to model accepting dynamic batch size.
  *
  * 1. Load model with input layout=nhwc, batch_size=-1, resolution 1x2, initial internal layout: nchw, batch_size=1
  * 2. Do the inference with batch=5 binary image tensor 1x1 - expect status INVALID_SHAPE, because if any dimension is dynamic, we perform no resize operation.
  */
-TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAnyResolutionNotMatching) {
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputBatchSizeAnyResolutionNotMatching) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -1143,22 +1247,21 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAnyResolutionNotMatc
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(-1,1,2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     const int batchSize = 5;
     // Perform inference with binary input 1x1, expect status BINARY_IMAGES_RESOLUTION_MISMATCH, because if any dimension is dynamic, we perform no resize operation.
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5", batchSize), ovms::StatusCode::INVALID_SHAPE);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5", batchSize), ovms::StatusCode::INVALID_SHAPE);
 }
 
-/**
- * Scenario - send binary input request to model accepting dynamic batch size.
+/* Scenario - send binary input request to model accepting dynamic batch size.
  *
  * 1. Load model with input layout=nhwc, batch_size=-1, resolution 1x1, initial internal layout: nchw, batch_size=1
  * 2. Do the inference with batch=5 binary image tensor 1x1 - expect status OK, and correct results.
  */
-TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAnyResolutionMatching) {
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputBatchSizeAnyResolutionMatching) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -1166,24 +1269,23 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputBatchSizeAnyResolutionMatchin
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(-1,1,1,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     const int batchSize = 5;
     // Perform inference with binary input, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5", batchSize), ovms::StatusCode::OK);
-    checkOutputShape(response, {5, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5", batchSize), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {5, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0, 37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
 
-/**
- * Scenario - send binary input request to model accepting dynamic resolution.
+/* Scenario - send binary input request to model accepting dynamic resolution.
  *
  * 1. Load model with input layout=nhwc, shape 1,-1,-1,3, initial internal layout: nchw, batch_size=1
  * 2. Do the inference with resolution 1x1 binary image tensor - expect status OK and result in NCHW layout
  */
-TEST_F(TestPredict, PerformInferenceWithBinaryInputResolutionAny) {
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputResolutionAny) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -1191,24 +1293,24 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputResolutionAny) {
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(1,-1,-1,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     // Perform inference with binary input, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 }
 
-/**
- * Scenario - send binary input request to model accepting range of resolution.
+/* Scenario - send binary input request to model accepting range of resolution.
  *
  * 1. Load model with input layout=nhwc, shape 1,1:2,1:2,3, initial internal layout: nchw, batch_size=1
  * 2. Do the inference with resolution 4x4 binary image tensor - expect status OK and reshaped to 2x2
  * 3. Do the inference with resolution 1x1 binary image tensor - expect status OK and result in NCHW layout
  */
-TEST_F(TestPredict, PerformInferenceWithBinaryInputResolutionRange) {
+/* TODO
+TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputResolutionRange) {
     using namespace ovms;
 
     // Prepare model with changed layout to nhwc (internal layout=nchw)
@@ -1216,22 +1318,22 @@ TEST_F(TestPredict, PerformInferenceWithBinaryInputResolutionRange) {
     config.setBatchingParams("0");
     ASSERT_EQ(config.parseShapeParameter("(1,1:2,1:2,3)"), ovms::StatusCode::OK);
     ASSERT_EQ(config.parseLayoutParameter("nhwc:nchw"), ovms::StatusCode::OK);
-    ASSERT_EQ(manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
 
-    tensorflow::serving::PredictResponse response;
+    typename TypeParam::second_type response;
 
     ASSERT_EQ(
-        performInferenceWithRequest(
+        this->performInferenceWithRequest(
             prepareBinary4x4PredictRequest(INCREMENT_1x3x4x5_MODEL_INPUT_NAME), response, "increment_1x3x4x5"),
         ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 2, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputShape(response, {1, 3, 2, 2}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
 
     response.Clear();
 
     // Perform inference with binary input, ensure status OK and correct results
-    ASSERT_EQ(performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
-    checkOutputShape(response, {1, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-    checkOutputValues(response, {37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
-}
+    ASSERT_EQ(this->performInferenceWithBinaryImageInput(response, INCREMENT_1x3x4x5_MODEL_INPUT_NAME, "increment_1x3x4x5"), ovms::StatusCode::OK);
+    this->checkOutputShape(response, {1, 3, 1, 1}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+    this->checkOutputValues(response, {37.0, 28.0, 238.0}, INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME);
+}*/
 
 #pragma GCC diagnostic pop

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -1053,8 +1053,8 @@ TYPED_TEST(TestPredict, PerformInferenceWithBinaryInputNoInputShape) {
 
     // Perform inference with binary input, ensure status INVALID_NO_OF_SHAPE_DIMENSIONS
     ASSERT_EQ(this->performInferenceWithRequest(request, response, "increment_1x3x4x5"), ovms::StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS);
-}*/
-//TODO FIXME
+} */
+// TODO FIXME
 
 /*
  * Scenario - perform inference with with batch size set to auto and batch size not matching on position other than first
@@ -1163,7 +1163,6 @@ TYPED_TEST(TestPredict, PerformInferenceDummyBatchSizeAny) {
 
 ovms::Precision getPrecisionFromResponse(KFSResponseType& response, const std::string& name) {
     KFSOutputTensorIteratorType it;
-    ;
     size_t bufferId;
     auto status = getOutput(response, name, it, bufferId);
     EXPECT_TRUE(status.ok());

--- a/src/test/stateful_modelinstance_test.cpp
+++ b/src/test/stateful_modelinstance_test.cpp
@@ -92,7 +92,7 @@ public:
     std::string modelPath;
     std::string dummyModelName;
     ovms::model_version_t modelVersion;
-    inputs_info_t2 modelInput;
+    inputs_info_t modelInput;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
     std::unique_ptr<ov::Core> ieCore;
@@ -124,7 +124,7 @@ public:
 
 class StatefulModelInstanceInputValidation : public ::testing::Test {
 public:
-    inputs_info_t2 modelInput;
+    inputs_info_t modelInput;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
     std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
     std::unique_ptr<ov::Core> ieCore;
@@ -297,7 +297,7 @@ public:
     }
 };
 
-void RunStatefulPredict(const std::shared_ptr<ovms::ModelInstance> modelInstance, inputs_info_t2 modelInput, uint64_t seqId, uint32_t sequenceControl) {
+void RunStatefulPredict(const std::shared_ptr<ovms::ModelInstance> modelInstance, inputs_info_t modelInput, uint64_t seqId, uint32_t sequenceControl) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request, modelInput);
     setRequestSequenceId(&request, seqId);
@@ -311,7 +311,7 @@ void RunStatefulPredict(const std::shared_ptr<ovms::ModelInstance> modelInstance
     EXPECT_TRUE(CheckSequenceIdResponse(response, seqId));
 }
 
-void RunStatefulPredicts(const std::shared_ptr<ovms::ModelInstance> modelInstance, inputs_info_t2 modelInput, int numberOfNoControlRequests, uint64_t seqId,
+void RunStatefulPredicts(const std::shared_ptr<ovms::ModelInstance> modelInstance, inputs_info_t modelInput, int numberOfNoControlRequests, uint64_t seqId,
     std::future<void>* waitBeforeSequenceStarted,
     std::future<void>* waitAfterSequenceStarted,
     std::future<void>* waitBeforeSequenceFinished) {
@@ -348,7 +348,7 @@ void RunStatefulPredicts(const std::shared_ptr<ovms::ModelInstance> modelInstanc
     RunStatefulPredict(modelInstance, modelInput, seqId, ovms::SEQUENCE_END);
 }
 
-void RunStatefulPredictsOnMockedInferStart(const std::shared_ptr<MockedStatefulModelInstance> modelInstance, inputs_info_t2 modelInput, uint64_t seqId, SequenceTimeoutScenarios sequenceTimeoutScenario) {
+void RunStatefulPredictsOnMockedInferStart(const std::shared_ptr<MockedStatefulModelInstance> modelInstance, inputs_info_t modelInput, uint64_t seqId, SequenceTimeoutScenarios sequenceTimeoutScenario) {
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> unload_guard;
     std::promise<void> waitBeforeSequenceStarted, waitAfterSequenceStarted, waitBeforeSequenceFinished;
 
@@ -440,7 +440,7 @@ void RunStatefulPredictsOnMockedInferStart(const std::shared_ptr<MockedStatefulM
     }
 }
 
-void RunStatefulPredictsOnMockedInferMiddle(const std::shared_ptr<MockedStatefulModelInstance> modelInstance, inputs_info_t2 modelInput, uint64_t seqId, SequenceTimeoutScenarios sequenceTimeoutScenario) {
+void RunStatefulPredictsOnMockedInferMiddle(const std::shared_ptr<MockedStatefulModelInstance> modelInstance, inputs_info_t modelInput, uint64_t seqId, SequenceTimeoutScenarios sequenceTimeoutScenario) {
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> unload_guard;
     std::promise<void> waitBeforeSequenceStarted, waitAfterSequenceStarted, waitBeforeSequenceFinished;
 
@@ -543,7 +543,7 @@ void RunStatefulPredictsOnMockedInferMiddle(const std::shared_ptr<MockedStateful
     }
 }
 
-void RunStatefulPredictsOnMockedInferEnd(const std::shared_ptr<MockedStatefulModelInstance> modelInstance, inputs_info_t2 modelInput, uint64_t seqId, SequenceTimeoutScenarios sequenceTimeoutScenario) {
+void RunStatefulPredictsOnMockedInferEnd(const std::shared_ptr<MockedStatefulModelInstance> modelInstance, inputs_info_t modelInput, uint64_t seqId, SequenceTimeoutScenarios sequenceTimeoutScenario) {
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> unload_guard;
     std::promise<void> waitBeforeSequenceStarted, waitAfterSequenceStarted, waitBeforeSequenceFinished;
 

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -18,9 +18,77 @@
 #include <functional>
 
 #include "../prediction_service_utils.hpp"
+#include "../tensorinfo.hpp"
 
 using tensorflow::serving::PredictRequest;
 using tensorflow::serving::PredictResponse;
+
+using ovms::TensorInfo;
+
+//void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_kfs_t requestInputs, const std::vector<float>& data) {
+void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data) {
+ //   ::inference::ModelInferRequest request;
+    request.mutable_inputs()->Clear();
+    request.mutable_raw_input_contents()->Clear();
+    for (auto const& it : requestInputs) {
+        prepareKFSInferInputTensor(request, it.first, it.second, data);
+    }
+}
+
+void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data) {
+    //    tensorflow::serving::PredictRequest request;
+    request.mutable_inputs()->clear();
+    for (auto const& it : requestInputs) {
+        auto& name = it.first;
+        auto [shape, precision] = it.second;
+
+        auto& input = (*request.mutable_inputs())[name];
+        auto datatype = TensorInfo::getPrecisionAsDataType(precision);
+        input.set_dtype(datatype);
+        size_t numberOfElements = 1;
+        for (auto const& dim : shape) {
+            input.mutable_tensor_shape()->add_dim()->set_size(dim);
+            numberOfElements *= dim;
+        }
+        switch (datatype) {
+        case tensorflow::DataType::DT_HALF: {
+            if (data.size() == 0) {
+                for (size_t i = 0; i < numberOfElements; i++) {
+                    input.add_half_val('1');
+                }
+            } else {
+                for (size_t i = 0; i < data.size(); i++) {
+                    input.add_half_val(data[i]);
+                }
+            }
+            break;
+        }
+        case tensorflow::DataType::DT_UINT16: {
+            if (data.size() == 0) {
+                for (size_t i = 0; i < numberOfElements; i++) {
+                    input.add_int_val('1');
+                }
+            } else {
+                for (size_t i = 0; i < data.size(); i++) {
+                    input.add_int_val(data[i]);
+                }
+            }
+            break;
+        }
+        default: {
+            if (data.size() == 0) {
+                // TODO in case of DT_HALF & DT_UINT16 we add tensor content two times
+                *input.mutable_tensor_content() = std::string(numberOfElements * tensorflow::DataTypeSize(datatype), '1');
+            } else {
+                std::string content;
+                content.resize(numberOfElements * tensorflow::DataTypeSize(datatype));
+                std::memcpy(content.data(), data.data(), content.size());
+                *input.mutable_tensor_content() = content;
+            }
+        }
+        }
+    }
+}
 
 void waitForOVMSConfigReload(ovms::ModelManager& manager) {
     // This is effectively multiplying by 1.2 to have 1 config reload in between
@@ -223,6 +291,13 @@ std::string* findKFSInferInputTensorContent(::inference::ModelInferRequest& requ
         content = request.mutable_raw_input_contents()->Mutable(bufferId);
     }
     return content;
+}
+void prepareKFSInferInputTensor(::inference::ModelInferRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
+    const std::vector<float>& data) {
+        auto [shape, type] = inputInfo;
+    prepareKFSInferInputTensor(request, name,
+                    {shape, TensorInfo::getPrecisionAsKFSPrecision(type)}, 
+                    data);
 }
 
 void prepareKFSInferInputTensor(::inference::ModelInferRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const std::string>& inputInfo,

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -25,9 +25,7 @@ using tensorflow::serving::PredictResponse;
 
 using ovms::TensorInfo;
 
-//void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_kfs_t requestInputs, const std::vector<float>& data) {
 void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data) {
- //   ::inference::ModelInferRequest request;
     request.mutable_inputs()->Clear();
     request.mutable_raw_input_contents()->Clear();
     for (auto const& it : requestInputs) {
@@ -36,7 +34,6 @@ void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_
 }
 
 void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data) {
-    //    tensorflow::serving::PredictRequest request;
     request.mutable_inputs()->clear();
     for (auto const& it : requestInputs) {
         auto& name = it.first;
@@ -294,10 +291,10 @@ std::string* findKFSInferInputTensorContent(::inference::ModelInferRequest& requ
 }
 void prepareKFSInferInputTensor(::inference::ModelInferRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
     const std::vector<float>& data) {
-        auto [shape, type] = inputInfo;
+    auto [shape, type] = inputInfo;
     prepareKFSInferInputTensor(request, name,
-                    {shape, TensorInfo::getPrecisionAsKFSPrecision(type)}, 
-                    data);
+        {shape, TensorInfo::getPrecisionAsKFSPrecision(type)},
+        data);
 }
 
 void prepareKFSInferInputTensor(::inference::ModelInferRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const std::string>& inputInfo,

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -25,7 +25,7 @@ using tensorflow::serving::PredictResponse;
 
 using ovms::TensorInfo;
 
-void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data) {
+void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_t requestInputs, const std::vector<float>& data) {
     request.mutable_inputs()->Clear();
     request.mutable_raw_input_contents()->Clear();
     for (auto const& it : requestInputs) {
@@ -33,7 +33,7 @@ void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_
     }
 }
 
-void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data) {
+void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t requestInputs, const std::vector<float>& data) {
     request.mutable_inputs()->clear();
     for (auto const& it : requestInputs) {
         auto& name = it.first;

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -38,9 +38,7 @@
 #include "../node_library.hpp"
 #include "../tensorinfo.hpp"
 
-using inputs_info_t = std::map<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>>;
-using inputs_info_t2 = std::map<std::string, std::tuple<ovms::shape_t, ovms::Precision>>;
-using inputs_info_kfs_t = std::map<std::string, std::tuple<ovms::shape_t, const std::string>>;
+using inputs_info_t = std::map<std::string, std::tuple<ovms::shape_t, ovms::Precision>>;
 
 const std::string dummy_model_location = std::filesystem::current_path().u8string() + "/src/test/dummy";
 const std::string dummy_fp64_model_location = std::filesystem::current_path().u8string() + "/src/test/dummy_fp64";
@@ -135,7 +133,7 @@ ovms::tensor_map_t prepareTensors(
     const std::unordered_map<std::string, ovms::Shape>&& tensors,
     ovms::Precision precision = ovms::Precision::FP32);
 
-void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data = {});
+void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {});
 
 ::inference::ModelInferRequest_InferInputTensor* findKFSInferInputTensor(::inference::ModelInferRequest& request, const std::string& name);
 std::string* findKFSInferInputTensorContent(::inference::ModelInferRequest& request, const std::string& name);
@@ -145,7 +143,7 @@ void prepareKFSInferInputTensor(::inference::ModelInferRequest& request, const s
 void prepareKFSInferInputTensor(::inference::ModelInferRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
     const std::vector<float>& data = {});
 
-void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_t2 requestInputs, const std::vector<float>& data = {});
+void preparePredictRequest(::inference::ModelInferRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {});
 
 tensorflow::serving::PredictRequest prepareBinaryPredictRequest(const std::string& inputName, const int batchSize = 1);
 tensorflow::serving::PredictRequest prepareBinary4x4PredictRequest(const std::string& inputName, const int batchSize = 1);


### PR DESCRIPTION
Binary input tests excluded or skipped temporarily disabled as support for
binary inputs for KFS is not present yet.

JIRA:CVS-84719