### PR TITLE
Add all ready versions into ModelMetadataResponse

### DIFF
--- a/src/kfs_grpc_inference_service.hpp
+++ b/src/kfs_grpc_inference_service.hpp
@@ -28,6 +28,7 @@
 namespace ovms {
 
 using inference::GRPCInferenceService;
+class Model;
 class ModelManager;
 class ModelInstance;
 class TensorInfo;
@@ -41,7 +42,7 @@ public:
     ::grpc::Status ServerMetadata(::grpc::ServerContext* context, const ::inference::ServerMetadataRequest* request, ::inference::ServerMetadataResponse* response) override;
     ::grpc::Status ModelMetadata(::grpc::ServerContext* context, const ::inference::ModelMetadataRequest* request, ::inference::ModelMetadataResponse* response) override;
     ::grpc::Status ModelInfer(::grpc::ServerContext* context, const ::inference::ModelInferRequest* request, ::inference::ModelInferResponse* response) override;
-    static Status buildResponse(std::shared_ptr<ModelInstance> instance, ::inference::ModelMetadataResponse* response);
+    static Status buildResponse(Model& model, ModelInstance& instance, ::inference::ModelMetadataResponse* response);
     static Status buildResponse(PipelineDefinition& pipelineDefinition, ::inference::ModelMetadataResponse* response);
     static Status buildResponse(std::shared_ptr<ModelInstance> instance, ::inference::ModelReadyResponse* response);
     static Status buildResponse(PipelineDefinition& pipelineDefinition, ::inference::ModelReadyResponse* response);

--- a/src/modelversionstatus.cpp
+++ b/src/modelversionstatus.cpp
@@ -112,4 +112,11 @@ void ModelVersionStatus::logStatus() {
         ModelVersionStateToString(state),
         ModelVersionStatusErrorCodeToString(errorCode));
 }
+
+void ModelVersionStatus::setState(ModelVersionState state, ModelVersionStatusErrorCode error_code) {
+    SPDLOG_DEBUG("{}: {} - {} (previous state: {}) -> error: {}", __func__, this->modelName, this->version, ModelVersionStateToString(this->state), ModelVersionStatusErrorCodeToString(error_code));
+    this->state = state;
+    errorCode = error_code;
+    logStatus();
+}
 }  // namespace ovms

--- a/src/modelversionstatus.hpp
+++ b/src/modelversionstatus.hpp
@@ -96,6 +96,7 @@ public:
     void setUnloading(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK);
 
     void setEnd(ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK);
+    void setState(ModelVersionState state, ModelVersionStatusErrorCode error_code = ModelVersionStatusErrorCode::OK);
 
 private:
     void logStatus();

--- a/src/test/ensemble_mapping_config_tests.cpp
+++ b/src/test/ensemble_mapping_config_tests.cpp
@@ -383,7 +383,7 @@ TEST_F(ModelWithInputOutputNameMappedModel, GetModelMetadataOnKFSEndpoint) {
     instance = model->getDefaultModelInstance();
     ASSERT_NE(instance, nullptr);
 
-    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(instance, &kfsResponse), ovms::StatusCode::OK);
+    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &kfsResponse), ovms::StatusCode::OK);
 
     EXPECT_EQ(kfsResponse.inputs_size(), 1);
     auto input = kfsResponse.inputs().at(0);

--- a/src/test/kfs_metadata_test.cpp
+++ b/src/test/kfs_metadata_test.cpp
@@ -154,7 +154,7 @@ TEST_F(ModelMetadataResponseBuild, BasicResponseMetadata) {
 TEST_F(ModelMetadataResponseBuild, BasicResponseMetadata2Versions) {
     prepare();
     // we add version - 1 since the default is the highest. We don't want to bother preparing inputs/outputs info for them as well
-    // for second version - we just want for it to in various states
+    // for second version - we just want it to be in various states
     model_version_t secondVersion = instance->getVersion() - 1;
     auto secondInstance = std::make_shared<MockModelInstanceChangingStates>(modelName, secondVersion, *ieCore);
     model->addOneVersion(secondVersion, secondInstance);

--- a/src/test/kfs_metadata_test.cpp
+++ b/src/test/kfs_metadata_test.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "../kfs_grpc_inference_service.hpp"
+#include "../modelversionstatus.hpp"
 #include "../pipelinedefinition.hpp"
 #include "mockmodelinstancechangingstates.hpp"
 #include "test_utils.hpp"
@@ -24,18 +25,37 @@ using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
+using ovms::Model;
+using ovms::model_version_t;
+using ovms::ModelInstance;
+using ovms::ModelVersionState;
+
 struct Info {
     ovms::Precision precision;
     ovms::shape_t shape;
 };
 using tensor_desc_map_t = std::unordered_map<std::string, Info>;
 
+static const std::string MODEL_NAME{"UNUSED_NAME"};
+
 class ModelMetadataResponseBuild : public ::testing::Test {
+    class MockModel : public Model {
+    public:
+        MockModel(const std::string& name, std::shared_ptr<ModelInstance> instance) :
+            Model(name, false /*stateful*/, nullptr) {
+            modelVersions.insert({instance->getVersion(), instance});
+        }
+        void addOneVersion(model_version_t version, std::shared_ptr<ModelInstance> instance) {
+            modelVersions.emplace(version, instance);
+        }
+    };
+
+protected:
     class MockModelInstance : public MockModelInstanceChangingStates {
     public:
-        MockModelInstance(ov::Core& ieCore) :
-            MockModelInstanceChangingStates("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {
-            status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_MODEL_VERSION, ovms::ModelVersionState::AVAILABLE);
+        MockModelInstance(ov::Core& ieCore, model_version_t version = UNUSED_MODEL_VERSION) :
+            MockModelInstanceChangingStates(MODEL_NAME, version, ieCore) {
+            status = ovms::ModelVersionStatus(MODEL_NAME, this->getVersion(), ovms::ModelVersionState::AVAILABLE);
         }
 
         // Keeps the model in loading state forever
@@ -47,9 +67,9 @@ class ModelMetadataResponseBuild : public ::testing::Test {
         MOCK_METHOD(const ovms::tensor_map_t&, getInputsInfo, (), (const, override));
         MOCK_METHOD(const ovms::tensor_map_t&, getOutputsInfo, (), (const, override));
         MOCK_METHOD(const std::string&, getName, (), (const, override));
-        MOCK_METHOD(ovms::model_version_t, getVersion, (), (const, override));
     };
 
+private:
     tensor_desc_map_t inputTensors;
     tensor_desc_map_t outputTensors;
     ovms::tensor_map_t servableInputs;
@@ -58,6 +78,7 @@ class ModelMetadataResponseBuild : public ::testing::Test {
 public:
     void prepare(tensor_desc_map_t inTensors, tensor_desc_map_t outTensors) {
         instance = std::make_shared<NiceMock<MockModelInstance>>(*ieCore);
+        model = std::make_unique<MockModel>(MODEL_NAME, instance);
 
         inputTensors = inTensors;
         outputTensors = outTensors;
@@ -81,8 +102,6 @@ public:
             .WillByDefault(ReturnRef(servableOutputs));
         ON_CALL(*instance, getName())
             .WillByDefault(ReturnRef(modelName));
-        ON_CALL(*instance, getVersion())
-            .WillByDefault(Return(modelVersion));
     }
 
     void prepare() {
@@ -106,9 +125,9 @@ public:
 
 protected:
     std::string modelName = "resnet";
-    ovms::model_version_t modelVersion = 23;
 
     std::shared_ptr<NiceMock<MockModelInstance>> instance;
+    std::unique_ptr<MockModel> model;
     ::inference::ModelMetadataResponse response;
     std::unique_ptr<ov::Core> ieCore;
 
@@ -124,26 +143,53 @@ protected:
 TEST_F(ModelMetadataResponseBuild, BasicResponseMetadata) {
     prepare();
 
-    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
+    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &response), ovms::StatusCode::OK);
 
-    EXPECT_EQ(response.name(), "resnet");
-
+    EXPECT_EQ(response.name(), modelName);
     EXPECT_EQ(response.versions_size(), 1);
-    EXPECT_EQ(response.versions().at(0), "23");
+    EXPECT_EQ(response.versions().at(0), std::to_string(UNUSED_MODEL_VERSION));
 
     EXPECT_EQ(response.platform(), "OpenVINO");
+}
+TEST_F(ModelMetadataResponseBuild, BasicResponseMetadata2Versions) {
+    prepare();
+    // we add version - 1 since the default is the highest. We don't want to bother preparing inputs/outputs info for them as well
+    // for second version - we just want for it to in various states
+    model_version_t secondVersion = instance->getVersion() - 1;
+    auto secondInstance = std::make_shared<MockModelInstanceChangingStates>(modelName, secondVersion, *ieCore);
+    model->addOneVersion(secondVersion, secondInstance);
+    for (auto state : {ModelVersionState::START,
+             ModelVersionState::LOADING,
+             ModelVersionState::AVAILABLE,
+             ModelVersionState::UNLOADING,
+             ModelVersionState::END}) {
+        response.Clear();
+        secondInstance->setState(state);
+        ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &response), ovms::StatusCode::OK);
+
+        EXPECT_EQ(response.name(), modelName);
+        EXPECT_EQ(response.platform(), "OpenVINO");
+        if (state == ModelVersionState::AVAILABLE) {
+            EXPECT_EQ(response.versions_size(), 2) << "failed for state: " << ovms::ModelVersionStateToString(state);
+            EXPECT_EQ(response.versions().at(0), std::to_string(secondVersion)) << "failed for state: " << ovms::ModelVersionStateToString(state) << "failed for state: " << ovms::ModelVersionStateToString(state);
+            EXPECT_EQ(response.versions().at(1), std::to_string(UNUSED_MODEL_VERSION)) << "failed for state: " << ovms::ModelVersionStateToString(state);
+        } else {
+            EXPECT_EQ(response.versions_size(), 1) << "failed for state: " << ovms::ModelVersionStateToString(state);
+            EXPECT_EQ(response.versions().at(0), std::to_string(UNUSED_MODEL_VERSION)) << "failed for state: " << ovms::ModelVersionStateToString(state);
+        }
+    }
 }
 
 TEST_F(ModelMetadataResponseBuild, ModelVersionNotLoadedAnymore) {
     prepare();
     instance->retireModel();
-    EXPECT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(instance, &response), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
+    EXPECT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &response), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
 }
 
 TEST_F(ModelMetadataResponseBuild, ModelVersionNotLoadedYet) {
     prepare();
     instance->loadModel(DUMMY_MODEL_CONFIG);
-    EXPECT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(instance, &response), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_YET);
+    EXPECT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &response), ovms::StatusCode::MODEL_VERSION_NOT_LOADED_YET);
 }
 
 TEST_F(ModelMetadataResponseBuild, SingleInputSingleOutputValidResponse) {
@@ -151,7 +197,7 @@ TEST_F(ModelMetadataResponseBuild, SingleInputSingleOutputValidResponse) {
     tensor_desc_map_t outputs = tensor_desc_map_t({{"SingleOutput", {ovms::Precision::I32, {1, 2000}}}});
     prepare(inputs, outputs);
 
-    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
+    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &response), ovms::StatusCode::OK);
 
     EXPECT_EQ(response.inputs_size(), 1);
     auto input = response.inputs().at(0);
@@ -175,7 +221,7 @@ TEST_F(ModelMetadataResponseBuild, DoubleInputDoubleOutputValidResponse) {
         {"SecondOutput", {ovms::Precision::FP32, {1, 3, 400, 400}}}});
     prepare(inputs, outputs);
 
-    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(instance, &response), ovms::StatusCode::OK);
+    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &response), ovms::StatusCode::OK);
 
     EXPECT_EQ(response.inputs_size(), 2);
     auto firstInput = response.inputs().at(0);

--- a/src/test/mockmodelinstancechangingstates.hpp
+++ b/src/test/mockmodelinstancechangingstates.hpp
@@ -21,6 +21,7 @@
 
 #include "../model.hpp"
 #include "../modelinstance.hpp"
+#include "../modelversionstatus.hpp"
 #include "../status.hpp"
 #include "test_utils.hpp"
 
@@ -52,6 +53,9 @@ public:
     }
     void cleanupFailedLoad() override {
         status.setLoading(ovms::ModelVersionStatusErrorCode::UNKNOWN);
+    }
+    void setState(ovms::ModelVersionState state) {
+        status.setState(state);
     }
 };
 


### PR DESCRIPTION
Previously only the one version which gave the inputs/outputs info was
put into response.

Additionally removed unnecessary mocks in metadata test.

JIRA:CVS-87761