### PR TITLE
Fix misleading DAG validation error message

### DIFF
--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -412,7 +412,7 @@ public:
     Status checkForForbiddenDynamicParameters() {
         const auto& config = dependantModelInstance->getModelConfig();
         if (config.getBatchingMode() == Mode::AUTO || config.anyShapeSetToAuto()) {
-            SPDLOG_LOGGER_ERROR(modelmanager_logger, "Validation of pipeline: {} definition failed. Node name: {} used model name: {} with dynamic batch/shape parameter which is forbidden.",
+            SPDLOG_LOGGER_ERROR(modelmanager_logger, "Validation of pipeline: {} definition failed. Node name: {} used model name: {} with batch/shape parameter set to 'auto' which is forbidden. Use dynamic shape.",
                 pipelineName,
                 dependantNodeInfo.nodeName,
                 dependantNodeInfo.modelName);


### PR DESCRIPTION
Reported in issue: https://github.com/openvinotoolkit/model_server/issues/1343
Changing log message to make it clear using *'auto'* is not allowed in DAG