### PR TITLE
Fix OVMS shutdown when using http endpoint

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -93,6 +93,8 @@ cc_library(
         "http_rest_api_handler.hpp",
         "http_server.cpp",
         "http_server.hpp",
+        "httpservermodule.cpp",
+        "httpservermodule.hpp",
         "layout.cpp",
         "layout.hpp",
         "layout_configuration.cpp",

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020,2021 Intel Corporation
+# Copyright (c) 2020-2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -103,6 +103,11 @@ uint getGRPCServersCount(const ovms::Config& config) {
     return std::max<uint>(1, config.grpcWorkers());
 }
 
+GRPCServerModule::~GRPCServerModule() {
+    if (state != ModuleState::SHUTDOWN)
+        this->shutdown();
+}
+
 GRPCServerModule::GRPCServerModule(Server& server) :
     server(server),
     tfsPredictService(this->server),
@@ -171,6 +176,7 @@ void GRPCServerModule::shutdown() {
         server->Shutdown();
         SPDLOG_INFO("Shutdown gRPC server");
     }
+    servers.clear();
     state = ModuleState::SHUTDOWN;
     SPDLOG_INFO("{} shutdown", GRPC_SERVER_MODULE_NAME);
 }

--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -104,8 +104,7 @@ uint getGRPCServersCount(const ovms::Config& config) {
 }
 
 GRPCServerModule::~GRPCServerModule() {
-    if (state != ModuleState::SHUTDOWN)
-        this->shutdown();
+    this->shutdown();
 }
 
 GRPCServerModule::GRPCServerModule(Server& server) :
@@ -170,6 +169,8 @@ int GRPCServerModule::start(const ovms::Config& config) {
 }
 
 void GRPCServerModule::shutdown() {
+    if (state == ModuleState::SHUTDOWN)
+        return;
     state = ModuleState::STARTED_SHUTDOWN;
     SPDLOG_INFO("{} shutting down", GRPC_SERVER_MODULE_NAME);
     for (const auto& server : servers) {

--- a/src/httpservermodule.cpp
+++ b/src/httpservermodule.cpp
@@ -32,6 +32,7 @@ HTTPServerModule::HTTPServerModule(ovms::Server& ovmsServer) :
     ovmsServer(ovmsServer) {}
 int HTTPServerModule::start(const ovms::Config& config) {
     state = ModuleState::STARTED_INITIALIZE;
+    SPDLOG_INFO("{} starting", HTTP_SERVER_MODULE);
     const std::string server_address = config.restBindAddress() + ":" + std::to_string(config.restPort());
     int workers = config.restWorkers() ? config.restWorkers() : 10;
 
@@ -44,6 +45,7 @@ int HTTPServerModule::start(const ovms::Config& config) {
         return EXIT_FAILURE;
     }
     state = ModuleState::INITIALIZED;
+    SPDLOG_INFO("{} started", HTTP_SERVER_MODULE);
     return EXIT_SUCCESS;
 }
 void HTTPServerModule::shutdown() {

--- a/src/httpservermodule.cpp
+++ b/src/httpservermodule.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #include "httpservermodule.hpp"
 
+#include <string>
 #include <utility>
 
 #include "config.hpp"

--- a/src/httpservermodule.cpp
+++ b/src/httpservermodule.cpp
@@ -32,7 +32,7 @@ HTTPServerModule::HTTPServerModule(ovms::Server& ovmsServer) :
     ovmsServer(ovmsServer) {}
 int HTTPServerModule::start(const ovms::Config& config) {
     state = ModuleState::STARTED_INITIALIZE;
-    SPDLOG_INFO("{} starting", HTTP_SERVER_MODULE);
+    SPDLOG_INFO("{} starting", HTTP_SERVER_MODULE_NAME);
     const std::string server_address = config.restBindAddress() + ":" + std::to_string(config.restPort());
     int workers = config.restWorkers() ? config.restWorkers() : 10;
 
@@ -45,7 +45,7 @@ int HTTPServerModule::start(const ovms::Config& config) {
         return EXIT_FAILURE;
     }
     state = ModuleState::INITIALIZED;
-    SPDLOG_INFO("{} started", HTTP_SERVER_MODULE);
+    SPDLOG_INFO("{} started", HTTP_SERVER_MODULE_NAME);
     return EXIT_SUCCESS;
 }
 void HTTPServerModule::shutdown() {

--- a/src/httpservermodule.cpp
+++ b/src/httpservermodule.cpp
@@ -1,5 +1,5 @@
 //****************************************************************************
-// Copyright 2020-2021 Intel Corporation
+// Copyright 2022 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/httpservermodule.hpp
+++ b/src/httpservermodule.hpp
@@ -1,5 +1,5 @@
 //****************************************************************************
-// Copyright 2022 Intel Corporation
+// Copyright 2020-2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,35 +13,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#pragma once
+
 #include <memory>
 #include <utility>
-#include <vector>
 
-#include <grpcpp/server.h>
-
-#include "model_service.hpp"
-#include "prediction_service.hpp"
-#include "servablemanagermodule.hpp"
-#include "server.hpp"
+#include "http_server.hpp"
 
 namespace ovms {
+class Server;
 class Config;
-
-class GRPCServerModule : public Module {
-    Server& server;
-    PredictionServiceImpl tfsPredictService;
-    ModelServiceImpl tfsModelService;
-    mutable KFSInferenceServiceImpl kfsGrpcInferenceService;
-    std::vector<std::unique_ptr<grpc::Server>> servers;
+// TODO should replace all messages like
+// start REST Server with start HTTP Server
+// start Server with start gRPC server
+// this should be synchronized with validation tests changes
+class HTTPServerModule : public Module {
+    std::unique_ptr<ovms::http_server> server;
+    Server& ovmsServer;
 
 public:
-    GRPCServerModule(Server& server);
-    ~GRPCServerModule();
-    int start(const ovms::Config& config) override;
+    HTTPServerModule(Server& ovmsServer);
+    ~HTTPServerModule();
+    int start(const Config& config) override;
     void shutdown() override;
-
-    const GetModelMetadataImpl& getTFSModelMetadataImpl() const;
-    KFSInferenceServiceImpl& getKFSGrpcImpl() const;
 };
-}  // namespace ovms
+}  //namespace ovms

--- a/src/httpservermodule.hpp
+++ b/src/httpservermodule.hpp
@@ -18,10 +18,10 @@
 #include <memory>
 #include <utility>
 
+#include "server.hpp"
 #include "http_server.hpp"
 
 namespace ovms {
-class Server;
 class Config;
 // TODO should replace all messages like
 // start REST Server with start HTTP Server

--- a/src/httpservermodule.hpp
+++ b/src/httpservermodule.hpp
@@ -1,3 +1,4 @@
+#pragma once
 //****************************************************************************
 // Copyright 2020-2021 Intel Corporation
 //
@@ -36,4 +37,4 @@ public:
     int start(const Config& config) override;
     void shutdown() override;
 };
-}  //namespace ovms
+}  // namespace ovms

--- a/src/httpservermodule.hpp
+++ b/src/httpservermodule.hpp
@@ -1,6 +1,5 @@
-#pragma once
 //****************************************************************************
-// Copyright 2020-2021 Intel Corporation
+// Copyright 2022 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
+#pragma once
 
 #include <memory>
 #include <utility>
 
-#include "server.hpp"
 #include "http_server.hpp"
+#include "server.hpp"
 
 namespace ovms {
 class Config;

--- a/src/servablemanagermodule.cpp
+++ b/src/servablemanagermodule.cpp
@@ -44,12 +44,19 @@ int ServableManagerModule::start(const ovms::Config& config) {
     return EXIT_FAILURE;
 }
 void ServableManagerModule::shutdown() {
+    if (state == ModuleState::SHUTDOWN)
+        return;
     state = ModuleState::STARTED_SHUTDOWN;
     SPDLOG_INFO("{} shutting down", SERVABLE_MANAGER_MODULE_NAME);
     servableManager->join();
     state = ModuleState::SHUTDOWN;
     SPDLOG_INFO("{} shutdown", SERVABLE_MANAGER_MODULE_NAME);
 }
+
+ServableManagerModule::~ServableManagerModule() {
+    this->shutdown();
+}
+
 ModelManager& ServableManagerModule::getServableManager() const {
     return *servableManager;
 }

--- a/src/servablemanagermodule.hpp
+++ b/src/servablemanagermodule.hpp
@@ -28,6 +28,7 @@ protected:
 
 public:
     ServableManagerModule();
+    ~ServableManagerModule();
     int start(const ovms::Config& config) override;
     void shutdown() override;
     ModelManager& getServableManager() const;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -196,6 +196,10 @@ public:
         state = ModuleState::SHUTDOWN;
 #endif
     }
+    ~ProfilerModule() {
+        if (state != SHUTDOWN)
+                this->shutdown();
+    }
 };
 #endif
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -190,7 +190,8 @@ public:
     void shutdown() override {
 #ifdef MTR_ENABLED
         if (state == ModuleState::SHUTDOWN)
-            return state = ModuleState::STARTED_SHUTDOWN;
+            return;
+        state = ModuleState::STARTED_SHUTDOWN;
         profiler.reset();
         state = ModuleState::SHUTDOWN;
 #endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,5 +1,5 @@
 //****************************************************************************
-// Copyright 2020-2021 Intel Corporation
+// Copyright 2020-2022 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -197,8 +197,7 @@ public:
 #endif
     }
     ~ProfilerModule() {
-        if (state != SHUTDOWN)
-                this->shutdown();
+        this->shutdown();
     }
 };
 #endif

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -73,6 +73,9 @@ public:
     // TODO potentially to be hiden under protected and exposed only in tests by inheritance
     // #KFS_CLEANUP
     int startModules(ovms::Config& config);
-    void shutdownModules(ovms::Config& config);
+    void shutdownModules();
+
+private:
+    void ensureModuleShutdown(const std::string& name);
 };
 }  // namespace ovms

--- a/src/test/http_rest_api_handler_test.cpp
+++ b/src/test/http_rest_api_handler_test.cpp
@@ -59,8 +59,7 @@ public:
     ServerShutdownGuard(ovms::Server& ovmsServer) :
         ovmsServer(ovmsServer) {}
     ~ServerShutdownGuard() {
-        auto& config = ovms::Config::instance();
-        ovmsServer.shutdownModules(config);
+        ovmsServer.shutdownModules();
     }
 };
 


### PR DESCRIPTION
The issue was that when removing HTTP Server and related TFS server
object it did not always shutdown correctly when forced to in its
destructor. It always works properly when we do proper shutdown so this
change enforces shutdown in case of not fail during OVMS startup.

JIRA:CVS-89655