### PR TITLE
Fix minitrace, logging when starting with single model

### DIFF
--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -110,7 +110,7 @@ private:
     /**
      * @brief Watcher thread for monitor changes in config
      */
-    void watcher(std::future<void> exitSignal);
+    void watcher(std::future<void> exitSignal, bool watchConfigFile);
 
     /**
      * @brief Cleaner thread for sequence and resources cleanup
@@ -350,7 +350,7 @@ public:
      * @brief Starts monitoring as new thread
      * 
      */
-    void startWatcher();
+    void startWatcher(bool watchConfigFile);
 
     /**
      * @brief Gracefully finish the thread

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -218,7 +218,7 @@ public:
     int start(const Config& config) override {
         state = ModuleState::STARTED_INITIALIZE;
         auto profiler = std::make_unique<Profiler>(config.tracePath());
-        if (!profiler.isInitialized()) {
+        if (!profiler->isInitialized()) {
             SPDLOG_ERROR("Cannot open file for profiler, --trace_path: {}", config.tracePath());
             return EXIT_FAILURE;
         }

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -506,7 +506,7 @@ TEST(ModelManager, ConfigReloadingShouldAddNewModel) {
         .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
 
     auto status = manager.startFromFile(fileToReload);
-    manager.startWatcher();
+    manager.startWatcher(true);
     auto models = manager.getModels().size();
     EXPECT_EQ(models, 1);
     EXPECT_EQ(status, ovms::StatusCode::OK);
@@ -948,7 +948,7 @@ TEST(ModelManager, ConfigReloadingShouldRetireModelInstancesOfModelRemovedFromJs
     manager.registerVersionToLoad(1);
     manager.registerVersionToLoad(2);
     auto status = manager.startFromFile(fileToReload);
-    manager.startWatcher();
+    manager.startWatcher(true);
     auto models = manager.getModels();
     ASSERT_EQ(models.size(), 2);
     ASSERT_EQ(status, ovms::StatusCode::OK);


### PR DESCRIPTION
ModelManager watcher was checking for config file changes regardlessly
from launch mode. Now it checks config file only if it is started with
--config_path.