### PR TITLE
KServe API perf fixes part1

### DIFF
--- a/src/deserialization.cpp
+++ b/src/deserialization.cpp
@@ -19,6 +19,7 @@ namespace ovms {
 
 template <>
 Status InputSink<ov::InferRequest&>::give(const std::string& name, ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     Status status;
     try {
         requester.set_tensor(name, tensor);
@@ -40,6 +41,7 @@ Status InputSink<ov::InferRequest&>::give(const std::string& name, ov::Tensor& t
 
 ov::Tensor makeTensor(const tensorflow::TensorProto& requestInput,
     const std::shared_ptr<TensorInfo>& tensorInfo) {
+    OVMS_PROFILE_FUNCTION();
     ov::Shape shape;
     for (int i = 0; i < requestInput.tensor_shape().dim_size(); i++) {
         shape.push_back(requestInput.tensor_shape().dim(i).size());
@@ -51,6 +53,7 @@ ov::Tensor makeTensor(const tensorflow::TensorProto& requestInput,
 ov::Tensor makeTensor(const ::inference::ModelInferRequest::InferInputTensor& requestInput,
     const std::shared_ptr<TensorInfo>& tensorInfo,
     const std::string& buffer) {
+    OVMS_PROFILE_FUNCTION();
     ov::Shape shape;
     for (int i = 0; i < requestInput.shape_size(); i++) {
         shape.push_back(requestInput.shape().at(i));
@@ -61,6 +64,7 @@ ov::Tensor makeTensor(const ::inference::ModelInferRequest::InferInputTensor& re
 }
 ov::Tensor makeTensor(const ::inference::ModelInferRequest::InferInputTensor& requestInput,
     const std::shared_ptr<TensorInfo>& tensorInfo) {
+    OVMS_PROFILE_FUNCTION();
     ov::Shape shape;
     for (int i = 0; i < requestInput.shape_size(); i++) {
         shape.push_back(requestInput.shape().at(i));

--- a/src/deserialization.hpp
+++ b/src/deserialization.hpp
@@ -51,6 +51,7 @@ public:
         const ::inference::ModelInferRequest::InferInputTensor& requestInput,
         const std::shared_ptr<TensorInfo>& tensorInfo,
         const std::string* buffer) {
+        OVMS_PROFILE_FUNCTION();
         if (nullptr != buffer) {
             switch (tensorInfo->getPrecision()) {
             case ovms::Precision::FP64:
@@ -212,6 +213,7 @@ public:
     static ov::Tensor deserializeTensorProto(
         const tensorflow::TensorProto& requestInput,
         const std::shared_ptr<TensorInfo>& tensorInfo) {
+        OVMS_PROFILE_FUNCTION();
         switch (tensorInfo->getPrecision()) {
         case ovms::Precision::FP32:
         case ovms::Precision::I32:

--- a/src/exit_node.cpp
+++ b/src/exit_node.cpp
@@ -46,6 +46,7 @@ Status ExitNode<ResponseType>::execute(session_key_t sessionId, PipelineEventQue
 
 template <>
 Status OutputGetter<const TensorMap&>::get(const std::string& name, ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     auto it = outputSource.find(name);
     if (it == outputSource.end()) {
         SPDLOG_LOGGER_DEBUG(dag_executor_logger, "Failed to find expected pipeline output when serializing response: {}", name);

--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -15,11 +15,11 @@
 //*****************************************************************************
 #include "http_rest_api_handler.hpp"
 
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -232,7 +232,7 @@ void HttpRestApiHandler::parseParams(Value& scope, Document& doc) {
 }
 
 std::string HttpRestApiHandler::preprocessInferRequest(std::string request_body) {
-    static std::map<std::string, std::string> types = {
+    static std::unordered_map<std::string, std::string> types = {
         {"BOOL", "bool_contents"},
         {"INT8", "int_contents"},
         {"INT16", "int_contents"},

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -37,6 +37,9 @@ void set_log_level(const std::string log_level, std::shared_ptr<spdlog::logger> 
         } else if (log_level == "ERROR") {
             logger->set_level(spdlog::level::err);
             logger->flush_on(spdlog::level::err);
+        } else if (log_level == "WARNING") {
+            logger->set_level(spdlog::level::warn);
+            logger->flush_on(spdlog::level::warn);
         } else if (log_level == "TRACE") {
             logger->set_level(spdlog::level::trace);
             logger->flush_on(spdlog::level::trace);

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -970,6 +970,7 @@ Status ModelInstance::reloadModelIfRequired(
     const std::optional<Dimension>& requestedBatchSize,
     const std::map<std::string, shape_t>& requestedShapes,
     std::unique_ptr<ModelInstanceUnloadGuard>& modelUnloadGuardPtr) {
+    OVMS_PROFILE_FUNCTION();
     Status status = validationStatus;
     if (status.batchSizeChangeRequired()) {
         try {
@@ -1140,9 +1141,11 @@ Status ModelInstance::infer(const tensorflow::serving::PredictRequest* requestPr
     if (!status.ok())
         return status;
     timer.start("get infer request");
+    OVMS_PROFILE_SYNC_BEGIN("getInferRequest");
     ExecutingStreamIdGuard executingStreamIdGuard(getInferRequestsQueue());
     int executingInferId = executingStreamIdGuard.getId();
     ov::InferRequest& inferRequest = executingStreamIdGuard.getInferRequest();
+    OVMS_PROFILE_SYNC_END("getInferRequest");
     timer.stop("get infer request");
     SPDLOG_DEBUG("Getting infer req duration in model {}, version {}, nireq {}: {:.3f} ms",
         requestProto->model_spec().name(), getVersion(), executingInferId, timer.elapsed<microseconds>("get infer request") / 1000);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -246,10 +246,12 @@ Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
             OVMS_PROFILE_SCOPE("Create Shard");
             ov::Tensor dividedTensor;
             this->createShardedTensor(dividedTensor, ovElementTypeToOvmsPrecision(tensor.get_element_type()), newDims, tensor, i, step, metadata, tensorName);
-            std::stringstream ss;
-            ss << "Node: " << getName() << " input demultiplied: " << tensorName
-               << "; Actual: " << TensorInfo::shapeToString(dividedTensor.get_shape());
-            SPDLOG_LOGGER_DEBUG(dag_executor_logger, "{}", ss.str());
+            if (spdlog::default_logger()->level() <= spdlog::level::debug) {
+                std::stringstream ss;
+                ss << "Node: " << getName() << " input demultiplied: " << tensorName
+                   << "; Actual: " << TensorInfo::shapeToString(dividedTensor.get_shape());
+                SPDLOG_LOGGER_DEBUG(dag_executor_logger, "{}", ss.str());
+            }
             auto sessionKey = newSessionMetadatas[i].getSessionKey();
             auto it = nodeSessionOutputs.find(sessionKey);
             if (it == nodeSessionOutputs.end()) {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -246,7 +246,7 @@ Status Node::demultiplyOutputs(SessionResults& nodeSessionOutputs) {
             OVMS_PROFILE_SCOPE("Create Shard");
             ov::Tensor dividedTensor;
             this->createShardedTensor(dividedTensor, ovElementTypeToOvmsPrecision(tensor.get_element_type()), newDims, tensor, i, step, metadata, tensorName);
-            if (spdlog::default_logger()->level() <= spdlog::level::debug) {
+            if (dag_executor_logger->level() <= spdlog::level::debug) {
                 std::stringstream ss;
                 ss << "Node: " << getName() << " input demultiplied: " << tensorName
                    << "; Actual: " << TensorInfo::shapeToString(dividedTensor.get_shape());

--- a/src/nodesessionmetadata.cpp
+++ b/src/nodesessionmetadata.cpp
@@ -118,15 +118,6 @@ std::string NodeSessionMetadata::getSessionKey(const std::set<std::string>& igno
     cached = true;
     this->cachedSessionKey = createSessionKey(ignoredNodeNames);
     return this->cachedSessionKey;
-
-    if (ignoredNodeNames.size()) {
-        cached = false;
-        this->cachedSessionKey = createSessionKey(ignoredNodeNames);
-    } else if (!cached) {
-        this->cachedSessionKey = createSessionKey(ignoredNodeNames);
-        cached = true;
-    }
-    return this->cachedSessionKey;
 }
 
 std::pair<NodeSessionMetadata, CollapseDetails> NodeSessionMetadata::getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const {

--- a/src/nodesessionmetadata.cpp
+++ b/src/nodesessionmetadata.cpp
@@ -109,11 +109,11 @@ std::string NodeSessionMetadata::createSessionKey(const std::set<std::string>& i
 std::string NodeSessionMetadata::getSessionKey(const std::set<std::string>& ignoredNodeNames) const {
     // if set not empty then we need to regenerate the cache and mark it as not cached
     // we don't want to store previous set but we want to limit recreation of the key
-    if (cached && (ignoredNodeNames.size() == 0)) {
-        return this->cachedSessionKey;
-    }
     if (ignoredNodeNames.size() != 0) {
         return createSessionKey(ignoredNodeNames);
+    }
+    if (cached) {
+        return this->cachedSessionKey;
     }
     cached = true;
     this->cachedSessionKey = createSessionKey(ignoredNodeNames);

--- a/src/nodesessionmetadata.cpp
+++ b/src/nodesessionmetadata.cpp
@@ -53,6 +53,7 @@ std::vector<NodeSessionMetadata> NodeSessionMetadata::generateSubsessions(const 
     for (auto& meta : metas) {
         meta.details.insert({nodeName, {counter, subsessionSize}});
         meta.sessionsLevels.push_back(nodeName);
+        meta.cached = false;
         ++counter;
     }
     SPDLOG_LOGGER_TRACE(dag_executor_logger, "Generated subsession levels: {}",
@@ -65,7 +66,7 @@ std::vector<NodeSessionMetadata> NodeSessionMetadata::generateSubsessions(const 
     return metas;
 }
 
-std::string NodeSessionMetadata::getSessionKey(const std::set<std::string>& ignoredNodeNames) const {
+std::string NodeSessionMetadata::createSessionKey(const std::set<std::string>& ignoredNodeNames) const {
     if (details.size() == 0) {
         return "";
     }
@@ -103,6 +104,29 @@ std::string NodeSessionMetadata::getSessionKey(const std::set<std::string>& igno
         }
     }
     return ss.str();
+}
+
+std::string NodeSessionMetadata::getSessionKey(const std::set<std::string>& ignoredNodeNames) const {
+    // if set not empty then we need to regenerate the cache and mark it as not cached
+    // we don't want to store previous set but we want to limit recreation of the key
+    if (cached && (ignoredNodeNames.size() == 0)) {
+        return this->cachedSessionKey;
+    }
+    if (ignoredNodeNames.size() != 0) {
+        return createSessionKey(ignoredNodeNames);
+    }
+    cached = true;
+    this->cachedSessionKey = createSessionKey(ignoredNodeNames);
+    return this->cachedSessionKey;
+
+    if (ignoredNodeNames.size()) {
+        cached = false;
+        this->cachedSessionKey = createSessionKey(ignoredNodeNames);
+    } else if (!cached) {
+        this->cachedSessionKey = createSessionKey(ignoredNodeNames);
+        cached = true;
+    }
+    return this->cachedSessionKey;
 }
 
 std::pair<NodeSessionMetadata, CollapseDetails> NodeSessionMetadata::getCollapsedSessionMetadata(const std::set<std::string>& ignoredNodeNames) const {

--- a/src/nodesessionmetadata.hpp
+++ b/src/nodesessionmetadata.hpp
@@ -39,6 +39,8 @@ class NodeSessionMetadata {
     std::unordered_map<std::string, std::tuple<session_id_t, session_id_t>> details;
     std::vector<std::string> sessionsLevels;
     ExecutionContext context;
+    mutable std::string cachedSessionKey = "";
+    mutable bool cached = false;
 
 protected:
     NodeSessionMetadata();
@@ -52,5 +54,8 @@ public:
     session_id_t getSubsessionSize(const std::string& subsessionName) const;
     session_id_t getShardId(const std::set<std::string>& collapsedNames = {}) const;
     ExecutionContext getContext() const;
+
+private:
+    std::string createSessionKey(const std::set<std::string>& ignoredNodeNames = {}) const;
 };
 }  // namespace ovms

--- a/src/precision.cpp
+++ b/src/precision.cpp
@@ -24,8 +24,8 @@
 
 namespace ovms {
 
-std::string toString(Precision precision) {
-    static std::unordered_map<Precision, const char*> precisionMap{
+const std::string& toString(Precision precision) {
+    static std::unordered_map<Precision, std::string> precisionMap{
         {Precision::BF16, "BF16"},
         {Precision::FP64, "FP64"},
         {Precision::FP32, "FP32"},
@@ -49,7 +49,8 @@ std::string toString(Precision precision) {
         {Precision::CUSTOM, "CUSTOM"}};
     auto it = precisionMap.find(precision);
     if (it == precisionMap.end()) {
-        return "UNKNOWN";
+        static const std::string UNKNOWN{"UNKNOWN"};
+        return UNKNOWN;
     }
     return it->second;
 }
@@ -149,7 +150,7 @@ size_t KFSDataTypeSize(const KFSDataType& datatype) {
     return it->second;
 }
 
-KFSDataType ovmsPrecisionToKFSPrecision(Precision precision) {
+const KFSDataType& ovmsPrecisionToKFSPrecision(Precision precision) {
     static std::unordered_map<Precision, KFSDataType> precisionMap{
         {Precision::FP64, "FP64"},
         {Precision::FP32, "FP32"},
@@ -175,7 +176,8 @@ KFSDataType ovmsPrecisionToKFSPrecision(Precision precision) {
     // {Precision::UNDEFINED, "UNDEFINED"}};
     auto it = precisionMap.find(precision);
     if (it == precisionMap.end()) {
-        return "INVALID";
+        static const std::string invalid{"INVALID"};
+        return invalid;
     }
     return it->second;
 }

--- a/src/precision.hpp
+++ b/src/precision.hpp
@@ -53,7 +53,7 @@ enum class Precision {
     BIN
 };
 
-std::string toString(Precision precision);
+const std::string& toString(Precision precision);
 
 Precision fromString(const std::string& s);
 
@@ -62,7 +62,7 @@ Precision TFSPrecisionToOvmsPrecision(const TFSDataType& s);
 
 size_t KFSDataTypeSize(const KFSDataType& datatype);
 
-KFSDataType ovmsPrecisionToKFSPrecision(Precision precision);
+const KFSDataType& ovmsPrecisionToKFSPrecision(Precision precision);
 
 ov::element::Type_t ovmsPrecisionToIE2Precision(Precision precision);
 

--- a/src/queue.hpp
+++ b/src/queue.hpp
@@ -26,6 +26,8 @@
 #include <utility>
 #include <vector>
 
+// #include "profiler.hpp"
+
 namespace ovms {
 
 template <typename T>
@@ -35,6 +37,7 @@ public:
     * @brief Allocating idle stream for execution
     */
     std::future<int> getIdleStream() {
+        // OVMS_PROFILE_FUNCTION();
         int value;
         std::promise<int> idleStreamPromise;
         std::future<int> idleStreamFuture = idleStreamPromise.get_future();
@@ -53,6 +56,7 @@ public:
     }
 
     std::optional<int> tryToGetIdleStream() {
+        // OVMS_PROFILE_FUNCTION();
         int value;
         std::unique_lock<std::mutex> lk(front_mut);
         if (streams[front_idx] < 0) {  // we need to wait for any idle stream to be returned
@@ -70,6 +74,7 @@ public:
     * @brief Release stream after execution
     */
     void returnStream(int streamID) {
+        // OVMS_PROFILE_FUNCTION();
         std::unique_lock<std::mutex> lk(queue_mutex);
         if (promises.size()) {
             std::promise<int> promise = std::move(promises.front());

--- a/src/rest_parser.hpp
+++ b/src/rest_parser.hpp
@@ -15,8 +15,8 @@
 //*****************************************************************************
 #pragma once
 
-#include <map>
 #include <string>
+#include <unordered_map>
 
 #include <rapidjson/document.h>
 #include <spdlog/spdlog.h>
@@ -71,7 +71,7 @@ class RestParser {
     /**
      * @brief Request content precision
      */
-    std::map<std::string, ovms::Precision> tensorPrecisionMap;
+    std::unordered_map<std::string, ovms::Precision> tensorPrecisionMap;
 
     void removeUnusedInputs();
 

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -24,6 +24,7 @@ Status serializePrecision(
     tensorflow::TensorProto& responseOutput,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     if (servableOutput->getOvPrecision() != tensor.get_element_type()) {
         SPDLOG_ERROR("Failed to serialize tensor: {}. There is difference in precision expected:{} vs actual:{}",
             servableOutput->getName(),
@@ -62,6 +63,7 @@ Status serializePrecision(
     ::inference::ModelInferResponse::InferOutputTensor& responseOutput,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     if (servableOutput->getOvPrecision() != tensor.get_element_type()) {
         SPDLOG_ERROR("Failed to serialize tensor: {}. There is difference in precision expected:{} vs actual:{}",
             servableOutput->getName(),
@@ -101,6 +103,7 @@ Status serializeShape(
     tensorflow::TensorProto& responseOutput,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     responseOutput.mutable_tensor_shape()->Clear();
     auto& effectiveNetworkOutputShape = servableOutput->getShape();
     ov::Shape actualTensorShape = tensor.get_shape();
@@ -125,6 +128,7 @@ Status serializeShape(
     ::inference::ModelInferResponse::InferOutputTensor& responseOutput,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     responseOutput.clear_shape();
     auto& effectiveNetworkOutputShape = servableOutput->getShape();
     ov::Shape actualTensorShape = tensor.get_shape();
@@ -146,6 +150,7 @@ Status serializeShape(
 }
 
 void serializeContent(std::string* content, ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     // We only fill if the content is not already filled.
     // It can be filled in gather exit node handler.
     if (content->size() == 0) {
@@ -157,6 +162,7 @@ Status serializeTensorToTensorProto(
     tensorflow::TensorProto& responseOutput,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     auto status = serializePrecision(responseOutput, servableOutput, tensor);
     if (!status.ok()) {
         return status;
@@ -174,6 +180,7 @@ Status serializeTensorToTensorProto(
     std::string* rawOutputContents,
     const std::shared_ptr<TensorInfo>& servableOutput,
     ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     auto status = serializePrecision(responseOutput, servableOutput, tensor);
     if (!status.ok()) {
         return status;
@@ -188,6 +195,7 @@ Status serializeTensorToTensorProto(
 
 template <>
 Status OutputGetter<ov::InferRequest&>::get(const std::string& name, ov::Tensor& tensor) {
+    OVMS_PROFILE_FUNCTION();
     try {
         tensor = outputSource.get_tensor(name);
     } catch (const ov::Exception& e) {
@@ -200,16 +208,19 @@ Status OutputGetter<ov::InferRequest&>::get(const std::string& name, ov::Tensor&
 
 template <>
 tensorflow::TensorProto& ProtoGetter<tensorflow::serving::PredictResponse*, tensorflow::TensorProto&>::createOutput(const std::string& name) {
+    OVMS_PROFILE_FUNCTION();
     return (*protoStorage->mutable_outputs())[name];
 }
 
 template <>
 std::string* ProtoGetter<tensorflow::serving::PredictResponse*, tensorflow::TensorProto&>::createContent(const std::string& name) {
+    OVMS_PROFILE_FUNCTION();
     return nullptr;
 }
 
 template <>
 ::inference::ModelInferResponse::InferOutputTensor& ProtoGetter<::inference::ModelInferResponse*, ::inference::ModelInferResponse::InferOutputTensor&>::createOutput(const std::string& name) {
+    OVMS_PROFILE_FUNCTION();
     for (int i = 0; i < protoStorage->outputs_size(); i++) {
         auto& tensor = *protoStorage->mutable_outputs(i);
         if (tensor.name() == name) {
@@ -223,6 +234,7 @@ template <>
 
 template <>
 std::string* ProtoGetter<::inference::ModelInferResponse*, ::inference::ModelInferResponse::InferOutputTensor&>::createContent(const std::string& name) {
+    OVMS_PROFILE_FUNCTION();
     for (int i = 0; i < protoStorage->outputs_size(); i++) {
         auto& tensor = *protoStorage->mutable_outputs(i);
         if (tensor.name() == name) {

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -107,6 +107,7 @@ Status serializePredictResponse(
     const tensor_map_t& outputMap,
     ::inference::ModelInferResponse* response,
     outputNameChooser_t outputNameChooser) {
+    OVMS_PROFILE_FUNCTION();
     Status status;
     ProtoGetter<::inference::ModelInferResponse*, ::inference::ModelInferResponse::InferOutputTensor&> protoGetter(response);
     for (const auto& [outputName, outputInfo] : outputMap) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -182,12 +182,17 @@ public:
     ProfilerModule() = default;
     int start(const Config& config) override {
         state = ModuleState::STARTED_INITIALIZE;
-        auto profiler = std::make_unique<Profiler>(config.tracePath());
-        if (!profiler->isInitialized()) {
+        SPDLOG_INFO("{} starting", PROFILER_MODULE_NAME);
+        this->profiler = std::make_unique<Profiler>(config.tracePath());
+        if (!this->profiler) {
+            return EXIT_FAILURE;
+        }
+        if (!this->profiler->isInitialized()) {
             SPDLOG_ERROR("Cannot open file for profiler, --trace_path: {}", config.tracePath());
             return EXIT_FAILURE;
         }
         state = ModuleState::INITIALIZED;
+        SPDLOG_INFO("{} started", PROFILER_MODULE_NAME);
         return EXIT_SUCCESS;
     }
     void shutdown() override {
@@ -195,8 +200,10 @@ public:
         if (state == ModuleState::SHUTDOWN)
             return;
         state = ModuleState::STARTED_SHUTDOWN;
+        SPDLOG_INFO("{} shutting down", PROFILER_MODULE_NAME);
         profiler.reset();
         state = ModuleState::SHUTDOWN;
+        SPDLOG_INFO("{} shutdown", PROFILER_MODULE_NAME);
 #endif
     }
     ~ProfilerModule() {

--- a/src/tensorinfo.cpp
+++ b/src/tensorinfo.cpp
@@ -121,7 +121,7 @@ void TensorInfo::setPrecision(const ovms::Precision& requestedPrecision) {
     precision = requestedPrecision;
 }
 
-std::string TensorInfo::getPrecisionAsString(Precision precision) {
+const std::string& TensorInfo::getPrecisionAsString(Precision precision) {
     return toString(precision);
 }
 
@@ -129,19 +129,19 @@ ov::element::Type TensorInfo::getOvPrecision() const {
     return ovmsPrecisionToIE2Precision(precision);
 }
 
-std::string TensorInfo::getPrecisionAsString() const {
+const std::string& TensorInfo::getPrecisionAsString() const {
     return getPrecisionAsString(precision);
 }
 
-std::string TensorInfo::getPrecisionAsKFSPrecision(Precision precision) {
+const std::string& TensorInfo::getPrecisionAsKFSPrecision(Precision precision) {
     return ovmsPrecisionToKFSPrecision(precision);
 }
 
-std::string TensorInfo::getPrecisionAsKFSPrecision() const {
+const std::string& TensorInfo::getPrecisionAsKFSPrecision() const {
     return getPrecisionAsKFSPrecision(precision);
 }
 
-std::string TensorInfo::getStringFromLayout(const Layout& layout) {
+const std::string& TensorInfo::getStringFromLayout(const Layout& layout) {
     return layout;
 }
 

--- a/src/tensorinfo.hpp
+++ b/src/tensorinfo.hpp
@@ -173,14 +173,14 @@ public:
         *
         * @return const std::string
         */
-    std::string getPrecisionAsString() const;
+    const std::string& getPrecisionAsString() const;
 
     /**
         * @brief Get the Precision As String object representing KFS precision
         *
         * @return const std::string
         */
-    std::string getPrecisionAsKFSPrecision() const;
+    const std::string& getPrecisionAsKFSPrecision() const;
 
     /**
         * @brief Get the string representation of TensorInfo object
@@ -189,9 +189,9 @@ public:
         */
     std::string asString() const;
 
-    static std::string getPrecisionAsString(Precision precision);
+    static const std::string& getPrecisionAsString(Precision precision);
 
-    static std::string getPrecisionAsKFSPrecision(Precision precision);
+    static const std::string& getPrecisionAsKFSPrecision(Precision precision);
 
     /**
          * @brief Get the layout name from Layout
@@ -199,7 +199,7 @@ public:
          * @param Layout
          * @return std::string
          */
-    static std::string getStringFromLayout(const Layout& layout);
+    static const std::string& getStringFromLayout(const Layout& layout);
 
     /**
          * @brief Get the Layout string

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -27,6 +27,28 @@ struct is_chrono_duration_type : std::false_type {};
 template <typename T, typename U>
 struct is_chrono_duration_type<std::chrono::duration<T, U>> : std::true_type {};
 
+typedef unsigned int SIZE_TYPE;
+template <SIZE_TYPE N>
+class Timer2 {
+    std::array<std::chrono::high_resolution_clock::time_point, N> startTimestamps;
+    std::array<std::chrono::high_resolution_clock::time_point, N> stopTimestamps;
+
+public:
+    void start(SIZE_TYPE i) {
+        startTimestamps[i] = std::chrono::high_resolution_clock::now();
+    }
+
+    void stop(SIZE_TYPE i) {
+        stopTimestamps[i] = std::chrono::high_resolution_clock::now();
+    }
+
+    template <typename T>
+    double elapsed(SIZE_TYPE i) {
+        static_assert(is_chrono_duration_type<T>::value, "Non supported type.");
+        return std::chrono::duration_cast<T>(stopTimestamps[i] - startTimestamps[i]).count();
+    }
+};
+
 class Timer {
     std::unordered_map<std::string, std::chrono::high_resolution_clock::time_point> startTimestamps;
     std::unordered_map<std::string, std::chrono::high_resolution_clock::time_point> stopTimestamps;


### PR DESCRIPTION
* cache DAG session key
* prepare new timer
* avoid string copy if not necessary
* fix setting warning level
* fix starting profiler

Timer is yet to be used after metrics integration.

JIRA:CVS-87759, CVS-90529