### PR TITLE
Fail build script immediately when custom node image building fails

### DIFF
--- a/src/custom_nodes/Makefile
+++ b/src/custom_nodes/Makefile
@@ -33,11 +33,11 @@ all:
 	@cp -r ../queue.hpp ./queue.hpp
 	for NODE_NAME in $(NODES); do \
 		echo "Building $$NODE_NAME" ; \
-		docker build -f Dockerfile.$(BASE_OS) -t custom_node_build_image:latest --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} --build-arg no_proxy=${no_proxy} --build-arg NODE_NAME=$$NODE_NAME . ; \
+		docker build -f Dockerfile.$(BASE_OS) -t custom_node_build_image:latest --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} --build-arg no_proxy=${no_proxy} --build-arg NODE_NAME=$$NODE_NAME . || exit 1 ; \
 		mkdir -p ./lib/$(BASE_OS) ; \
-		docker cp $$(docker create --rm custom_node_build_image:latest):/custom_nodes/lib/libcustom_node_$$NODE_NAME.so ./lib/$(BASE_OS)/ ; \
+		docker cp $$(docker create --rm custom_node_build_image:latest):/custom_nodes/lib/libcustom_node_$$NODE_NAME.so ./lib/$(BASE_OS)/ || exit 1 ; \
 		echo "Built $$NODE_NAME" ; \
-	done
+	done || exit 1
 	@rm ./queue.hpp
 	@rm install_opencv.sh
 	@rm opencv_cmake_flags.txt


### PR DESCRIPTION
Previously it was possible to end script with exit code 0 when custom node building failed.
In rare scenarios it was possible to fail image building process and retrieve old custom node artifacts from old images.