### PR TITLE
CVS-91223 Klocwork metrics triage

### DIFF
--- a/src/metric.hpp
+++ b/src/metric.hpp
@@ -50,6 +50,7 @@ private:
     MetricCounter(prometheus::Counter& counterImpl);
     MetricCounter(const MetricCounter&) = delete;
     MetricCounter(MetricCounter&&) = delete;
+    MetricCounter& operator=(const MetricCounter&) = delete;
 
 public:
     void increment(double value = 1.0f);
@@ -65,6 +66,7 @@ public:
     MetricGauge(prometheus::Gauge& gaugeImpl);
     MetricGauge(const MetricGauge&) = delete;
     MetricGauge(MetricCounter&&) = delete;
+    MetricGauge& operator=(const MetricGauge&) = delete;
 
     void increment(double value = 1.0f);
     void decrement(double value = 1.0f);
@@ -81,6 +83,7 @@ public:
     MetricHistogram(prometheus::Histogram& histogramImpl);
     MetricHistogram(const MetricHistogram&) = delete;
     MetricHistogram(MetricCounter&&) = delete;
+    MetricHistogram& operator=(const MetricHistogram&) = delete;
 
     void observe(double value);
 

--- a/src/metric_family.hpp
+++ b/src/metric_family.hpp
@@ -37,6 +37,7 @@ private:
     MetricFamily(const std::string& name, const std::string& description, prometheus::Registry& registryImplRef);
     MetricFamily(const MetricFamily&) = delete;
     MetricFamily(MetricFamily&&) = delete;
+    MetricFamily& operator=(const MetricFamily&) = delete;
 
 public:
     std::unique_ptr<MetricType> addMetric(

--- a/src/metric_registry.hpp
+++ b/src/metric_registry.hpp
@@ -30,6 +30,7 @@ public:
     MetricRegistry();
     MetricRegistry(const MetricRegistry&) = delete;
     MetricRegistry(MetricRegistry&&) = delete;
+    MetricRegistry& operator=(const MetricRegistry&) = delete;
 
     template <typename MetricType>
     std::shared_ptr<MetricFamily<MetricType>> createFamily(const std::string& name, const std::string& description) {

--- a/src/model_metric_reporter.cpp
+++ b/src/model_metric_reporter.cpp
@@ -16,6 +16,7 @@
 #include "model_metric_reporter.hpp"
 
 #include <cmath>
+#include <exception>
 
 #include "execution_context.hpp"
 #include "metric_config.hpp"
@@ -27,6 +28,11 @@ namespace ovms {
 constexpr int NUMBER_OF_BUCKETS = 33;
 constexpr double BUCKET_POWER_BASE = 1.8;
 constexpr double BUCKET_MULTIPLIER = 10;
+
+#define THROW_IF_NULL(VAR, MESSAGE)      \
+    if (VAR == nullptr) {                \
+        throw std::logic_error(MESSAGE); \
+    }
 
 ServableMetricReporter::ServableMetricReporter(const MetricConfig* metricConfig, MetricRegistry* registry, const std::string& modelName, model_version_t modelVersion) :
     registry(registry) {
@@ -45,6 +51,7 @@ ServableMetricReporter::ServableMetricReporter(const MetricConfig* metricConfig,
     std::string familyName = "ovms_requests_success";
     auto family = registry->createFamily<MetricCounter>(familyName,
         "Number of successful requests to a model or a DAG.");
+    THROW_IF_NULL(family, "cannot create family");
 
     if (metricConfig->isFamilyEnabled(familyName)) {
         // TFS
@@ -53,73 +60,87 @@ ServableMetricReporter::ServableMetricReporter(const MetricConfig* metricConfig,
             {"api", "TensorFlowServing"},
             {"method", "Predict"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestSuccessGrpcPredict, "cannot create metric");
 
         this->requestSuccessGrpcGetModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "TensorFlowServing"},
             {"method", "GetModelMetadata"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestSuccessGrpcGetModelMetadata, "cannot create metric");
 
         this->requestSuccessGrpcGetModelStatus = family->addMetric({{"name", modelName},
             {"api", "TensorFlowServing"},
             {"method", "GetModelStatus"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestSuccessGrpcGetModelStatus, "cannot create metric");
 
         this->requestSuccessRestPredict = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "TensorFlowServing"},
             {"method", "Predict"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestSuccessRestPredict, "cannot create metric");
 
         this->requestSuccessRestGetModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "TensorFlowServing"},
             {"method", "GetModelMetadata"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestSuccessRestGetModelMetadata, "cannot create metric");
 
         this->requestSuccessRestGetModelStatus = family->addMetric({{"name", modelName},
             {"api", "TensorFlowServing"},
             {"method", "GetModelStatus"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestSuccessRestGetModelStatus, "cannot create metric");
+
         // KFS
         this->requestSuccessGrpcModelInfer = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "KServe"},
             {"method", "ModelInfer"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestSuccessGrpcModelInfer, "cannot create metric");
 
         this->requestSuccessGrpcModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "KServe"},
             {"method", "ModelMetadata"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestSuccessGrpcModelMetadata, "cannot create metric");
 
         this->requestSuccessGrpcModelReady = family->addMetric({{"name", modelName},
             {"api", "KServe"},
             {"method", "ModelReady"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestSuccessGrpcModelReady, "cannot create metric");
 
         this->requestSuccessRestModelInfer = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "KServe"},
             {"method", "ModelInfer"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestSuccessRestModelInfer, "cannot create metric");
 
         this->requestSuccessRestModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "KServe"},
             {"method", "ModelMetadata"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestSuccessRestModelMetadata, "cannot create metric");
 
         this->requestSuccessRestModelReady = family->addMetric({{"name", modelName},
             {"api", "KServe"},
             {"method", "ModelReady"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestSuccessRestModelReady, "cannot create metric");
     }
 
     familyName = "ovms_requests_fail";
     family = registry->createFamily<MetricCounter>(familyName,
         "Number of failed requests to a model or a DAG.");
+    THROW_IF_NULL(family, "cannot create family");
 
     if (metricConfig->isFamilyEnabled(familyName)) {
         // TFS
@@ -128,34 +149,40 @@ ServableMetricReporter::ServableMetricReporter(const MetricConfig* metricConfig,
             {"api", "TensorFlowServing"},
             {"method", "Predict"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestFailGrpcPredict, "cannot create metric");
 
         this->requestFailGrpcGetModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "TensorFlowServing"},
             {"method", "GetModelMetadata"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestFailGrpcGetModelMetadata, "cannot create metric");
 
         this->requestFailGrpcGetModelStatus = family->addMetric({{"name", modelName},
             {"api", "TensorFlowServing"},
             {"method", "GetModelStatus"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestFailGrpcGetModelStatus, "cannot create metric");
 
         this->requestFailRestPredict = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "TensorFlowServing"},
             {"method", "Predict"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestFailRestPredict, "cannot create metric");
 
         this->requestFailRestGetModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "TensorFlowServing"},
             {"method", "GetModelMetadata"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestFailRestGetModelMetadata, "cannot create metric");
 
         this->requestFailRestGetModelStatus = family->addMetric({{"name", modelName},
             {"api", "TensorFlowServing"},
             {"method", "GetModelStatus"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestFailRestGetModelStatus, "cannot create metric");
 
         // KFS
         this->requestFailGrpcModelInfer = family->addMetric({{"name", modelName},
@@ -163,50 +190,59 @@ ServableMetricReporter::ServableMetricReporter(const MetricConfig* metricConfig,
             {"api", "KServe"},
             {"method", "ModelInfer"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestFailGrpcModelInfer, "cannot create metric");
 
         this->requestFailGrpcModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "KServe"},
             {"method", "ModelMetadata"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestFailGrpcModelMetadata, "cannot create metric");
 
         this->requestFailGrpcModelReady = family->addMetric({{"name", modelName},
             {"api", "KServe"},
             {"method", "ModelReady"},
             {"interface", "gRPC"}});
+        THROW_IF_NULL(this->requestFailGrpcModelReady, "cannot create metric");
 
         this->requestFailRestModelInfer = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "KServe"},
             {"method", "ModelInfer"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestFailRestModelInfer, "cannot create metric");
 
         this->requestFailRestModelMetadata = family->addMetric({{"name", modelName},
             {"version", std::to_string(modelVersion)},
             {"api", "KServe"},
             {"method", "ModelMetadata"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestFailRestModelMetadata, "cannot create metric");
 
         this->requestFailRestModelReady = family->addMetric({{"name", modelName},
             {"api", "KServe"},
             {"method", "ModelReady"},
             {"interface", "REST"}});
+        THROW_IF_NULL(this->requestFailRestModelReady, "cannot create metric");
     }
 
     familyName = "ovms_request_time_us";
     auto requestTimeFamily = registry->createFamily<MetricHistogram>(familyName,
         "Processing time of requests to a model or a DAG.");
+    THROW_IF_NULL(requestTimeFamily, "cannot create family");
 
     if (metricConfig->isFamilyEnabled(familyName)) {
         this->requestTimeGrpc = requestTimeFamily->addMetric({{"name", modelName},
                                                                  {"version", std::to_string(modelVersion)},
                                                                  {"interface", "gRPC"}},
             this->buckets);
+        THROW_IF_NULL(this->requestTimeGrpc, "cannot create metric");
 
         this->requestTimeRest = requestTimeFamily->addMetric({{"name", modelName},
                                                                  {"version", std::to_string(modelVersion)},
                                                                  {"interface", "REST"}},
             this->buckets);
+        THROW_IF_NULL(this->requestTimeRest, "cannot create metric");
     }
 }
 
@@ -222,52 +258,64 @@ ModelMetricReporter::ModelMetricReporter(const MetricConfig* metricConfig, Metri
 
     std::string familyName = "ovms_inference_time_us";
     if (metricConfig->isFamilyEnabled(familyName)) {
-        this->inferenceTime = registry->createFamily<MetricHistogram>(familyName,
-                                          "Inference execution time in the OpenVINO backend.")
-                                  ->addMetric(
-                                      {{"name", modelName}, {"version", std::to_string(modelVersion)}},
-                                      this->buckets);
+        auto family = registry->createFamily<MetricHistogram>(familyName,
+            "Inference execution time in the OpenVINO backend.");
+        THROW_IF_NULL(family, "cannot create family");
+        this->inferenceTime = family->addMetric(
+            {{"name", modelName}, {"version", std::to_string(modelVersion)}},
+            this->buckets);
+        THROW_IF_NULL(this->inferenceTime, "cannot create metric");
     }
 
     familyName = "ovms_wait_for_infer_req_time_us";
     if (metricConfig->isFamilyEnabled(familyName)) {
-        this->waitForInferReqTime = registry->createFamily<MetricHistogram>(familyName,
-                                                "Request waiting time in the scheduling queue.")
-                                        ->addMetric(
-                                            {{"name", modelName}, {"version", std::to_string(modelVersion)}},
-                                            this->buckets);
+        auto family = registry->createFamily<MetricHistogram>(familyName,
+            "Request waiting time in the scheduling queue.");
+        THROW_IF_NULL(family, "cannot create family");
+        this->waitForInferReqTime = family->addMetric(
+            {{"name", modelName}, {"version", std::to_string(modelVersion)}},
+            this->buckets);
+        THROW_IF_NULL(this->waitForInferReqTime, "cannot create metric");
     }
 
     familyName = "ovms_streams";
     if (metricConfig->isFamilyEnabled(familyName)) {
-        this->streams = registry->createFamily<MetricGauge>(familyName,
-                                    "Number of OpenVINO execution streams.")
-                            ->addMetric(
-                                {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        auto family = registry->createFamily<MetricGauge>(familyName,
+            "Number of OpenVINO execution streams.");
+        THROW_IF_NULL(family, "cannot create family");
+        this->streams = family->addMetric(
+            {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        THROW_IF_NULL(this->streams, "cannot create metric");
     }
 
     familyName = "ovms_infer_req_queue_size";
     if (metricConfig->isFamilyEnabled(familyName)) {
-        this->inferReqQueueSize = registry->createFamily<MetricGauge>(familyName,
-                                              "Inference request queue size (nireq).")
-                                      ->addMetric(
-                                          {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        auto family = registry->createFamily<MetricGauge>(familyName,
+            "Inference request queue size (nireq).");
+        THROW_IF_NULL(family, "cannot create family");
+        this->inferReqQueueSize = family->addMetric(
+            {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        THROW_IF_NULL(this->inferReqQueueSize, "cannot create metric");
     }
 
     familyName = "ovms_infer_req_active";
     if (metricConfig->isFamilyEnabled(familyName)) {
-        this->inferReqActive = registry->createFamily<MetricGauge>(familyName,
-                                           "Number of currently consumed inference request from the processing queue.")
-                                   ->addMetric(
-                                       {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        auto family = registry->createFamily<MetricGauge>(familyName,
+            "Number of currently consumed inference request from the processing queue.");
+        THROW_IF_NULL(family, "cannot create family");
+        this->inferReqActive = family->addMetric(
+            {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        THROW_IF_NULL(this->inferReqActive, "cannot create metric");
     }
 
     familyName = "ovms_current_requests";
     if (metricConfig->isFamilyEnabled(familyName)) {
-        this->currentRequests = registry->createFamily<MetricGauge>(familyName,
-                                            "Number of inference requests currently in process.")
-                                    ->addMetric(
-                                        {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        auto family = registry->createFamily<MetricGauge>(familyName,
+            "Number of inference requests currently in process.");
+        THROW_IF_NULL(family, "cannot create family");
+        this->currentRequests = family->addMetric(
+            {{"name", modelName}, {"version", std::to_string(modelVersion)}});
+        THROW_IF_NULL(this->currentRequests, "cannot create metric");
     }
 }
 

--- a/src/model_metric_reporter.cpp
+++ b/src/model_metric_reporter.cpp
@@ -19,6 +19,7 @@
 #include <exception>
 
 #include "execution_context.hpp"
+#include "logging.hpp"
 #include "metric_config.hpp"
 #include "metric_family.hpp"
 #include "metric_registry.hpp"
@@ -29,9 +30,10 @@ constexpr int NUMBER_OF_BUCKETS = 33;
 constexpr double BUCKET_POWER_BASE = 1.8;
 constexpr double BUCKET_MULTIPLIER = 10;
 
-#define THROW_IF_NULL(VAR, MESSAGE)      \
-    if (VAR == nullptr) {                \
-        throw std::logic_error(MESSAGE); \
+#define THROW_IF_NULL(VAR, MESSAGE)                        \
+    if (VAR == nullptr) {                                  \
+        SPDLOG_LOGGER_ERROR(modelmanager_logger, MESSAGE); \
+        throw std::logic_error(MESSAGE);                   \
     }
 
 ServableMetricReporter::ServableMetricReporter(const MetricConfig* metricConfig, MetricRegistry* registry, const std::string& modelName, model_version_t modelVersion) :


### PR DESCRIPTION
- remove assignment operator for metrics classes
- handle errors during metric famil/metric creation (impossible in normal ovms flow)

Situation in which the metric creation fails will cause ovms to stop with error indicating bug inside ovms.