### PR TITLE
Fix debug build with -O0 optimization level

### DIFF
--- a/src/layout_configuration.cpp
+++ b/src/layout_configuration.cpp
@@ -24,6 +24,8 @@
 
 namespace ovms {
 
+const char LayoutConfiguration::LAYOUT_CONFIGURATION_DELIMETER = ':';
+
 LayoutConfiguration::LayoutConfiguration(const char* layout) :
     LayoutConfiguration(std::string(layout)) {
 }

--- a/src/layout_configuration.hpp
+++ b/src/layout_configuration.hpp
@@ -25,7 +25,7 @@ namespace ovms {
 class Status;
 
 class LayoutConfiguration {
-    static const char LAYOUT_CONFIGURATION_DELIMETER = ':';
+    static const char LAYOUT_CONFIGURATION_DELIMETER;
     Layout tensor;
     Layout model;
 


### PR DESCRIPTION
With -O0 optimization level compiler had issues with passing LAYOUT_CONFIGURATION_DELIMETER by reference to std::count in `LayoutConfiguration::fromString`
Observed only with -O0