### PR TITLE
Add missing header for building OVMS with OV 22.3

### DIFF
--- a/src/ov_utils.hpp
+++ b/src/ov_utils.hpp
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include <openvino/openvino.hpp>
+#include <ie_plugin_config.hpp>
 #include <spdlog/spdlog.h>
 
 #include "modelconfig.hpp"


### PR DESCRIPTION
Build OVMS with latest openvino github, failed with error: 'METRIC_KEY' was not declared in this scope.
Step to reproduce this issue on model server master: 
```
git clone https://github.com/openvinotoolkit/model_server && cd model_server
OV_USE_BINARY=0 make docker_build
```
Error message:
```
src/ov_utils.cpp: In function 'void ovms::insertSupportedKeys(std::set<std::__cxx11::basic_string<char> >&, const string&, const ov::Core&)':
src/ov_utils.cpp:87:55: error: 'SUPPORTED_CONFIG_KEYS' was not declared in this scope
   87 |     const std::string supportedConfigKey = METRIC_KEY(SUPPORTED_CONFIG_KEYS);
      |                                                       ^~~~~~~~~~~~~~~~~~~~~
src/ov_utils.cpp:87:44: error: 'METRIC_KEY' was not declared in this scope
   87 |     const std::string supportedConfigKey = METRIC_KEY(SUPPORTED_CONFIG_KEYS);
      |                                            ^~~~~~~~~~
[0m[91mTarget //src:ovms failed to build
Use --verbose_failures to see the command lines of failed build steps.
[0m[91mINFO: Elapsed time: 75.515s, Critical Path: 57.48s
INFO: 3286 processes: 1583 internal, 1703 local.
FAILED: Build did NOT complete successfully
[0m[91mFAILED: Build did NOT complete successfully
[0mThe command '/bin/bash -c bazel build ${debug_bazel_flags} ${minitrace_flags} --jobs $JOBS //src:ovms' returned a non-zero code: 1
Makefile:159: recipe for target 'docker_build' failed
make: *** [docker_build] Error 1
```
This PR fix this issue by adding missing header <ie_plugin_config.hpp> in src/ov_utils.hpp for METRIC_KEY variable. 