### PR TITLE
CVS-95439 CLI parser decoupled from ovms::Config

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -230,7 +230,7 @@ RUN if [ "$CHECK_COVERAGE" == "1" ] ; then true ; else bazel test ${debug_bazel_
     bazel coverage --test_output=streamed --combined_report=lcov //src:ovms_test &&\
     genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" &&\
     bazel test ${debug_bazel_flags} --jobs $JOBS --test_summary=detailed --test_output=streamed //src:ovms_test
-    
+
 RUN bazel build ${debug_bazel_flags} ${minitrace_flags} --jobs $JOBS //src:ovms
 RUN bazel build ${debug_bazel_flags} --jobs $JOBS //src:libsampleloader.so
 

--- a/check_coverage.bat
+++ b/check_coverage.bat
@@ -5,8 +5,8 @@
 #MIN_FUNCTION_COV=87.4
 
 #Rhel
-MIN_LINES_COV=73.5
-MIN_FUNCTION_COV=74.4
+MIN_LINES_COV=53.5
+MIN_FUNCTION_COV=54.4
 
 
 LINES_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | head -n 1`

--- a/check_coverage.bat
+++ b/check_coverage.bat
@@ -5,8 +5,8 @@
 #MIN_FUNCTION_COV=87.4
 
 #Rhel
-MIN_LINES_COV=53.5
-MIN_FUNCTION_COV=54.4
+MIN_LINES_COV=73.7
+MIN_FUNCTION_COV=74.1
 
 
 LINES_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | head -n 1`

--- a/cppclean.sh
+++ b/cppclean.sh
@@ -38,11 +38,11 @@ if [ ${NO_WARNINGS_DIRECT} -gt 14 ]; then
     echo "Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_DIRECT}";
     exit 1;
 fi
-if [ ${NO_WARNINGS_NOTUSED} -gt 2 ]; then
+if [ ${NO_WARNINGS_NOTUSED} -gt 3 ]; then
     echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_NOTUSED}";
     exit 1;
 fi
-if [ ${NO_WARNINGS} -gt  180 ]; then
+if [ ${NO_WARNINGS} -gt  181 ]; then
     echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
     exit 1
 fi

--- a/src/BUILD
+++ b/src/BUILD
@@ -98,6 +98,8 @@ cc_library(
         "buffer.hpp",
         "cleaner_utils.cpp",
         "cleaner_utils.hpp",
+        "cli_parser.cpp",
+        "cli_parser.hpp",
         "config.cpp",
         "config.hpp",
         "custom_node.cpp",

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -1,0 +1,269 @@
+//*****************************************************************************
+// Copyright 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include "cli_parser.hpp"
+
+#include <iostream>
+#include <string>
+
+#include <sysexits.h>
+
+#include "poc_api_impl.hpp"
+#include "version.hpp"
+
+namespace ovms {
+
+void CLIParser::parse(int argc, char** argv) {
+    try {
+        options = std::make_unique<cxxopts::Options>(argv[0], "OpenVINO Model Server");
+
+        // clang-format off
+        options->add_options()
+            ("h, help",
+                "Show this help message and exit")
+            ("version",
+                "Show binary version")
+            ("port",
+                "gRPC server port",
+                cxxopts::value<uint64_t>()->default_value("9178"),
+                "PORT")
+            ("grpc_bind_address",
+                "Network interface address to bind to for the gRPC API",
+                cxxopts::value<std::string>()->default_value("0.0.0.0"),
+                "GRPC_BIND_ADDRESS")
+            ("rest_port",
+                "REST server port, the REST server will not be started if rest_port is blank or set to 0",
+                cxxopts::value<uint64_t>()->default_value("0"),
+                "REST_PORT")
+            ("rest_bind_address",
+                "Network interface address to bind to for the REST API",
+                cxxopts::value<std::string>()->default_value("0.0.0.0"),
+                "REST_BIND_ADDRESS")
+            ("grpc_workers",
+                "Number of gRPC servers. Default 1. Increase for multi client, high throughput scenarios",
+                cxxopts::value<uint>()->default_value("1"),
+                "GRPC_WORKERS")
+            ("rest_workers",
+                "Number of worker threads in REST server - has no effect if rest_port is not set. Default value depends on number of CPUs. ",
+                cxxopts::value<uint>(),
+                "REST_WORKERS")
+            ("log_level",
+                "serving log level - one of TRACE, DEBUG, INFO, WARNING, ERROR",
+                cxxopts::value<std::string>()->default_value("INFO"), "LOG_LEVEL")
+            ("log_path",
+                "Optional path to the log file",
+                cxxopts::value<std::string>(), "LOG_PATH")
+#ifdef MTR_ENABLED
+            ("trace_path",
+                "Path to the trace file",
+                cxxopts::value<std::string>(), "TRACE_PATH")
+#endif
+            ("grpc_channel_arguments",
+                "A comma separated list of arguments to be passed to the grpc server. (e.g. grpc.max_connection_age_ms=2000)",
+                cxxopts::value<std::string>(), "GRPC_CHANNEL_ARGUMENTS")
+            ("file_system_poll_wait_seconds",
+                "Time interval between config and model versions changes detection. Default is 1. Zero or negative value disables changes monitoring.",
+                cxxopts::value<uint>()->default_value("1"),
+                "FILE_SYSTEM_POLL_WAIT_SECONDS")
+            ("sequence_cleaner_poll_wait_minutes",
+                "Time interval between two consecutive sequence cleanup scans. Default is 5. Zero value disables sequence cleaner.",
+                cxxopts::value<uint32_t>()->default_value("5"),
+                "SEQUENCE_CLEANER_POLL_WAIT_MINUTES")
+            ("custom_node_resources_cleaner_interval",
+                "Time interval between two consecutive resources cleanup scans. Default is 1. Must be greater than 0.",
+                cxxopts::value<uint32_t>()->default_value("1"),
+                "CUSTOM_NODE_RESOURCES_CLEANER_INTERVAL")
+            ("cache_dir",
+                "Overrides model cache directory. By default cache files are saved into /opt/cache if the directory is present. When enabled, first model load will produce cache files.",
+                cxxopts::value<std::string>(),
+                "CACHE_DIR")
+            ("cpu_extension",
+                "A path to shared library containing custom CPU layer implementation. Default: empty.",
+                cxxopts::value<std::string>()->default_value(""),
+                "CPU_EXTENSION");
+
+        options->add_options("multi model")
+            ("config_path",
+                "Absolute path to json configuration file",
+                cxxopts::value<std::string>(), "CONFIG_PATH");
+
+        options->add_options("single model")
+            ("model_name",
+                "Name of the model",
+                cxxopts::value<std::string>(),
+                "MODEL_NAME")
+            ("model_path",
+                "Absolute path to model, as in tf serving",
+                cxxopts::value<std::string>(),
+                "MODEL_PATH")
+            ("batch_size",
+                "Resets models batchsize, int value or auto. This parameter will be ignored if shape is set",
+                cxxopts::value<std::string>(),
+                "BATCH_SIZE")
+            ("shape",
+                "Resets models shape (model must support reshaping). If set, batch_size parameter is ignored",
+                cxxopts::value<std::string>(),
+                "SHAPE")
+            ("layout",
+                "Resets model layout.",
+                cxxopts::value<std::string>(),
+                "LAYOUT")
+            ("model_version_policy",
+                "Model version policy",
+                cxxopts::value<std::string>(),
+                "MODEL_VERSION_POLICY")
+            ("nireq",
+                "Size of inference request queue for model executions. Recommended to be >= parallel executions. Default value calculated by OpenVINO based on available resources. Request for 0 is treated as request for default value",
+                cxxopts::value<uint32_t>(),
+                "NIREQ")
+            ("target_device",
+                "Target device to run the inference",
+                cxxopts::value<std::string>()->default_value("CPU"),
+                "TARGET_DEVICE")
+            ("plugin_config",
+                "A dictionary of plugin configuration keys and their values, eg \"{\\\"CPU_THROUGHPUT_STREAMS\\\": \\\"1\\\"}\". Default throughput streams for CPU and GPU are calculated by OpenVINO",
+                cxxopts::value<std::string>(),
+                "PLUGIN_CONFIG")
+            ("stateful",
+                "Flag indicating model is stateful",
+                cxxopts::value<bool>()->default_value("false"),
+                "STATEFUL")
+            ("metrics_enable",
+                "Flag enabling metrics endpoint on rest_port.",
+                cxxopts::value<bool>()->default_value("false"),
+                "METRICS")
+            ("metrics_list",
+                "Comma separated list of metrics. If unset, only default metrics will be enabled. Default metrics: ovms_requests_success, ovms_requests_fail, ovms_request_time_us, ovms_streams, ovms_inference_time_us, ovms_wait_for_infer_req_time_us. When set, only the listed metrics will be enabled. Optional metrics: ovms_infer_req_queue_size, ovms_infer_req_active.",
+                cxxopts::value<std::string>()->default_value(""),
+                "METRICS_LIST")
+            ("idle_sequence_cleanup",
+                "Flag indicating if model is subject to sequence cleaner scans",
+                cxxopts::value<bool>()->default_value("true"),
+                "IDLE_SEQUENCE_CLEANUP")
+            ("low_latency_transformation",
+                "Flag indicating that Model Server should perform low latency transformation on that model",
+                cxxopts::value<bool>()->default_value("false"),
+                "LOW_LATENCY_TRANSFORMATION")
+            ("max_sequence_number",
+                "Determines how many sequences can be processed concurrently by one model instance. When that value is reached, attempt to start a new sequence will result in error.",
+                cxxopts::value<uint32_t>(),
+                "MAX_SEQUENCE_NUMBER");
+
+        result = std::make_unique<cxxopts::ParseResult>(options->parse(argc, argv));
+
+        if (result->count("version")) {
+            std::string project_name(PROJECT_NAME);
+            std::string project_version(PROJECT_VERSION);
+            std::cout << project_name + " " + project_version << std::endl;
+            std::cout << "OpenVINO backend " << OPENVINO_NAME << std::endl;
+            exit(EX_OK);
+        }
+
+        if (result->count("help") || result->arguments().size() == 0) {
+            std::cout << options->help({"", "multi model", "single model"}) << std::endl;
+            exit(EX_OK);
+        }
+    } catch (const cxxopts::OptionException& e) {
+        std::cerr << "error parsing options: " << e.what() << std::endl;
+        exit(EX_USAGE);
+    }
+}
+
+void CLIParser::prepare(GeneralOptionsImpl* go, MultiModelOptionsImpl* mmo) {
+    go->grpcPort = result->operator[]("port").as<uint64_t>();
+    go->restPort = result->operator[]("rest_port").as<uint64_t>();
+
+    if (result->count("model_name"))
+        mmo->modelName = result->operator[]("model_name").as<std::string>();
+    if (result->count("model_path"))
+        mmo->modelPath = result->operator[]("model_path").as<std::string>();
+
+    if (result->count("max_sequence_number"))
+        mmo->maxSequenceNumber = result->operator[]("max_sequence_number").as<uint32_t>();
+
+    if (result != nullptr && result->count("cpu_extension")) {
+        go->cpuExtensionLibraryPath = result->operator[]("cpu_extension").as<std::string>();
+    }
+
+    if (result->count("grpc_bind_address"))
+        go->grpcBindAddress = result->operator[]("grpc_bind_address").as<std::string>();
+
+    if (result->count("rest_bind_address"))
+        go->restBindAddress = result->operator[]("rest_bind_address").as<std::string>();
+
+    go->grpcWorkers = result->operator[]("grpc_workers").as<uint>();
+
+    if (result->count("rest_workers"))
+        go->restWorkers = result->operator[]("rest_workers").as<uint>();
+
+    if (result->count("batch_size"))
+        mmo->batchSize = result->operator[]("batch_size").as<std::string>();
+
+    if (result->count("shape"))
+        mmo->shape = result->operator[]("shape").as<std::string>();
+
+    if (result->count("layout"))
+        mmo->layout = result->operator[]("layout").as<std::string>();
+
+    if (result->count("model_version_policy"))
+        mmo->modelVersionPolicy = result->operator[]("model_version_policy").as<std::string>();
+
+    if (result->count("nireq"))
+        mmo->nireq = result->operator[]("nireq").as<uint32_t>();
+
+    if (result->count("target_device"))
+        mmo->targetDevice = result->operator[]("target_device").as<std::string>();
+
+    if (result->count("plugin_config"))
+        mmo->pluginConfig = result->operator[]("plugin_config").as<std::string>();
+
+    if (result->count("stateful"))
+        mmo->stateful = result->operator[]("stateful").as<bool>();
+
+    go->metricsEnabled = result->operator[]("metrics_enable").as<bool>();
+    go->metricsList = result->operator[]("metrics_list").as<std::string>();
+
+    if (result->count("idle_sequence_cleanup"))
+        mmo->idleSequenceCleanup = result->operator[]("idle_sequence_cleanup").as<bool>();
+
+    if (result->count("low_latency_transformation"))
+        mmo->lowLatencyTransformation = result->operator[]("low_latency_transformation").as<bool>();
+
+    if (result->count("log_level"))
+        go->logLevel = result->operator[]("log_level").as<std::string>();
+    if (result->count("log_path"))
+        go->logPath = result->operator[]("log_path").as<std::string>();
+
+#ifdef MTR_ENABLED
+    if (result->count("trace_path"))
+        go->tracePath = result->operator[]("trace_path").as<std::string>();
+#endif
+
+    if (result->count("grpc_channel_arguments"))
+        go->grpcChannelArguments = result->operator[]("grpc_channel_arguments").as<std::string>();
+
+    go->filesystemPollWaitSeconds = result->operator[]("file_system_poll_wait_seconds").as<uint>();
+    go->sequenceCleanerPollWaitMinutes = result->operator[]("sequence_cleaner_poll_wait_minutes").as<uint32_t>();
+    go->resourcesCleanerPollWaitSeconds = result->operator[]("custom_node_resources_cleaner_interval").as<uint32_t>();
+
+    if (result != nullptr && result->count("cache_dir")) {
+        go->cacheDir = result->operator[]("cache_dir").as<std::string>();
+    }
+
+    if (result->count("config_path"))
+        mmo->configPath = result->operator[]("config_path").as<std::string>();
+}
+
+}  // namespace ovms

--- a/src/cli_parser.hpp
+++ b/src/cli_parser.hpp
@@ -13,15 +13,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#include "poc_api_impl.hpp"
+#pragma once
 
-#include "server.hpp"
+#include <memory>
+
+#include <cxxopts.hpp>
 
 namespace ovms {
 
-int ServerImpl::start(GeneralOptionsImpl* go, MultiModelOptionsImpl* mmo) {
-    Server& server = Server::instance();
-    return server.start(go, mmo);
-}
+struct GeneralOptionsImpl;
+struct SingleModelOptionsImpl;
+struct MultiModelOptionsImpl;
+
+class CLIParser {
+    std::unique_ptr<cxxopts::Options> options;
+    std::unique_ptr<cxxopts::ParseResult> result;
+
+public:
+    CLIParser() = default;
+    void parse(int argc, char** argv);
+
+    void prepare(GeneralOptionsImpl*, MultiModelOptionsImpl*);
+};
 
 }  // namespace ovms

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -15,19 +15,16 @@
 //*****************************************************************************
 #include "config.hpp"
 
-#include <algorithm>
 #include <filesystem>
 #include <limits>
 #include <regex>
 #include <thread>
 
-#include <boost/algorithm/string.hpp>
 #include <sysexits.h>
 
-#include "logging.hpp"
+#include "cli_parser.hpp"
 #include "modelconfig.hpp"
 #include "poc_api_impl.hpp"
-#include "version.hpp"
 
 namespace ovms {
 
@@ -35,218 +32,23 @@ const uint AVAILABLE_CORES = std::thread::hardware_concurrency();
 const uint MAX_PORT_NUMBER = std::numeric_limits<ushort>::max();
 
 const uint64_t DEFAULT_REST_WORKERS = AVAILABLE_CORES * 4.0;
-const std::string DEFAULT_REST_WORKERS_STRING{std::to_string(DEFAULT_REST_WORKERS)};
 const uint64_t MAX_REST_WORKERS = 10'000;
 
-uint32_t Config::__maxSequenceNumber() const {
-    if (!result->count("max_sequence_number")) {
-        return DEFAULT_MAX_SEQUENCE_NUMBER;
-    }
-    return result->operator[]("max_sequence_number").as<uint32_t>();
-}
-uint32_t Config::maxSequenceNumber() const { return _maxSequenceNumber; }
-
 Config& Config::parse(int argc, char** argv) {
-    try {
-        options = std::make_unique<cxxopts::Options>(argv[0], "OpenVINO Model Server");
-
-        // clang-format off
-        options->add_options()
-            ("h, help",
-                "Show this help message and exit")
-            ("version",
-                "Show binary version")
-            ("port",
-                "gRPC server port",
-                cxxopts::value<uint64_t>()->default_value("9178"),
-                "PORT")
-            ("grpc_bind_address",
-                "Network interface address to bind to for the gRPC API",
-                cxxopts::value<std::string>()->default_value("0.0.0.0"),
-                "GRPC_BIND_ADDRESS")
-            ("rest_port",
-                "REST server port, the REST server will not be started if rest_port is blank or set to 0",
-                cxxopts::value<uint64_t>()->default_value("0"),
-                "REST_PORT")
-            ("rest_bind_address",
-                "Network interface address to bind to for the REST API",
-                cxxopts::value<std::string>()->default_value("0.0.0.0"),
-                "REST_BIND_ADDRESS")
-            ("grpc_workers",
-                "Number of gRPC servers. Default 1. Increase for multi client, high throughput scenarios",
-                cxxopts::value<uint>()->default_value("1"),
-                "GRPC_WORKERS")
-            ("rest_workers",
-                "Number of worker threads in REST server - has no effect if rest_port is not set. Default value depends on number of CPUs. ",
-                cxxopts::value<uint>()->default_value(DEFAULT_REST_WORKERS_STRING.c_str()),
-                "REST_WORKERS")
-            ("log_level",
-                "serving log level - one of TRACE, DEBUG, INFO, WARNING, ERROR",
-                cxxopts::value<std::string>()->default_value("INFO"), "LOG_LEVEL")
-            ("log_path",
-                "Optional path to the log file",
-                cxxopts::value<std::string>(), "LOG_PATH")
-#ifdef MTR_ENABLED
-            ("trace_path",
-                "Path to the trace file",
-                cxxopts::value<std::string>(), "TRACE_PATH")
-#endif
-            ("grpc_channel_arguments",
-                "A comma separated list of arguments to be passed to the grpc server. (e.g. grpc.max_connection_age_ms=2000)",
-                cxxopts::value<std::string>(), "GRPC_CHANNEL_ARGUMENTS")
-            ("file_system_poll_wait_seconds",
-                "Time interval between config and model versions changes detection. Default is 1. Zero or negative value disables changes monitoring.",
-                cxxopts::value<uint>()->default_value("1"),
-                "FILE_SYSTEM_POLL_WAIT_SECONDS")
-            ("sequence_cleaner_poll_wait_minutes",
-                "Time interval between two consecutive sequence cleanup scans. Default is 5. Zero value disables sequence cleaner.",
-                cxxopts::value<uint32_t>()->default_value("5"),
-                "SEQUENCE_CLEANER_POLL_WAIT_MINUTES")
-            ("custom_node_resources_cleaner_interval",
-                "Time interval between two consecutive resources cleanup scans. Default is 1. Must be greater than 0.",
-                cxxopts::value<uint32_t>()->default_value("1"),
-                "CUSTOM_NODE_RESOURCES_CLEANER_INTERVAL")
-            ("cache_dir",
-                "Overrides model cache directory. By default cache files are saved into /opt/cache if the directory is present. When enabled, first model load will produce cache files.",
-                cxxopts::value<std::string>(),
-                "CACHE_DIR")
-            ("cpu_extension",
-                "A path to shared library containing custom CPU layer implementation. Default: empty.",
-                cxxopts::value<std::string>()->default_value(""),
-                "CPU_EXTENSION");
-        options->add_options("multi model")
-            ("config_path",
-                "Absolute path to json configuration file",
-                cxxopts::value<std::string>(), "CONFIG_PATH");
-
-        options->add_options("single model")
-            ("model_name",
-                "Name of the model",
-                cxxopts::value<std::string>(),
-                "MODEL_NAME")
-            ("model_path",
-                "Absolute path to model, as in tf serving",
-                cxxopts::value<std::string>(),
-                "MODEL_PATH")
-            ("batch_size",
-                "Resets models batchsize, int value or auto. This parameter will be ignored if shape is set",
-                cxxopts::value<std::string>(),
-                "BATCH_SIZE")
-            ("shape",
-                "Resets models shape (model must support reshaping). If set, batch_size parameter is ignored",
-                cxxopts::value<std::string>(),
-                "SHAPE")
-            ("layout",
-                "Resets model layout.",
-                cxxopts::value<std::string>(),
-                "LAYOUT")
-            ("model_version_policy",
-                "Model version policy",
-                cxxopts::value<std::string>(),
-                "MODEL_VERSION_POLICY")
-            ("nireq",
-                "Size of inference request queue for model executions. Recommended to be >= parallel executions. Default value calculated by OpenVINO based on available resources. Request for 0 is treated as request for default value",
-                cxxopts::value<uint32_t>(),
-                "NIREQ")
-            ("target_device",
-                "Target device to run the inference",
-                cxxopts::value<std::string>()->default_value("CPU"),
-                "TARGET_DEVICE")
-            ("plugin_config",
-                "A dictionary of plugin configuration keys and their values, eg \"{\\\"PERFORMANCE_HINT\\\": \\\"LATENCY\\\"}\". Default is PERFORMANCE_HINT set to THROUGHPUT mode. ",
-                cxxopts::value<std::string>(),
-                "PLUGIN_CONFIG")
-            ("stateful",
-                "Flag indicating model is stateful",
-                cxxopts::value<bool>()->default_value("false"),
-                "STATEFUL")
-            ("metrics_enable",
-                "Flag enabling metrics endpoint on rest_port.",
-                cxxopts::value<bool>()->default_value("false"),
-                "METRICS")
-            ("metrics_list",
-                "Comma separated list of metrics. If unset, only default metrics will be enabled. Default metrics: ovms_requests_success, ovms_requests_fail, ovms_request_time_us, ovms_streams, ovms_inference_time_us, ovms_wait_for_infer_req_time_us. When set, only the listed metrics will be enabled. Optional metrics: ovms_infer_req_queue_size, ovms_infer_req_active.",
-                cxxopts::value<std::string>()->default_value(""),
-                "METRICS_LIST")
-            ("idle_sequence_cleanup",
-                "Flag indicating if model is subject to sequence cleaner scans",
-                cxxopts::value<bool>()->default_value("true"),
-                "IDLE_SEQUENCE_CLEANUP")
-            ("low_latency_transformation",
-                "Flag indicating that Model Server should perform low latency transformation on that model",
-                cxxopts::value<bool>()->default_value("false"),
-                "LOW_LATENCY_TRANSFORMATION")
-            ("max_sequence_number",
-                "Determines how many sequences can be processed concurrently by one model instance. When that value is reached, attempt to start a new sequence will result in error.",
-                cxxopts::value<uint32_t>(),
-                "MAX_SEQUENCE_NUMBER");
-
-        // clang-format on
-
-        result = std::make_unique<cxxopts::ParseResult>(options->parse(argc, argv));
-
-        if (result->count("version")) {
-            std::string project_name(PROJECT_NAME);
-            std::string project_version(PROJECT_VERSION);
-            std::cout << project_name + " " + project_version << std::endl;
-            std::cout << "OpenVINO backend " << OPENVINO_NAME << std::endl;
-            exit(EX_OK);
-        }
-
-        if (result->count("help") || result->arguments().size() == 0) {
-            std::cout << options->help({"", "multi model", "single model"}) << std::endl;
-            exit(EX_OK);
-        }
-
-        this->_configPath = __configPath();
-        this->_port = __port();
-        this->_cpuExtensionLibraryPath = __cpuExtensionLibraryPath();
-        this->_grpcBindAddress = __grpcBindAddress();
-        this->_restPort = __restPort();
-        this->_restBindAddress = __restBindAddress();
-        this->_grpcWorkers = __grpcWorkers();
-        this->_restWorkers = __restWorkers();
-        this->_modelName = __modelName();
-        this->_modelPath = __modelPath();
-        this->_batchSize = __batchSize();
-        this->_shape = __shape();
-        this->_layout = __layout();
-        this->_modelVersionPolicy = __modelVersionPolicy();
-        this->_nireq = __nireq();
-        this->_targetDevice = __targetDevice();
-        this->_pluginConfig = __pluginConfig();
-        this->_stateful = __stateful();
-        this->_metricsEnabled = __metricsEnabled();
-        this->_metricsList = __metricsList();
-        this->_idleSequenceCleanup = __idleSequenceCleanup();
-        this->_lowLatencyTransformation = __lowLatencyTransformation();
-        this->_maxSequenceNumber = __maxSequenceNumber();
-        this->_logLevel = __logLevel();
-        this->_logPath = __logPath();
-#ifdef MTR_ENABLED
-        this->_tracePath = __tracePath();
-#endif
-        this->_grpcChannelArguments = __grpcChannelArguments();
-        this->_filesystemPollWaitSeconds = __filesystemPollWaitSeconds();
-        this->_sequenceCleanerPollWaitMinutes = __sequenceCleanerPollWaitMinutes();
-        this->_resourcesCleanerPollWaitSeconds = __resourcesCleanerPollWaitSeconds();
-        this->_cacheDir = __cacheDir();
-
-        validate();
-    } catch (const cxxopts::OptionException& e) {
-        std::cerr << "error parsing options: " << e.what() << std::endl;
+    ovms::CLIParser p;
+    ovms::GeneralOptionsImpl go;
+    ovms::MultiModelOptionsImpl mmo;
+    p.parse(argc, argv);
+    p.prepare(&go, &mmo);
+    if (!this->parse(&go, &mmo))  // TODO: Ret val
         exit(EX_USAGE);
-    }
-
-    return instance();
+    return *this;
 }
 
-Config& Config::parse(GeneralOptionsImpl* go, MultiModelOptionsImpl* mmo) {
-    // TODO: Implement
-    this->_port = go->grpcPort;
-    this->_restPort = go->restPort;
-    this->_configPath = mmo->configPath;
-    return instance();
+bool Config::parse(GeneralOptionsImpl* go, MultiModelOptionsImpl* mmo) {
+    this->go = *go;
+    this->mmo = *mmo;
+    return validate();
 }
 
 bool Config::check_hostname_or_ip(const std::string& input) {
@@ -271,333 +73,143 @@ bool Config::check_hostname_or_ip(const std::string& input) {
     }
 }
 
-void Config::validate() {
-    // cannot set both config path & model_name/model_path
-    if (result->count("config_path") && (result->count("model_name") || result->count("model_path"))) {
+bool Config::validate() {
+    if (!configPath().empty() && (!modelName().empty() || !modelPath().empty())) {
         std::cerr << "Use either config_path or model_path with model_name" << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
-    if (!result->count("config_path") && !(result->count("model_name") && result->count("model_path"))) {
+    if (configPath().empty() && !(!modelName().empty() && !modelPath().empty())) {
         std::cerr << "Use config_path or model_path with model_name" << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
-    if (result->count("config_path") && (result->count("batch_size") || result->count("shape") ||
-                                            result->count("nireq") || result->count("model_version_policy") || result->count("target_device") ||
-                                            result->count("plugin_config"))) {
+    if (!configPath().empty() && (!this->mmo.batchSize.empty() || !shape().empty() ||
+                                     nireq() != 0 || !modelVersionPolicy().empty() || !this->mmo.targetDevice.empty() ||
+                                     !pluginConfig().empty())) {
         std::cerr << "Model parameters in CLI are exclusive with the config file" << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // check grpc_workers value
-    if (result->count("grpc_workers") && ((this->grpcWorkers() > AVAILABLE_CORES) || (this->grpcWorkers() < 1))) {
+    if (((grpcWorkers() > AVAILABLE_CORES) || (grpcWorkers() < 1))) {
         std::cerr << "grpc_workers count should be from 1 to CPU core count : " << AVAILABLE_CORES << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // check rest_workers value
-    if (result->count("rest_workers") && ((this->restWorkers() > MAX_REST_WORKERS) || (this->restWorkers() < 2))) {
+    if (((restWorkers() > MAX_REST_WORKERS) || (restWorkers() < 2))) {
         std::cerr << "rest_workers count should be from 2 to " << MAX_REST_WORKERS << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
-    if (result->count("rest_workers") && (this->restWorkers() != DEFAULT_REST_WORKERS) && this->restPort() == 0) {
+    if (this->go.restWorkers.has_value() && restPort() == 0) {
         std::cerr << "rest_workers is set but rest_port is not set. rest_port is required to start rest servers" << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
-    // check docker ports
-    if (result->count("port") && ((this->port() > MAX_PORT_NUMBER) || (this->port() < 0))) {
+    if (port() && ((port() > MAX_PORT_NUMBER) || (port() < 0))) {
         std::cerr << "port number out of range from 0 to " << MAX_PORT_NUMBER << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
-    if (result->count("rest_port") && ((this->restPort() > MAX_PORT_NUMBER) || (this->restPort() < 0))) {
+
+    if (restPort() != 0 && ((restPort() > MAX_PORT_NUMBER) || (restPort() < 0))) {
         std::cerr << "rest_port number out of range from 0 to " << MAX_PORT_NUMBER << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // metrics on rest port
-    if (result->count("metrics_enable") && !result->count("rest_port")) {
+    if (metricsEnabled() && restPort() == 0) {
         std::cerr << "rest_port setting is missing, metrics are enabled on rest port" << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // metrics on rest port
-    if ((result->count("metrics_enable") || result->count("metrics_list")) && result->count("config_path")) {
+    if ((metricsEnabled() || !metricsList().empty()) && !configPath().empty()) {
         std::cerr << "metrics_enable or metrics_list and config_path cant be used together. Use json config file to enable metrics when using config_path." << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // metrics_list without metrics_enable
-    if (!result->count("metrics_enable") && result->count("metrics_list")) {
+    if (!metricsEnabled() && !metricsList().empty()) {
         std::cerr << "metrics_enable setting is missing, required when metrics_list is provided" << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // check bind addresses:
-    if (result->count("rest_bind_address") && check_hostname_or_ip(this->restBindAddress()) == false) {
+    if (!restBindAddress().empty() && check_hostname_or_ip(restBindAddress()) == false) {
         std::cerr << "rest_bind_address has invalid format: proper hostname or IP address expected." << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
-    if (result->count("grpc_bind_address") && check_hostname_or_ip(this->grpcBindAddress()) == false) {
+    if (!grpcBindAddress().empty() && check_hostname_or_ip(grpcBindAddress()) == false) {
         std::cerr << "grpc_bind_address has invalid format: proper hostname or IP address expected." << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // port and rest_port cannot be the same
-    if (this->port() == this->restPort()) {
+    if (port() == restPort()) {
         std::cerr << "port and rest_port cannot have the same values" << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // check cpu_extension path:
-    if (result->count("cpu_extension") && !std::filesystem::exists(this->cpuExtensionLibraryPath())) {
+    if (!cpuExtensionLibraryPath().empty() && !std::filesystem::exists(cpuExtensionLibraryPath())) {
         std::cerr << "File path provided as an --cpu_extension parameter does not exists in the filesystem: " << this->cpuExtensionLibraryPath() << std::endl;
-        exit(EX_USAGE);
+        return false;
     }
 
     // check log_level values
-    if (result->count("log_level")) {
-        std::vector v({"TRACE", "DEBUG", "INFO", "WARNING", "ERROR"});
-        if (std::find(v.begin(), v.end(), this->logLevel()) == v.end()) {
-            std::cerr << "log_level should be one of: TRACE, DEBUG, INFO, WARNING, ERROR" << std::endl;
-            exit(EX_USAGE);
-        }
-    }
-
-    // check stateful flags:
-    if ((result->count("low_latency_transformation") || result->count("max_sequence_number") || result->count("idle_sequence_cleanup")) && !result->count("stateful")) {
-        std::cerr << "Setting low_latency_transformation, max_sequence_number and idle_sequence_cleanup require setting stateful flag for the model." << std::endl;
-        exit(EX_USAGE);
-    }
-    return;
-}
-
-const std::string& Config::__configPath() const {
-    if (result->count("config_path"))
-        return result->operator[]("config_path").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::configPath() const { return _configPath; }
-
-uint64_t Config::__port() const {
-    return result->operator[]("port").as<uint64_t>();
-}
-
-uint64_t Config::port() const { return _port; }
-
-const std::string Config::__cpuExtensionLibraryPath() const {
-    if (result != nullptr && result->count("cpu_extension")) {
-        return result->operator[]("cpu_extension").as<std::string>();
-    }
-    return "";
-}
-
-const std::string Config::cpuExtensionLibraryPath() const { return _cpuExtensionLibraryPath; }
-
-const std::string Config::__grpcBindAddress() const {
-    if (result->count("grpc_bind_address"))
-        return result->operator[]("grpc_bind_address").as<std::string>();
-    return "0.0.0.0";
-}
-
-const std::string Config::grpcBindAddress() const { return _grpcBindAddress; }
-
-uint64_t Config::__restPort() const {
-    return result->operator[]("rest_port").as<uint64_t>();
-}
-
-uint64_t Config::restPort() const { return _restPort; }
-
-const std::string Config::__restBindAddress() const {
-    if (result->count("rest_bind_address"))
-        return result->operator[]("rest_bind_address").as<std::string>();
-    return "0.0.0.0";
-}
-
-const std::string Config::restBindAddress() const { return _restBindAddress; }
-
-uint Config::__grpcWorkers() const {
-    return result->operator[]("grpc_workers").as<uint>();
-}
-
-uint Config::grpcWorkers() const { return _grpcWorkers; }
-
-uint Config::__restWorkers() const {
-    return result->operator[]("rest_workers").as<uint>();
-}
-
-uint Config::restWorkers() const { return _restWorkers; }
-
-const std::string& Config::__modelName() const {
-    if (result->count("model_name"))
-        return result->operator[]("model_name").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::modelName() const { return _modelName; }
-
-const std::string& Config::__modelPath() const {
-    if (result->count("model_path"))
-        return result->operator[]("model_path").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::modelPath() const { return _modelPath; }
-
-const std::string& Config::__batchSize() const {
-    if (!result->count("batch_size")) {
-        static const std::string d = "0";
-        return d;
-    }
-    return result->operator[]("batch_size").as<std::string>();
-}
-
-const std::string& Config::batchSize() const { return _batchSize; }
-
-const std::string& Config::__shape() const {
-    if (result->count("shape"))
-        return result->operator[]("shape").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::Config::shape() const { return _shape; }
-
-const std::string& Config::__layout() const {
-    if (result->count("layout"))
-        return result->operator[]("layout").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::layout() const { return _layout; }
-
-const std::string& Config::__modelVersionPolicy() const {
-    if (result->count("model_version_policy"))
-        return result->operator[]("model_version_policy").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::modelVersionPolicy() const { return _modelVersionPolicy; }
-
-uint32_t Config::__nireq() const {
-    if (!result->count("nireq")) {
-        return 0;
-    }
-    return result->operator[]("nireq").as<uint32_t>();
-}
-
-uint32_t Config::nireq() const { return _nireq; }
-
-const std::string& Config::__targetDevice() const {
-    return result->operator[]("target_device").as<std::string>();
-}
-
-const std::string& Config::targetDevice() const { return _targetDevice; }
-
-const std::string& Config::__pluginConfig() const {
-    if (result->count("plugin_config"))
-        return result->operator[]("plugin_config").as<std::string>();
-    return empty;
-}
-const std::string& Config::Config::pluginConfig() const { return _pluginConfig; }
-
-bool Config::__stateful() const {
-    return result->operator[]("stateful").as<bool>();
-}
-
-bool Config::stateful() const { return _stateful; }
-
-bool Config::__metricsEnabled() const {
-    if (!result->count("metrics_enable")) {
+    std::vector v({"TRACE", "DEBUG", "INFO", "WARNING", "ERROR"});
+    if (std::find(v.begin(), v.end(), logLevel()) == v.end()) {
+        std::cerr << "log_level should be one of: TRACE, DEBUG, INFO, WARNING, ERROR" << std::endl;
         return false;
     }
-    return result->operator[]("metrics_enable").as<bool>();
-}
-
-bool Config::metricsEnabled() const { return _metricsEnabled; }
-
-std::string Config::__metricsList() const {
-    if (!result->count("metrics_list")) {
-        return std::string("");
+    // check stateful flags:
+    if ((this->mmo.lowLatencyTransformation.has_value() || this->mmo.maxSequenceNumber.has_value() || this->mmo.idleSequenceCleanup.has_value()) && !stateful()) {
+        std::cerr << "Setting low_latency_transformation, max_sequence_number and idle_sequence_cleanup require setting stateful flag for the model." << std::endl;
+        return false;
     }
-    return result->operator[]("metrics_list").as<std::string>();
+    return true;
 }
 
-std::string Config::metricsList() const { return _metricsList; }
-
-bool Config::__idleSequenceCleanup() const {
-    return result->operator[]("idle_sequence_cleanup").as<bool>();
+const std::string& Config::configPath() const { return this->mmo.configPath; }
+uint64_t Config::port() const { return this->go.grpcPort; }
+const std::string Config::cpuExtensionLibraryPath() const { return this->go.cpuExtensionLibraryPath; }
+const std::string Config::grpcBindAddress() const { return this->go.grpcBindAddress; }
+uint64_t Config::restPort() const { return this->go.restPort; }
+const std::string Config::restBindAddress() const { return this->go.restBindAddress; }
+uint Config::grpcWorkers() const { return this->go.grpcWorkers; }
+uint Config::restWorkers() const { return this->go.restWorkers.value_or(DEFAULT_REST_WORKERS); }
+const std::string& Config::modelName() const { return this->mmo.modelName; }
+const std::string& Config::modelPath() const { return this->mmo.modelPath; }
+const std::string& Config::batchSize() const {
+    static const std::string defaultBatch = "0";
+    return this->mmo.batchSize.empty() ? defaultBatch : this->mmo.batchSize;
 }
-
-bool Config::idleSequenceCleanup() const { return _idleSequenceCleanup; }
-
-bool Config::__lowLatencyTransformation() const {
-    return result->operator[]("low_latency_transformation").as<bool>();
+const std::string& Config::Config::shape() const { return this->mmo.shape; }
+const std::string& Config::layout() const { return this->mmo.layout; }
+const std::string& Config::modelVersionPolicy() const { return this->mmo.modelVersionPolicy; }
+uint32_t Config::nireq() const { return this->mmo.nireq; }
+const std::string& Config::targetDevice() const {
+    static const std::string defaultTargetDevice = "CPU";
+    return this->mmo.targetDevice.empty() ? defaultTargetDevice : this->mmo.targetDevice;
 }
-
-bool Config::lowLatencyTransformation() const { return _lowLatencyTransformation; }
-
-const std::string& Config::__logLevel() const {
-    if (result->count("log_level"))
-        return result->operator[]("log_level").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::logLevel() const { return _logLevel; }
-
-const std::string& Config::__logPath() const {
-    if (result->count("log_path"))
-        return result->operator[]("log_path").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::logPath() const { return _logPath; }
-
+const std::string& Config::Config::pluginConfig() const { return this->mmo.pluginConfig; }
+bool Config::stateful() const { return this->mmo.stateful.value_or(false); }
+bool Config::metricsEnabled() const { return this->go.metricsEnabled; }
+std::string Config::metricsList() const { return this->go.metricsList; }
+bool Config::idleSequenceCleanup() const { return this->mmo.idleSequenceCleanup.value_or(true); }
+uint32_t Config::maxSequenceNumber() const { return this->mmo.maxSequenceNumber.value_or(DEFAULT_MAX_SEQUENCE_NUMBER); }
+bool Config::lowLatencyTransformation() const { return this->mmo.lowLatencyTransformation.value_or(false); }
+const std::string& Config::logLevel() const { return this->go.logLevel; }
+const std::string& Config::logPath() const { return this->go.logPath; }
 #ifdef MTR_ENABLED
-const std::string& Config::__tracePath() const {
-    if (result->count("trace_path"))
-        return result->operator[]("trace_path").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::tracePath() const { return _tracePath; }
+const std::string& Config::tracePath() const { return this->go.tracePath; }
 #endif
-
-const std::string& Config::__grpcChannelArguments() const {
-    if (result->count("grpc_channel_arguments"))
-        return result->operator[]("grpc_channel_arguments").as<std::string>();
-    return empty;
-}
-
-const std::string& Config::grpcChannelArguments() const { return _grpcChannelArguments; }
-
-uint Config::__filesystemPollWaitSeconds() const {
-    return result->operator[]("file_system_poll_wait_seconds").as<uint>();
-}
-
-uint Config::filesystemPollWaitSeconds() const { return _filesystemPollWaitSeconds; }
-
-uint32_t Config::__sequenceCleanerPollWaitMinutes() const {
-    return result->operator[]("sequence_cleaner_poll_wait_minutes").as<uint32_t>();
-}
-
-uint32_t Config::sequenceCleanerPollWaitMinutes() const { return _sequenceCleanerPollWaitMinutes; }
-
-uint32_t Config::__resourcesCleanerPollWaitSeconds() const {
-    return result->operator[]("custom_node_resources_cleaner_interval").as<uint32_t>();
-}
-
-uint32_t Config::resourcesCleanerPollWaitSeconds() const { return _resourcesCleanerPollWaitSeconds; }
-
-const std::string Config::__cacheDir() const {
-    if (result != nullptr && result->count("cache_dir")) {
-        return result->operator[]("cache_dir").as<std::string>();
-    }
-    return empty;
-}
-
-const std::string Config::cacheDir() const { return _cacheDir; }
+const std::string& Config::grpcChannelArguments() const { return this->go.grpcChannelArguments; }
+uint Config::filesystemPollWaitSeconds() const { return this->go.filesystemPollWaitSeconds; }
+uint32_t Config::sequenceCleanerPollWaitMinutes() const { return this->go.sequenceCleanerPollWaitMinutes; }
+uint32_t Config::resourcesCleanerPollWaitSeconds() const { return this->go.resourcesCleanerPollWaitSeconds; }
+const std::string Config::cacheDir() const { return this->go.cacheDir; }
 
 }  // namespace ovms

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -40,7 +40,7 @@ Config& Config::parse(int argc, char** argv) {
     ovms::MultiModelOptionsImpl mmo;
     p.parse(argc, argv);
     p.prepare(&go, &mmo);
-    if (!this->parse(&go, &mmo))  // TODO: Ret val
+    if (!this->parse(&go, &mmo))
         exit(EX_USAGE);
     return *this;
 }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -15,80 +15,36 @@
 //*****************************************************************************
 #pragma once
 
-#include <memory>
+#include <optional>
 #include <string>
-#include <vector>
 
-#include <cxxopts.hpp>
+#include "poc_api_impl.hpp"
 
 namespace ovms {
-class GeneralOptionsImpl;
-class MultiModelOptionsImpl;
 
 /**
      * @brief Provides all the configuration options from command line
      */
 class Config {
-private:
+protected:
     /**
          * @brief A default constructor is private
          */
     Config() = default;
 
+private:
     /**
          * @brief Private copying constructor
          */
     Config(const Config&) = delete;
 
     /**
-         * @brief cxxopts options dictionary definition
-         */
-    std::unique_ptr<cxxopts::Options> options;
-
-    /**
-         * @brief cxxopts contains parsed parameters
-         */
-    std::unique_ptr<cxxopts::ParseResult> result;
-
-    /**
          * @brief 
          */
     const std::string empty;
 
-    // new
-    std::string _configPath;
-    uint64_t _port = 9178;
-    std::string _cpuExtensionLibraryPath;
-    std::string _grpcBindAddress = "0.0.0.0";
-    uint64_t _restPort = 0;
-    std::string _restBindAddress = "0.0.0.0";
-    uint _grpcWorkers = 1;
-    uint _restWorkers = 8;  // TODO: In OVMS this is nproc * 4
-    std::string _modelName;
-    std::string _modelPath;
-    std::string _batchSize;
-    std::string _shape;
-    std::string _layout;
-    std::string _modelVersionPolicy;
-    uint32_t _nireq = 0;
-    std::string _targetDevice;
-    std::string _pluginConfig;
-    bool _stateful = false;
-    bool _metricsEnabled = false;
-    std::string _metricsList;
-    bool _idleSequenceCleanup = true;
-    bool _lowLatencyTransformation = false;
-    uint32_t _maxSequenceNumber = 500;
-    std::string _logLevel = "DEBUG";
-    std::string _logPath;
-#ifdef MTR_ENABLED
-    std::string _tracePath;
-#endif
-    std::string _grpcChannelArguments;
-    uint _filesystemPollWaitSeconds = 1;
-    uint32_t _sequenceCleanerPollWaitMinutes = 5;
-    uint32_t _resourcesCleanerPollWaitSeconds = 1;
-    std::string _cacheDir;
+    GeneralOptionsImpl go;
+    MultiModelOptionsImpl mmo;
 
 public:
     /**
@@ -109,14 +65,14 @@ public:
          * @return Config& 
          */
     Config& parse(int argc, char** argv);
-    Config& parse(GeneralOptionsImpl*, MultiModelOptionsImpl*);
+    bool parse(GeneralOptionsImpl*, MultiModelOptionsImpl*);
 
     /**
          * @brief Validate passed arguments
          * 
          * @return void 
          */
-    void validate();
+    bool validate();
 
     /**
          * @brief checks if input is a proper hostname or IP address value
@@ -130,7 +86,6 @@ public:
          * 
          * @return std::string 
          */
-    const std::string& __configPath() const;  // TODO: Move to CLI parser when ready
     const std::string& configPath() const;
 
     /**
@@ -138,7 +93,6 @@ public:
          * 
          * @return uint64_t
          */
-    uint64_t __port() const;
     uint64_t port() const;
 
     /**
@@ -146,7 +100,6 @@ public:
          * 
          * @return const std::string
          */
-    const std::string __cpuExtensionLibraryPath() const;  // TODO: Move to CLI parser when ready
     const std::string cpuExtensionLibraryPath() const;
 
     /**
@@ -154,7 +107,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string __grpcBindAddress() const;  // TODO: Move to CLI parser when ready
     const std::string grpcBindAddress() const;
 
     /**
@@ -162,7 +114,6 @@ public:
          * 
          * @return uint64_t
          */
-    uint64_t __restPort() const;
     uint64_t restPort() const;
 
     /**
@@ -170,7 +121,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string __restBindAddress() const;  // TODO: Move to CLI parser when ready
     const std::string restBindAddress() const;
 
     /**
@@ -178,7 +128,6 @@ public:
          * 
          * @return uint
          */
-    uint __grpcWorkers() const;  // TODO: Move to CLI parser when ready
     uint grpcWorkers() const;
 
     /**
@@ -186,7 +135,6 @@ public:
          * 
          * @return uint
          */
-    uint __restWorkers() const;  // TODO: Move to CLI parser when ready
     uint restWorkers() const;
 
     /**
@@ -194,7 +142,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string& __modelName() const;  // TODO: Move to CLI parser when ready
     const std::string& modelName() const;
 
     /**
@@ -202,7 +149,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string& __modelPath() const;  // TODO: Move to CLI parser when ready
     const std::string& modelPath() const;
 
     /**
@@ -210,7 +156,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string& __batchSize() const;  // TODO: Move to CLI parser when ready
     const std::string& batchSize() const;
 
     /**
@@ -218,7 +163,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string& __shape() const;  // TODO: Move to CLI parser when ready
     const std::string& shape() const;
 
     /**
@@ -226,7 +170,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string& __layout() const;  // TODO: Move to CLI parser when ready
     const std::string& layout() const;
 
     /**
@@ -234,7 +177,6 @@ public:
          * 
          * @return const std::string&
          */
-    const std::string& __modelVersionPolicy() const;  // TODO: Move to CLI parser when ready
     const std::string& modelVersionPolicy() const;
 
     /**
@@ -242,7 +184,6 @@ public:
          *
          * @return uint 
          */
-    uint32_t __nireq() const;
     uint32_t nireq() const;
 
     /**
@@ -250,7 +191,6 @@ public:
          * 
          * @return const std::string& 
          */
-    const std::string& __targetDevice() const;  // TODO: Move to CLI parser when ready
     const std::string& targetDevice() const;
 
     /**
@@ -258,7 +198,6 @@ public:
          * 
          * @return const std::string& 
          */
-    const std::string& __pluginConfig() const;  // TODO: Move to CLI parser when ready
     const std::string& pluginConfig() const;
 
     /**
@@ -266,7 +205,6 @@ public:
          *
          * @return bool
          */
-    bool __stateful() const;  // TODO: Move to CLI parser when ready
     bool stateful() const;
 
     /**
@@ -274,7 +212,6 @@ public:
      *
      * @return bool
      */
-    bool __metricsEnabled() const;  // TODO: Move to CLI parser when ready
     bool metricsEnabled() const;
 
     /**
@@ -282,7 +219,6 @@ public:
         *
         * @return std::string
         */
-    std::string __metricsList() const;  // TODO: Move to CLI parser when ready
     std::string metricsList() const;
 
     /**
@@ -290,7 +226,6 @@ public:
      *
      * @return uint
      */
-    bool __idleSequenceCleanup() const;  // TODO: Move to CLI parser when ready
     bool idleSequenceCleanup() const;
 
     /**
@@ -298,7 +233,6 @@ public:
          *
          * @return bool
          */
-    bool __lowLatencyTransformation() const;  // TODO: Move to CLI parser when ready
     bool lowLatencyTransformation() const;
 
     /**
@@ -306,7 +240,6 @@ public:
      *
      * @return uint
      */
-    uint32_t __maxSequenceNumber() const;  // TODO: Move to CLI parser when ready
     uint32_t maxSequenceNumber() const;
 
     /**
@@ -314,7 +247,6 @@ public:
         *
         * @return const std::string&
         */
-    const std::string& __logLevel() const;  // TODO: Move to CLI parser when ready
     const std::string& logLevel() const;
 
     /**
@@ -322,7 +254,6 @@ public:
          *
         * @return const std::string&
         */
-    const std::string& __logPath() const;  // TODO: Move to CLI parser when ready
     const std::string& logPath() const;
 
 #ifdef MTR_ENABLED
@@ -331,7 +262,6 @@ public:
          *
         * @return const std::string&
         */
-    const std::string& __tracePath() const;  // TODO: Move to CLI parser when ready
     const std::string& tracePath() const;
 #endif
 
@@ -340,7 +270,6 @@ public:
         *
         * @return const std::string&
         */
-    const std::string& __grpcChannelArguments() const;  // TODO: Move to CLI parser when ready
     const std::string& grpcChannelArguments() const;
 
     /**
@@ -348,7 +277,6 @@ public:
      * 
      * @return uint 
      */
-    uint __filesystemPollWaitSeconds() const;  // TODO: Move to CLI parser when ready
     uint filesystemPollWaitSeconds() const;
 
     /**
@@ -356,7 +284,6 @@ public:
      * 
      * @return uint32_t
      */
-    uint32_t __sequenceCleanerPollWaitMinutes() const;  // TODO: Move to CLI parser when ready
     uint32_t sequenceCleanerPollWaitMinutes() const;
 
     /**
@@ -364,7 +291,6 @@ public:
      * 
      * @return uint32_t
      */
-    uint32_t __resourcesCleanerPollWaitSeconds() const;  // TODO: Move to CLI parser when ready
     uint32_t resourcesCleanerPollWaitSeconds() const;
 
     /**
@@ -372,7 +298,6 @@ public:
          * 
          * @return const std::string& 
          */
-    const std::string __cacheDir() const;  // TODO: Move to CLI parser when ready
     const std::string cacheDir() const;
 };
 }  // namespace ovms

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright 2018-2020 Intel Corporation
+// Copyright 2018-2022 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-
 #include "server.hpp"
 
 using ovms::Server;

--- a/src/main3.cpp
+++ b/src/main3.cpp
@@ -30,12 +30,16 @@ int main(int argc, char** argv) {
     OVMS_ServerGeneralOptionsSetRestPort(go, 11338);
     OVMS_ServerMultiModelOptionsSetConfigPath(mmo, "/ovms/src/test/c_api/config.json");
 
-    OVMS_ServerStartFromConfigurationFile(srv, go, mmo);
+    OVMS_Status* res = OVMS_ServerStartFromConfigurationFile(srv, go, mmo);
 
     OVMS_ServerDelete(srv);
     OVMS_ServerMultiModelOptionsDelete(mmo);
     OVMS_ServerGeneralOptionsDelete(go);
 
-    std::cout << "Finish" << std::endl;
+    if (res == 0) {
+        std::cout << "Finish with success" << std::endl;
+    } else {
+        std::cout << "Finish with fail" << std::endl;
+    }
     return 0;
 }

--- a/src/poc_api_impl.hpp
+++ b/src/poc_api_impl.hpp
@@ -14,21 +14,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
+#include <cstdint>
+#include <optional>
 #include <string>
 
 namespace ovms {
 
 struct GeneralOptionsImpl {
-    uint64_t grpcPort;
-    uint64_t restPort;
+    uint64_t grpcPort = 9178;
+    uint64_t restPort = 0;
+    std::string grpcBindAddress = "0.0.0.0";
+    std::string restBindAddress = "0.0.0.0";
+    uint grpcWorkers = 1;
+    std::optional<uint> restWorkers;
+    bool metricsEnabled = false;
+    std::string metricsList;
+    std::string cpuExtensionLibraryPath;
+    std::string logLevel = "INFO";
+    std::string logPath;
+#ifdef MTR_ENABLED
+    std::string tracePath;
+#endif
+    std::string grpcChannelArguments;
+    uint filesystemPollWaitSeconds = 1;
+    uint32_t sequenceCleanerPollWaitMinutes = 5;
+    uint32_t resourcesCleanerPollWaitSeconds = 1;
+    std::string cacheDir;
 };
 
 struct MultiModelOptionsImpl {
+    std::string modelName;
+    std::string modelPath;
+    std::string batchSize;
+    std::string shape;
+    std::string layout;
+    std::string modelVersionPolicy;
+    uint32_t nireq = 0;
+    std::string targetDevice;
+    std::string pluginConfig;
+    std::optional<bool> stateful;
+    std::optional<bool> lowLatencyTransformation;
+    std::optional<uint32_t> maxSequenceNumber;
+    std::optional<bool> idleSequenceCleanup;
+
     std::string configPath;
 };
 
 struct ServerImpl {
-    void start(GeneralOptionsImpl*, MultiModelOptionsImpl*);
+    int start(GeneralOptionsImpl*, MultiModelOptionsImpl*);
 };
 
 }  // namespace ovms

--- a/src/pocapi.cpp
+++ b/src/pocapi.cpp
@@ -57,7 +57,7 @@ OVMS_Status* OVMS_ServerStartFromConfigurationFile(OVMS_Server* server,
     ovms::GeneralOptionsImpl* go = (ovms::GeneralOptionsImpl*)general_options;
     ovms::MultiModelOptionsImpl* mmo = (ovms::MultiModelOptionsImpl*)multi_model_specific_options;
     std::int64_t res = srv->start(go, mmo);
-    return (OVMS_Status*)res;
+    return (OVMS_Status*)res;  // TODO: Return proper OVMS_Status instead of a raw status code
 }
 
 OVMS_Status* OVMS_ServerGeneralOptionsSetGrpcPort(OVMS_ServerGeneralOptions* options,

--- a/src/pocapi.cpp
+++ b/src/pocapi.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #include "pocapi.hpp"
 
+#include <cstdint>
 #include <string>
 
 #include "poc_api_impl.hpp"
@@ -55,8 +56,8 @@ OVMS_Status* OVMS_ServerStartFromConfigurationFile(OVMS_Server* server,
     ovms::ServerImpl* srv = (ovms::ServerImpl*)server;
     ovms::GeneralOptionsImpl* go = (ovms::GeneralOptionsImpl*)general_options;
     ovms::MultiModelOptionsImpl* mmo = (ovms::MultiModelOptionsImpl*)multi_model_specific_options;
-    srv->start(go, mmo);
-    return 0;
+    std::int64_t res = srv->start(go, mmo);
+    return (OVMS_Status*)res;
 }
 
 OVMS_Status* OVMS_ServerGeneralOptionsSetGrpcPort(OVMS_ServerGeneralOptions* options,

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -421,12 +421,12 @@ TEST(OvmsConfigTest, positiveSingle) {
         "--metrics_enable",
         "--metrics_list",
         "ovms_streams,ovms_other",
-        // "--idle_sequence_cleanup", "false",  // TOOD: cannot disable, change to --disable_idle_seq_cleanup?
+        "--idle_sequence_cleanup=false",
         "--low_latency_transformation",
         "--max_sequence_number",
         "52",
     };
-    int arg_count = 54;
+    int arg_count = 55;
     MockedConfig config;
     config.parse(arg_count, n_argv);
 
@@ -457,7 +457,7 @@ TEST(OvmsConfigTest, positiveSingle) {
     EXPECT_EQ(config.stateful(), true);
     EXPECT_EQ(config.metricsEnabled(), true);
     EXPECT_EQ(config.metricsList(), "ovms_streams,ovms_other");
-    // EXPECT_EQ(config.idleSequenceCleanup(), false);  // TOOD: cannot disable, change to --disable_idle_seq_cleanup?
+    EXPECT_EQ(config.idleSequenceCleanup(), false);
     EXPECT_EQ(config.lowLatencyTransformation(), true);
     EXPECT_EQ(config.maxSequenceNumber(), 52);
 }

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -98,6 +98,42 @@ TEST_F(OvmsConfigDeathTest, negativeTwoParams) {
     EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Use either config_path or model_path");
 }
 
+TEST_F(OvmsConfigDeathTest, negativeConfigPathWithBatchSize) {
+    char* n_argv[] = {"ovms", "--config_path", "/path1", "--batch_size", "5"};
+    int arg_count = 5;
+    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
+}
+
+TEST_F(OvmsConfigDeathTest, negativeConfigPathWithShape) {
+    char* n_argv[] = {"ovms", "--config_path", "/path1", "--shape", "(1,2)"};
+    int arg_count = 5;
+    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
+}
+
+TEST_F(OvmsConfigDeathTest, negativeConfigPathWithNireq) {
+    char* n_argv[] = {"ovms", "--config_path", "/path1", "--nireq", "3"};
+    int arg_count = 5;
+    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
+}
+
+TEST_F(OvmsConfigDeathTest, negativeConfigPathWithModelVersionPolicy) {
+    char* n_argv[] = {"ovms", "--config_path", "/path1", "--model_version_policy", "policy"};
+    int arg_count = 5;
+    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
+}
+
+TEST_F(OvmsConfigDeathTest, negativeConfigPathWithTargetDevice) {
+    char* n_argv[] = {"ovms", "--config_path", "/path1", "--target_device", "GPU"};
+    int arg_count = 5;
+    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
+}
+
+TEST_F(OvmsConfigDeathTest, negativeConfigPathWithPluginConfig) {
+    char* n_argv[] = {"ovms", "--config_path", "/path1", "--plugin_config", "setting"};
+    int arg_count = 5;
+    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
+}
+
 TEST_F(OvmsConfigDeathTest, negativeMissingPathAndName) {
     char* n_argv[] = {"ovms", "--rest_port", "8080"};
     int arg_count = 3;
@@ -286,13 +322,144 @@ TEST_F(OvmsParamsTest, hostname_ip_regex) {
     EXPECT_EQ(ovms::Config::check_hostname_or_ip(too_long), false);
 }
 
-TEST(OvmsConfigTest, positive) {
-    char* n_argv[] = {"ovms", "--config_path", "/path1", "--port", "44", "--rest_port", "45"};
-    int arg_count = 7;
-    ovms::Config::instance().parse(arg_count, n_argv);
-    EXPECT_EQ(ovms::Config::instance().port(), 44);
-    EXPECT_EQ(ovms::Config::instance().restPort(), 45);
-    EXPECT_EQ(ovms::Config::instance().configPath(), "/path1");
+class MockedConfig : public ovms::Config {
+public:
+    MockedConfig() {}
+};
+
+TEST(OvmsConfigTest, positiveMulti) {
+    char* n_argv[] = {"ovms",
+        "--port", "44",
+        "--grpc_workers", "2",
+        "--grpc_bind_address", "1.1.1.1",
+        "--rest_port", "45",
+        "--rest_workers", "46",
+        "--rest_bind_address", "2.2.2.2",
+        "--grpc_channel_arguments", "grpc_channel_args",
+        "--file_system_poll_wait_seconds", "2",
+        "--sequence_cleaner_poll_wait_minutes", "7",
+        "--custom_node_resources_cleaner_interval", "8",
+        "--cpu_extension", "/ovms",
+        "--cache_dir", "/tmp/model_cache",
+        "--log_path", "/tmp/log_path",
+        "--log_level", "ERROR",
+
+        "--config_path", "/config.json"};
+    int arg_count = 31;
+    MockedConfig config;
+    config.parse(arg_count, n_argv);
+
+    EXPECT_EQ(config.port(), 44);
+    EXPECT_EQ(config.grpcWorkers(), 2);
+    EXPECT_EQ(config.grpcBindAddress(), "1.1.1.1");
+    EXPECT_EQ(config.restPort(), 45);
+    EXPECT_EQ(config.restWorkers(), 46);
+    EXPECT_EQ(config.restBindAddress(), "2.2.2.2");
+    EXPECT_EQ(config.grpcChannelArguments(), "grpc_channel_args");
+    EXPECT_EQ(config.filesystemPollWaitSeconds(), 2);
+    EXPECT_EQ(config.sequenceCleanerPollWaitMinutes(), 7);
+    EXPECT_EQ(config.resourcesCleanerPollWaitSeconds(), 8);
+    EXPECT_EQ(config.cpuExtensionLibraryPath(), "/ovms");
+    EXPECT_EQ(config.cacheDir(), "/tmp/model_cache");
+    EXPECT_EQ(config.logPath(), "/tmp/log_path");
+    EXPECT_EQ(config.logLevel(), "ERROR");
+
+    EXPECT_EQ(config.configPath(), "/config.json");
+}
+
+TEST(OvmsConfigTest, positiveSingle) {
+    char* n_argv[] = {
+        "ovms",
+        "--port",
+        "44",
+        "--grpc_workers",
+        "2",
+        "--grpc_bind_address",
+        "1.1.1.1",
+        "--rest_port",
+        "45",
+        "--rest_workers",
+        "46",
+        "--rest_bind_address",
+        "2.2.2.2",
+        "--grpc_channel_arguments",
+        "grpc_channel_args",
+        "--file_system_poll_wait_seconds",
+        "2",
+        "--sequence_cleaner_poll_wait_minutes",
+        "7",
+        "--custom_node_resources_cleaner_interval",
+        "8",
+        "--cpu_extension",
+        "/ovms",
+        "--cache_dir",
+        "/tmp/model_cache",
+        "--log_path",
+        "/tmp/log_path",
+        "--log_level",
+        "ERROR",
+
+        "--model_name",
+        "model",
+        "--model_path",
+        "/path",
+        "--batch_size",
+        "(3:5)",
+        "--shape",
+        "(3:5,5:6)",
+        "--layout",
+        "nchw:nhwc",
+        "--model_version_policy",
+        "setting",
+        "--nireq",
+        "2",
+        "--target_device",
+        "GPU",
+        "--plugin_config",
+        "pluginsetting",
+        "--stateful",
+        "--metrics_enable",
+        "--metrics_list",
+        "ovms_streams,ovms_other",
+        // "--idle_sequence_cleanup", "false",  // TOOD: cannot disable, change to --disable_idle_seq_cleanup?
+        "--low_latency_transformation",
+        "--max_sequence_number",
+        "52",
+    };
+    int arg_count = 54;
+    MockedConfig config;
+    config.parse(arg_count, n_argv);
+
+    EXPECT_EQ(config.port(), 44);
+    EXPECT_EQ(config.grpcWorkers(), 2);
+    EXPECT_EQ(config.grpcBindAddress(), "1.1.1.1");
+    EXPECT_EQ(config.restPort(), 45);
+    EXPECT_EQ(config.restWorkers(), 46);
+    EXPECT_EQ(config.restBindAddress(), "2.2.2.2");
+    EXPECT_EQ(config.grpcChannelArguments(), "grpc_channel_args");
+    EXPECT_EQ(config.filesystemPollWaitSeconds(), 2);
+    EXPECT_EQ(config.sequenceCleanerPollWaitMinutes(), 7);
+    EXPECT_EQ(config.resourcesCleanerPollWaitSeconds(), 8);
+    EXPECT_EQ(config.cpuExtensionLibraryPath(), "/ovms");
+    EXPECT_EQ(config.cacheDir(), "/tmp/model_cache");
+    EXPECT_EQ(config.logPath(), "/tmp/log_path");
+    EXPECT_EQ(config.logLevel(), "ERROR");
+
+    EXPECT_EQ(config.modelPath(), "/path");
+    EXPECT_EQ(config.modelName(), "model");
+    EXPECT_EQ(config.batchSize(), "(3:5)");
+    EXPECT_EQ(config.shape(), "(3:5,5:6)");
+    EXPECT_EQ(config.layout(), "nchw:nhwc");
+    EXPECT_EQ(config.modelVersionPolicy(), "setting");
+    EXPECT_EQ(config.nireq(), 2);
+    EXPECT_EQ(config.targetDevice(), "GPU");
+    EXPECT_EQ(config.pluginConfig(), "pluginsetting");
+    EXPECT_EQ(config.stateful(), true);
+    EXPECT_EQ(config.metricsEnabled(), true);
+    EXPECT_EQ(config.metricsList(), "ovms_streams,ovms_other");
+    // EXPECT_EQ(config.idleSequenceCleanup(), false);  // TOOD: cannot disable, change to --disable_idle_seq_cleanup?
+    EXPECT_EQ(config.lowLatencyTransformation(), true);
+    EXPECT_EQ(config.maxSequenceNumber(), 52);
 }
 
 #pragma GCC diagnostic pop

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,8 @@ paramiko==2.11.0
 psutil==5.7.3
 pytest==5.3.5
 pytest-json==0.4.0
-tensorflow-serving-api==2.7.0
+tensorflow-serving-api==2.10.0
+tensorflow==2.10.0
 retry==0.9.2
 bandit
 protobuf>=3.18,<4.0.0


### PR DESCRIPTION
CLI parser decoupled from ovms::Config class. This enables C-API and OVMS to use ovms::Config for internal behavior and use CLI parser to be used within OVMS.
- server option validation has been moved from cli parser to ovms::Config to support both - C-API and OVMS