### PR TITLE
CVS-95536 Make all unsupported http methods defined in RFC2616 return 406

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,6 +66,8 @@ git_repository(
     patches = ["net_http.patch", "listen.patch"]
     #                             ^^^^^^^^^^^^
     #                       make bind address configurable
+    #          ^^^^^^^^^^^^
+    #        allow all http methods
 )
 
 # minitrace

--- a/external/net_http.patch
+++ b/external/net_http.patch
@@ -1,9 +1,9 @@
 diff --git a/tensorflow_serving/util/BUILD b/tensorflow_serving/util/BUILD
-index 5beb2fb..e7b166c 100644
+index 5beb2fb1..e7b166c1 100644
 --- a/tensorflow_serving/util/BUILD
 +++ b/tensorflow_serving/util/BUILD
 @@ -4,7 +4,7 @@ load("//tensorflow_serving:serving.bzl", "serving_proto_library")
-
+ 
  package(
      default_visibility = [
 -        "//tensorflow_serving:internal",
@@ -12,13 +12,13 @@ index 5beb2fb..e7b166c 100644
      features = ["-layering_check"],
  )
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc b/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc
-index 36c925a..86a5ba9 100644
+index 237443dd..1b7d0563 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_server.cc
-@@ -105,6 +105,11 @@ bool EvHTTPServer::Initialize() {
+@@ -105,13 +105,18 @@ bool EvHTTPServer::Initialize() {
      return false;
    }
-
+ 
 +  std::size_t maxBodySize = 1024 * 1024 * 1024;
 +  evhttp_set_max_body_size(ev_http_, maxBodySize);
 +  std::size_t maxHeadersSize = 8 * 1024;
@@ -27,12 +27,20 @@ index 36c925a..86a5ba9 100644
    // By default libevents only allow GET, POST, HEAD, PUT, DELETE request
    // we have to manually turn OPTIONS and PATCH flag on documentation:
    // (http://www.wangafu.net/~nickm/libevent-2.0/doxygen/html/http_8h.html)
+   evhttp_set_allowed_methods(
+       ev_http_, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_HEAD |
+                     EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_OPTIONS |
+-                    EVHTTP_REQ_PATCH);
++                    EVHTTP_REQ_CONNECT | EVHTTP_REQ_TRACE | EVHTTP_REQ_PATCH);
+   evhttp_set_gencb(ev_http_, &DispatchEvRequestFn, this);
+ 
+   return true;
 diff --git a/tensorflow_serving/util/net_http/server/public/BUILD b/tensorflow_serving/util/net_http/server/public/BUILD
-index e7f96d9..89d1a9c 100644
+index e7f96d98..89d1a9c0 100644
 --- a/tensorflow_serving/util/net_http/server/public/BUILD
 +++ b/tensorflow_serving/util/net_http/server/public/BUILD
 @@ -2,9 +2,7 @@
-
+ 
  package(
      default_visibility = [
 -        ":http_server_clients",
@@ -41,4 +49,4 @@ index e7f96d9..89d1a9c 100644
 +        "//visibility:public",
      ],
  )
-
+ 


### PR DESCRIPTION
Adding similar handling for CONNECT & TRACE as for other unsupported methods: HEAD/PUT/DELETE/OPTIONS/TRACE - HTTP status 406.
Other methods not specified in [RFC2616 ](https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1) are still falling back to TFS handling, returning 501.
http://www.wangafu.net/~nickm/libevent-2.0/doxygen/html/http_8h.html#ac858319d667267f9fc848c2bb6931aa3