### PR TITLE
Increase wait time for dag loaded state

### DIFF
--- a/src/pipelinedefinition.cpp
+++ b/src/pipelinedefinition.cpp
@@ -186,7 +186,7 @@ void PipelineDefinition::retire(ModelManager& manager) {
 Status PipelineDefinition::waitForLoaded(std::unique_ptr<PipelineDefinitionUnloadGuard>& unloadGuard, const uint waitForLoadedTimeoutMicroseconds) {
     unloadGuard = std::make_unique<PipelineDefinitionUnloadGuard>(*this);
 
-    const uint waitLoadedTimestepMicroseconds = 100;
+    const uint waitLoadedTimestepMicroseconds = 1000;
     const uint waitCheckpoints = waitForLoadedTimeoutMicroseconds / waitLoadedTimestepMicroseconds;
     uint waitCheckpointsCounter = waitCheckpoints;
     std::mutex cvMtx;

--- a/src/pipelinedefinition.hpp
+++ b/src/pipelinedefinition.hpp
@@ -103,7 +103,7 @@ private:
     Shape getNodeGatherShape(const NodeInfo& info) const;
 
 public:
-    static constexpr uint64_t WAIT_FOR_LOADED_DEFAULT_TIMEOUT_MICROSECONDS = 10000;
+    static constexpr uint64_t WAIT_FOR_LOADED_DEFAULT_TIMEOUT_MICROSECONDS = 500000;
     PipelineDefinition(const std::string& pipelineName,
         const std::vector<NodeInfo>& nodeInfos,
         const pipeline_connections_t& connections,

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -1864,7 +1864,7 @@ TEST_F(StressPipelineCustomNodesConfigChanges, RemoveCustomLibraryDuringPredictL
         allowedLoadResults);
 }
 TEST_F(StressPipelineCustomNodesConfigChanges, ChangeCustomLibraryParamDuringPredictLoad) {
-    // we change used PARAM durign load. This change does not effect results, but is should be enough to verify
+    // we change used PARAM during load. This change does not effect results, but should be enough to verify
     // correctness of this operation - no segfaults etc.
     SetUpConfig(stressPipelineCustomNodeDifferentOperationsThenDummyThenChooseMaximumConfig);
     bool performWholeConfigReload = true;

--- a/src/test/stateful_modelinstance_test.cpp
+++ b/src/test/stateful_modelinstance_test.cpp
@@ -810,7 +810,9 @@ TEST_F(StatefulModelInstanceTempDir, statefulInferMultipleThreads) {
     uint16_t numberOfThreadsWaitingOnStart = 30;
     uint16_t numberOfThreadsWaitingOnEnd = 30;
 
-    std::vector<std::promise<void>> releaseWaitBeforeSequenceStarted(numberOfThreadsWaitingOnStart + numberOfThreadsWaitingOnEnd), releaseWaitAfterSequenceStarted(numberOfThreadsWaitingOnStart), releaseWaitBeforeSequenceFinished(numberOfThreadsWaitingOnEnd);
+    std::vector<std::promise<void>> releaseWaitBeforeSequenceStarted(numberOfThreadsWaitingOnStart + numberOfThreadsWaitingOnEnd);
+    std::vector<std::promise<void>> releaseWaitAfterSequenceStarted(numberOfThreadsWaitingOnStart);
+    std::vector<std::promise<void>> releaseWaitBeforeSequenceFinished(numberOfThreadsWaitingOnEnd);
     std::vector<std::thread> inferThreads;
 
     for (auto i = 0u; i < numberOfThreadsWaitingOnStart; ++i) {


### PR DESCRIPTION
Without this we sporadically hit the PIPELINE_NOT_LOADED_YET status in CI. This can hapen under heavy machine workload as the timeout for waiting was 10ms and sporadically it was ~70ms on some machines.

Adding this status to allowed statuses list for this test would lower the test value since we can hit it when eg. there is unsuccessful validation.

If the threshold is not increased the PIPELINE_NOT_LOADED_YET status code would encourage to try to send request again so it seems that's better to wait a bit longer than force client to retry with request.

JIRA:CVS-63360