### PR TITLE
Fix sequence manager unit test sporadic

### DIFF
--- a/src/test/modelinstance_test.cpp
+++ b/src/test/modelinstance_test.cpp
@@ -315,7 +315,7 @@ TEST_F(TestLoadModel, CheckIfNonExistingXmlFileReturnsFileInvalid) {
         false,      // is stateful
         false,      // idle sequence cleanup enabled
         false,      // low latency transformation enabled
-        500,        // steteful sequence max number,
+        500,        // stateful sequence max number,
         "",         // cache dir
         version,    // version
         modelPath,  // local path
@@ -351,7 +351,7 @@ TEST_F(TestLoadModel, CheckIfNonExistingBinFileReturnsFileInvalid) {
         false,      // is stateful
         false,      // idle sequence cleanup enabled
         false,      // low latency transformation enabled
-        500,        // steteful sequence max number,
+        500,        // stateful sequence max number,
         "",         // cache dir
         version,    // version
         modelPath,  // local path

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -61,7 +61,7 @@ const ovms::ModelConfig DUMMY_MODEL_CONFIG{
     false,                 // is stateful
     true,                  // idle sequence cleanup enabled
     false,                 // low latency transformation enabled
-    500,                   // steteful sequence max number
+    500,                   // stateful sequence max number
     "",                    // cache directory
     1,                     // model_version unused since version are read from path
     dummy_model_location,  // local path
@@ -76,7 +76,7 @@ const ovms::ModelConfig DUMMY_FP64_MODEL_CONFIG{
     false,                      // is stateful
     true,                       // idle sequence cleanup enabled
     false,                      // low latency transformation enabled
-    500,                        // steteful sequence max number
+    500,                        // stateful sequence max number
     "",                         // cache directory
     1,                          // model_version unused since version are read from path
     dummy_fp64_model_location,  // local path
@@ -91,7 +91,7 @@ const ovms::ModelConfig SUM_MODEL_CONFIG{
     false,               // is stateful
     true,                // idle sequence cleanup enabled
     false,               // low latency transformation enabled
-    500,                 // steteful sequence max number
+    500,                 // stateful sequence max number
     "",                  // cache directory
     1,                   // model_version unused since version are read from path
     sum_model_location,  // local path
@@ -106,7 +106,7 @@ const ovms::ModelConfig INCREMENT_1x3x4x5_MODEL_CONFIG{
     false,                             // is stateful
     true,                              // idle sequence cleanup enabled
     false,                             // low latency transformation enabled
-    500,                               // steteful sequence max number
+    500,                               // stateful sequence max number
     "",                                // cache directory
     1,                                 // model_version unused since version are read from path
     increment_1x3x4x5_model_location,  // local path


### PR DESCRIPTION
- wait for all inferences to be finished before checking sequence manager count
- increase to max 5s timeout for slower machines to pass
- lower number of inferences from 100 to 25