### PR TITLE
ovmsclient 2022.3 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ test_functional: venv
 test_client_lib:
 	@cd client/python/ovmsclient/lib && \
 		make style || exit 1 && \
-		. .venv/bin/activate; make build || exit 1 && \
+		. .venv-ovmsclient/bin/activate; make build || exit 1 && \
 		make test TEST_TYPE=FULL || exit 1 && \
 		make clean
 

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ test_functional: venv
 test_client_lib:
 	@cd client/python/ovmsclient/lib && \
 		make style || exit 1 && \
-		. .venv-ovmsclient/bin/activate; pip3 install protobuf==3.19.4; make build || exit 1 && \
+		. .venv-ovmsclient/bin/activate; make build || exit 1 && \
 		make test TEST_TYPE=FULL || exit 1 && \
 		make clean
 

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ test_functional: venv
 test_client_lib:
 	@cd client/python/ovmsclient/lib && \
 		make style || exit 1 && \
-		. .venv-ovmsclient/bin/activate; make build || exit 1 && \
+		. .venv-ovmsclient/bin/activate; pip3 install protobuf==3.19.4; make build || exit 1 && \
 		make test TEST_TYPE=FULL || exit 1 && \
 		make clean
 

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ test_client_lib:
 	@cd client/python/ovmsclient/lib && \
 		make style || exit 1 && \
 		. .venv/bin/activate; make build || exit 1 && \
-		make test || exit 1 && \
+		make test TEST_TYPE=FULL || exit 1 && \
 		make clean
 
 tools_get_deps:

--- a/client/python/ovmsclient/Dockerfile.redhat
+++ b/client/python/ovmsclient/Dockerfile.redhat
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi:8.4
-ARG FINAL_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:8.4
+ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi:8.7
+ARG FINAL_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 FROM $BASE_IMAGE as base_build

--- a/client/python/ovmsclient/lib/.gitignore
+++ b/client/python/ovmsclient/lib/.gitignore
@@ -2,4 +2,5 @@ build/
 dist/
 tensorflow/
 tensorflow_serving/
+ovmsclient/tfs_compat/protos/
 *.egg-info/

--- a/client/python/ovmsclient/lib/Makefile
+++ b/client/python/ovmsclient/lib/Makefile
@@ -15,7 +15,7 @@
 #
 
 VIRTUALENV_EXE := python3 -m virtualenv -p python3
-VIRTUALENV_DIR := .venv
+VIRTUALENV_DIR := .venv-ovmsclient
 ACTIVATE="$(VIRTUALENV_DIR)/bin/activate"
 
 PACKAGE_PATH := dist/ovmsclient-2022.3-py3-none-any.whl
@@ -58,13 +58,13 @@ test: venv
 	@. $(ACTIVATE); pytest -v tests/
 ifeq ($(TEST_TYPE), FULL)
 	@echo "Installing NumPy version: 1.23"
-	@pip3 install numpy==1.23
+	@. $(ACTIVATE); pip3 install numpy==1.23
 	@echo "Rerunning ovmsclient tests with NumPy 1.23"
 	@. $(ACTIVATE); pytest -v tests/
 endif
 
 clean:
-	@rm -rf tf/ tfs/ tensorflow/ tensorflow_serving/ build/ dist/
+	@rm -rf tf/ tfs/ compiled_protos/ build/ dist/ ovmsclient/tfs_compat/protos
 
 style: venv
 	@. $(ACTIVATE); pip3 install flake8==5.0.1

--- a/client/python/ovmsclient/lib/Makefile
+++ b/client/python/ovmsclient/lib/Makefile
@@ -18,7 +18,8 @@ VIRTUALENV_EXE := python3 -m virtualenv -p python3
 VIRTUALENV_DIR := .venv
 ACTIVATE="$(VIRTUALENV_DIR)/bin/activate"
 
-PACKAGE_PATH := dist/ovmsclient-2022.2-py3-none-any.whl
+PACKAGE_PATH := dist/ovmsclient-2022.3-py3-none-any.whl
+TEST_TYPE := BASIC
 
 .PHONY: build-deps build-package build test clean style
 
@@ -55,6 +56,12 @@ test: venv
 	@. $(ACTIVATE); pip3 install $(PACKAGE_PATH) --force-reinstall
 	@echo "Running ovmsclient tests"
 	@. $(ACTIVATE); pytest -v tests/
+ifeq ($(TEST_TYPE), FULL)
+	@echo "Installing NumPy version: 1.23"
+	@pip3 install numpy==1.23
+	@echo "Rerunning ovmsclient tests with NumPy 1.23"
+	@. $(ACTIVATE); pytest -v tests/
+endif
 
 clean:
 	@rm -rf tf/ tfs/ tensorflow/ tensorflow_serving/ build/ dist/

--- a/client/python/ovmsclient/lib/README.md
+++ b/client/python/ovmsclient/lib/README.md
@@ -6,7 +6,7 @@ OVMS client library contains only the necessary dependencies, so the whole packa
 
 As OpenVINO Model Server API is compatible with TensorFlow Serving, it's possible to use `ovmsclient` with TensorFlow Serving instances on: Predict, GetModelMetadata and GetModelStatus endpoints.
 
-See [API documentation](https://github.com/openvinotoolkit/model_server/blob/releases/2022/1/client/python/ovmsclient/lib/docs/README.md) for details on what the library provides.
+See [API documentation](https://github.com/openvinotoolkit/model_server/blob/releases/2022/3/client/python/ovmsclient/lib/docs/README.md) for details on what the library provides.
 
 ```bash
 git clone https://github.com/openvinotoolkit/model_server.git
@@ -44,7 +44,7 @@ Assuming you have TFS API built, you can use `make build-package` target to buil
 
 **To install the package run:**
 ```bash
-pip3 install --force-reinstall --no-deps dist/ovmsclient-2022.2-py3-none-any.whl
+pip3 install --force-reinstall --no-deps dist/ovmsclient-2022.3-py3-none-any.whl
 ```
 
 *Note*: For development purposes you may want to repeatedly reinstall the package.
@@ -61,7 +61,7 @@ make build-package
 ```
  - `make test` - runs tests on `ovmsclient` package. By default the package located in `dist/` directory is used. To specify custom package path pass `PACKAGE_PATH` option like: 
 
-   `make test PACKAGE_PATH=/opt/packages/ovmsclient-2022.2-py3-none-any.whl`
+   `make test PACKAGE_PATH=/opt/packages/ovmsclient-2022.3-py3-none-any.whl`
 ```bash
 make test
 ```
@@ -136,4 +136,4 @@ results = client.predict(inputs=inputs, model_name="model")
 #
 ```
 
-For more details on `ovmsclient` see [API reference](https://github.com/openvinotoolkit/model_server/blob/releases/2022/1/client/python/ovmsclient/lib/docs/README.md)
+For more details on `ovmsclient` see [API reference](https://github.com/openvinotoolkit/model_server/blob/releases/2022/3/client/python/ovmsclient/lib/docs/README.md)

--- a/client/python/ovmsclient/lib/docs/pypi_overview.md
+++ b/client/python/ovmsclient/lib/docs/pypi_overview.md
@@ -9,7 +9,7 @@ The `ovmsclient` package works both with OpenVINO&trade; Model Server and Tensor
 The `ovmsclient` can replace `tensorflow-serving-api` package with reduced footprint and simplified interface.
 
 
-See [API reference](https://github.com/openvinotoolkit/model_server/blob/releases/2022/2/client/python/ovmsclient/lib/docs/README.md) for usage details.
+See [API reference](https://github.com/openvinotoolkit/model_server/blob/releases/2022/3/client/python/ovmsclient/lib/docs/README.md) for usage details.
 
 
 ## Usage example
@@ -38,4 +38,4 @@ results = client.predict(inputs=inputs, model_name="model")
 
 ```
 
-Learn more on `ovmsclient` [documentation site](https://github.com/openvinotoolkit/model_server/tree/releases/2022/2/client/python/ovmsclient/lib).
+Learn more on `ovmsclient` [documentation site](https://github.com/openvinotoolkit/model_server/tree/releases/2022/3/client/python/ovmsclient/lib).

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/requests.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/requests.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 #
 
-from tensorflow.core.framework.tensor_pb2 import TensorProto
-from tensorflow_serving.apis import get_model_status_pb2, get_model_metadata_pb2, predict_pb2
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_pb2 import TensorProto
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis import (get_model_status_pb2,
+                                                                  get_model_metadata_pb2,
+                                                                  predict_pb2)
 
 from ovmsclient.tfs_compat.base.requests import (PredictRequest, ModelMetadataRequest,
                                                  ModelStatusRequest, _check_model_spec)

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/responses.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/responses.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-from tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus
-from tensorflow_serving.apis import get_model_metadata_pb2
-from tensorflow.core.framework.types_pb2 import DataType
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis import get_model_metadata_pb2
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.types_pb2 import DataType
 
 from ovmsclient.tfs_compat.base.responses import (PredictResponse, ModelMetadataResponse,
                                                   ModelStatusResponse)

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/serving_client.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/serving_client.py
@@ -16,8 +16,8 @@
 
 from grpc import RpcError, ssl_channel_credentials, secure_channel, insecure_channel
 
-from tensorflow_serving.apis import prediction_service_pb2_grpc
-from tensorflow_serving.apis import model_service_pb2_grpc
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis import prediction_service_pb2_grpc
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis import model_service_pb2_grpc
 
 from ovmsclient.tfs_compat.base.serving_client import ServingClient
 from ovmsclient.tfs_compat.grpc.requests import (make_status_request,

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/tensors.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/tensors.py
@@ -42,8 +42,9 @@ NP_TO_TENSOR_MAP = {
     np.uint64: TensorType(TensorDtype=DataType.DT_UINT64, TensorProtoField="uint64_val"),
     np.complex64: TensorType(TensorDtype=DataType.DT_COMPLEX64, TensorProtoField="scomplex_val"),
     np.complex128: TensorType(TensorDtype=DataType.DT_COMPLEX128, TensorProtoField="dcomplex_val"),
-    np.bool_: TensorType(TensorDtype=DataType.DT_BOOL, TensorProtoField="bool_val"), # previously deperecated np.bool is now removed 
-    bool: TensorType(TensorDtype=DataType.DT_BOOL, TensorProtoField="bool_val"), # standard Python bool and np.bool_ replace np.bool
+    # Standard Python bool and np.bool_ replace deprecated np.bool type
+    np.bool_: TensorType(TensorDtype=DataType.DT_BOOL, TensorProtoField="bool_val"),
+    bool: TensorType(TensorDtype=DataType.DT_BOOL, TensorProtoField="bool_val"),
     np.bytes_: TensorType(TensorDtype=DataType.DT_STRING, TensorProtoField="string_val")
 }
 
@@ -81,13 +82,16 @@ def _cast_bytes_to_dtype(values, dtype):
 def _is_bytes_shape_valid(inferred_shape, tensor_values):
     return (len(inferred_shape) > 1 or (len(tensor_values.shape) > 1 and inferred_shape == []))
 
+
 def _check_if_array_homogeneous(tensor_values):
-    # Exception details match numpy ValueError thrown on attempt to create inhomogeneous numpy array in versions >=1.24
-    # This function has been created to provide the same user experience for both pre and post 1.24 numpy versions
+    #  Exception details match numpy ValueError thrown on attempt to create inhomogeneous
+    #  numpy array in versions >=1.24. This function has been created to provide
+    #  the same user experience for both pre and post 1.24 numpy versions.
     if tensor_values.dtype.type is np.object_ or tensor_values.dtype.type is object:
-            raise ValueError('setting an array element with a sequence. The requested array '
-                             f'has an inhomogeneous shape after {len(tensor_values.shape)} dimensions. ' 
-                             f'The detected shape was {tensor_values.shape} + inhomogeneous part.')
+        raise ValueError('setting an array element with a sequence. The requested array has '
+                         f'an inhomogeneous shape after {len(tensor_values.shape)} dimensions. '
+                         f'The detected shape was {tensor_values.shape} + inhomogeneous part.')
+
 
 @ovmsclient_export("make_tensor_proto", grpcclient="make_tensor_proto")
 def make_tensor_proto(values, dtype=None, shape=None):

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/tensors.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/tensors.py
@@ -42,7 +42,8 @@ NP_TO_TENSOR_MAP = {
     np.uint64: TensorType(TensorDtype=DataType.DT_UINT64, TensorProtoField="uint64_val"),
     np.complex64: TensorType(TensorDtype=DataType.DT_COMPLEX64, TensorProtoField="scomplex_val"),
     np.complex128: TensorType(TensorDtype=DataType.DT_COMPLEX128, TensorProtoField="dcomplex_val"),
-    np.bool: TensorType(TensorDtype=DataType.DT_BOOL, TensorProtoField="bool_val"),
+    np.bool_: TensorType(TensorDtype=DataType.DT_BOOL, TensorProtoField="bool_val"), # previously deperecated np.bool is now removed 
+    bool: TensorType(TensorDtype=DataType.DT_BOOL, TensorProtoField="bool_val"), # standard Python bool and np.bool_ replace np.bool
     np.bytes_: TensorType(TensorDtype=DataType.DT_STRING, TensorProtoField="string_val")
 }
 
@@ -77,18 +78,16 @@ def _cast_bytes_to_dtype(values, dtype):
         raise ValueError(f'could not cast bytes to {dtype}. {e_info}')
 
 
-def _get_dense_dimensions(values):
-    if not isinstance(values, (list, np.ndarray)):
-        return []
-    elif len(values) == 0:
-        return [0]
-    else:
-        return [len(values)] + _get_dense_dimensions(values[0])
-
-
 def _is_bytes_shape_valid(inferred_shape, tensor_values):
     return (len(inferred_shape) > 1 or (len(tensor_values.shape) > 1 and inferred_shape == []))
 
+def _check_if_array_homogeneous(tensor_values):
+    # Exception details match numpy ValueError thrown on attempt to create inhomogeneous numpy array in versions >=1.24
+    # This function has been created to provide the same user experience for both pre and post 1.24 numpy versions
+    if tensor_values.dtype.type is np.object_ or tensor_values.dtype.type is object:
+            raise ValueError('setting an array element with a sequence. The requested array '
+                             f'has an inhomogeneous shape after {len(tensor_values.shape)} dimensions. ' 
+                             f'The detected shape was {tensor_values.shape} + inhomogeneous part.')
 
 @ovmsclient_export("make_tensor_proto", grpcclient="make_tensor_proto")
 def make_tensor_proto(values, dtype=None, shape=None):
@@ -146,11 +145,8 @@ def make_tensor_proto(values, dtype=None, shape=None):
     if isinstance(values, np.ndarray):
         tensor_values = values
     elif isinstance(values, list):
-        dense_dimensions = _get_dense_dimensions(values)
         tensor_values = np.array(values)
-        if (list(tensor_values.shape) != dense_dimensions):
-            raise ValueError(f'argument must be a dense tensor: {values} - got shape '
-                             f'{list(tensor_values.shape)}, but wanted {dense_dimensions}')
+        _check_if_array_homogeneous(tensor_values)
     elif np.isscalar(values):
         tensor_values = np.array([values])
     else:
@@ -274,7 +270,7 @@ def make_ndarray(tensor_proto):
     elif np_dtype == np.complex128:
         it = iter(tensor_proto.dcomplex_val)
         values = np.array([complex(x[0], x[1]) for x in zip(it, it)], dtype=np_dtype)
-    elif np_dtype == np.bool:
+    elif np_dtype == np.bool_ or np_dtype == bool:
         values = np.fromiter(tensor_proto.bool_val, dtype=np_dtype)
     else:
         raise TypeError("Unsupported tensor type: %s" % tensor_proto.dtype)

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/tensors.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/grpc/tensors.py
@@ -15,9 +15,9 @@
 #
 
 from typing import NamedTuple
-from tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
-from tensorflow.core.framework.tensor_pb2 import TensorProto
-from tensorflow.core.framework.types_pb2 import DataType
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_pb2 import TensorProto
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.types_pb2 import DataType
 import numpy as np
 
 from ovmsclient.util.ovmsclient_export import ovmsclient_export

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/http/requests.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/http/requests.py
@@ -20,7 +20,8 @@ import numpy as np
 from ovmsclient.tfs_compat.base.requests import (PredictRequest, ModelMetadataRequest,
                                                  ModelStatusRequest, _check_model_spec)
 from ovmsclient.tfs_compat.grpc.tensors import (NP_TO_TENSOR_MAP, DataType,
-                                                _get_dense_dimensions, _is_bytes_shape_valid)
+                                                _is_bytes_shape_valid, 
+                                                _check_if_array_homogeneous)
 
 
 class HttpPredictRequest(PredictRequest):
@@ -172,11 +173,8 @@ def _parse_input_data(values):
     if isinstance(values, np.ndarray):
         tensor_values = values
     elif isinstance(values, list):
-        dense_dimensions = _get_dense_dimensions(values)
         tensor_values = np.array(values)
-        if (list(tensor_values.shape) != dense_dimensions):
-            raise ValueError(f'argument must be a dense tensor: {values} - got shape '
-                             f'{list(tensor_values.shape)}, but wanted {dense_dimensions}')
+        _check_if_array_homogeneous(tensor_values)
     elif np.isscalar(values):
         tensor_values = np.array([values])
     else:

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/http/requests.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/http/requests.py
@@ -20,7 +20,7 @@ import numpy as np
 from ovmsclient.tfs_compat.base.requests import (PredictRequest, ModelMetadataRequest,
                                                  ModelStatusRequest, _check_model_spec)
 from ovmsclient.tfs_compat.grpc.tensors import (NP_TO_TENSOR_MAP, DataType,
-                                                _is_bytes_shape_valid, 
+                                                _is_bytes_shape_valid,
                                                 _check_if_array_homogeneous)
 
 

--- a/client/python/ovmsclient/lib/ovmsclient/tfs_compat/http/responses.py
+++ b/client/python/ovmsclient/lib/ovmsclient/tfs_compat/http/responses.py
@@ -16,7 +16,7 @@
 
 import json
 import numpy as np
-from tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
+from ovmsclient.tfs_compat.protos.tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
 from ovmsclient.tfs_compat.base.responses import (PredictResponse, ModelMetadataResponse,
                                                   ModelStatusResponse)
 from ovmsclient.tfs_compat.base.errors import raise_from_http_response

--- a/client/python/ovmsclient/lib/scripts/build_tfs_api.sh
+++ b/client/python/ovmsclient/lib/scripts/build_tfs_api.sh
@@ -30,15 +30,27 @@ trap cleanup_tmp_dirs EXIT
 git clone --branch v2.5.0 --depth 1 https://github.com/tensorflow/tensorflow.git tf
 git clone --branch 2.5.1 --depth 1 https://github.com/tensorflow/serving.git tfs
 
-protoc --proto_path=$PWD/tfs --proto_path=$PWD/tf --python_out=$PWD \
-$PWD/tf/tensorflow/core/framework/*.proto \
-$PWD/tf/tensorflow/core/example/*.proto \
-$PWD/tf/tensorflow/core/protobuf/*.proto \
-$PWD/tfs/tensorflow_serving/util/*.proto \
-$PWD/tfs/tensorflow_serving/config/*.proto \
-$PWD/tfs/tensorflow_serving/core/*.proto \
-$PWD/tfs/tensorflow_serving/apis/*.proto
+mkdir -p ovmsclient/tfs_compat/protos
+mkdir compiled_protos
+cp -R tf/tensorflow ovmsclient/tfs_compat/protos/tensorflow
+cp -R tfs/tensorflow_serving ovmsclient/tfs_compat/protos/tensorflow_serving 
+find ovmsclient/tfs_compat/protos -name "*.proto" -exec sed -i -E 's/import "tensorflow/import "ovmsclient\/tfs_compat\/protos\/tensorflow/g' {} \;
 
-cp tfs/tensorflow_serving/apis/prediction_service_pb2_grpc.py tensorflow_serving/apis/.
-cp tfs/tensorflow_serving/apis/model_service_pb2_grpc.py tensorflow_serving/apis/.
+protoc --proto_path=$PWD --python_out=$PWD/compiled_protos \
+$PWD/ovmsclient/tfs_compat/protos/tensorflow/core/framework/*.proto \
+$PWD/ovmsclient/tfs_compat/protos/tensorflow/core/example/*.proto \
+$PWD/ovmsclient/tfs_compat/protos/tensorflow/core/protobuf/*.proto \
+$PWD/ovmsclient/tfs_compat/protos/tensorflow_serving/util/*.proto \
+$PWD/ovmsclient/tfs_compat/protos/tensorflow_serving/config/*.proto \
+$PWD/ovmsclient/tfs_compat/protos/tensorflow_serving/core/*.proto \
+$PWD/ovmsclient/tfs_compat/protos/tensorflow_serving/apis/*.proto
+
+sed -i 's/from tensorflow_serving.apis/from ovmsclient.tfs_compat.protos.tensorflow_serving.apis/g' ovmsclient/tfs_compat/protos/tensorflow_serving/apis/prediction_service_pb2_grpc.py
+sed -i 's/from tensorflow_serving.apis/from ovmsclient.tfs_compat.protos.tensorflow_serving.apis/g' ovmsclient/tfs_compat/protos/tensorflow_serving/apis/model_service_pb2_grpc.py
+
+cp ovmsclient/tfs_compat/protos/tensorflow_serving/apis/prediction_service_pb2_grpc.py compiled_protos/ovmsclient/tfs_compat/protos/tensorflow_serving/apis/.
+cp ovmsclient/tfs_compat/protos/tensorflow_serving/apis/model_service_pb2_grpc.py compiled_protos/ovmsclient/tfs_compat/protos/tensorflow_serving/apis/.
+
+rm -rf ovmsclient/tfs_compat/protos
+cp -R compiled_protos/ovmsclient/tfs_compat/protos ovmsclient/tfs_compat/protos
 

--- a/client/python/ovmsclient/lib/setup.py
+++ b/client/python/ovmsclient/lib/setup.py
@@ -60,6 +60,6 @@ setuptools.setup(
      cmdclass={
         "build_apis": BuildApis,
      },
-     packages=setuptools.find_namespace_packages(include=["ovmsclient*", "tensorflow*", "tensorflow_serving*"]),
+     packages=setuptools.find_namespace_packages(include=["ovmsclient*"]),
      install_requires=["grpcio>=1.47.0", "protobuf>=3.19.4", "numpy>=1.16.6", "requests>=2.27.1"],
  )

--- a/client/python/ovmsclient/lib/setup.py
+++ b/client/python/ovmsclient/lib/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Intel Corporation
+# Copyright (c) 2021-2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,17 +49,17 @@ long_description = (this_directory / "docs/pypi_overview.md").read_text()
 
 setuptools.setup(
      name="ovmsclient",
-     version="2022.2",
+     version="2022.3",
      license="Apache License 2.0",
      author="Intel Corporation",
      author_email="ovms.engineering@intel.com",
      description="Python client for OpenVINO Model Server",
      long_description=long_description,
      long_description_content_type="text/markdown",
-     url="https://github.com/openvinotoolkit/model_server/tree/releases/2022/2/client/python/ovmsclient/lib",
+     url="https://github.com/openvinotoolkit/model_server/tree/releases/2022/3/client/python/ovmsclient/lib",
      cmdclass={
         "build_apis": BuildApis,
      },
      packages=setuptools.find_namespace_packages(include=["ovmsclient*", "tensorflow*", "tensorflow_serving*"]),
-     install_requires=["grpcio==1.47.0", "protobuf>=3.19.4,<4.0.0", "numpy>=1.16.6,<=1.23.1", "requests==2.27.1"],
+     install_requires=["grpcio>=1.47.0", "protobuf>=3.19.4", "numpy>=1.16.6", "requests>=2.27.1"],
  )

--- a/client/python/ovmsclient/lib/tests/config.py
+++ b/client/python/ovmsclient/lib/tests/config.py
@@ -342,8 +342,9 @@ PREDICT_INVALID_PARAMS = [
     ),
     (
         [{"input": [[1, 2], [3, 4, 5]]}, "model_name", 1, 1],
-        ValueError, "argument must be a dense tensor: [[1, 2], [3, 4, 5]] "
-                    "- got shape [2], but wanted [2, 2]"
+        ValueError, "setting an array element with a sequence. "
+                    "The requested array has an inhomogeneous shape after 1 dimensions. " 
+                    "The detected shape was (2,) + inhomogeneous part."
     ),
     # Model name check
     ([{"input": 1.0}, ("model", "name"), 1, 10], TypeError,

--- a/client/python/ovmsclient/lib/tests/config.py
+++ b/client/python/ovmsclient/lib/tests/config.py
@@ -343,7 +343,7 @@ PREDICT_INVALID_PARAMS = [
     (
         [{"input": [[1, 2], [3, 4, 5]]}, "model_name", 1, 1],
         ValueError, "setting an array element with a sequence. "
-                    "The requested array has an inhomogeneous shape after 1 dimensions. " 
+                    "The requested array has an inhomogeneous shape after 1 dimensions. "
                     "The detected shape was (2,) + inhomogeneous part."
     ),
     # Model name check

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/config.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/config.py
@@ -20,14 +20,14 @@ from ovmsclient.tfs_compat.base.errors import ModelNotFoundError, InvalidInputEr
 
 from config import CallCount, PATH_VALID # noqa
 
-from tensorflow.core.framework.tensor_pb2 import TensorProto
-from tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
-from tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus
-from tensorflow.core.framework.types_pb2 import DataType
-from tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
-from tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusRequest
-from tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataRequest
-from tensorflow_serving.apis.predict_pb2 import PredictRequest
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_pb2 import TensorProto
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus # noqa
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.types_pb2 import DataType
+from ovmsclient.tfs_compat.protos.tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusRequest # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataRequest # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.predict_pb2 import PredictRequest
 
 from ovmsclient.tfs_compat.grpc.requests import (GrpcModelMetadataRequest, GrpcModelStatusRequest,
                                                  GrpcPredictRequest)

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/config.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/config.py
@@ -161,13 +161,13 @@ PREDICT_REQUEST_INVALID_INPUTS = [
         "input1": [[1.0, 2.0], [1.0, 2.0, 3.0]]
     }, 'model_name', 0, ValueError,
      ("setting an array element with a sequence. "
-      "The requested array has an inhomogeneous shape after 1 dimensions. " 
+      "The requested array has an inhomogeneous shape after 1 dimensions. "
       "The detected shape was (2,) + inhomogeneous part.")),
     ({
         "input1": [[(1, 2, 3)], [(1, 2)], [(1, 2, 3)]]
-    }, 'model_name', 0, ValueError, 
+    }, 'model_name', 0, ValueError,
      ("setting an array element with a sequence. "
-      "The requested array has an inhomogeneous shape after 2 dimensions. " 
+      "The requested array has an inhomogeneous shape after 2 dimensions. "
       "The detected shape was (3, 1) + inhomogeneous part.")),
     ({
         "input1": float128(2.5)

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/config.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/config.py
@@ -160,11 +160,15 @@ PREDICT_REQUEST_INVALID_INPUTS = [
     ({
         "input1": [[1.0, 2.0], [1.0, 2.0, 3.0]]
     }, 'model_name', 0, ValueError,
-     ("argument must be a dense tensor: [[1.0, 2.0], [1.0, 2.0, 3.0]] - "
-      "got shape [2], but wanted [2, 2]")),
+     ("setting an array element with a sequence. "
+      "The requested array has an inhomogeneous shape after 1 dimensions. " 
+      "The detected shape was (2,) + inhomogeneous part.")),
     ({
         "input1": [[(1, 2, 3)], [(1, 2)], [(1, 2, 3)]]
-    }, 'model_name', 0, TypeError, "provided values type is not valid"),
+    }, 'model_name', 0, ValueError, 
+     ("setting an array element with a sequence. "
+      "The requested array has an inhomogeneous shape after 2 dimensions. " 
+      "The detected shape was (3, 1) + inhomogeneous part.")),
     ({
         "input1": float128(2.5)
     }, 'model_name', 0, TypeError, "provided values type is not valid"),

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_requests.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_requests.py
@@ -118,7 +118,7 @@ def test_make_predict_request_invalid_model_spec(mocker, name, version,
     mock_method.assert_called_once()
 
 
-@pytest.mark.causes_deprecation_warning
+@pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 @pytest.mark.parametrize("""inputs, name, version,
                             expected_exception, expected_message""", PREDICT_REQUEST_INVALID_INPUTS)
 def test_make_predict_request_invalid_inputs(mocker, inputs, name, version,

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_requests.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_requests.py
@@ -16,9 +16,9 @@
 
 import pytest
 
-from tensorflow.core.framework.tensor_pb2 import TensorProto
-from tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataRequest
-from tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusRequest
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_pb2 import TensorProto
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataRequest # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusRequest # noqa
 
 from ovmsclient.tfs_compat.grpc.requests import (GrpcModelMetadataRequest, GrpcPredictRequest,
                                                  make_metadata_request, make_predict_request,
@@ -27,7 +27,7 @@ from ovmsclient.tfs_compat.grpc.requests import (GrpcModelMetadataRequest, GrpcP
 from tfs_compat_grpc.config import (PREDICT_REQUEST_INVALID_INPUTS, PREDICT_REQUEST_VALID)
 from config import (MODEL_SPEC_INVALID, MODEL_SPEC_VALID)
 
-from tensorflow_serving.apis.predict_pb2 import PredictRequest
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.predict_pb2 import PredictRequest
 
 
 @pytest.mark.parametrize("name, version", MODEL_SPEC_VALID)

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_responses.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_responses.py
@@ -18,10 +18,10 @@ from numpy import ndarray
 from numpy.core.numeric import array_equal
 import pytest
 
-from tensorflow.core.framework.types_pb2 import DataType
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.types_pb2 import DataType
 
-from tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus
-from tensorflow_serving.apis.predict_pb2 import PredictResponse
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.predict_pb2 import PredictResponse
 
 from ovmsclient.tfs_compat.grpc.responses import (GrpcModelMetadataResponse,
                                                   GrpcModelStatusResponse,

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_serving_client.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_grpc_serving_client.py
@@ -19,13 +19,14 @@ import pytest
 import numpy as np
 from ovmsclient.tfs_compat.grpc.requests import GrpcPredictRequest
 
-from tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataRequest
-from tensorflow_serving.apis.model_service_pb2_grpc import ModelServiceStub
-from tensorflow_serving.apis.predict_pb2 import PredictRequest, PredictResponse
-from tensorflow_serving.apis.prediction_service_pb2_grpc import PredictionServiceStub
-from tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusRequest, ModelVersionStatus
-from tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
-from tensorflow.core.framework.types_pb2 import DataType
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataRequest # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.model_service_pb2_grpc import ModelServiceStub # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.predict_pb2 import (PredictRequest,
+                                                                              PredictResponse)
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.prediction_service_pb2_grpc import PredictionServiceStub # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusRequest, ModelVersionStatus # noqa
+from ovmsclient.tfs_compat.protos.tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.types_pb2 import DataType
 
 from ovmsclient.tfs_compat.grpc.serving_client import make_grpc_client
 from ovmsclient.tfs_compat.grpc.requests import GrpcModelStatusRequest, GrpcModelMetadataRequest

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_tensors.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_tensors.py
@@ -546,7 +546,7 @@ def test_make_tensor_proto_invalid_dimensions():
         make_tensor_proto(values=values, shape=[2, 3], dtype=DataType.DT_FLOAT)
     exception = exception_info.value
     assert str(exception) == ("setting an array element with a sequence. "
-                              "The requested array has an inhomogeneous shape after 1 dimensions. " 
+                              "The requested array has an inhomogeneous shape after 1 dimensions. "
                               "The detected shape was (2,) + inhomogeneous part.")
 
 
@@ -567,7 +567,7 @@ def test_make_tensor_proto_invalid_string_dimensions():
                           shape=None, dtype=DataType.DT_STRING)
     exception = exception_info.value
     assert str(exception) == ("setting an array element with a sequence. "
-                              "The requested array has an inhomogeneous shape after 1 dimensions. " 
+                              "The requested array has an inhomogeneous shape after 1 dimensions. "
                               "The detected shape was (2,) + inhomogeneous part.")
 
 
@@ -578,18 +578,18 @@ def test_make_tensor_proto_invalid_dimensions_2():
         make_tensor_proto(values=values, shape=[2, 3], dtype=DataType.DT_FLOAT)
     exception = exception_info.value
     assert str(exception) == ("setting an array element with a sequence. "
-                              "The requested array has an inhomogeneous shape after 2 dimensions. " 
+                              "The requested array has an inhomogeneous shape after 2 dimensions. "
                               "The detected shape was (3, 1) + inhomogeneous part.")
 
 
 @pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 def test_make_tensor_proto_invalid_dimensions_no_shape_provided():
-    values = [[[1,2], [3,4]], [[1,2], [3,4]], [[1,2,3],[4]]]
+    values = [[[1, 2], [3, 4]], [[1, 2], [3, 4]], [[1, 2, 3], [4]]]
     with pytest.raises(ValueError) as exception_info:
         make_tensor_proto(values=values, shape=None, dtype=DataType.DT_INT8)
     exception = exception_info.value
     assert str(exception) == ("setting an array element with a sequence. "
-                              "The requested array has an inhomogeneous shape after 2 dimensions. " 
+                              "The requested array has an inhomogeneous shape after 2 dimensions. "
                               "The detected shape was (3, 2) + inhomogeneous part.")
 
 

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_tensors.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_tensors.py
@@ -539,14 +539,15 @@ def test_make_tensor_proto_invalid_shape_element_values():
     assert str(exception) == "shape type should be list or tuple with unsigned integers"
 
 
-@pytest.mark.causes_deprecation_warning
+@pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 def test_make_tensor_proto_invalid_dimensions():
     values = [[1.0, 2.0], [1.0, 2.0, 3.0]]
     with pytest.raises(ValueError) as exception_info:
         make_tensor_proto(values=values, shape=[2, 3], dtype=DataType.DT_FLOAT)
     exception = exception_info.value
-    assert str(exception) == ("argument must be a dense tensor: [[1.0, 2.0], [1.0, 2.0, 3.0]] "
-                              "- got shape [2], but wanted [2, 2]")
+    assert str(exception) == ("setting an array element with a sequence. "
+                              "The requested array has an inhomogeneous shape after 1 dimensions. " 
+                              "The detected shape was (2,) + inhomogeneous part.")
 
 
 def test_make_tensor_proto_invalid_string_to_float_dtype():
@@ -558,36 +559,38 @@ def test_make_tensor_proto_invalid_string_to_float_dtype():
                               "buffer size must be a multiple of element size")
 
 
-@pytest.mark.causes_deprecation_warning
+@pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 def test_make_tensor_proto_invalid_string_dimensions():
     values = bytes([0x13, 0x00])
     with pytest.raises(ValueError) as exception_info:
         make_tensor_proto(values=[[values, values, values], [values, values]],
                           shape=None, dtype=DataType.DT_STRING)
     exception = exception_info.value
-    assert str(exception) == ("argument must be a dense tensor: "
-                              f"{[[values, values, values], [values, values]]} "
-                              "- got shape [2], but wanted [2, 3]")
+    assert str(exception) == ("setting an array element with a sequence. "
+                              "The requested array has an inhomogeneous shape after 1 dimensions. " 
+                              "The detected shape was (2,) + inhomogeneous part.")
 
 
-@pytest.mark.causes_deprecation_warning
+@pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 def test_make_tensor_proto_invalid_dimensions_2():
     values = [[(1, 2, 3)], [(1, 2)], [(1, 2, 3)]]
     with pytest.raises(ValueError) as exception_info:
         make_tensor_proto(values=values, shape=[2, 3], dtype=DataType.DT_FLOAT)
     exception = exception_info.value
-    assert str(exception) == ("could not cast values to <class 'numpy.float32'>. "
-                              "setting an array element with a sequence.")
+    assert str(exception) == ("setting an array element with a sequence. "
+                              "The requested array has an inhomogeneous shape after 2 dimensions. " 
+                              "The detected shape was (3, 1) + inhomogeneous part.")
 
 
-@pytest.mark.causes_deprecation_warning
+@pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 def test_make_tensor_proto_invalid_dimensions_no_shape_provided():
-    values = [[1, 2, 3], [4, 5]]
+    values = [[[1,2], [3,4]], [[1,2], [3,4]], [[1,2,3],[4]]]
     with pytest.raises(ValueError) as exception_info:
         make_tensor_proto(values=values, shape=None, dtype=DataType.DT_INT8)
     exception = exception_info.value
-    assert str(exception) == ("argument must be a dense tensor: [[1, 2, 3], [4, 5]] "
-                              "- got shape [2], but wanted [2, 3]")
+    assert str(exception) == ("setting an array element with a sequence. "
+                              "The requested array has an inhomogeneous shape after 2 dimensions. " 
+                              "The detected shape was (3, 2) + inhomogeneous part.")
 
 
 def test_make_tensor_proto_invalid_shape_type():

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_tensors.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/test_tensors.py
@@ -15,9 +15,9 @@
 #
 
 import pytest
-from tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
-from tensorflow.core.framework.tensor_pb2 import TensorProto
-from tensorflow.core.framework.types_pb2 import DataType
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_pb2 import TensorProto
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.types_pb2 import DataType
 from ovmsclient.tfs_compat.grpc.tensors import TENSOR_TO_NP_MAP, make_ndarray, make_tensor_proto
 import numpy as np
 

--- a/client/python/ovmsclient/lib/tests/tfs_compat_grpc/utils.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_grpc/utils.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-from tensorflow.core.protobuf.meta_graph_pb2 import SignatureDef, TensorInfo
-from tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
-from tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataResponse, SignatureDefMap
-from tensorflow_serving.apis.model_pb2 import ModelSpec
-from tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusResponse, ModelVersionStatus
-from tensorflow_serving.util.status_pb2 import StatusProto
+from ovmsclient.tfs_compat.protos.tensorflow.core.protobuf.meta_graph_pb2 import SignatureDef, TensorInfo # noqa
+from ovmsclient.tfs_compat.protos.tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_metadata_pb2 import GetModelMetadataResponse, SignatureDefMap # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.model_pb2 import ModelSpec
+from ovmsclient.tfs_compat.protos.tensorflow_serving.apis.get_model_status_pb2 import GetModelStatusResponse, ModelVersionStatus # noqa
+from ovmsclient.tfs_compat.protos.tensorflow_serving.util.status_pb2 import StatusProto
 
 from google.protobuf.any_pb2 import Any
 

--- a/client/python/ovmsclient/lib/tests/tfs_compat_http/config.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_http/config.py
@@ -20,7 +20,7 @@ from json.decoder import JSONDecodeError
 import requests
 from http import HTTPStatus
 from numpy import array, int32, float32, float128
-from tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
+from ovmsclient.tfs_compat.protos.tensorflow.core.protobuf.error_codes_pb2 import Code as ErrorCode
 
 from ovmsclient.tfs_compat.base.errors import InvalidInputError, ModelNotFoundError
 from config import CallCount, PATH_VALID # noqa

--- a/client/python/ovmsclient/lib/tests/tfs_compat_http/config.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_http/config.py
@@ -42,13 +42,13 @@ PREDICT_REQUEST_INVALID_INPUTS = [
         "input1": [[1.0, 2.0], [1.0, 2.0, 3.0]]
     }, 'model_name', 0, ValueError,
      ("setting an array element with a sequence. "
-      "The requested array has an inhomogeneous shape after 1 dimensions. " 
+      "The requested array has an inhomogeneous shape after 1 dimensions. "
       "The detected shape was (2,) + inhomogeneous part.")),
     ({
         "input1": [[(1, 2, 3)], [(1, 2)], [(1, 2, 3)]]
-    }, 'model_name', 0, ValueError, 
+    }, 'model_name', 0, ValueError,
      ("setting an array element with a sequence. "
-      "The requested array has an inhomogeneous shape after 2 dimensions. " 
+      "The requested array has an inhomogeneous shape after 2 dimensions. "
       "The detected shape was (3, 1) + inhomogeneous part.")),
     ({
         "input1": float128(2.5)
@@ -127,12 +127,13 @@ PARSE_INPUT_DATA_VALID = [
 PARSE_INPUT_DATA_INVALID = [
     ([[1.0, 2.0], [1.0, 2.0, 3.0]], ValueError,
      ("setting an array element with a sequence. "
-      "The requested array has an inhomogeneous shape after 1 dimensions. " 
+      "The requested array has an inhomogeneous shape after 1 dimensions. "
       "The detected shape was (2,) + inhomogeneous part.")),
 
     ([[(1, 2, 3)], [(1, 2)], [(1, 2, 3)]],
-     ValueError, ("setting an array element with a sequence. "
-      "The requested array has an inhomogeneous shape after 2 dimensions. " 
+     ValueError,
+     ("setting an array element with a sequence. "
+      "The requested array has an inhomogeneous shape after 2 dimensions. "
       "The detected shape was (3, 1) + inhomogeneous part.")),
 
     ([1, 2, 3, "str"],

--- a/client/python/ovmsclient/lib/tests/tfs_compat_http/config.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_http/config.py
@@ -41,11 +41,15 @@ PREDICT_REQUEST_INVALID_INPUTS = [
     ({
         "input1": [[1.0, 2.0], [1.0, 2.0, 3.0]]
     }, 'model_name', 0, ValueError,
-     ("argument must be a dense tensor: [[1.0, 2.0], [1.0, 2.0, 3.0]] - "
-      "got shape [2], but wanted [2, 2]")),
+     ("setting an array element with a sequence. "
+      "The requested array has an inhomogeneous shape after 1 dimensions. " 
+      "The detected shape was (2,) + inhomogeneous part.")),
     ({
         "input1": [[(1, 2, 3)], [(1, 2)], [(1, 2, 3)]]
-    }, 'model_name', 0, TypeError, "provided values type is not valid"),
+    }, 'model_name', 0, ValueError, 
+     ("setting an array element with a sequence. "
+      "The requested array has an inhomogeneous shape after 2 dimensions. " 
+      "The detected shape was (3, 1) + inhomogeneous part.")),
     ({
         "input1": float128(2.5)
     }, 'model_name', 0, TypeError, "provided values type is not valid"),
@@ -122,11 +126,14 @@ PARSE_INPUT_DATA_VALID = [
 # expected_exception, expected_message)
 PARSE_INPUT_DATA_INVALID = [
     ([[1.0, 2.0], [1.0, 2.0, 3.0]], ValueError,
-     ("argument must be a dense tensor: [[1.0, 2.0], [1.0, 2.0, 3.0]] - "
-      "got shape [2], but wanted [2, 2]")),
+     ("setting an array element with a sequence. "
+      "The requested array has an inhomogeneous shape after 1 dimensions. " 
+      "The detected shape was (2,) + inhomogeneous part.")),
 
     ([[(1, 2, 3)], [(1, 2)], [(1, 2, 3)]],
-     TypeError, "provided values type is not valid"),
+     ValueError, ("setting an array element with a sequence. "
+      "The requested array has an inhomogeneous shape after 2 dimensions. " 
+      "The detected shape was (3, 1) + inhomogeneous part.")),
 
     ([1, 2, 3, "str"],
      TypeError, "provided values type is not valid"),

--- a/client/python/ovmsclient/lib/tests/tfs_compat_http/test_http_requests.py
+++ b/client/python/ovmsclient/lib/tests/tfs_compat_http/test_http_requests.py
@@ -59,7 +59,7 @@ def test_make_predict_request_invalid_model_spec(mocker, name, version,
     mock_method.assert_called_once()
 
 
-@pytest.mark.causes_deprecation_warning
+@pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 @pytest.mark.parametrize("""inputs, name, version,
                             expected_exception, expected_message""", PREDICT_REQUEST_INVALID_INPUTS)
 def test_make_predict_request_invalid_inputs(mocker, inputs, name, version,
@@ -78,12 +78,12 @@ def test_parse_input_data_valid(input, expected_parsed_input):
     assert parsed_input == expected_parsed_input
 
 
-@pytest.mark.causes_deprecation_warning
+@pytest.mark.causes_deprecation_warning(triggered_by="numpy<1.24")
 @pytest.mark.parametrize("""input, expected_exception, expected_message""",
                          PARSE_INPUT_DATA_INVALID)
 def test_parse_input_data_invalid(input, expected_exception, expected_message):
     with pytest.raises(expected_exception) as e_info:
-        _parse_input_data(input)(input)
+        _parse_input_data(input)
     assert str(e_info.value) == expected_message
 
 


### PR DESCRIPTION
- update links in PyPi overview 
- update base image for RedHat Dockerfile to UBI 8.7
- remove upper bounds for dependencies
- make adjustments so it can work with >= 1.24 numpy version and unify behavior for pre and post 1.24 for inhomogeneous array creation attempt
- add Makefile argument for also testing with numpy==1.23
- changed location of TF protos to stay under ovmsclient namespace - that way it can reside in the same Python environment with tensorflow without overwriting one another