### PR TITLE
Override config metrics enable with cli

### DIFF
--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -90,6 +90,14 @@ void CLIParser::parse(int argc, char** argv) {
                 "Overrides model cache directory. By default cache files are saved into /opt/cache if the directory is present. When enabled, first model load will produce cache files.",
                 cxxopts::value<std::string>(),
                 "CACHE_DIR")
+            ("metrics_enable",
+                "Flag enabling metrics endpoint on rest_port.",
+                cxxopts::value<bool>()->default_value("false"),
+                "METRICS")
+            ("metrics_list",
+                "Comma separated list of metrics. If unset, only default metrics will be enabled. Default metrics: ovms_requests_success, ovms_requests_fail, ovms_request_time_us, ovms_streams, ovms_inference_time_us, ovms_wait_for_infer_req_time_us. When set, only the listed metrics will be enabled. Optional metrics: ovms_infer_req_queue_size, ovms_infer_req_active.",
+                cxxopts::value<std::string>()->default_value(""),
+                "METRICS_LIST")
             ("cpu_extension",
                 "A path to shared library containing custom CPU layer implementation. Default: empty.",
                 cxxopts::value<std::string>()->default_value(""),
@@ -141,14 +149,6 @@ void CLIParser::parse(int argc, char** argv) {
                 "Flag indicating model is stateful",
                 cxxopts::value<bool>()->default_value("false"),
                 "STATEFUL")
-            ("metrics_enable",
-                "Flag enabling metrics endpoint on rest_port.",
-                cxxopts::value<bool>()->default_value("false"),
-                "METRICS")
-            ("metrics_list",
-                "Comma separated list of metrics. If unset, only default metrics will be enabled. Default metrics: ovms_requests_success, ovms_requests_fail, ovms_request_time_us, ovms_streams, ovms_inference_time_us, ovms_wait_for_infer_req_time_us. When set, only the listed metrics will be enabled. Optional metrics: ovms_infer_req_queue_size, ovms_infer_req_active.",
-                cxxopts::value<std::string>()->default_value(""),
-                "METRICS_LIST")
             ("idle_sequence_cleanup",
                 "Flag indicating if model is subject to sequence cleaner scans",
                 cxxopts::value<bool>()->default_value("true"),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -125,11 +125,6 @@ bool Config::validate() {
         return false;
     }
 
-    // metrics on rest port
-    if ((metricsEnabled() || !metricsList().empty()) && !configPath().empty()) {
-        SPDLOG_WARN("When used cli param config.json cannot contain metrics configuration");
-    }
-
     // metrics_list without metrics_enable
     if (!metricsEnabled() && !metricsList().empty()) {
         std::cerr << "metrics_enable setting is missing, required when metrics_list is provided" << std::endl;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -127,7 +127,7 @@ bool Config::validate() {
 
     // metrics on rest port
     if ((metricsEnabled() || !metricsList().empty()) && !configPath().empty()) {
-        SPDLOG_WARN("metrics related parameters in CLI will overwrite metrics configuration from the config file.");
+        SPDLOG_WARN("When used cli param config.json cannot contain metrics configuration");
     }
 
     // metrics_list without metrics_enable

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -25,6 +25,7 @@
 #include "cli_parser.hpp"
 #include "modelconfig.hpp"
 #include "server_settings.hpp"
+#include <spdlog/spdlog.h>
 
 namespace ovms {
 
@@ -126,8 +127,7 @@ bool Config::validate() {
 
     // metrics on rest port
     if ((metricsEnabled() || !metricsList().empty()) && !configPath().empty()) {
-        std::cerr << "metrics_enable or metrics_list and config_path cant be used together. Use json config file to enable metrics when using config_path." << std::endl;
-        return false;
+        SPDLOG_WARN("metrics_enable will override config contents");
     }
 
     // metrics_list without metrics_enable

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -127,7 +127,7 @@ bool Config::validate() {
 
     // metrics on rest port
     if ((metricsEnabled() || !metricsList().empty()) && !configPath().empty()) {
-        SPDLOG_WARN("metrics_enable will override config contents");
+        SPDLOG_WARN("metrics related parameters in CLI will overwrite metrics configuration from the config file.");
     }
 
     // metrics_list without metrics_enable

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,12 +20,12 @@
 #include <regex>
 #include <thread>
 
+#include <spdlog/spdlog.h>
 #include <sysexits.h>
 
 #include "cli_parser.hpp"
 #include "modelconfig.hpp"
 #include "server_settings.hpp"
-#include <spdlog/spdlog.h>
 
 namespace ovms {
 

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -587,13 +587,13 @@ Status ModelManager::loadMetricsConfig(rapidjson::Document& configJson) {
     const auto itr2 = configJson.FindMember("monitoring");
     auto& config = ovms::Config::instance();
     if (itr2 == configJson.MemberEnd() || !itr2->value.IsObject()) {
-        if(config.metricsEnabled()){
+        if (config.metricsEnabled()) {
             return this->metricConfig.loadFromCLIString(true, config.metricsList());
         }
         SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Configuration file doesn't have monitoring property.");
         return StatusCode::OK;
     } else {
-        if(config.metricsEnabled()){
+        if (config.metricsEnabled()) {
             SPDLOG_LOGGER_ERROR(modelmanager_logger, "When used cli param config.json cannot contain metrics configuration");
             return StatusCode::CONFIG_FILE_INVALID;
         }

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -595,7 +595,7 @@ Status ModelManager::loadMetricsConfig(rapidjson::Document& configJson) {
     } else {
         if(config.metricsEnabled()){
             SPDLOG_LOGGER_ERROR(modelmanager_logger, "When used cli param config.json cannot contain metrics configuration");
-            return StatusCode::INTERNAL_ERROR;
+            return StatusCode::CONFIG_FILE_INVALID;
         }
         const auto& metrics = itr2->value.GetObject();
         SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Parsing monitoring metrics config settings.");

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -594,7 +594,7 @@ Status ModelManager::loadMetricsConfig(rapidjson::Document& configJson) {
         return StatusCode::OK;
     } else {
         if (config.metricsEnabled()) {
-            SPDLOG_LOGGER_ERROR(modelmanager_logger, "When used cli param config.json cannot contain metrics configuration");
+            SPDLOG_LOGGER_ERROR(modelmanager_logger, "Metrics configuration duplicated in configuration file and CLI parameters");
             return StatusCode::CONFIG_FILE_INVALID;
         }
         const auto& metrics = itr2->value.GetObject();

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -757,17 +757,17 @@ Status ModelManager::loadConfig(const std::string& jsonFilename, const bool over
 
     // Reading metric config only once per server start
     if (!this->metricConfigLoadedOnce) {
-        if(overrideMetricsEnable){
-            if(!configJson.HasMember("monitoring")){
+        if (overrideMetricsEnable) {
+            if (!configJson.HasMember("monitoring")) {
                 configJson.AddMember("monitoring", rapidjson::Value(rapidjson::kObjectType), configJson.GetAllocator());
             }
-            if(!configJson["monitoring"].HasMember("metrics")){
+            if (!configJson["monitoring"].HasMember("metrics")) {
                 configJson["monitoring"].AddMember("metrics", rapidjson::Value(rapidjson::kObjectType), configJson.GetAllocator());
             }
-            if(!configJson["monitoring"]["metrics"].HasMember("enable")){
+            if (!configJson["monitoring"]["metrics"].HasMember("enable")) {
                 configJson["monitoring"]["metrics"].AddMember("enable", true, configJson.GetAllocator());
 
-            }else{
+            } else {
                 configJson["monitoring"]["metrics"]["enable"].SetBool(true);
             }
         }

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -328,7 +328,7 @@ public:
      * @param filename
      * @return status
      */
-    Status startFromFile(const std::string& jsonFilename, const bool overrideMetricsEnable = false);
+    Status startFromFile(const std::string& jsonFilename);
 
     /**
      * @brief Starts model manager using command line arguments
@@ -436,7 +436,7 @@ public:
      * @param jsonFilename configuration file
      * @return Status 
      */
-    Status loadConfig(const std::string& jsonFilename, const bool overrideMetricsEnable = false);
+    Status loadConfig(const std::string& jsonFilename);
 
     /**
      * @brief Updates OVMS configuration with cached configuration file. Will check for newly added model versions

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -328,7 +328,7 @@ public:
      * @param filename
      * @return status
      */
-    Status startFromFile(const std::string& jsonFilename);
+    Status startFromFile(const std::string& jsonFilename, const bool overrideMetricsEnable = false);
 
     /**
      * @brief Starts model manager using command line arguments
@@ -436,7 +436,7 @@ public:
      * @param jsonFilename configuration file
      * @return Status 
      */
-    Status loadConfig(const std::string& jsonFilename);
+    Status loadConfig(const std::string& jsonFilename, const bool overrideMetricsEnable = false);
 
     /**
      * @brief Updates OVMS configuration with cached configuration file. Will check for newly added model versions

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -333,8 +333,8 @@ TEST_F(ModelManagerMetricsTestNoPort, ConfigDisabledMetrics) {
     SetUpConfig(modelMetricsMissingPortWithDisabledMetrics);
     std::filesystem::copy("/ovms/src/test/dummy", modelPath, std::filesystem::copy_options::recursive);
     createConfigFileWithContent(ovmsConfig, configFilePath);
-    char* n_argv[] = {(char*)"ovms", (char*)"--model_path", (char*)"/path/to/model", (char*)"--model_name", (char*)"some_name", (char*)"--metrics_enable", (char*)"--rest_port", (char*)"8000"};
-    int arg_count = 8;
+    char* n_argv[] = {(char*)"ovms", (char*)"--model_path", (char*)"/path/to/model", (char*)"--model_name", (char*)"some_name", (char*)"--metrics_enable", (char*)"--rest_port", (char*)"8000", (char*)"--metrics_list", (char*)"ovms_streams"};
+    int arg_count = 10;
     ovms::Config::instance().parse(arg_count, n_argv);
     ConstructorEnabledModelManager manager;
     auto status = manager.startFromFile(configFilePath);

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -270,6 +270,28 @@ static const char* modelMetricsMissingPort = R"(
         }
 })";
 
+static const char* modelMetricsMissingPortWithDisabledMetrics = R"(
+{
+    "model_config_list": [
+        {
+            "config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy",
+                "target_device": "CPU",
+                "model_version_policy": {"latest": {"num_versions":1}},
+                "nireq": 100,
+                "shape": {"b": "(1,10) "}
+            }
+        }
+    ],
+    "monitoring":
+        {
+            "metrics":
+            {
+                "enable" : false
+            }
+        }
+})";
 TEST_F(ModelManagerMetricsTestNoPort, RestPortMissingWithMetrics) {
     SetUpConfig(modelMetricsMissingPort);
     std::filesystem::copy("/ovms/src/test/dummy", modelPath, std::filesystem::copy_options::recursive);
@@ -277,6 +299,16 @@ TEST_F(ModelManagerMetricsTestNoPort, RestPortMissingWithMetrics) {
 
     ConstructorEnabledModelManager manager;
     auto status = manager.startFromFile(configFilePath);
+    EXPECT_EQ(status, ovms::StatusCode::METRICS_REST_PORT_MISSING);
+}
+
+TEST_F(ModelManagerMetricsTestNoPort, RestPortMissingWithConfigDisabledMetrics) {
+    SetUpConfig(modelMetricsMissingPortWithDisabledMetrics);
+    std::filesystem::copy("/ovms/src/test/dummy", modelPath, std::filesystem::copy_options::recursive);
+    createConfigFileWithContent(ovmsConfig, configFilePath);
+
+    ConstructorEnabledModelManager manager;
+    auto status = manager.startFromFile(configFilePath, true);
     EXPECT_EQ(status, ovms::StatusCode::METRICS_REST_PORT_MISSING);
 }
 

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -308,7 +308,7 @@ TEST_F(ModelManagerMetricsTestNoPort, RestPortMissingWithConfigDisabledMetrics) 
     createConfigFileWithContent(ovmsConfig, configFilePath);
 
     ConstructorEnabledModelManager manager;
-    auto status = manager.startFromFile(configFilePath, true);
+    auto status = manager.startFromFile(configFilePath);
     EXPECT_EQ(status, ovms::StatusCode::METRICS_REST_PORT_MISSING);
 }
 

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -129,6 +129,13 @@ TEST_F(OvmsConfigDeathTest, negativeConfigPathWithTargetDevice) {
     EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
 }
 
+TEST_F(OvmsConfigDeathTest, metricListInCli) {
+    char* n_argv[] = {"ovms", "--config_path", "/path/to/config", "--metrics_enable", "--rest_port", "8080"};
+    int arg_count = 6;
+    ovms::Config::instance().parse(arg_count, n_argv);
+    EXPECT_TRUE(ovms::Config::instance().validate());
+}
+
 TEST_F(OvmsConfigDeathTest, negativeConfigPathWithPluginConfig) {
     char* n_argv[] = {"ovms", "--config_path", "/path1", "--plugin_config", "setting"};
     int arg_count = 5;

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -129,7 +129,7 @@ TEST_F(OvmsConfigDeathTest, negativeConfigPathWithTargetDevice) {
     EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "Model parameters in CLI are exclusive with the config file");
 }
 
-TEST_F(OvmsConfigDeathTest, metricListInCli) {
+TEST_F(OvmsConfigDeathTest, OVMSDuplicatedMetricsConfig) {
     char* n_argv[] = {"ovms", "--config_path", "/path/to/config", "--metrics_enable", "--rest_port", "8080"};
     int arg_count = 6;
     ovms::Config::instance().parse(arg_count, n_argv);

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -159,24 +159,6 @@ TEST_F(OvmsConfigDeathTest, metricEnablingInCli) {
     EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "rest_port setting is missing, metrics are enabled on rest port");
 }
 
-TEST_F(OvmsConfigDeathTest, metricListInCli) {
-    char* n_argv[] = {"ovms", "--config_path", "/path/to/config", "--metrics_list", "metric1,metric2"};
-    int arg_count = 5;
-    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "metrics_enable or metrics_list and config_path cant be used together. Use json config file to enable metrics when using config_path.");
-}
-
-TEST_F(OvmsConfigDeathTest, metricEnablingInCliWithPort) {
-    char* n_argv[] = {"ovms", "--config_path", "/path/to/config", "--metrics_enable", "--rest_port", "8080"};
-    int arg_count = 6;
-    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "metrics_enable or metrics_list and config_path cant be used together. Use json config file to enable metrics when using config_path.");
-}
-
-TEST_F(OvmsConfigDeathTest, metricListAndEnableInCli) {
-    char* n_argv[] = {"ovms", "--config_path", "/path/to/config", "--metrics_list", "metric1,metric2", "--metrics_enable", "--rest_port", "8080"};
-    int arg_count = 8;
-    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv), ::testing::ExitedWithCode(EX_USAGE), "metrics_enable or metrics_list and config_path cant be used together. Use json config file to enable metrics when using config_path.");
-}
-
 TEST_F(OvmsConfigDeathTest, negativeMissingName) {
     char* n_argv[] = {"ovms", "--model_path", "/path/to/model"};
     int arg_count = 3;


### PR DESCRIPTION
Allows using metrics_enable param in CLI even with config. CLI will overwrite config setting if defined. Added warning in the logs.
JIRA:CVS-99880