### PR TITLE
CVS-102160 Fix incorrect mapping_config.json behavior during reload

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -251,13 +251,8 @@ Status Model::reloadVersions(std::shared_ptr<model_versions_t> versionsToReload,
     for (const auto version : *versionsToReload) {
         SPDLOG_INFO("Will reload model: {}; version: {} ...", getName(), version);
         config.setVersion(version);
-        auto status = config.parseModelMapping();
-        if ((!status.ok()) && (status != StatusCode::FILE_INVALID)) {
-            SPDLOG_ERROR("Error while parsing model mapping for model {}; error: {}", getName(), status.string());
-        }
 
         auto modelVersion = getModelInstanceByVersion(version);
-
         if (!modelVersion) {
             SPDLOG_ERROR("Error occurred while reloading model: {}; version: {}; Model version was not found",
                 getName(),
@@ -271,6 +266,10 @@ Status Model::reloadVersions(std::shared_ptr<model_versions_t> versionsToReload,
             downloadModels(fs, config, versionsToReload);
         } else {
             config.setLocalPath(modelVersion->getModelConfig().getLocalPath());
+        }
+        auto status = config.parseModelMapping();
+        if ((!status.ok()) && (status != StatusCode::FILE_INVALID)) {
+            SPDLOG_ERROR("Error while parsing model mapping for model {}; error: {}", getName(), status.string());
         }
         status = modelVersion->reloadModel(config);
         if (!status.ok()) {


### PR DESCRIPTION
There was issue when model is reloaded or added back to config.json. mapping_config.json file was not applied for first version in set of version to load due to wrong path to mapping_config.json.