### PR TITLE
CVS-103854 Fix KFS REST & tfs/kfs gRPC

### DIFF
--- a/check_coverage.bat
+++ b/check_coverage.bat
@@ -5,8 +5,8 @@
 #MIN_FUNCTION_COV=88.3
 
 #Rhel
-MIN_LINES_COV=74.9
-MIN_FUNCTION_COV=75.7
+MIN_LINES_COV=74.8
+MIN_FUNCTION_COV=75.8
 
 LINES_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | head -n 1`
 FUNC_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | tail -n 1`

--- a/check_coverage.bat
+++ b/check_coverage.bat
@@ -5,8 +5,8 @@
 #MIN_FUNCTION_COV=88.3
 
 #Rhel
-MIN_LINES_COV=74.9
-MIN_FUNCTION_COV=75.7
+MIN_LINES_COV=74.8  # TODO: decrease after adding unit tests
+MIN_FUNCTION_COV=75.8
 
 LINES_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | head -n 1`
 FUNC_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | tail -n 1`

--- a/check_coverage.bat
+++ b/check_coverage.bat
@@ -5,8 +5,8 @@
 #MIN_FUNCTION_COV=88.3
 
 #Rhel
-MIN_LINES_COV=74.8  # TODO: decrease after adding unit tests
-MIN_FUNCTION_COV=75.8
+MIN_LINES_COV=74.9
+MIN_FUNCTION_COV=75.7
 
 LINES_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | head -n 1`
 FUNC_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | tail -n 1`

--- a/cppclean.sh
+++ b/cppclean.sh
@@ -42,7 +42,7 @@ if [ ${NO_WARNINGS_NOTUSED} -gt 3 ]; then
     echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_NOTUSED}";
     exit 1;
 fi
-if [ ${NO_WARNINGS} -gt  194 ]; then
+if [ ${NO_WARNINGS} -gt  196 ]; then
     echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
     exit 1
 fi

--- a/src/capi_frontend/capi_utils.cpp
+++ b/src/capi_frontend/capi_utils.cpp
@@ -25,11 +25,12 @@
 #include "../logging.hpp"
 #include "../shape.hpp"
 #include "../status.hpp"
+#include "../tensorinfo.hpp"
 
 namespace ovms {
 
-std::string tensorShapeToString(const Shape& shape) {
-    return shape.toString();
+std::string tensorShapeToString(const shape_t& shape) {
+    return TensorInfo::shapeToString(shape);
 }
 
 OVMS_DataType getPrecisionAsOVMSDataType(Precision precision) {

--- a/src/capi_frontend/capi_utils.hpp
+++ b/src/capi_frontend/capi_utils.hpp
@@ -18,14 +18,14 @@
 
 #include "../ovms.h"  // NOLINT
 #include "../precision.hpp"
+#include "../shape.hpp"
 
 namespace ovms {
 class InferenceRequest;
 class InferenceResponse;
-class Shape;
 class Status;
-std::string tensorShapeToString(const Shape& tensorShape);
 
+std::string tensorShapeToString(const shape_t& tensorShape);
 OVMS_DataType getPrecisionAsOVMSDataType(Precision precision);
 Precision getOVMSDataTypeAsPrecision(OVMS_DataType datatype);
 Status isNativeFileFormatUsed(const InferenceRequest& request, const std::string& name, bool& nativeFileFormatUsed);

--- a/src/inferencerequest.cpp
+++ b/src/inferencerequest.cpp
@@ -89,6 +89,8 @@ const InferenceParameter* InferenceRequest::getParameter(const char* name) const
         return &it->second;
     return nullptr;
 }
+
+// Assuming the request is already validated, therefore no need to check for negative values or zeros
 Status InferenceRequest::getBatchSize(size_t& batchSize, size_t batchSizeIndex) const {
     if (inputs.size() == 0) {
         return StatusCode::INTERNAL_ERROR;
@@ -100,9 +102,6 @@ Status InferenceRequest::getBatchSize(size_t& batchSize, size_t batchSizeIndex) 
         return StatusCode::INTERNAL_ERROR;
     }
     batchSize = shape[batchSizeIndex];
-    if (batchSize <= 0) {
-        return StatusCode::INVALID_BATCH_SIZE;
-    }
     return StatusCode::OK;
 }
 std::map<std::string, shape_t> InferenceRequest::getRequestShapes() const {

--- a/src/inferencerequest.cpp
+++ b/src/inferencerequest.cpp
@@ -100,6 +100,9 @@ Status InferenceRequest::getBatchSize(size_t& batchSize, size_t batchSizeIndex) 
         return StatusCode::INTERNAL_ERROR;
     }
     batchSize = shape[batchSizeIndex];
+    if (batchSize <= 0) {
+        return StatusCode::INVALID_BATCH_SIZE;
+    }
     return StatusCode::OK;
 }
 std::map<std::string, shape_t> InferenceRequest::getRequestShapes() const {

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -1154,9 +1154,11 @@ Status ModelInstance::infer(const RequestType* requestProto,
     if (!status.ok())
         return status;
     status = validate(requestProto);
-    auto requestBatchSize = getRequestBatchSize(requestProto, this->getBatchSizeIndex());
-    auto requestShapes = getRequestShapes(requestProto);
-    status = reloadModelIfRequired(status, requestBatchSize, requestShapes, modelUnloadGuardPtr);
+    if (status.batchSizeChangeRequired() || status.reshapeRequired()) {
+        auto requestBatchSize = getRequestBatchSize(requestProto, this->getBatchSizeIndex());
+        auto requestShapes = getRequestShapes(requestProto);
+        status = reloadModelIfRequired(status, requestBatchSize, requestShapes, modelUnloadGuardPtr);
+    }
     if (!status.ok())
         return status;
     status = requestProcessor->prepare();

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -1155,6 +1155,8 @@ Status ModelInstance::infer(const RequestType* requestProto,
         return status;
     status = validate(requestProto);
     if (status.batchSizeChangeRequired() || status.reshapeRequired()) {
+        // We are ensured that request shape is valid and convertible to model shape (non negative, non zero)
+        // We can use it to perform reshape via shape=auto
         auto requestBatchSize = getRequestBatchSize(requestProto, this->getBatchSizeIndex());
         auto requestShapes = getRequestShapes(requestProto);
         status = reloadModelIfRequired(status, requestBatchSize, requestShapes, modelUnloadGuardPtr);

--- a/src/predict_request_validation_utils.cpp
+++ b/src/predict_request_validation_utils.cpp
@@ -32,6 +32,7 @@
 #include "modelconfig.hpp"
 #include "profiler.hpp"
 #include "status.hpp"
+#include "tensorinfo.hpp"
 #include "tfs_frontend/tfs_utils.hpp"
 
 namespace ovms {
@@ -61,6 +62,7 @@ dimension_value_t RequestShapeInfo<TFSInputTensorType, TFSShapeType>::getDim(siz
 }
 template <>
 dimension_value_t RequestShapeInfo<InferenceTensor, shape_t>::getDim(size_t i) {
+    // TODO: Handle max int64 situation?
     return tensor.getShape()[i];
 }
 template <>

--- a/src/predict_request_validation_utils.cpp
+++ b/src/predict_request_validation_utils.cpp
@@ -32,7 +32,6 @@
 #include "modelconfig.hpp"
 #include "profiler.hpp"
 #include "status.hpp"
-#include "tensorinfo.hpp"
 #include "tfs_frontend/tfs_utils.hpp"
 
 namespace ovms {
@@ -60,9 +59,10 @@ template <>
 dimension_value_t RequestShapeInfo<TFSInputTensorType, TFSShapeType>::getDim(size_t i) {
     return tensor.tensor_shape().dim(i).size();
 }
+
+// int64_t
 template <>
 dimension_value_t RequestShapeInfo<InferenceTensor, shape_t>::getDim(size_t i) {
-    // TODO: Handle max int64 situation?
     return tensor.getShape()[i];
 }
 template <>

--- a/src/predict_request_validation_utils.cpp
+++ b/src/predict_request_validation_utils.cpp
@@ -60,7 +60,6 @@ dimension_value_t RequestShapeInfo<TFSInputTensorType, TFSShapeType>::getDim(siz
     return tensor.tensor_shape().dim(i).size();
 }
 
-// int64_t
 template <>
 dimension_value_t RequestShapeInfo<InferenceTensor, shape_t>::getDim(size_t i) {
     return tensor.getShape()[i];

--- a/src/prediction_service_utils.cpp
+++ b/src/prediction_service_utils.cpp
@@ -48,7 +48,12 @@ std::optional<Dimension> getRequestBatchSize(const ::KFSRequest* request, const 
         SPDLOG_DEBUG("Failed to get batch size of a request. Batch size index out of shape range. Validation of request failed");
         return std::nullopt;
     }
-    return Dimension(requestInput->shape()[batchSizeIndex]);
+    auto value = requestInput->shape()[batchSizeIndex];
+    if (value <= 0) {
+        SPDLOG_DEBUG("Failed to get batch size of a request. Batch size cannot be a negative number or 0. Validation of request failed");
+        return std::nullopt;
+    }
+    return Dimension(value);
 }
 
 std::map<std::string, shape_t> getRequestShapes(const ::KFSRequest* request) {
@@ -82,7 +87,12 @@ std::optional<Dimension> getRequestBatchSize(const tensorflow::serving::PredictR
         SPDLOG_DEBUG("Failed to get batch size of a request. Batch size index out of shape range. Validation of request failed");
         return std::nullopt;
     }
-    return Dimension(requestInput.tensor_shape().dim(batchSizeIndex).size());
+    auto value = requestInput.tensor_shape().dim(batchSizeIndex).size();
+    if (value <= 0) {
+        SPDLOG_DEBUG("Failed to get batch size of a request. Batch size cannot be a negative number or 0. Validation of request failed");
+        return std::nullopt;
+    }
+    return Dimension(value);
 }
 
 std::map<std::string, shape_t> getRequestShapes(const tensorflow::serving::PredictRequest* request) {

--- a/src/prediction_service_utils.cpp
+++ b/src/prediction_service_utils.cpp
@@ -33,6 +33,7 @@ using tensorflow::serving::PredictResponse;
 
 namespace ovms {
 
+// Assuming the request is already validated, therefore no need to check for negative values or zeros
 std::optional<Dimension> getRequestBatchSize(const ::KFSRequest* request, const size_t batchSizeIndex) {
     auto requestInputItr = request->inputs().begin();
     if (requestInputItr == request->inputs().end()) {
@@ -48,14 +49,10 @@ std::optional<Dimension> getRequestBatchSize(const ::KFSRequest* request, const 
         SPDLOG_DEBUG("Failed to get batch size of a request. Batch size index out of shape range. Validation of request failed");
         return std::nullopt;
     }
-    auto value = requestInput->shape()[batchSizeIndex];
-    if (value <= 0) {
-        SPDLOG_DEBUG("Failed to get batch size of a request. Batch size cannot be a negative number or 0. Validation of request failed");
-        return std::nullopt;
-    }
-    return Dimension(value);
+    return Dimension(requestInput->shape()[batchSizeIndex]);
 }
 
+// Assuming the request is already validated, therefore no need to check for negative values or zeros
 std::map<std::string, shape_t> getRequestShapes(const ::KFSRequest* request) {
     std::map<std::string, shape_t> requestShapes;
     for (auto& it : request->inputs()) {
@@ -70,6 +67,7 @@ std::map<std::string, shape_t> getRequestShapes(const ::KFSRequest* request) {
     return requestShapes;
 }
 
+// Assuming the request is already validated, therefore no need to check for negative values or zeros
 std::optional<Dimension> getRequestBatchSize(const tensorflow::serving::PredictRequest* request, const size_t batchSizeIndex) {
     auto requestInputItr = request->inputs().begin();
     if (requestInputItr == request->inputs().end()) {
@@ -87,14 +85,10 @@ std::optional<Dimension> getRequestBatchSize(const tensorflow::serving::PredictR
         SPDLOG_DEBUG("Failed to get batch size of a request. Batch size index out of shape range. Validation of request failed");
         return std::nullopt;
     }
-    auto value = requestInput.tensor_shape().dim(batchSizeIndex).size();
-    if (value <= 0) {
-        SPDLOG_DEBUG("Failed to get batch size of a request. Batch size cannot be a negative number or 0. Validation of request failed");
-        return std::nullopt;
-    }
-    return Dimension(value);
+    return Dimension(requestInput.tensor_shape().dim(batchSizeIndex).size());
 }
 
+// Assuming the request is already validated, therefore no need to check for negative values or zeros
 std::map<std::string, shape_t> getRequestShapes(const tensorflow::serving::PredictRequest* request) {
     std::map<std::string, shape_t> requestShapes;
     for (auto& it : request->inputs()) {

--- a/src/rest_parser.cpp
+++ b/src/rest_parser.cpp
@@ -618,6 +618,10 @@ Status KFSRestParser::parseInput(rapidjson::Value& node, bool onlyOneInput) {
         if (!dim.IsInt()) {
             return StatusCode::REST_COULD_NOT_PARSE_INPUT;
         }
+        if (dim.GetInt() <= 0) {
+            SPDLOG_DEBUG("Shape dimension is invalid: {}", dim.GetInt());
+            return StatusCode::REST_COULD_NOT_PARSE_INPUT;
+        }
         input->mutable_shape()->Add(dim.GetInt());
     }
 

--- a/src/test/c_api_tests.cpp
+++ b/src/test/c_api_tests.cpp
@@ -349,7 +349,7 @@ TEST_F(CapiInference, Basic) {
     ASSERT_NE(nullptr, request);
 
     // adding input
-    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()));
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()));
     // setting buffer
     std::array<float, DUMMY_MODEL_INPUT_SIZE> data{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     uint32_t notUsedNum = 0;
@@ -430,9 +430,9 @@ TEST_F(CapiInference, Basic) {
     // one will be removed together with request but without buffer attached
     // one will be removed with buffer directly
     // one will be removed without buffer directly
-    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, "INPUT_WITHOUT_BUFFER_REMOVED_WITH_REQUEST", OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()));
-    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, "INPUT_WITH_BUFFER_REMOVED_DIRECTLY", OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()));
-    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, "INPUT_WITHOUT_BUFFER_REMOVED_DIRECTLY", OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()));
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, "INPUT_WITHOUT_BUFFER_REMOVED_WITH_REQUEST", OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()));
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, "INPUT_WITH_BUFFER_REMOVED_DIRECTLY", OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()));
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, "INPUT_WITHOUT_BUFFER_REMOVED_DIRECTLY", OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()));
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestInputSetData(request, "INPUT_WITH_BUFFER_REMOVED_DIRECTLY", reinterpret_cast<void*>(data.data()), sizeof(float) * data.size(), OVMS_BUFFERTYPE_CPU, notUsedNum));
     // we will add buffer and remove it to check separate buffer removal
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestInputSetData(request, "INPUT_WITHOUT_BUFFER_REMOVED_DIRECTLY", reinterpret_cast<void*>(data.data()), sizeof(float) * data.size(), OVMS_BUFFERTYPE_CPU, notUsedNum));
@@ -490,12 +490,12 @@ TEST_F(CapiInference, NegativeInference) {
     ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_Inference(cserver, request, &response), StatusCode::INVALID_NO_OF_INPUTS);
 
     // negative no input buffer
-    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(nullptr, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()), StatusCode::NONEXISTENT_REQUEST);
-    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(request, nullptr, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()), StatusCode::NONEXISTENT_STRING);
+    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(nullptr, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()), StatusCode::NONEXISTENT_REQUEST);
+    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(request, nullptr, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()), StatusCode::NONEXISTENT_STRING);
     ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, nullptr, DUMMY_MODEL_SHAPE.size()), StatusCode::NONEXISTENT_TABLE);
-    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()));
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()));
     // fail with adding input second time
-    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()), StatusCode::DOUBLE_TENSOR_INSERT);
+    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()), StatusCode::DOUBLE_TENSOR_INSERT);
     ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_Inference(cserver, request, &response), StatusCode::INVALID_CONTENT_SIZE);
 
     // setting buffer
@@ -529,7 +529,7 @@ TEST_F(CapiInference, NegativeInference) {
     // negative no model
     ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_Inference(cserver, request, &response), StatusCode::PIPELINE_DEFINITION_NAME_MISSING);
 
-    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(nullptr, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()), StatusCode::NONEXISTENT_REQUEST);
+    ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestAddInput(nullptr, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()), StatusCode::NONEXISTENT_REQUEST);
     ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_Inference(cserver, requestNoModel, &reponseNoModel), StatusCode::NONEXISTENT_REQUEST);
     OVMS_InferenceRequestDelete(requestNoModel);
 
@@ -642,7 +642,7 @@ TEST_F(CapiInference, CallInferenceServerNotStarted) {
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestNew(&request, cserver, "dummy", 1));
     ASSERT_NE(nullptr, cserver);
     ASSERT_NE(nullptr, request);
-    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()));
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()));
     std::array<float, DUMMY_MODEL_INPUT_SIZE> data{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     uint32_t notUsedNum = 0;
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestInputSetData(request, DUMMY_MODEL_INPUT_NAME, reinterpret_cast<void*>(data.data()), sizeof(float) * data.size(), OVMS_BUFFERTYPE_CPU, notUsedNum));
@@ -720,7 +720,7 @@ TEST_F(CapiDagInference, BasicDummyDag) {
     ASSERT_NE(nullptr, request);
 
     // adding input
-    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size()));
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestAddInput(request, DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, reinterpret_cast<const size_t*>(DUMMY_MODEL_SHAPE.data()), DUMMY_MODEL_SHAPE.size()));
     // setting buffer
     std::array<float, DUMMY_MODEL_INPUT_SIZE> data{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestInputSetData(request, DUMMY_MODEL_INPUT_NAME, reinterpret_cast<void*>(data.data()), sizeof(float) * data.size(), OVMS_BUFFERTYPE_CPU, notUsedNum));

--- a/src/test/capi_predict_validation_test.cpp
+++ b/src/test/capi_predict_validation_test.cpp
@@ -398,7 +398,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSize) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize);
+        requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -425,7 +425,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeZero) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
-        requestData, decrementBufferSize);
+        requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -440,7 +440,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectBufferType) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize, static_cast<OVMS_BufferType>(999));
+        requestData, std::nullopt, decrementBufferSize, static_cast<OVMS_BufferType>(999));
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
 }
@@ -455,7 +455,7 @@ TEST_F(CAPIPredictValidation, RequestNegativeBufferType) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize, static_cast<OVMS_BufferType>(-22));
+        requestData, std::nullopt, decrementBufferSize, static_cast<OVMS_BufferType>(-22));
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
 }
@@ -470,7 +470,7 @@ TEST_F(CAPIPredictValidation, RequestIncorectDeviceId) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
+        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_DEVICE_ID) << status.string();
 }
@@ -485,7 +485,7 @@ TEST_F(CAPIPredictValidation, RequestIncorectBufferType) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize, OVMS_BUFFERTYPE_GPU);
+        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_GPU);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
 }
@@ -501,7 +501,7 @@ TEST_F(CAPIPredictValidation, RequestCorectDeviceId) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize, OVMS_BUFFERTYPE_GPU, 1);
+        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_GPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
 }
@@ -516,7 +516,7 @@ TEST_F(CAPIPredictValidation, RequestNotNullDeviceId) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
+        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_DEVICE_ID) << status.string();
 }
@@ -533,7 +533,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeBatchAuto) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize);
+        requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -550,7 +550,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeShapeAuto) {
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, decrementBufferSize);
+        requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -585,7 +585,7 @@ TEST_P(CAPIPredictValidationInputTensorContent, RequestCorrectContentSizeInputTe
     preparePredictRequest(request,
         {{inputName,
             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, testedPrecision}}},
-        requestData,  // data,
+        requestData, std::nullopt,  // data,
         false);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
@@ -787,7 +787,7 @@ TEST_F(CAPIPredictValidationDynamicModel, RequestDimensionInRangeWrongTensorCont
             {"Input_U8_100:200_any_CN",
                 std::tuple<ovms::shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
         },
-        requestData, decrementBufferSize);
+        requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }

--- a/src/test/capi_predict_validation_test.cpp
+++ b/src/test/capi_predict_validation_test.cpp
@@ -67,13 +67,13 @@ protected:
 
         preparePredictRequest(request,
             {{"Input_FP32_1_224_224_3_NHWC",
-                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+                 std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
                 {"Input_U8_1_3_62_62_NCHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
                 {"Input_I64_1_6_128_128_16_NCDHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
                 {"Input_U16_1_2_8_4_NCHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
             requestData);
     }
 };
@@ -86,13 +86,13 @@ TEST_F(CAPIPredictValidation, ValidRequest) {
 TEST_F(CAPIPredictValidation, InvalidPrecision) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, static_cast<ovms::Precision>(99)}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, static_cast<ovms::Precision>(99)}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_PRECISION) << status.string();
@@ -107,7 +107,7 @@ TEST_F(CAPIPredictValidation, RequestNotEnoughInputs) {
 TEST_F(CAPIPredictValidation, RequestTooManyInputs) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_NO_OF_INPUTS) << status.string();
@@ -116,13 +116,13 @@ TEST_F(CAPIPredictValidation, RequestTooManyInputs) {
 TEST_F(CAPIPredictValidation, RequestMissingInputName) {
     preparePredictRequest(request,
         {{"BadInput_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
 
     auto status = instance->mockValidate(&request);
@@ -133,7 +133,7 @@ TEST_F(CAPIPredictValidation, RequestWrongInputName) {
     request.removeInput("Input_U16_1_2_8_4_NCHW");
     preparePredictRequest(request,
         {{"BADInput_FP32_1_224_224_3_NHWC",
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_NO_OF_INPUTS) << status.string();
@@ -142,13 +142,13 @@ TEST_F(CAPIPredictValidation, RequestWrongInputName) {
 TEST_F(CAPIPredictValidation, RequestTooManyShapeDimensions) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 8, 4}, ovms::Precision::U16}}},
         requestData);
 
     auto status = instance->mockValidate(&request);
@@ -158,13 +158,13 @@ TEST_F(CAPIPredictValidation, RequestTooManyShapeDimensions) {
 TEST_F(CAPIPredictValidation, RequestNotEnoughShapeDimensions) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62, 5}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62, 5}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16, 6}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16, 6}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4, 5}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4, 5}, ovms::Precision::U16}}},
         requestData);
 
     auto status = instance->mockValidate(&request);
@@ -174,13 +174,13 @@ TEST_F(CAPIPredictValidation, RequestNotEnoughShapeDimensions) {
 TEST_F(CAPIPredictValidation, RequestWrongBatchSize) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{2, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{2, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);  // dim(0) is batch size
 
     auto status = instance->mockValidate(&request);
@@ -191,13 +191,13 @@ TEST_F(CAPIPredictValidation, RequestWrongBatchSizeAuto) {
     modelConfig.setBatchingParams("auto");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{2, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{2, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::BATCHSIZE_CHANGE_REQUIRED) << status.string();
@@ -254,13 +254,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValues) {
     modelConfig.setBatchingParams("auto");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 17}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 17}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
 
     auto status = instance->mockValidate(&request);
@@ -271,13 +271,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValuesTwoInputsOneWrong) {  // on
     modelConfig.parseShapeParameter("{\"Input_U8_1_3_62_62_NCHW\": \"auto\"}");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 17}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 17}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
 
     auto status = instance->mockValidate(&request);
@@ -288,13 +288,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValuesAuto) {
     modelConfig.parseShapeParameter("{\"Input_U8_1_3_62_62_NCHW\": \"auto\"}");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 61, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 61, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED) << status.string();
@@ -304,13 +304,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValuesAutoTwoInputs) {
     modelConfig.parseShapeParameter("{\"Input_U8_1_3_62_62_NCHW\": \"auto\", \"Input_U16_1_2_8_4_NCHW\": \"auto\"}");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 61, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 61, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 2, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 2, 4}, ovms::Precision::U16}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED);
@@ -320,13 +320,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValuesAutoNoNamedInput) {
     modelConfig.parseShapeParameter("auto");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 214, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 214, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 61, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 61, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 1, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 1, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 2, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 2, 4}, ovms::Precision::U16}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::RESHAPE_REQUIRED);
@@ -336,13 +336,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValuesAutoFirstDim) {
     modelConfig.parseShapeParameter("{\"Input_U8_1_3_62_62_NCHW\": \"auto\"}");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
 
     auto status = instance->mockValidate(&request);
@@ -359,13 +359,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValuesFixed) {
     modelConfig.parseShapeParameter("{\"Input_U8_1_3_62_62_NCHW\": \"(1,3,62,62)\"}");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 4, 63, 63}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 4, 63, 63}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_SHAPE) << status.string();
@@ -375,13 +375,13 @@ TEST_F(CAPIPredictValidation, RequestWrongShapeValuesFixedFirstDim) {
     modelConfig.parseShapeParameter("{\"Input_U8_1_3_62_62_NCHW\": \"(1,3,62,62)\"}");
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{2, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BATCH_SIZE) << status.string();
@@ -391,13 +391,13 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSize) {
     decrementBufferSize = 1;
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
@@ -424,7 +424,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeZero) {
 
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
         requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
@@ -433,13 +433,13 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeZero) {
 TEST_F(CAPIPredictValidation, RequestIncorrectBufferType) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize, static_cast<OVMS_BufferType>(999));
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
@@ -448,13 +448,13 @@ TEST_F(CAPIPredictValidation, RequestIncorrectBufferType) {
 TEST_F(CAPIPredictValidation, RequestNegativeBufferType) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize, static_cast<OVMS_BufferType>(-22));
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
@@ -463,13 +463,13 @@ TEST_F(CAPIPredictValidation, RequestNegativeBufferType) {
 TEST_F(CAPIPredictValidation, RequestIncorectDeviceId) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_DEVICE_ID) << status.string();
@@ -478,13 +478,13 @@ TEST_F(CAPIPredictValidation, RequestIncorectDeviceId) {
 TEST_F(CAPIPredictValidation, RequestIncorectBufferType) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_GPU);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
@@ -494,13 +494,13 @@ TEST_F(CAPIPredictValidation, RequestCorectDeviceId) {
     GTEST_SKIP() << "Enable when Other buffer types are supported";
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_GPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
@@ -509,13 +509,13 @@ TEST_F(CAPIPredictValidation, RequestCorectDeviceId) {
 TEST_F(CAPIPredictValidation, RequestNotNullDeviceId) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_DEVICE_ID) << status.string();
@@ -526,13 +526,13 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeBatchAuto) {
     decrementBufferSize = 1;
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
@@ -543,13 +543,13 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeShapeAuto) {
     decrementBufferSize = 1;
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
@@ -584,7 +584,7 @@ TEST_P(CAPIPredictValidationInputTensorContent, RequestCorrectContentSizeInputTe
     ON_CALL(*instance, getModelConfig()).WillByDefault(ReturnRef(modelConfig));
     preparePredictRequest(request,
         {{inputName,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, testedPrecision}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, testedPrecision}}},
         requestData, std::nullopt,  // data,
         false);
     auto status = instance->mockValidate(&request);
@@ -594,13 +594,13 @@ TEST_P(CAPIPredictValidationInputTensorContent, RequestCorrectContentSizeInputTe
 TEST_F(CAPIPredictValidation, RequestWrongPrecision) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
-             std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_1_3_62_62_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::Q78}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::Q78}},
             {"Input_I64_1_6_128_128_16_NCDHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
         requestData);
 
     auto status = instance->mockValidate(&request);
@@ -622,9 +622,9 @@ protected:
         preparePredictRequest(request,
             {
                 {"Input_FP32_224_224_3_1_HWCN",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
                 {"Input_U8_3_1_128_CNH",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
             },
             requestData);
     }
@@ -640,9 +640,9 @@ TEST_F(CAPIPredictValidationArbitraryBatchPosition, RequestWrongBatchSize) {
     preparePredictRequest(request,
         {
             {"Input_FP32_224_224_3_1_HWCN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{224, 224, 3, 10}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{224, 224, 3, 10}, ovms::Precision::FP32}},
             {"Input_U8_3_1_128_CNH",
-                std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
         },
         requestData);
     auto status = instance->mockValidate(&request);
@@ -655,9 +655,9 @@ TEST_F(CAPIPredictValidationArbitraryBatchPosition, RequestWrongBatchSizeAuto) {
     preparePredictRequest(request,
         {
             {"Input_FP32_224_224_3_1_HWCN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{224, 224, 3, 10}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{224, 224, 3, 10}, ovms::Precision::FP32}},
             {"Input_U8_3_1_128_CNH",
-                std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
         },
         requestData);
 
@@ -670,9 +670,9 @@ TEST_F(CAPIPredictValidationArbitraryBatchPosition, RequestWrongShapeValues) {
     preparePredictRequest(request,
         {
             {"Input_FP32_224_224_3_1_HWCN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{221, 224, 3, 1}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{221, 224, 3, 1}, ovms::Precision::FP32}},
             {"Input_U8_3_1_128_CNH",
-                std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
         },
         requestData);
     auto status = instance->mockValidate(&request);
@@ -685,9 +685,9 @@ TEST_F(CAPIPredictValidationArbitraryBatchPosition, RequestWrongShapeValuesAuto)
     preparePredictRequest(request,
         {
             {"Input_FP32_224_224_3_1_HWCN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{10, 224, 3, 1}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{10, 224, 3, 1}, ovms::Precision::FP32}},
             {"Input_U8_3_1_128_CNH",
-                std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
         },
         requestData);
     auto status = instance->mockValidate(&request);
@@ -710,9 +710,9 @@ protected:
         preparePredictRequest(request,
             {
                 {"Input_FP32_any_224:512_224:512_3_NHWC",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
                 {"Input_U8_100:200_any_CN",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
             },
             requestData);
     }
@@ -727,9 +727,9 @@ TEST_F(CAPIPredictValidationDynamicModel, RequestBatchNotInRangeFirstPosition) {
     preparePredictRequest(request,
         {
             {"Input_FP32_any_224:512_224:512_3_NHWC",
-                std::tuple<ovms::shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
             {"Input_U8_100:200_any_CN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
         },
         requestData);
 
@@ -742,9 +742,9 @@ TEST_F(CAPIPredictValidationDynamicModel, RequestDimensionNotInRangeFirstPositio
     preparePredictRequest(request,
         {
             {"Input_FP32_any_224:512_224:512_3_NHWC",
-                std::tuple<ovms::shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
             {"Input_U8_100:200_any_CN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{98, 1}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{98, 1}, ovms::Precision::U8}},
         },
         requestData);
     auto status = instance->mockValidate(&request);
@@ -755,9 +755,9 @@ TEST_F(CAPIPredictValidationDynamicModel, RequestBatchNotInRangeSecondPosition) 
     preparePredictRequest(request,
         {
             {"Input_FP32_any_224:512_224:512_3_NHWC",
-                std::tuple<ovms::shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
             {"Input_U8_100:200_any_CN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{100, 98}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{100, 98}, ovms::Precision::U8}},
         },
         requestData);
     servableInputs["Input_U8_100:200_any_CN"] = std::make_shared<ovms::TensorInfo>("Input_U8_100:200_any_CN", ovms::Precision::U8, ovms::Shape{{100, 200}, {1, 5}}, ovms::Layout{"CN"});
@@ -769,9 +769,9 @@ TEST_F(CAPIPredictValidationDynamicModel, RequestDimensionNotInRangeSecondPositi
     preparePredictRequest(request,
         {
             {"Input_FP32_any_224:512_224:512_3_NHWC",
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, 223, 224, 3}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, 223, 224, 3}, ovms::Precision::FP32}},
             {"Input_U8_100:200_any_CN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
         },
         requestData);
     auto status = instance->mockValidate(&request);
@@ -783,9 +783,9 @@ TEST_F(CAPIPredictValidationDynamicModel, RequestDimensionInRangeWrongTensorCont
     preparePredictRequest(request,
         {
             {"Input_FP32_any_224:512_224:512_3_NHWC",
-                std::tuple<ovms::shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
+                std::tuple<signed_shape_t, ovms::Precision>{{16, 300, 320, 3}, ovms::Precision::FP32}},
             {"Input_U8_100:200_any_CN",
-                std::tuple<ovms::shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
+                std::tuple<signed_shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
         },
         requestData, std::nullopt, decrementBufferSize);
     auto status = instance->mockValidate(&request);
@@ -813,7 +813,7 @@ TEST_P(CAPIPredictValidationPrecision, ValidPrecisions) {
     preparePredictRequest(request,
         {
             {tensorName,
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
         },
         requestData);
     auto status = ovms::request_validation_utils::validate(request, mockedInputsInfo, "dummy", ovms::model_version_t{1});

--- a/src/test/capi_predict_validation_test.cpp
+++ b/src/test/capi_predict_validation_test.cpp
@@ -398,7 +398,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSize) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize);
+        requestData, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -425,7 +425,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeZero) {
     preparePredictRequest(request,
         {{"Input_FP32_1_224_224_3_NHWC",
             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}}},
-        requestData, std::nullopt, decrementBufferSize);
+        requestData, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -440,7 +440,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectBufferType) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize, static_cast<OVMS_BufferType>(999));
+        requestData, decrementBufferSize, static_cast<OVMS_BufferType>(999));
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
 }
@@ -455,7 +455,7 @@ TEST_F(CAPIPredictValidation, RequestNegativeBufferType) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize, static_cast<OVMS_BufferType>(-22));
+        requestData, decrementBufferSize, static_cast<OVMS_BufferType>(-22));
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
 }
@@ -470,7 +470,7 @@ TEST_F(CAPIPredictValidation, RequestIncorectDeviceId) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
+        requestData, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_DEVICE_ID) << status.string();
 }
@@ -485,7 +485,7 @@ TEST_F(CAPIPredictValidation, RequestIncorectBufferType) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_GPU);
+        requestData, decrementBufferSize, OVMS_BUFFERTYPE_GPU);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BUFFER_TYPE) << status.string();
 }
@@ -501,7 +501,7 @@ TEST_F(CAPIPredictValidation, RequestCorectDeviceId) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_GPU, 1);
+        requestData, decrementBufferSize, OVMS_BUFFERTYPE_GPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
 }
@@ -516,7 +516,7 @@ TEST_F(CAPIPredictValidation, RequestNotNullDeviceId) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
+        requestData, decrementBufferSize, OVMS_BUFFERTYPE_CPU, 1);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_DEVICE_ID) << status.string();
 }
@@ -533,7 +533,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeBatchAuto) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize);
+        requestData, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -550,7 +550,7 @@ TEST_F(CAPIPredictValidation, RequestIncorrectContentSizeShapeAuto) {
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             {"Input_U16_1_2_8_4_NCHW",
                 std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-        requestData, std::nullopt, decrementBufferSize);
+        requestData, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }
@@ -585,7 +585,7 @@ TEST_P(CAPIPredictValidationInputTensorContent, RequestCorrectContentSizeInputTe
     preparePredictRequest(request,
         {{inputName,
             std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, testedPrecision}}},
-        requestData, std::nullopt,  // data,
+        requestData,  // data,
         false);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
@@ -787,7 +787,7 @@ TEST_F(CAPIPredictValidationDynamicModel, RequestDimensionInRangeWrongTensorCont
             {"Input_U8_100:200_any_CN",
                 std::tuple<signed_shape_t, ovms::Precision>{{101, 16}, ovms::Precision::U8}},
         },
-        requestData, std::nullopt, decrementBufferSize);
+        requestData, decrementBufferSize);
     auto status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INVALID_CONTENT_SIZE) << status.string();
 }

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -602,7 +602,7 @@ TEST_F(TestCustomLoader, CustomLoaderPrediction) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 }
 
@@ -651,7 +651,7 @@ TEST_F(TestCustomLoader, CustomLoaderPredictDeletePredict) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     tensorflow::serving::PredictResponse response;
     ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::OK);
 
@@ -678,7 +678,7 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewVersionPredict) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Copy version 1 to version 2
@@ -688,7 +688,7 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewVersionPredict) {
 
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 2, request);
 }
 
@@ -708,7 +708,7 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewModelPredict) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Copy model1 to model2
@@ -725,7 +725,7 @@ TEST_F(TestCustomLoader, CustomLoaderPredictNewModelPredict) {
 
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
     performPredict("dummy-new", 1, request);
 }
@@ -746,7 +746,7 @@ TEST_F(TestCustomLoader, CustomLoaderPredictRemoveCustomLoaderOptionsPredict) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Replace model path in the config string
@@ -776,7 +776,7 @@ TEST_F(TestCustomLoader, PredictNormalModelAddCustomLoaderOptionsPredict) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 
     // Replace model path in the config string
@@ -807,7 +807,7 @@ TEST_F(TestCustomLoader, CustomLoaderOptionWithUnknownLibrary) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     tensorflow::serving::PredictResponse response;
     ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::MODEL_VERSION_MISSING);
 }
@@ -825,7 +825,7 @@ TEST_F(TestCustomLoader, CustomLoaderWithMissingModelFiles) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     tensorflow::serving::PredictResponse response;
     ASSERT_EQ(performInferenceWithRequest(request, response), ovms::StatusCode::MODEL_VERSION_MISSING);
 }
@@ -897,7 +897,7 @@ TEST_F(TestCustomLoader, CustomLoaderPredictionUsingManyCustomLoaders) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
 
     performPredict("dummy-a", 1, request);
     performPredict("dummy-b", 1, request);
@@ -1041,7 +1041,7 @@ TEST_F(TestCustomLoader, CustomLoaderMultipleLoaderWithSameLoaderName) {
     tensorflow::serving::PredictRequest request;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 }
 

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -1402,7 +1402,7 @@ public:
     }
     virtual inputs_info_t getExpectedInputsInfo() {
         return {{pipelineInputName,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}}};
+            std::tuple<signed_shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}}};
     }
 
     virtual tensorflow::serving::PredictRequest preparePipelinePredictRequest() {
@@ -1829,7 +1829,7 @@ TEST_F(StressPipelineCustomNodesWithPreallocatedBuffersConfigChanges, IncreaseQu
 }
 
 class StressPipelineCustomNodesConfigChanges : public StressPipelineConfigChanges {
-    const size_t differentOpsFactorsInputSize = 4;
+    const int64_t differentOpsFactorsInputSize = 4;
     const std::vector<float> factorsData{1., 3, 2, 2};
     const std::string pipelineFactorsInputName{"pipeline_factors"};
 
@@ -1845,9 +1845,9 @@ public:
     }
     inputs_info_t getExpectedInputsInfo() override {
         return {{pipelineInputName,
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}},
             {pipelineFactorsInputName,
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, differentOpsFactorsInputSize}, ovms::Precision::FP32}}};
+                std::tuple<signed_shape_t, ovms::Precision>{{1, differentOpsFactorsInputSize}, ovms::Precision::FP32}}};
     }
     void checkPipelineResponse(const std::string& pipelineOutputName,
         tensorflow::serving::PredictRequest& request,

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -71,11 +71,11 @@ protected:
             StatusCode::OK);
         dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(pipelineOutputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
         dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(pipelineInputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
     }
 
@@ -288,11 +288,11 @@ protected:
             StatusCode::OK);
         dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(pipelineOutputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
         dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(pipelineInputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
     }
 };

--- a/src/test/ensemble_tests.cpp
+++ b/src/test/ensemble_tests.cpp
@@ -70,20 +70,20 @@ public:
         requestData = bs1requestData;
         dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
         dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
     }
 
-    void prepareRequest(const std::vector<float>& requestData, TFSRequestType& request, const std::string& customPipelineInputName, const std::vector<size_t>& shape = {1, DUMMY_MODEL_INPUT_SIZE}) {
+    void prepareRequest(const std::vector<float>& requestData, TFSRequestType& request, const std::string& customPipelineInputName, const signed_shape_t& shape = {1, DUMMY_MODEL_INPUT_SIZE}) {
         request.Clear();
         preparePredictRequest(request, inputs_info_t{{customPipelineInputName, {shape, ovms::Precision::FP32}}}, requestData);
     }
 
-    void prepareRequest(const std::vector<float>& requestData, KFSRequest& request, const std::string& customPipelineInputName, const std::vector<size_t>& shape = {1, DUMMY_MODEL_INPUT_SIZE}) {
+    void prepareRequest(const std::vector<float>& requestData, KFSRequest& request, const std::string& customPipelineInputName, const signed_shape_t& shape = {1, DUMMY_MODEL_INPUT_SIZE}) {
         request.Clear();
         prepareKFSInferInputTensor(request, customPipelineInputName, std::make_tuple(shape, ovmsPrecisionToKFSPrecision(ovms::Precision::FP32)), requestData);
     }
@@ -105,11 +105,11 @@ public:
     const std::string customPipelineOutputName = "custom_dummy_output";
     std::shared_ptr<ovms::TensorInfo> dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
         ovms::Precision::FP32,
-        DUMMY_MODEL_SHAPE,
+        DUMMY_MODEL_SHAPE_META,
         Layout{"NC"});
     std::shared_ptr<ovms::TensorInfo> dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
         ovms::Precision::FP32,
-        DUMMY_MODEL_SHAPE,
+        DUMMY_MODEL_SHAPE_META,
         Layout{"NC"});
 
     std::vector<float> requestData;
@@ -137,11 +137,11 @@ protected:
         requestData = bs1requestData;
         dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
         dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
     }
 
@@ -225,11 +225,11 @@ protected:
     const std::string customPipelineOutputName = "custom_dummy_output";
     std::shared_ptr<ovms::TensorInfo> dagDummyModelOutputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineOutputName,
         ovms::Precision::FP32,
-        DUMMY_MODEL_SHAPE,
+        DUMMY_MODEL_SHAPE_META,
         Layout{"NC"});
     std::shared_ptr<ovms::TensorInfo> dagDummyModelInputTensorInfo = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
         ovms::Precision::FP32,
-        DUMMY_MODEL_SHAPE,
+        DUMMY_MODEL_SHAPE_META,
         Layout{"NC"});
 
     std::vector<float> requestData;
@@ -677,7 +677,7 @@ TEST_F(EnsembleFlowTest, DummyModelDirectAndPipelineInference) {
     tensorflow::serving::PredictRequest simpleModelRequest;
     preparePredictRequest(simpleModelRequest,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     std::vector<float> requestData{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
     auto& input = (*simpleModelRequest.mutable_inputs())[DUMMY_MODEL_INPUT_NAME];
     input.mutable_tensor_content()->assign((char*)requestData.data(), requestData.size() * sizeof(float));
@@ -1518,7 +1518,7 @@ TEST_F(EnsembleFlowTest, ParallelDummyModels) {
         const std::string inputName = customPipelineInputName + std::to_string(i);
         inputsInfoTmp[inputName] = std::make_shared<ovms::TensorInfo>(inputName,
             ovms::Precision::FP32,
-            DUMMY_MODEL_SHAPE,
+            DUMMY_MODEL_SHAPE_META,
             Layout{"NC"});
     }
     const tensor_map_t inputsInfo = inputsInfoTmp;
@@ -1529,7 +1529,7 @@ TEST_F(EnsembleFlowTest, ParallelDummyModels) {
         outputsInfo.emplace(outputName,
             std::make_shared<ovms::TensorInfo>(outputName,
                 ovms::Precision::FP32,
-                DUMMY_MODEL_SHAPE,
+                DUMMY_MODEL_SHAPE_META,
                 Layout{"NC"}));
     }
     auto output_node = std::make_unique<ExitNode<PredictResponse>>(&response, outputsInfo);
@@ -1636,18 +1636,18 @@ TEST_F(EnsembleFlowTest, OrderOfScheduling) {
     tensor_map_t inputsInfoTmp;
     inputsInfoTmp[customPipelineInputName] = std::make_shared<ovms::TensorInfo>(customPipelineInputName,
         ovms::Precision::FP32,
-        DUMMY_MODEL_SHAPE,
+        DUMMY_MODEL_SHAPE_META,
         Layout{"NC"});
     auto input_node = std::make_unique<EntryNode<PredictRequest>>(&request, inputsInfoTmp);
 
     tensor_map_t outputsInfoTmp;
     outputsInfoTmp[customPipelineOutputName + "_1"] = std::make_shared<ovms::TensorInfo>(customPipelineOutputName + "_1",
         ovms::Precision::FP32,
-        DUMMY_MODEL_SHAPE,
+        DUMMY_MODEL_SHAPE_META,
         Layout{"NC"});
     outputsInfoTmp[customPipelineOutputName + "_2"] = std::make_shared<ovms::TensorInfo>(customPipelineOutputName + "_2",
         ovms::Precision::FP32,
-        DUMMY_MODEL_SHAPE,
+        DUMMY_MODEL_SHAPE_META,
         Layout{"NC"});
     auto output_node = std::make_unique<ExitNode<PredictResponse>>(&response, outputsInfoTmp);
 
@@ -3119,7 +3119,7 @@ TEST_F(EnsembleFlowTest, ErrorHandlingSkipsDeferredNodesExecutionIfExecutionFail
     const tensor_map_t inputsInfo{{"proto_input_1x10",
                                       std::make_shared<ovms::TensorInfo>("proto_input_1x10",
                                           ovms::Precision::FP32,
-                                          DUMMY_MODEL_SHAPE,
+                                          DUMMY_MODEL_SHAPE_META,
                                           Layout{"NC"})},
         {"proto_input_1x5",
             std::make_shared<ovms::TensorInfo>("proto_input_1x5",

--- a/src/test/kfs_rest_parser_test.cpp
+++ b/src/test/kfs_rest_parser_test.cpp
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
+#include <regex>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -874,4 +877,31 @@ TEST_F(KFSRestParserTest, parseInvalidDataNotHeterogenous) {
     })";
     auto status = parser.parse(request.c_str());
     ASSERT_EQ(status, StatusCode::OK);
+}
+
+TEST_F(KFSRestParserTest, parseNegativeBatch) {
+    std::string request = R"({
+    "inputs" : [
+        {
+        "name" : "b",
+        "shape" : [ $replace, 3 ],
+        "datatype" : "FP32",
+        "data" : [ [ 1.5, 2.9, 3.0 ], [ 1.5, 2.9, 3.0 ], [ 1.5, 2.9, 3.0 ] ]
+        }
+    ]
+    })";
+
+    for (double i : std::vector<double>{-5, -2.56, -7, -1, -0.5, -124, -0.0000000}) {
+        std::string replace = std::to_string(i);
+        std::string requestCopy = std::regex_replace(request, std::regex("\\$replace"), replace);
+        auto status = parser.parse(requestCopy.c_str());
+        ASSERT_NE(status, StatusCode::OK) << "for value: " << replace;
+    }
+
+    for (int i : std::vector<int>{-5, -8, -1, -0, -124}) {
+        std::string replace = std::to_string(i);
+        std::string requestCopy = std::regex_replace(request, std::regex("\\$replace"), replace);
+        auto status = parser.parse(requestCopy.c_str());
+        ASSERT_NE(status, StatusCode::OK) << "for value: " << replace;
+    }
 }

--- a/src/test/metrics_flow_test.cpp
+++ b/src/test/metrics_flow_test.cpp
@@ -112,7 +112,7 @@ protected:
 
     const int numberOfSuccessRequests = 5;
     const int numberOfFailedRequests = 7;
-    const size_t dynamicBatch = 3;
+    const int64_t dynamicBatch = 3;
 
     const Precision correctPrecision = Precision::FP32;
     const Precision wrongPrecision = Precision::I32;
@@ -166,7 +166,7 @@ TEST_F(MetricFlowTest, GrpcPredict) {
         request.Clear();
         response.Clear();
         request.mutable_model_spec()->mutable_name()->assign(dagName);
-        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, correctPrecision}}};
+        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {signed_shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, correctPrecision}}};
         preparePredictRequest(request, inputsMeta);
         ASSERT_EQ(impl.Predict(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
     }
@@ -176,7 +176,7 @@ TEST_F(MetricFlowTest, GrpcPredict) {
         request.Clear();
         response.Clear();
         request.mutable_model_spec()->mutable_name()->assign(dagName);
-        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, wrongPrecision}}};
+        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {signed_shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, wrongPrecision}}};
         preparePredictRequest(request, inputsMeta);
         ASSERT_EQ(impl.Predict(nullptr, &request, &response).error_code(), grpc::StatusCode::INVALID_ARGUMENT);
     }
@@ -280,7 +280,7 @@ TEST_F(MetricFlowTest, GrpcModelInfer) {
     for (int i = 0; i < numberOfSuccessRequests; i++) {
         request.Clear();
         response.Clear();
-        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, correctPrecision}}};
+        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {signed_shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, correctPrecision}}};
         preparePredictRequest(request, inputsMeta);
         request.mutable_model_name()->assign(dagName);
         ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
@@ -289,7 +289,7 @@ TEST_F(MetricFlowTest, GrpcModelInfer) {
     for (int i = 0; i < numberOfFailedRequests; i++) {
         request.Clear();
         response.Clear();
-        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, wrongPrecision}}};
+        inputs_info_t inputsMeta{{DUMMY_MODEL_INPUT_NAME, {signed_shape_t{dynamicBatch, 1, DUMMY_MODEL_INPUT_SIZE}, wrongPrecision}}};
         preparePredictRequest(request, inputsMeta);
         request.mutable_model_name()->assign(dagName);
         ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::INVALID_ARGUMENT);

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -62,11 +62,11 @@ protected:
         preparePredictRequest(request,
             {
                 {"Input_FP32_1_224_224_3_NHWC",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
                 {"Input_U8_1_3_62_62_NCHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
                 {"Input_I64_1_6_128_128_16_NCDHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
             });
 
         // U16 uses int_val instead of tensor_content so it needs separate test
@@ -489,9 +489,9 @@ protected:
         preparePredictRequest(request,
             {
                 {"Input_FP32_224_224_3_1_HWCN",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
                 {"Input_U8_3_1_128_CNH",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
             });
     }
 };
@@ -565,9 +565,9 @@ protected:
         preparePredictRequest(request,
             {
                 {"Input_FP32_any_224:512_224:512_3_NHWC",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
                 {"Input_U8_100:200_any_CN",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
             });
     }
 };
@@ -644,7 +644,7 @@ TEST_P(TfsPredictValidationPrecision, ValidPrecisions) {
     preparePredictRequest(request,
         {
             {tensorName,
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
         });
     auto status = ovms::request_validation_utils::validate(request, mockedInputsInfo, "dummy", ovms::model_version_t{1});
     EXPECT_EQ(status, ovms::StatusCode::OK) << "Precision validation failed:"
@@ -689,13 +689,13 @@ protected:
 
         preparePredictRequest(request,
             {{"Input_FP32_1_224_224_3_NHWC",
-                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+                 std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
                 {"Input_U8_1_3_62_62_NCHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
                 {"Input_I64_1_6_128_128_16_NCDHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
                 {"Input_U16_1_2_8_4_NCHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}});
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}});
     }
 };
 
@@ -1062,7 +1062,7 @@ TEST_F(KFSPredictValidationInputTensorContent, RequestInputTensorContentAndRawIn
     ON_CALL(*instance, getModelConfig()).WillByDefault(ReturnRef(modelConfig));
     preparePredictRequest(request,
         {{inputName,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 2}, testedPrecision}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 2}, testedPrecision}}},
         {},      // data,
         false);  // put buffer in InputTensorContent
     auto buf = findKFSInferInputTensor(request, inputName)->mutable_contents()->mutable_fp32_contents();
@@ -1085,7 +1085,7 @@ TEST_P(KFSPredictValidationInputTensorContent, RequestCorrectContentSizeInputTen
     ON_CALL(*instance, getModelConfig()).WillByDefault(ReturnRef(modelConfig));
     preparePredictRequest(request,
         {{inputName,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, testedPrecision}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, testedPrecision}}},
         {},     // data,
         true);  // put buffer in InputTensorContent
     auto status = instance->mockValidate(&request);
@@ -1121,13 +1121,13 @@ protected:
 
         preparePredictRequest(request,
             {{"Input_FP32_1_224_224_3_NHWC",
-                 std::tuple<ovms::shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
+                 std::tuple<signed_shape_t, ovms::Precision>{{1, 224, 224, 3}, ovms::Precision::FP32}},
                 {"Input_U8_1_3_62_62_NCHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 3, 62, 62}, ovms::Precision::U8}},
                 {"Input_I64_1_6_128_128_16_NCDHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
                 {"Input_U16_1_2_8_4_NCHW",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
             {},  // data,
             std::nullopt,
             true);  // put buffer in InputTensorContent
@@ -1186,9 +1186,9 @@ protected:
         preparePredictRequest(request,
             {
                 {"Input_FP32_224_224_3_1_HWCN",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{224, 224, 3, 1}, ovms::Precision::FP32}},
                 {"Input_U8_3_1_128_CNH",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{3, 1, 128}, ovms::Precision::U8}},
             });
     }
 };
@@ -1245,9 +1245,9 @@ protected:
         preparePredictRequest(request,
             {
                 {"Input_FP32_any_224:512_224:512_3_NHWC",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{requestBatchSize, 300, 320, 3}, ovms::Precision::FP32}},
                 {"Input_U8_100:200_any_CN",
-                    std::tuple<ovms::shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
+                    std::tuple<signed_shape_t, ovms::Precision>{{101, requestBatchSize}, ovms::Precision::U8}},
             });
     }
 };
@@ -1307,7 +1307,7 @@ TEST_P(KFSPredictValidationPrecision, ValidPrecisions) {
     preparePredictRequest(request,
         {
             {tensorName,
-                std::tuple<ovms::shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
+                std::tuple<signed_shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, testedPrecision}},
         });
     auto status = ovms::request_validation_utils::validate(request, mockedInputsInfo, "dummy", ovms::model_version_t{1});
     EXPECT_EQ(status, ovms::StatusCode::OK) << "Precision validation failed:"

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -1128,8 +1128,7 @@ protected:
                     std::tuple<signed_shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
                 {"Input_U16_1_2_8_4_NCHW",
                     std::tuple<signed_shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-            {},  // data,
-            std::nullopt,
+            {},     // data,
             true);  // put buffer in InputTensorContent
     }
 };

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -1128,7 +1128,8 @@ protected:
                     std::tuple<ovms::shape_t, ovms::Precision>{{1, 6, 128, 128, 16}, ovms::Precision::I64}},
                 {"Input_U16_1_2_8_4_NCHW",
                     std::tuple<ovms::shape_t, ovms::Precision>{{1, 2, 8, 4}, ovms::Precision::U16}}},
-            {},     // data,
+            {},  // data,
+            std::nullopt,
             true);  // put buffer in InputTensorContent
     }
 };

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -89,7 +89,7 @@ static ovms::Status getOutput(const TFSResponseType& response, const std::string
     return StatusCode::INVALID_MISSING_INPUT;
 }
 
-using inputs_info_elem_t = std::pair<std::string, std::tuple<ovms::shape_t, ovms::Precision>>;
+using inputs_info_elem_t = std::pair<std::string, std::tuple<signed_shape_t, ovms::Precision>>;
 static size_t calculateByteSize(const inputs_info_elem_t& e) {
     auto& [inputName, shapeDatatypeTuple] = e;
     auto& [shape, precision] = shapeDatatypeTuple;
@@ -154,7 +154,7 @@ public:
                         Preparer<RequestType> preparer;
                         preparer.preparePredictRequest(request,
                             {{DUMMY_MODEL_INPUT_NAME,
-                                std::tuple<ovms::shape_t, ovms::Precision>{{(initialBatchSize + (i % 3)), 10}, ovms::Precision::FP32}}});
+                                std::tuple<signed_shape_t, ovms::Precision>{{(initialBatchSize + (i % 3)), 10}, ovms::Precision::FP32}}});
 
                         performPredict(config.getName(), config.getVersion(), request,
                             std::move(std::make_unique<std::future<void>>(releaseWaitBeforeGettingModelInstance[i].get_future())));
@@ -168,7 +168,7 @@ public:
                         Preparer<RequestType> preparer;
                         preparer.preparePredictRequest(request,
                             {{DUMMY_MODEL_INPUT_NAME,
-                                std::tuple<ovms::shape_t, ovms::Precision>{{initialBatchSize, 10}, ovms::Precision::FP32}}});
+                                std::tuple<signed_shape_t, ovms::Precision>{{initialBatchSize, 10}, ovms::Precision::FP32}}});
 
                         performPredict(config.getName(), config.getVersion(), request, nullptr,
                             std::move(std::make_unique<std::future<void>>(releaseWaitBeforePerformInference[i].get_future())));
@@ -205,7 +205,7 @@ public:
                         Preparer<RequestType> preparer;
                         preparer.preparePredictRequest(request,
                             {{DUMMY_MODEL_INPUT_NAME,
-                                std::tuple<ovms::shape_t, ovms::Precision>{{(initialBatchSize + i), 10}, ovms::Precision::FP32}}});
+                                std::tuple<signed_shape_t, ovms::Precision>{{(initialBatchSize + i), 10}, ovms::Precision::FP32}}});
                         performPredict(config.getName(), config.getVersion(), request,
                             std::move(std::make_unique<std::future<void>>(releaseWaitBeforeGettingModelInstance[i].get_future())));
                     }));
@@ -221,7 +221,7 @@ public:
         }
     }
 
-    void checkOutputShape(const ResponseType& response, const ovms::shape_t& shape, const std::string& outputName = "a");
+    void checkOutputShape(const ResponseType& response, const signed_shape_t& shape, const std::string& outputName = "a");
 
     static void checkOutputValues(const TFSResponseType& response, const std::vector<float>& expectedValues, const std::string& outputName = INCREMENT_1x3x4x5_MODEL_OUTPUT_NAME) {
         ASSERT_EQ(response.outputs().count(outputName), 1);
@@ -288,33 +288,33 @@ public:
         return model->infer(&request, &response, unload_guard);
     }
 
-    ovms::Status performInferenceWithShape(ResponseType& response, const ovms::shape_t& shape = {1, 10}, const ovms::Precision precision = ovms::Precision::FP32) {
+    ovms::Status performInferenceWithShape(ResponseType& response, const signed_shape_t& shape = {1, 10}, const ovms::Precision precision = ovms::Precision::FP32) {
         RequestType request;
         Preparer<RequestType> preparer;
         preparer.preparePredictRequest(request,
-            {{DUMMY_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, ovms::Precision>{shape, precision}}});
+            {{DUMMY_MODEL_INPUT_NAME, std::tuple<signed_shape_t, ovms::Precision>{shape, precision}}});
         return performInferenceWithRequest(request, response);
     }
 
     ovms::Status performInferenceWithBatchSize(ResponseType& response, int batchSize = 1, const ovms::Precision precision = ovms::Precision::FP32, const size_t batchSizePosition = 0) {
-        ovms::shape_t shape = {1, 10};
+        signed_shape_t shape = {1, 10};
         shape[batchSizePosition] = batchSize;
         RequestType request;
         Preparer<RequestType> preparer;
         preparer.preparePredictRequest(request,
-            {{DUMMY_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, ovms::Precision>{shape, precision}}});
+            {{DUMMY_MODEL_INPUT_NAME, std::tuple<signed_shape_t, ovms::Precision>{shape, precision}}});
         return performInferenceWithRequest(request, response);
     }
 
-    ovms::Status performInferenceWithImageInput(ResponseType& response, const std::vector<size_t>& shape, const std::vector<float>& data = {}, const std::string& servableName = "increment_1x3x4x5", int batchSize = 1, const ovms::Precision precision = ovms::Precision::FP32) {
+    ovms::Status performInferenceWithImageInput(ResponseType& response, const signed_shape_t& shape, const std::vector<float>& data = {}, const std::string& servableName = "increment_1x3x4x5", int batchSize = 1, const ovms::Precision precision = ovms::Precision::FP32) {
         RequestType request;
         Preparer<RequestType> preparer;
         if (data.size()) {
             preparePredictRequest(request,
-                {{INCREMENT_1x3x4x5_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, ovms::Precision>{shape, precision}}}, data);
+                {{INCREMENT_1x3x4x5_MODEL_INPUT_NAME, std::tuple<signed_shape_t, ovms::Precision>{shape, precision}}}, data);
         } else {
             preparer.preparePredictRequest(request,
-                {{INCREMENT_1x3x4x5_MODEL_INPUT_NAME, std::tuple<ovms::shape_t, ovms::Precision>{shape, precision}}});
+                {{INCREMENT_1x3x4x5_MODEL_INPUT_NAME, std::tuple<signed_shape_t, ovms::Precision>{shape, precision}}});
         }
         return performInferenceWithRequest(request, response, servableName);
     }
@@ -334,7 +334,7 @@ public:
 };
 
 template <>
-void TestPredict<TFSInterface>::checkOutputShape(const TFSResponseType& response, const ovms::shape_t& shape, const std::string& outputName) {
+void TestPredict<TFSInterface>::checkOutputShape(const TFSResponseType& response, const signed_shape_t& shape, const std::string& outputName) {
     ASSERT_EQ(response.outputs().count(outputName), 1);
     const auto& output_tensor = response.outputs().at(outputName);
     ASSERT_EQ(output_tensor.tensor_shape().dim_size(), shape.size());
@@ -344,7 +344,7 @@ void TestPredict<TFSInterface>::checkOutputShape(const TFSResponseType& response
 }
 
 template <>
-void TestPredict<CAPIInterface>::checkOutputShape(const ovms::InferenceResponse& cresponse, const ovms::shape_t& shape, const std::string& outputName) {
+void TestPredict<CAPIInterface>::checkOutputShape(const ovms::InferenceResponse& cresponse, const signed_shape_t& shape, const std::string& outputName) {
     size_t outputCount = cresponse.getOutputCount();
     EXPECT_GE(1, outputCount);
     size_t outputId = 0;
@@ -369,7 +369,7 @@ void TestPredict<CAPIInterface>::checkOutputShape(const ovms::InferenceResponse&
 }
 
 template <>
-void TestPredict<KFSInterface>::checkOutputShape(const KFSResponse& response, const ovms::shape_t& shape, const std::string& outputName) {
+void TestPredict<KFSInterface>::checkOutputShape(const KFSResponse& response, const signed_shape_t& shape, const std::string& outputName) {
     auto it = response.outputs().begin();
     size_t bufferId;
     auto status = getOutput(response, outputName, it, bufferId);
@@ -485,7 +485,7 @@ TYPED_TEST(TestPredict, SuccesfullOnDummyModel) {
     Preparer<typename TypeParam::first_type> preparer;
     preparer.preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchSize(1);
 
@@ -582,7 +582,7 @@ TYPED_TEST(TestPredictWithMapping, SuccesfullOnDummyModelWithMapping) {
     typename TypeParam::first_type request;
     preparer.preparePredictRequest(request,
         {{this->dummyModelInputMapping,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     this->SetUp(oneDummyWithMappedInputConfig);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     ConstructorEnabledModelManager manager;
@@ -596,7 +596,7 @@ TYPED_TEST(TestPredictWithMapping, SuccesfullOnDummyModelWithMappingSpecificShap
     typename TypeParam::first_type request;
     preparer.preparePredictRequest(request,
         {{this->dummyModelInputMapping,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 5}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 5}, ovms::Precision::FP32}}});
     this->SetUp(oneDummyWithMappedInputSpecificAutoShapeConfig);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto status = config.parseShapeParameter("auto");
@@ -610,7 +610,7 @@ TYPED_TEST(TestPredictWithMapping, SuccesfullOnDummyModelWithMappingAnonymousSha
     typename TypeParam::first_type request;
     preparer.preparePredictRequest(request,
         {{this->dummyModelInputMapping,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 5}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 5}, ovms::Precision::FP32}}});
     this->SetUp(oneDummyWithMappedInputAnonymousAutoShapeConfig);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     auto status = config.parseShapeParameter("auto");
@@ -625,7 +625,7 @@ TYPED_TEST(TestPredict, SuccesfullReloadFromAlreadyLoadedWithNewBatchSize) {
     typename TypeParam::first_type request;
     preparer.preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     const auto initialBatchSize = config.getBatchSize();
     config.setBatchSize(initialBatchSize);
@@ -639,11 +639,11 @@ TYPED_TEST(TestPredict, SuccesfullReloadWhen1InferenceInProgress) {
     typename TypeParam::first_type requestBs1;
     preparer.preparePredictRequest(requestBs1,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     typename TypeParam::first_type requestBs2;
     preparer.preparePredictRequest(requestBs2,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{2, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{2, 10}, ovms::Precision::FP32}}});
 
     this->config.setBatchingParams("auto");
     this->config.setNireq(2);
@@ -674,11 +674,11 @@ TYPED_TEST(TestPredict, SuccesfullReloadWhen1InferenceAboutToStart) {
     typename TypeParam::first_type requestBs2;
     preparer.preparePredictRequest(requestBs2,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{2, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{2, 10}, ovms::Precision::FP32}}});
     typename TypeParam::first_type requestBs1;
     preparer.preparePredictRequest(requestBs1,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
 
     this->config.setBatchingParams("auto");
     this->config.setNireq(2);
@@ -749,7 +749,7 @@ TYPED_TEST(TestPredict, SuccesfullReshapeViaRequestOnDummyModel) {
     typename TypeParam::first_type request;
     preparer.preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 5}, ovms::Precision::FP32}}});
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 5}, ovms::Precision::FP32}}});
 
     typename TypeParam::second_type response;
 
@@ -1381,7 +1381,7 @@ TYPED_TEST(TestPredict, PerformInferenceDummyFp64) {
     typename TypeParam::second_type response;
 
     Preparer<typename TypeParam::first_type> preparer;
-    preparer.preparePredictRequest(request, {{"input:0", std::tuple<ovms::shape_t, ovms::Precision>{{3, 10}, ovms::Precision::FP64}}});
+    preparer.preparePredictRequest(request, {{"input:0", std::tuple<signed_shape_t, ovms::Precision>{{3, 10}, ovms::Precision::FP64}}});
     ASSERT_EQ(this->performInferenceWithRequest(request, response, "dummy_fp64"), ovms::StatusCode::OK);
     this->checkOutputShape(response, {3, 10}, "output:0");
     ASSERT_EQ(getPrecisionFromResponse(response, "output:0"), ovms::Precision::FP64);
@@ -1540,7 +1540,7 @@ TYPED_TEST(TestPredict, InferenceWithNegativeShape) {
     int64_t negativeBatch = -5;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}},
         data, negativeBatch);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchSize(1);
@@ -1559,7 +1559,7 @@ TYPED_TEST(TestPredict, InferenceWithNegativeShapeDynamicParameter) {
     int64_t negativeBatch = -5;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}},
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}},
         data, negativeBatch);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("auto");

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -1540,8 +1540,8 @@ TYPED_TEST(TestPredict, InferenceWithNegativeShape) {
     int64_t negativeBatch = -5;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}},
-        data, negativeBatch);
+            std::tuple<signed_shape_t, ovms::Precision>{{negativeBatch, 10}, ovms::Precision::FP32}}},
+        data);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchSize(1);
 
@@ -1559,8 +1559,8 @@ TYPED_TEST(TestPredict, InferenceWithNegativeShapeDynamicParameter) {
     int64_t negativeBatch = -5;
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}},
-        data, negativeBatch);
+            std::tuple<signed_shape_t, ovms::Precision>{{negativeBatch, 10}, ovms::Precision::FP32}}},
+        data);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     config.setBatchingParams("auto");
 

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -1553,4 +1553,23 @@ TYPED_TEST(TestPredict, InferenceWithNegativeShape) {
     ASSERT_NE(modelInstance->infer(&request, &response, modelInstanceUnloadGuard), ovms::StatusCode::OK);
 }
 
+TYPED_TEST(TestPredict, InferenceWithNegativeShapeDynamicParameter) {
+    typename TypeParam::first_type request;
+    std::vector<float> data{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    int64_t negativeBatch = -5;
+    preparePredictRequest(request,
+        {{DUMMY_MODEL_INPUT_NAME,
+            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}},
+        data, negativeBatch);
+    ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
+    config.setBatchingParams("auto");
+
+    ASSERT_EQ(this->manager.reloadModelWithVersions(config), ovms::StatusCode::OK_RELOADED);
+    std::shared_ptr<ovms::ModelInstance> modelInstance;
+    std::unique_ptr<ovms::ModelInstanceUnloadGuard> modelInstanceUnloadGuard;
+    ASSERT_EQ(this->manager.getModelInstance(config.getName(), config.getVersion(), modelInstance, modelInstanceUnloadGuard), ovms::StatusCode::OK);
+    typename TypeParam::second_type response;
+    ASSERT_NE(modelInstance->infer(&request, &response, modelInstanceUnloadGuard), ovms::StatusCode::OK);
+}
+
 #pragma GCC diagnostic pop

--- a/src/test/stateful_modelinstance_test.cpp
+++ b/src/test/stateful_modelinstance_test.cpp
@@ -98,8 +98,8 @@ public:
     std::string dummyModelName;
     ovms::model_version_t modelVersion;
     inputs_info_t modelInput;
-    std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
-    std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
+    std::pair<std::string, std::tuple<signed_shape_t, tensorflow::DataType>> sequenceId;
+    std::pair<std::string, std::tuple<signed_shape_t, tensorflow::DataType>> sequenceControlStart;
     std::unique_ptr<ov::Core> ieCore;
 
     void SetUpConfig(const std::string& configContent) {
@@ -118,7 +118,7 @@ public:
         SetUpConfig(modelStatefulConfig);
         std::filesystem::copy("/ovms/src/test/dummy", modelPath, std::filesystem::copy_options::recursive);
         modelInput = {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<ovms::shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}};
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}};
     }
 
     void TearDown() override {
@@ -130,8 +130,8 @@ public:
 class StatefulModelInstanceInputValidation : public ::testing::Test {
 public:
     inputs_info_t modelInput;
-    std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceId;
-    std::pair<std::string, std::tuple<ovms::shape_t, tensorflow::DataType>> sequenceControlStart;
+    std::pair<std::string, std::tuple<signed_shape_t, tensorflow::DataType>> sequenceId;
+    std::pair<std::string, std::tuple<signed_shape_t, tensorflow::DataType>> sequenceControlStart;
     std::unique_ptr<ov::Core> ieCore;
 
     void SetUp() override {

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -95,7 +95,6 @@ void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_
             if (data.size() == 0) {
                 *input.mutable_tensor_content() = std::string(numberOfElements * tensorflow::DataTypeSize(datatype), '1');
             } else {
-                SPDLOG_INFO("MMMM Preparing {} bytes.", data.size() * tensorflow::DataTypeSize(datatype));
                 std::string content;
                 content.resize(data.size() * tensorflow::DataTypeSize(datatype));
                 std::memcpy(content.data(), data.data(), content.size());

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -384,7 +384,7 @@ std::string* findKFSInferInputTensorContentInRawInputs(::KFSRequest& request, co
     }
     return content;
 }
-void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
+void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<signed_shape_t, const ovms::Precision>& inputInfo,
     const std::vector<float>& data, std::optional<int64_t> overrideBatch, bool putBufferInInputTensorContent) {
     auto [shape, type] = inputInfo;
     prepareKFSInferInputTensor(request, name,
@@ -392,7 +392,7 @@ void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, 
         data, overrideBatch, putBufferInInputTensorContent);
 }
 
-void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
+void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<signed_shape_t, const ovms::Precision>& inputInfo,
     const std::vector<float>& data, std::optional<int64_t> overrideBatch, uint32_t decrementBufferSize, OVMS_BufferType bufferType, std::optional<uint32_t> deviceId) {
     auto [shape, type] = inputInfo;
     prepareCAPIInferInputTensor(request, name,
@@ -400,7 +400,7 @@ void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::str
         data, overrideBatch, decrementBufferSize, bufferType, deviceId);
 }
 
-void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<ovms::shape_t, OVMS_DataType>& inputInfo,
+void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<signed_shape_t, OVMS_DataType>& inputInfo,
     const std::vector<float>& data, std::optional<int64_t> overrideBatch, uint32_t decrementBufferSize, OVMS_BufferType bufferType, std::optional<uint32_t> deviceId) {
     auto [shape, datatype] = inputInfo;
     size_t elementsCount = 1;
@@ -413,7 +413,7 @@ void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::str
     if (overrideBatch.has_value()) {
         shape[0] = overrideBatch.value();
     }
-    request.addInput(name.c_str(), datatype, shape.data(), shape.size());
+    request.addInput(name.c_str(), datatype, reinterpret_cast<size_t*>(shape.data()), shape.size());
 
     size_t dataSize = elementsCount * ovms::DataTypeToByteSize(datatype);
     if (decrementBufferSize)
@@ -422,7 +422,7 @@ void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::str
     request.setInputBuffer(name.c_str(), data.data(), dataSize, bufferType, deviceId);
 }
 
-void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const std::string>& inputInfo,
+void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<signed_shape_t, const std::string>& inputInfo,
     const std::vector<float>& data, std::optional<int64_t> overrideBatch, bool putBufferInInputTensorContent) {
     auto it = request.mutable_inputs()->begin();
     size_t bufferId = 0;

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -45,7 +45,8 @@
 #include "../modelmanager.hpp"
 #include "../tensorinfo.hpp"
 
-using inputs_info_t = std::map<std::string, std::tuple<ovms::shape_t, ovms::Precision>>;
+using signed_shape_t = std::vector<int64_t>;
+using inputs_info_t = std::map<std::string, std::tuple<signed_shape_t, ovms::Precision>>;
 
 const std::string dummy_model_location = std::filesystem::current_path().u8string() + "/src/test/dummy";
 const std::string dummy_fp64_model_location = std::filesystem::current_path().u8string() + "/src/test/dummy_fp64";
@@ -117,7 +118,8 @@ constexpr const char* DUMMY_MODEL_OUTPUT_NAME = "a";
 constexpr const int DUMMY_MODEL_INPUT_SIZE = 10;
 constexpr const int DUMMY_MODEL_OUTPUT_SIZE = 10;
 constexpr const float DUMMY_ADDITION_VALUE = 1.0;
-const std::vector<size_t> DUMMY_MODEL_SHAPE{1, 10};
+const signed_shape_t DUMMY_MODEL_SHAPE{1, 10};
+const ovms::Shape DUMMY_MODEL_SHAPE_META{1, 10};
 
 constexpr const char* DUMMY_FP64_MODEL_INPUT_NAME = "input:0";
 constexpr const char* DUMMY_FP64_MODEL_OUTPUT_NAME = "output:0";
@@ -159,14 +161,14 @@ void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_
 KFSTensorInputProto* findKFSInferInputTensor(::KFSRequest& request, const std::string& name);
 std::string* findKFSInferInputTensorContentInRawInputs(::KFSRequest& request, const std::string& name);
 
-void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const std::string>& inputInfo,
+void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<signed_shape_t, const std::string>& inputInfo,
     const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
-void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
+void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<signed_shape_t, const ovms::Precision>& inputInfo,
     const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
 
-void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<ovms::shape_t, OVMS_DataType>& inputInfo,
+void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<signed_shape_t, OVMS_DataType>& inputInfo,
     const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
-void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
+void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<signed_shape_t, const ovms::Precision>& inputInfo,
     const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
 
 void preparePredictRequest(::KFSRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -154,24 +154,24 @@ ovms::tensor_map_t prepareTensors(
     const std::unordered_map<std::string, ovms::Shape>&& tensors,
     ovms::Precision precision = ovms::Precision::FP32);
 
-void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {});
+void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt);
 
 KFSTensorInputProto* findKFSInferInputTensor(::KFSRequest& request, const std::string& name);
 std::string* findKFSInferInputTensorContentInRawInputs(::KFSRequest& request, const std::string& name);
 
 void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const std::string>& inputInfo,
-    const std::vector<float>& data = {}, bool putBufferInInputTensorContent = false);
+    const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
 void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
-    const std::vector<float>& data = {}, bool putBufferInInputTensorContent = false);
+    const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
 
 void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<ovms::shape_t, OVMS_DataType>& inputInfo,
-    const std::vector<float>& data, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
+    const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
 void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<ovms::shape_t, const ovms::Precision>& inputInfo,
-    const std::vector<float>& data, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
+    const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
 
-void preparePredictRequest(::KFSRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {}, bool putBufferInInputTensorContent = false);
+void preparePredictRequest(::KFSRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
 
-void preparePredictRequest(ovms::InferenceRequest& request, inputs_info_t requestInputs, const std::vector<float>& data,
+void preparePredictRequest(ovms::InferenceRequest& request, inputs_info_t requestInputs, const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt,
     uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
 
 void prepareBinaryPredictRequest(tensorflow::serving::PredictRequest& request, const std::string& inputName, const int batchSize);

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -156,24 +156,24 @@ ovms::tensor_map_t prepareTensors(
     const std::unordered_map<std::string, ovms::Shape>&& tensors,
     ovms::Precision precision = ovms::Precision::FP32);
 
-void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt);
+void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {});
 
 KFSTensorInputProto* findKFSInferInputTensor(::KFSRequest& request, const std::string& name);
 std::string* findKFSInferInputTensorContentInRawInputs(::KFSRequest& request, const std::string& name);
 
 void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<signed_shape_t, const std::string>& inputInfo,
-    const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
+    const std::vector<float>& data = {}, bool putBufferInInputTensorContent = false);
 void prepareKFSInferInputTensor(::KFSRequest& request, const std::string& name, const std::tuple<signed_shape_t, const ovms::Precision>& inputInfo,
-    const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
+    const std::vector<float>& data = {}, bool putBufferInInputTensorContent = false);
 
 void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<signed_shape_t, OVMS_DataType>& inputInfo,
-    const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
+    const std::vector<float>& data, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
 void prepareCAPIInferInputTensor(ovms::InferenceRequest& request, const std::string& name, const std::tuple<signed_shape_t, const ovms::Precision>& inputInfo,
-    const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
+    const std::vector<float>& data, uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
 
-void preparePredictRequest(::KFSRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {}, std::optional<int64_t> overrideBatch = std::nullopt, bool putBufferInInputTensorContent = false);
+void preparePredictRequest(::KFSRequest& request, inputs_info_t requestInputs, const std::vector<float>& data = {}, bool putBufferInInputTensorContent = false);
 
-void preparePredictRequest(ovms::InferenceRequest& request, inputs_info_t requestInputs, const std::vector<float>& data, std::optional<int64_t> overrideBatch = std::nullopt,
+void preparePredictRequest(ovms::InferenceRequest& request, inputs_info_t requestInputs, const std::vector<float>& data,
     uint32_t decrementBufferSize = 0, OVMS_BufferType bufferType = OVMS_BUFFERTYPE_CPU, std::optional<uint32_t> deviceId = std::nullopt);
 
 void prepareBinaryPredictRequest(tensorflow::serving::PredictRequest& request, const std::string& inputName, const int batchSize);


### PR DESCRIPTION
- fix issue with negative value REST shape causing abnormal gRPC proto creation
- fix issue with gRPC negative shape value, causing abnormal behavior in post-validation steps
- added unit tests
- added support for signed values in shape in test framework for better corner case testing