### PR TITLE
Revert back decision logic for raw/non-raw placement of data in KServe outputs

### DIFF
--- a/src/dags/exit_node.cpp
+++ b/src/dags/exit_node.cpp
@@ -64,7 +64,7 @@ template <typename ResponseType>
 Status ExitNode<ResponseType>::fetchResults(const TensorMap& inputTensors) {
     OutputGetter<const TensorMap&> outputGetter(inputTensors);
     static const model_version_t version{1};
-    return serializePredictResponse(outputGetter, pipelineName, version, this->outputsInfo, this->response, getOutputMapKeyName);
+    return serializePredictResponse(outputGetter, pipelineName, version, this->outputsInfo, this->response, getOutputMapKeyName, useSharedOutputContent);
 }
 
 template <typename ResponseType>

--- a/src/dags/pipelinedefinition.cpp
+++ b/src/dags/pipelinedefinition.cpp
@@ -275,7 +275,7 @@ Status PipelineDefinition::create(std::unique_ptr<Pipeline>& pipeline,
                                              nodeResources.at(info.nodeName)));
             break;
         case NodeKind::EXIT: {
-            auto node = std::make_unique<ExitNode<ResponseType>>(response, getOutputsInfo(), info.gatherFromNode, useSharedOutputContent(request), getName());
+            auto node = std::make_unique<ExitNode<ResponseType>>(response, getOutputsInfo(), info.gatherFromNode, useSharedOutputContentFn(request), getName());
             exit = node.get();
             nodes.emplace(info.nodeName, std::move(node));
             break;

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -1207,7 +1207,7 @@ Status ModelInstance::infer(const RequestType* requestProto,
 
     timer.start(SERIALIZE);
     OutputGetter<ov::InferRequest&> outputGetter(inferRequest);
-    status = serializePredictResponse(outputGetter, getName(), getVersion(), getOutputsInfo(), responseProto, getTensorInfoName);
+    status = serializePredictResponse(outputGetter, getName(), getVersion(), getOutputsInfo(), responseProto, getTensorInfoName, useSharedOutputContentFn(requestProto));
     timer.stop(SERIALIZE);
     if (!status.ok())
         return status;

--- a/src/prediction_service_utils.cpp
+++ b/src/prediction_service_utils.cpp
@@ -115,9 +115,18 @@ std::map<std::string, shape_t> getRequestShapes(const InferenceRequest* request)
     return request->getRequestShapes();
 }
 
-template <>
-bool useSharedOutputContent(const ::inference::ModelInferRequest* request) {
+bool useSharedOutputContentFn(const tensorflow::serving::PredictRequest* request) {
+    // does not apply for TFS frontend
+    return false;
+}
+
+bool useSharedOutputContentFn(const ::KFSRequest* request) {
     return request->raw_input_contents().size() > 0;
+}
+
+bool useSharedOutputContentFn(const InferenceRequest* request) {
+    // does not apply for C-API frontend
+    return false;
 }
 
 }  // namespace ovms

--- a/src/prediction_service_utils.hpp
+++ b/src/prediction_service_utils.hpp
@@ -43,8 +43,7 @@ std::map<std::string, shape_t> getRequestShapes(const InferenceRequest* request)
  * which informs how response should be formated. Therefore return value should not have an impact for
  * any other frontend.
  */
-template <typename RequestType>
-bool useSharedOutputContent(const RequestType* request) {
-    return true;
-}
+bool useSharedOutputContentFn(const tensorflow::serving::PredictRequest* request);
+bool useSharedOutputContentFn(const ::KFSRequest* request);
+bool useSharedOutputContentFn(const InferenceRequest* request);
 }  // namespace ovms

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -92,7 +92,7 @@ Status serializePredictResponse(
     const tensor_map_t& outputMap,
     tensorflow::serving::PredictResponse* response,
     outputNameChooser_t outputNameChooser,
-    bool useSharedOutputContent = true) {
+    bool useSharedOutputContent = true) {  // does not apply for TFS frontend
     OVMS_PROFILE_FUNCTION();
     Status status;
     ProtoGetter<tensorflow::serving::PredictResponse*, tensorflow::TensorProto&> protoGetter(response);
@@ -151,7 +151,8 @@ Status serializePredictResponse(
     model_version_t servableVersion,
     const tensor_map_t& outputMap,
     InferenceResponse* response,
-    outputNameChooser_t outputNameChooser) {
+    outputNameChooser_t outputNameChooser,
+    bool useSharedOutputContent = true) {  // does not apply for C-API frontend
     OVMS_PROFILE_FUNCTION();
     Status status;
     uint32_t outputId = 0;


### PR DESCRIPTION
Revert commit: https://github.com/openvinotoolkit/model_server/commit/30da741ebd5daa09eba8163a27a3a7af3fe83f5f
Needs unit test