### PR TITLE
Add support for dtype: UINT8 input in the benchmark_client.

### DIFF
--- a/demos/benchmark/python/client.py
+++ b/demos/benchmark/python/client.py
@@ -363,6 +363,8 @@ class BaseClient(metaclass=abc.ABCMeta):
             dtype = tensorflow.dtypes.int32
         elif dtype == self.DTYPE_INT_64:
             dtype = tensorflow.dtypes.int64
+        elif dtype == self.DTYPE_UINT_8:
+            dtype = tensorflow.dtypes.uint8
         else: raise ValueError(f"not supported type: {dtype}")
         return shape, dtype
 


### PR DESCRIPTION
This PR adds support for input dtype UINT8 in the benchmark_client when creating dummy data.
Currently, the client raises an error for models that have UINT8 inputs.
This PR Fixes the following error:
```
Client 2.6
NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a localhost -r 30002 -m cv2-tf -b 1 -p 30001 -t 30 --report_warmup --print_all
          XI worker: request for metadata of model cv2-tf...
          XI worker: Metadata for model cv2-tf is downloaded...
          XI worker: set version of model cv2-tf: 1
          XI worker: inputs:
          XI worker:  input:
          XI worker:   name: input
          XI worker:   dtype: DT_UINT8
          XI worker:   tensorShape: {'dim': [{'size': '1'}, {'size': '224'}, {'size': '224'}, {'size': '3'}]}
          XI worker: outputs:
          XI worker:  linear/BiasAdd:
          XI worker:   name: linear/BiasAdd
          XI worker:   dtype: DT_FLOAT
          XI worker:   tensorShape: {'dim': [{'size': '1'}, {'size': '1000'}]}
          XI worker: new random range: 0.0, 255.0
          XI worker: batchsize sequence: [1]
          XI worker: dataset length (input): 1
Traceback (most recent call last):
  File "/ovms_benchmark_client/main.py", line 320, in <module>
    return_code, common_results = exec_single_client(xargs)
  File "/ovms_benchmark_client/main.py", line 145, in exec_single_client
    return_code, results = run_single_client(xargs, client, 0, False)
  File "/ovms_benchmark_client/main.py", line 106, in run_single_client
    client.prepare_data(xargs["data"], bs_list, dataset_length, forced_shape)
  File "/ovms_benchmark_client/client.py", line 285, in prepare_data
    self.generate_urandom_data(input_name, dataset_length)
  File "/ovms_benchmark_client/client.py", line 445, in generate_urandom_data
    shape, dtype = self.__fix_shape_and_type(input_name)
  File "/ovms_benchmark_client/client.py", line 366, in __fix_shape_and_type
    else: raise ValueError(f"not supported type: {dtype}")
ValueError: not supported type: DT_UINT8
```