### PR TITLE
Relative paths support

### DIFF
--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -30,7 +30,7 @@ echo "Number of warnings about not direct includes:" ${NO_WARNINGS_DIRECT}
 echo "Number of warnings about not used: " ${NO_WARNINGS_NOTUSED}
 
 trap "cat ${CPPCLEAN_RESULTS_FILE_SRC}" err exit
-if [ ${NO_WARNINGS_FORWARD} -gt 6 ]; then
+if [ ${NO_WARNINGS_FORWARD} -gt 7 ]; then
     echo "Failed due to not using forward declarations where possible: ${NO_WARNINGS_FORWARD}";
     exit 1;
 fi
@@ -42,7 +42,7 @@ if [ ${NO_WARNINGS_NOTUSED} -gt 7 ]; then
     echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_NOTUSED}";
     exit 1;
 fi
-if [ ${NO_WARNINGS} -gt  162 ]; then
+if [ ${NO_WARNINGS} -gt  164 ]; then
     echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
     exit 1
 fi

--- a/src/BUILD
+++ b/src/BUILD
@@ -177,6 +177,7 @@ cc_library(
         "dags/exit_node.hpp",
         "dags/exitnodesession.cpp",
         "dags/exitnodesession.hpp",
+        "filesystem.cpp",
         "filesystem.hpp",
         "get_model_metadata_impl.cpp",
         "get_model_metadata_impl.hpp",

--- a/src/azurefilesystem.cpp
+++ b/src/azurefilesystem.cpp
@@ -24,9 +24,6 @@
 
 namespace ovms {
 
-const std::string AzureFileSystem::AZURE_URL_FILE_PREFIX = "azfs://";
-const std::string AzureFileSystem::AZURE_URL_BLOB_PREFIX = "az://";
-
 static as::cloud_storage_account createDefaultOrAnonymousAccount() {
     try {
         const char* env_cred = std::getenv("AZURE_STORAGE_CONNECTION_STRING");

--- a/src/azurefilesystem.hpp
+++ b/src/azurefilesystem.hpp
@@ -131,10 +131,6 @@ public:
    */
     StatusCode deleteFileFolder(const std::string& path) override;
 
-    static const std::string AZURE_URL_FILE_PREFIX;
-
-    static const std::string AZURE_URL_BLOB_PREFIX;
-
 private:
     /**
    *

--- a/src/azurestorage.cpp
+++ b/src/azurestorage.cpp
@@ -555,9 +555,9 @@ StatusCode AzureStorageBlob::parseFilePath(const std::string& path) {
     fullUri_ = path;
     int share_start = 0;
     // Blob path
-    if (path.find(AzureFileSystem::AZURE_URL_BLOB_PREFIX) != std::string::npos) {
-        share_start = path.find(AzureFileSystem::AZURE_URL_BLOB_PREFIX) + AzureFileSystem::AZURE_URL_BLOB_PREFIX.size();
-    } else if (path.find(AzureFileSystem::AZURE_URL_FILE_PREFIX) != std::string::npos) {
+    if (path.find(FileSystem::AZURE_URL_BLOB_PREFIX) != std::string::npos) {
+        share_start = path.find(FileSystem::AZURE_URL_BLOB_PREFIX) + FileSystem::AZURE_URL_BLOB_PREFIX.size();
+    } else if (path.find(FileSystem::AZURE_URL_FILE_PREFIX) != std::string::npos) {
         // File path
         SPDLOG_LOGGER_ERROR(azurestorage_logger, "Wrong object type - az:// prefix in path required, azure:// found:", path);
         return StatusCode::AS_INVALID_PATH;
@@ -1154,9 +1154,9 @@ StatusCode AzureStorageFile::parseFilePath(const std::string& path) {
     fullUri_ = path;
     int share_start = 0;
     // File or directory path
-    if (path.find(AzureFileSystem::AZURE_URL_FILE_PREFIX) != std::string::npos) {
-        share_start = path.find(AzureFileSystem::AZURE_URL_FILE_PREFIX) + AzureFileSystem::AZURE_URL_FILE_PREFIX.size();
-    } else if (path.find(AzureFileSystem::AZURE_URL_BLOB_PREFIX) != std::string::npos) {
+    if (path.find(FileSystem::AZURE_URL_FILE_PREFIX) != std::string::npos) {
+        share_start = path.find(FileSystem::AZURE_URL_FILE_PREFIX) + FileSystem::AZURE_URL_FILE_PREFIX.size();
+    } else if (path.find(FileSystem::AZURE_URL_BLOB_PREFIX) != std::string::npos) {
         // Blob path
         SPDLOG_LOGGER_ERROR(azurestorage_logger, "Wrong object type. azfs:// prefix in path required, found az://:", path);
         return StatusCode::AS_INVALID_PATH;
@@ -1212,7 +1212,7 @@ std::shared_ptr<AzureStorageAdapter> AzureStorageFactory::getNewAzureStorageObje
 }
 
 bool AzureStorageFactory::isBlobStoragePath(std::string path) {
-    return (path.find(AzureFileSystem::AZURE_URL_BLOB_PREFIX) != std::string::npos);
+    return (path.find(FileSystem::AZURE_URL_BLOB_PREFIX) != std::string::npos);
 }
 
 }  // namespace ovms

--- a/src/dags/custom_node_library_manager.cpp
+++ b/src/dags/custom_node_library_manager.cpp
@@ -31,6 +31,16 @@ Status CustomNodeLibraryManager::loadLibrary(const std::string& name, const std:
         return StatusCode::PATH_INVALID;
     }
 
+    if (basePath.at(0) != '/') {
+        SPDLOG_LOGGER_ERROR(modelmanager_logger, "Path {} is relative, should have already been constructed as full path for library {}.", basePath, name);
+        return StatusCode::PATH_INVALID;
+    }
+
+    if (basePath.at(0) != '/') {
+        SPDLOG_LOGGER_ERROR(modelmanager_logger, "Path {} is relative, should have already been constructed as full path for library {}.", basePath, name);
+        return StatusCode::PATH_INVALID;
+    }
+
     auto it = libraries.find(name);
     if (it != libraries.end() && it->second.basePath == basePath) {
         SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Custom node library name: {} is already loaded", name);

--- a/src/dags/custom_node_library_manager.cpp
+++ b/src/dags/custom_node_library_manager.cpp
@@ -36,11 +36,6 @@ Status CustomNodeLibraryManager::loadLibrary(const std::string& name, const std:
         return StatusCode::PATH_INVALID;
     }
 
-    if (basePath.at(0) != '/') {
-        SPDLOG_LOGGER_ERROR(modelmanager_logger, "Path {} is relative, should have already been constructed as full path for library {}.", basePath, name);
-        return StatusCode::PATH_INVALID;
-    }
-
     auto it = libraries.find(name);
     if (it != libraries.end() && it->second.basePath == basePath) {
         SPDLOG_LOGGER_DEBUG(modelmanager_logger, "Custom node library name: {} is already loaded", name);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,0 +1,30 @@
+//*****************************************************************************
+// Copyright 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+
+#include "filesystem.hpp"
+
+namespace ovms {
+
+const std::string FileSystem::S3_URL_PREFIX = "s3://";
+
+const std::string FileSystem::GCS_URL_PREFIX = "gs://";
+
+const std::string FileSystem::AZURE_URL_FILE_PREFIX = "azfs://";
+
+const std::string FileSystem::AZURE_URL_BLOB_PREFIX = "az://";
+
+}  // namespace ovms

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -31,6 +31,7 @@ namespace ovms {
 namespace fs = std::filesystem;
 
 using files_list_t = std::set<std::string>;
+
 class FileSystem {
 public:
     /**
@@ -146,6 +147,30 @@ public:
         std::size_t lhs = path.find("../");
         std::size_t rhs = path.find("/..");
         return (std::string::npos != lhs && lhs == 0) || (std::string::npos != rhs && rhs == path.length() - 3) || std::string::npos != path.find("/../");
+    }
+
+    static const std::string S3_URL_PREFIX;
+
+    static const std::string GCS_URL_PREFIX;
+
+    static const std::string AZURE_URL_FILE_PREFIX;
+
+    static const std::string AZURE_URL_BLOB_PREFIX;
+
+    static bool isLocalFilesystem(const std::string& basePath) {
+        if (basePath.rfind(S3_URL_PREFIX, 0) == 0) {
+            return false;
+        }
+        if (basePath.rfind(GCS_URL_PREFIX, 0) == 0) {
+            return false;
+        }
+        if (basePath.rfind(AZURE_URL_FILE_PREFIX, 0) == 0) {
+            return false;
+        }
+        if (basePath.rfind(AZURE_URL_BLOB_PREFIX, 0) == 0) {
+            return false;
+        }
+        return true;
     }
 
     std::string appendSlash(const std::string& name) {

--- a/src/gcsfilesystem.cpp
+++ b/src/gcsfilesystem.cpp
@@ -39,11 +39,9 @@ namespace ovms {
 namespace fs = std::filesystem;
 namespace gcs = google::cloud::storage;
 
-const std::string GCSFileSystem::GCS_URL_PREFIX = "gs://";
-
 StatusCode GCSFileSystem::parsePath(const std::string& path,
     std::string* bucket, std::string* object) {
-    int bucket_start = path.find(GCS_URL_PREFIX) + GCS_URL_PREFIX.size();
+    int bucket_start = path.find(FileSystem::GCS_URL_PREFIX) + FileSystem::GCS_URL_PREFIX.size();
     int bucket_end = path.find("/", bucket_start);
     if (bucket_end > bucket_start) {
         *bucket = path.substr(bucket_start, bucket_end - bucket_start);

--- a/src/gcsfilesystem.hpp
+++ b/src/gcsfilesystem.hpp
@@ -131,8 +131,6 @@ public:
    */
     StatusCode deleteFileFolder(const std::string& path) override;
 
-    static const std::string GCS_URL_PREFIX;
-
 private:
     /**
     * @brief

--- a/src/mediapipe_internal/mediapipefactory.cpp
+++ b/src/mediapipe_internal/mediapipefactory.cpp
@@ -54,8 +54,12 @@ bool MediapipeFactory::definitionExists(const std::string& name) const {
 }
 
 MediapipeGraphDefinition* MediapipeFactory::findDefinitionByName(const std::string& name) const {
-    SPDLOG_ERROR("NOT_IMPLEMENTED");
-    return nullptr;  // TODO
+    auto it = definitions.find(name);
+    if (it == std::end(definitions)) {
+        return nullptr;
+    } else {
+        return it->second.get();
+    }
 }
 
 Status MediapipeFactory::reloadDefinition(const std::string& pipelineName,  // TODO

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -25,6 +25,7 @@
 
 #include "logging.hpp"
 #include "modelchangesubscription.hpp"
+#include "modelconfig.hpp"
 #include "modelversion.hpp"
 
 namespace ov {
@@ -34,7 +35,6 @@ class Core;
 namespace ovms {
 class FileSystem;
 class GlobalSequencesViewer;
-class ModelConfig;
 class ModelInstance;
 class PipelineDefinition;
 class MetricConfig;

--- a/src/modelconfig.cpp
+++ b/src/modelconfig.cpp
@@ -26,7 +26,6 @@
 #include <rapidjson/writer.h>
 #include <spdlog/spdlog.h>
 
-#include "logging.hpp"
 #include "model_version_policy.hpp"
 #include "schema.hpp"
 #include "stringutils.hpp"
@@ -504,7 +503,12 @@ Status ModelConfig::parseModelMapping() {
 
 Status ModelConfig::parseNode(const rapidjson::Value& v) {
     this->setName(v["name"].GetString());
-    this->setBasePath(v["base_path"].GetString());
+    try {
+        this->setBasePath(v["base_path"].GetString());
+    } catch (std::logic_error& e) {
+        SPDLOG_DEBUG("Relative path error: {}", e.what());
+        return StatusCode::INTERNAL_ERROR;
+    }
     Status firstErrorStatus = StatusCode::OK;
 
     // Check for optional parameters

--- a/src/modelconfig.hpp
+++ b/src/modelconfig.hpp
@@ -26,7 +26,9 @@
 
 #include <rapidjson/document.h>
 
+#include "filesystem.hpp"
 #include "layout_configuration.hpp"
+#include "logging.hpp"
 #include "metric_config.hpp"
 #include "modelversion.hpp"
 #include "shape.hpp"
@@ -57,6 +59,11 @@ private:
          * @brief Model uri path
          */
     std::string basePath;
+
+    /**
+         * @brief Json config directory path
+         */
+    std::string rootDirectoryPath;
 
     /**
          * @brief Model local destination path on disk after downloading from online storage
@@ -303,7 +310,27 @@ public:
          * @param basePath 
          */
     void setBasePath(const std::string& basePath) {
-        this->basePath = basePath;
+        if (!FileSystem::isLocalFilesystem(basePath)) {
+            // Cloud filesystem
+            this->basePath = basePath;
+        } else if (basePath.at(0) == '/') {
+            // Full path case
+            this->basePath = basePath;
+        } else {
+            // Relative path case
+            if (this->rootDirectoryPath.empty())
+                throw std::logic_error("Using model relative path without setting configuration directory path.");
+            this->basePath = this->rootDirectoryPath + basePath;
+        }
+    }
+
+    /**
+         * @brief Set root directory path
+         *
+         * @param rootDirectoryPath
+         */
+    void setRootDirectoryPath(const std::string& rootDirectoryPath) {
+        this->rootDirectoryPath = rootDirectoryPath;
     }
 
     /**

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -36,7 +36,6 @@
 #include "mediapipe_internal/mediapipefactory.hpp"
 #include "metric_config.hpp"
 #include "model.hpp"
-#include "modelconfig.hpp"
 #include "status.hpp"
 
 namespace ovms {
@@ -49,6 +48,7 @@ class CNLIMWrapper;
 class CustomLoaderConfig;
 class CustomNodeLibraryManager;
 class MetricRegistry;
+class ModelConfig;
 class FileSystem;
 struct FunctorSequenceCleaner;
 struct FunctorResourcesCleaner;
@@ -208,7 +208,31 @@ private:
 
     MetricRegistry* metricRegistry;
 
+    /**
+     * @brief Json config directory path
+     *
+     */
+    std::string rootDirectoryPath;
+
+    /**
+     * @brief Set json config directory path
+     *
+     * @param configFileFullPath
+     */
+    void setRootDirectoryPath(const std::string& configFileFullPath) {
+        auto configDirectory = configFileFullPath.substr(0, configFileFullPath.find_last_of("/\\") + 1);
+        std::string currentWorkingDir = std::filesystem::current_path();
+        configDirectory.empty() ? this->rootDirectoryPath = currentWorkingDir + "/" : this->rootDirectoryPath = configDirectory;
+    }
+
 public:
+    /**
+     * @brief Get the full path from relative or full path
+     *
+     * @return const std::string&
+     */
+    const std::string getFullPath(const std::string& pathToCheck) const;
+
     /**
      * @brief Mutex for blocking concurrent add & find of model
      */

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -438,8 +438,6 @@ void OVMS_InferenceResponseDelete(OVMS_InferenceResponse* response);
 // \param response The respons object. In case of success, caller takes the ownership of the response
 // \return OVMS_Status object in case of failure
 OVMS_Status* OVMS_Inference(OVMS_Server* server, OVMS_InferenceRequest* request, OVMS_InferenceResponse** response);
-OVMS_Status* OVMS_GRPCInference(const void* request, void* response);
-OVMS_Status* OVMS_GRPCInference2(void* server, const void* request, void* response);
 
 #ifdef __cplusplus
 }

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -438,6 +438,8 @@ void OVMS_InferenceResponseDelete(OVMS_InferenceResponse* response);
 // \param response The respons object. In case of success, caller takes the ownership of the response
 // \return OVMS_Status object in case of failure
 OVMS_Status* OVMS_Inference(OVMS_Server* server, OVMS_InferenceRequest* request, OVMS_InferenceResponse** response);
+OVMS_Status* OVMS_GRPCInference(const void* request, void* response);
+OVMS_Status* OVMS_GRPCInference2(void* server, const void* request, void* response);
 
 #ifdef __cplusplus
 }

--- a/src/s3filesystem.cpp
+++ b/src/s3filesystem.cpp
@@ -48,8 +48,6 @@ namespace ovms {
 namespace s3 = Aws::S3;
 namespace fs = std::filesystem;
 
-const std::string S3FileSystem::S3_URL_PREFIX = "s3://";
-
 StatusCode S3FileSystem::parsePath(const std::string& path, std::string* bucket, std::string* object) {
     std::smatch sm;
 
@@ -59,7 +57,7 @@ StatusCode S3FileSystem::parsePath(const std::string& path, std::string* bucket,
     }
 
     if (!std::regex_match(path, sm, s3_regex_)) {
-        int bucket_start = path.find(S3_URL_PREFIX) + S3_URL_PREFIX.size();
+        int bucket_start = path.find(FileSystem::S3_URL_PREFIX) + FileSystem::S3_URL_PREFIX.size();
         int bucket_end = path.find("/", bucket_start);
 
         if (bucket_end > bucket_start) {
@@ -85,8 +83,8 @@ StatusCode S3FileSystem::parsePath(const std::string& path, std::string* bucket,
 
 S3FileSystem::S3FileSystem(const Aws::SDKOptions& options, const std::string& s3_path) :
     options_(options),
-    s3_regex_(S3_URL_PREFIX + "([0-9a-zA-Z-.]+):([0-9]+)/([0-9a-z.-]+)(((/"
-                              "[0-9a-zA-Z.-_]+)*)?)"),
+    s3_regex_(FileSystem::S3_URL_PREFIX + "([0-9a-zA-Z-.]+):([0-9]+)/([0-9a-z.-]+)(((/"
+                                          "[0-9a-zA-Z.-_]+)*)?)"),
     proxy_regex_("^(https?)://(([^:]{1,128}):([^@]{1,256})@)?([^:/]{1,255})(:([0-9]{1,5}))?/?") {
     Aws::Client::ClientConfiguration config;
     Aws::Auth::AWSCredentials credentials;
@@ -254,7 +252,7 @@ StatusCode S3FileSystem::getDirectoryContents(const std::string& path, std::set<
     if (status != StatusCode::OK) {
         return status;
     }
-    std::string true_path = S3_URL_PREFIX + bucket + '/' + dir_path;
+    std::string true_path = FileSystem::S3_URL_PREFIX + bucket + '/' + dir_path;
 
     // Capture the full path to facilitate content listing
     full_dir = appendSlash(dir_path);
@@ -297,7 +295,7 @@ StatusCode S3FileSystem::getDirectorySubdirs(const std::string& path, std::set<s
     if (status != StatusCode::OK) {
         return status;
     }
-    std::string true_path = S3_URL_PREFIX + bucket + '/' + dir_path;
+    std::string true_path = FileSystem::S3_URL_PREFIX + bucket + '/' + dir_path;
     status = getDirectoryContents(true_path, subdirs);
     if (status != StatusCode::OK) {
         return status;
@@ -328,7 +326,7 @@ StatusCode S3FileSystem::getDirectoryFiles(const std::string& path, std::set<std
         return status;
     }
 
-    std::string true_path = S3_URL_PREFIX + bucket + '/' + dir_path;
+    std::string true_path = FileSystem::S3_URL_PREFIX + bucket + '/' + dir_path;
     status = getDirectoryContents(true_path, files);
     if (status != StatusCode::OK) {
         return status;
@@ -412,7 +410,7 @@ StatusCode S3FileSystem::downloadFileFolder(const std::string& path, const std::
         host_port = sm[2];
         bucket = sm[3];
         object = sm[4];
-        effective_path = S3_URL_PREFIX + bucket + object;
+        effective_path = FileSystem::S3_URL_PREFIX + bucket + object;
     } else {
         effective_path = path;
     }

--- a/src/s3filesystem.hpp
+++ b/src/s3filesystem.hpp
@@ -124,8 +124,6 @@ public:
      */
     StatusCode deleteFileFolder(const std::string& path) override;
 
-    static const std::string S3_URL_PREFIX;
-
 private:
     /**
      * @brief 

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -82,6 +82,50 @@ const char* custom_loader_config_model = R"({
       ]
     })";
 
+// config_model_with_customloader
+const char* custom_loader_config_model_relative_paths = R"({
+       "custom_loader_config_list":[
+         {
+          "config":{
+            "loader_name":"sample-loader",
+            "library_path": "libsampleloader.so"
+          }
+         }
+       ],
+      "model_config_list":[
+        {
+          "config":{
+            "name":"dummy",
+            "base_path": "test_cl_models/model1",
+            "nireq": 1,
+            "custom_loader_options": {"loader_name":  "sample-loader", "model_file":  "dummy.xml", "bin_file": "dummy.bin"}
+          }
+        }
+      ]
+    })";
+
+// config_model_with_customloader
+const char* custom_loader_config_model_relative_paths = R"({
+       "custom_loader_config_list":[
+         {
+          "config":{
+            "loader_name":"sample-loader",
+            "library_path": "libsampleloader.so"
+          }
+         }
+       ],
+      "model_config_list":[
+        {
+          "config":{
+            "name":"dummy",
+            "base_path": "test_cl_models/model1",
+            "nireq": 1,
+            "custom_loader_options": {"loader_name":  "sample-loader", "model_file":  "dummy.xml", "bin_file": "dummy.bin"}
+          }
+        }
+      ]
+    })";
+
 // config_no_model_with_customloader
 const char* custom_loader_config_model_deleted = R"({
        "custom_loader_config_list":[
@@ -603,6 +647,48 @@ TEST_F(TestCustomLoader, CustomLoaderPrediction) {
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+    performPredict("dummy", 1, request);
+}
+
+TEST_F(TestCustomLoader, CustomLoaderPredictionRelativePath) {
+    // Copy dummy model to temporary destination
+    std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
+    std::filesystem::copy("/ovms/bazel-bin/src/libsampleloader.so", cl_models_path, std::filesystem::copy_options::recursive);
+
+    // Replace model path in the config string
+    std::string configStr = custom_loader_config_model_relative_paths;
+    configStr.replace(configStr.find("test_cl_models"), std::string("test_cl_models").size(), cl_models_path);
+
+    // Create config file
+    std::string fileToReload = cl_models_path + "/cl_config.json";
+    createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
+
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
+        {{DUMMY_MODEL_INPUT_NAME,
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
+    performPredict("dummy", 1, request);
+}
+
+TEST_F(TestCustomLoader, CustomLoaderPredictionRelativePath) {
+    // Copy dummy model to temporary destination
+    std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
+    std::filesystem::copy("/ovms/bazel-bin/src/libsampleloader.so", cl_models_path, std::filesystem::copy_options::recursive);
+
+    // Replace model path in the config string
+    std::string configStr = custom_loader_config_model_relative_paths;
+    configStr.replace(configStr.find("test_cl_models"), std::string("test_cl_models").size(), cl_models_path);
+
+    // Create config file
+    std::string fileToReload = cl_models_path + "/cl_config.json";
+    createConfigFileWithContent(configStr, fileToReload);
+    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
+
+    tensorflow::serving::PredictRequest request;
+    preparePredictRequest(request,
+        {{DUMMY_MODEL_INPUT_NAME,
+            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 }
 

--- a/src/test/custom_loader_test.cpp
+++ b/src/test/custom_loader_test.cpp
@@ -104,28 +104,6 @@ const char* custom_loader_config_model_relative_paths = R"({
       ]
     })";
 
-// config_model_with_customloader
-const char* custom_loader_config_model_relative_paths = R"({
-       "custom_loader_config_list":[
-         {
-          "config":{
-            "loader_name":"sample-loader",
-            "library_path": "libsampleloader.so"
-          }
-         }
-       ],
-      "model_config_list":[
-        {
-          "config":{
-            "name":"dummy",
-            "base_path": "test_cl_models/model1",
-            "nireq": 1,
-            "custom_loader_options": {"loader_name":  "sample-loader", "model_file":  "dummy.xml", "bin_file": "dummy.bin"}
-          }
-        }
-      ]
-    })";
-
 // config_no_model_with_customloader
 const char* custom_loader_config_model_deleted = R"({
        "custom_loader_config_list":[
@@ -647,27 +625,6 @@ TEST_F(TestCustomLoader, CustomLoaderPrediction) {
     preparePredictRequest(request,
         {{DUMMY_MODEL_INPUT_NAME,
             std::tuple<ovms::signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
-    performPredict("dummy", 1, request);
-}
-
-TEST_F(TestCustomLoader, CustomLoaderPredictionRelativePath) {
-    // Copy dummy model to temporary destination
-    std::filesystem::copy("/ovms/src/test/dummy", cl_model_1_path, std::filesystem::copy_options::recursive);
-    std::filesystem::copy("/ovms/bazel-bin/src/libsampleloader.so", cl_models_path, std::filesystem::copy_options::recursive);
-
-    // Replace model path in the config string
-    std::string configStr = custom_loader_config_model_relative_paths;
-    configStr.replace(configStr.find("test_cl_models"), std::string("test_cl_models").size(), cl_models_path);
-
-    // Create config file
-    std::string fileToReload = cl_models_path + "/cl_config.json";
-    createConfigFileWithContent(configStr, fileToReload);
-    ASSERT_EQ(manager.loadConfig(fileToReload), ovms::StatusCode::OK);
-
-    tensorflow::serving::PredictRequest request;
-    preparePredictRequest(request,
-        {{DUMMY_MODEL_INPUT_NAME,
-            std::tuple<signed_shape_t, ovms::Precision>{{1, 10}, ovms::Precision::FP32}}});
     performPredict("dummy", 1, request);
 }
 

--- a/src/test/mediapipe/relative_paths/config_relative_dummy.json
+++ b/src/test/mediapipe/relative_paths/config_relative_dummy.json
@@ -1,0 +1,25 @@
+{
+    "model_config_list": [
+        {"config": {
+                "name": "dummy1",
+                "base_path": "dummy1",
+                "shape": "(1, 10)"
+		},
+         "config": {
+                "name": "dummy2",
+                "base_path": "dummy2",
+                "shape": "(1, 10)"
+		}
+	}
+    ],
+    "mediapipe_config_list": [
+        {
+            "name":"mediapipeAddADAPTFULL",
+            "graph_path":"graph1/graphaddadapterfull.pbtxt"
+        },
+        {
+            "name":"mediapipeAddADAPT",
+            "graph_path":"graph2/graphaddadapter.pbtxt"
+        }
+    ]
+}

--- a/src/test/mediapipe/relative_paths/config_relative_dummy.json
+++ b/src/test/mediapipe/relative_paths/config_relative_dummy.json
@@ -19,7 +19,7 @@
         },
         {
             "name":"mediapipeAddADAPT",
-            "graph_path":"graph2/graphaddadapter.pbtxt"
+            "graph_path":"graph2/graphadd.pbtxt"
         }
     ]
 }

--- a/src/test/mediapipe/relative_paths/config_relative_dummy_negative.json
+++ b/src/test/mediapipe/relative_paths/config_relative_dummy_negative.json
@@ -1,0 +1,25 @@
+{
+    "model_config_list": [
+        {"config": {
+                "name": "dummy1",
+                "base_path": "dummy1",
+                "shape": "(1, 10)"
+		},
+         "config": {
+                "name": "dummy2",
+                "base_path": "dummy2",
+                "shape": "(1, 10)"
+		}
+	}
+    ],
+    "mediapipe_config_list": [
+        {
+            "name":"mediapipeAddADAPTFULL",
+            "graph_path":"graph3/graphaddadapterfull.pbtxt"
+        },
+        {
+            "name":"mediapipeAddADAPT",
+            "graph_path":"graph4/graphaddadapter.pbtxt"
+        }
+    ]
+}

--- a/src/test/mediapipe/relative_paths/dummy1/1/dummy.xml
+++ b/src/test/mediapipe/relative_paths/dummy1/1/dummy.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<net name="saved_model" version="10">
+	<layers>
+		<layer id="0" name="b" type="Parameter" version="opset1">
+			<data element_type="f32" shape="1,10"/>
+			<output>
+				<port id="0" precision="FP32">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="1" name="c/read/Output_0/Data_/copy_const" type="Const" version="opset1">
+			<data element_type="f32" offset="0" shape="1,1" size="4"/>
+			<output>
+				<port id="1" precision="FP32">
+					<dim>1</dim>
+					<dim>1</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="2" name="a" type="Add" version="opset1">
+			<input>
+				<port id="0">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+				<port id="1">
+					<dim>1</dim>
+					<dim>1</dim>
+				</port>
+			</input>
+			<output>
+				<port id="2" precision="FP32">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="3" name="a/sink_port_0" type="Result" version="opset1">
+			<input>
+				<port id="0">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+			</input>
+		</layer>
+	</layers>
+	<edges>
+		<edge from-layer="0" from-port="0" to-layer="2" to-port="0"/>
+		<edge from-layer="1" from-port="1" to-layer="2" to-port="1"/>
+		<edge from-layer="2" from-port="2" to-layer="3" to-port="0"/>
+	</edges>
+	<meta_data>
+		<MO_version value="2020.1.0-61-gd349c3ba4a"/>
+		<cli_parameters>
+			<blobs_as_inputs value="True"/>
+			<caffe_parser_path value="DIR"/>
+			<data_type value="float"/>
+			<disable_nhwc_to_nchw value="False"/>
+			<disable_omitting_optional value="False"/>
+			<disable_resnet_optimization value="False"/>
+			<enable_concat_optimization value="False"/>
+			<enable_flattening_nested_params value="False"/>
+			<enable_ssd_gluoncv value="False"/>
+			<extensions value="DIR"/>
+			<framework value="tf"/>
+			<freeze_placeholder_with_value value="{}"/>
+			<generate_deprecated_IR_V2 value="False"/>
+			<generate_deprecated_IR_V7 value="False"/>
+			<generate_experimental_IR_V10 value="True"/>
+			<input value="b"/>
+			<input_model_is_text value="False"/>
+			<input_shape value="[1,10]"/>
+			<k value="DIR/CustomLayersMapping.xml"/>
+			<keep_quantize_ops_in_IR value="True"/>
+			<keep_shape_ops value="False"/>
+			<legacy_mxnet_model value="False"/>
+			<log_level value="ERROR"/>
+			<mean_scale_values value="{}"/>
+			<mean_values value="()"/>
+			<model_name value="saved_model"/>
+			<move_to_preprocess value="False"/>
+			<output_dir value="DIR"/>
+			<placeholder_data_types value="{}"/>
+			<placeholder_shapes value="{'b': array([ 1, 10])}"/>
+			<progress value="False"/>
+			<remove_memory value="False"/>
+			<remove_output_softmax value="False"/>
+			<reverse_input_channels value="False"/>
+			<save_params_from_nd value="False"/>
+			<saved_model_dir value="DIR"/>
+			<scale_values value="()"/>
+			<silent value="False"/>
+			<stream_output value="False"/>
+			<unset unset_cli_parameters="batch, counts, disable_fusing, disable_gfusing, finegrain_fusing, input_checkpoint, input_meta_graph, input_model, input_proto, input_symbol, mean_file, mean_file_offsets, nd_prefix_name, output, pretrained_model_name, saved_model_tags, scale, tensorboard_logdir, tensorflow_custom_layer_libraries, tensorflow_custom_operations_config_update, tensorflow_object_detection_api_pipeline_config, tensorflow_operation_patterns, tensorflow_subgraph_patterns, tensorflow_use_custom_operations_config, transformations_config"/>
+		</cli_parameters>
+	</meta_data>
+</net>

--- a/src/test/mediapipe/relative_paths/dummy2/1/dummy.xml
+++ b/src/test/mediapipe/relative_paths/dummy2/1/dummy.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<net name="saved_model" version="10">
+	<layers>
+		<layer id="0" name="b" type="Parameter" version="opset1">
+			<data element_type="f32" shape="1,10"/>
+			<output>
+				<port id="0" precision="FP32">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="1" name="c/read/Output_0/Data_/copy_const" type="Const" version="opset1">
+			<data element_type="f32" offset="0" shape="1,1" size="4"/>
+			<output>
+				<port id="1" precision="FP32">
+					<dim>1</dim>
+					<dim>1</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="2" name="a" type="Add" version="opset1">
+			<input>
+				<port id="0">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+				<port id="1">
+					<dim>1</dim>
+					<dim>1</dim>
+				</port>
+			</input>
+			<output>
+				<port id="2" precision="FP32">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="3" name="a/sink_port_0" type="Result" version="opset1">
+			<input>
+				<port id="0">
+					<dim>1</dim>
+					<dim>10</dim>
+				</port>
+			</input>
+		</layer>
+	</layers>
+	<edges>
+		<edge from-layer="0" from-port="0" to-layer="2" to-port="0"/>
+		<edge from-layer="1" from-port="1" to-layer="2" to-port="1"/>
+		<edge from-layer="2" from-port="2" to-layer="3" to-port="0"/>
+	</edges>
+	<meta_data>
+		<MO_version value="2020.1.0-61-gd349c3ba4a"/>
+		<cli_parameters>
+			<blobs_as_inputs value="True"/>
+			<caffe_parser_path value="DIR"/>
+			<data_type value="float"/>
+			<disable_nhwc_to_nchw value="False"/>
+			<disable_omitting_optional value="False"/>
+			<disable_resnet_optimization value="False"/>
+			<enable_concat_optimization value="False"/>
+			<enable_flattening_nested_params value="False"/>
+			<enable_ssd_gluoncv value="False"/>
+			<extensions value="DIR"/>
+			<framework value="tf"/>
+			<freeze_placeholder_with_value value="{}"/>
+			<generate_deprecated_IR_V2 value="False"/>
+			<generate_deprecated_IR_V7 value="False"/>
+			<generate_experimental_IR_V10 value="True"/>
+			<input value="b"/>
+			<input_model_is_text value="False"/>
+			<input_shape value="[1,10]"/>
+			<k value="DIR/CustomLayersMapping.xml"/>
+			<keep_quantize_ops_in_IR value="True"/>
+			<keep_shape_ops value="False"/>
+			<legacy_mxnet_model value="False"/>
+			<log_level value="ERROR"/>
+			<mean_scale_values value="{}"/>
+			<mean_values value="()"/>
+			<model_name value="saved_model"/>
+			<move_to_preprocess value="False"/>
+			<output_dir value="DIR"/>
+			<placeholder_data_types value="{}"/>
+			<placeholder_shapes value="{'b': array([ 1, 10])}"/>
+			<progress value="False"/>
+			<remove_memory value="False"/>
+			<remove_output_softmax value="False"/>
+			<reverse_input_channels value="False"/>
+			<save_params_from_nd value="False"/>
+			<saved_model_dir value="DIR"/>
+			<scale_values value="()"/>
+			<silent value="False"/>
+			<stream_output value="False"/>
+			<unset unset_cli_parameters="batch, counts, disable_fusing, disable_gfusing, finegrain_fusing, input_checkpoint, input_meta_graph, input_model, input_proto, input_symbol, mean_file, mean_file_offsets, nd_prefix_name, output, pretrained_model_name, saved_model_tags, scale, tensorboard_logdir, tensorflow_custom_layer_libraries, tensorflow_custom_operations_config_update, tensorflow_object_detection_api_pipeline_config, tensorflow_operation_patterns, tensorflow_subgraph_patterns, tensorflow_use_custom_operations_config, transformations_config"/>
+		</cli_parameters>
+	</meta_data>
+</net>

--- a/src/test/mediapipe/relative_paths/graph1/graphaddadapterfull.pbtxt
+++ b/src/test/mediapipe/relative_paths/graph1/graphaddadapterfull.pbtxt
@@ -1,0 +1,52 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in1"
+input_stream: "in2"
+output_stream: "out"
+node {
+  calculator: "ModelAPISessionCalculator"
+  output_side_packet: "SESSION:session"
+  node_options: {
+    [type.googleapis.com / mediapipe.ModelAPIOVMSSessionCalculatorOptions]: {
+      servable_name: "add"
+      servable_version: "1"
+    }
+  }
+}
+node {
+  calculator: "ModelAPISideFeedCalculator"
+  input_side_packet: "SESSION:session"
+  input_stream: "INPUT1:in1"
+  input_stream: "INPUT2:in2"
+  output_stream: "SUM:out"
+  node_options: {
+    [type.googleapis.com / mediapipe.ModelAPIInferenceCalculatorOptions]: {
+      tag_to_input_tensor_names {
+        key: "INPUT1"
+        value: "input1"
+      }
+      tag_to_input_tensor_names {
+        key: "INPUT2"
+        value: "input2"
+      }
+      tag_to_output_tensor_names {
+        key: "SUM"
+        value: "sum"
+      }
+    }
+  }
+}
+

--- a/src/test/mediapipe/relative_paths/graph2/graphadd.pbtxt
+++ b/src/test/mediapipe/relative_paths/graph2/graphadd.pbtxt
@@ -1,0 +1,42 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in1"
+input_stream: "in2"
+output_stream: "out"
+node {
+  calculator: "OVMSOVCalculator"
+  input_stream: "INPUT1:in1"
+  input_stream: "INPUT2:in2"
+  output_stream: "SUM:out"
+  node_options: {
+        [type.googleapis.com / mediapipe.OVMSCalculatorOptions]: {
+          servable_name: "add"
+          servable_version: "1"
+          tag_to_input_tensor_names {
+            key: "INPUT1"
+            value: "input1"
+          }
+          tag_to_input_tensor_names {
+            key: "INPUT2"
+            value: "input2"
+          }
+          tag_to_output_tensor_names {
+            key: "SUM"
+            value: "sum"
+          }
+        }
+  }
+}

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -270,7 +270,7 @@ node {
     const std::string configJsonPath = this->directoryPath + "/config.json";
     createConfigFileWithContent(configJson, configJsonPath);
     this->SetUpServer(configJsonPath.c_str());
-     // INFER
+    // INFER
     const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
     KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
     ::KFSRequest request;

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -188,6 +188,104 @@ TEST_F(MediapipeConfig, MediapipeAdd) {
     manager.join();
 }
 
+class MediapipeNoTagMapping : public TestWithTempDir {
+protected:
+    ovms::Server& server = ovms::Server::instance();
+    const Precision precision = Precision::FP32;
+    std::unique_ptr<std::thread> t;
+    std::string port = "9178";
+    void SetUpServer(const char* configPath) {
+        server.setShutdownRequest(0);
+        randomizePort(this->port);
+        char* argv[] = {(char*)"ovms",
+            (char*)"--config_path",
+            (char*)configPath,
+            (char*)"--port",
+            (char*)port.c_str()};
+        int argc = 5;
+        t.reset(new std::thread([&argc, &argv, this]() {
+            EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
+        }));
+        auto start = std::chrono::high_resolution_clock::now();
+        while ((server.getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
+               (!server.isReady()) &&
+               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
+        }
+    }
+    void TearDown() {
+        server.setShutdownRequest(1);
+        t->join();
+        server.setShutdownRequest(0);
+        TestWithTempDir::TearDown();
+    }
+};
+
+TEST_F(MediapipeNoTagMapping, DummyUppercase) {
+    // Here we use dummy with uppercase input/output
+    // and we shouldn't need tag mapping
+    ConstructorEnabledModelManager manager;
+    // create config file
+    std::string configJson = R"(
+{
+    "model_config_list": [
+        {"config": {
+                "name": "dummyUpper",
+                "base_path": "/ovms/src/test/dummyUppercase"
+        }
+        }
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"mediapipeDummyUppercase",
+        "graph_path":"PATH_TO_REPLACE"
+    }
+    ]
+})";
+    const std::string pathToReplace = "PATH_TO_REPLACE";
+    auto it = configJson.find(pathToReplace);
+    ASSERT_NE(it, std::string::npos);
+    const std::string graphPbtxt = R"(
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "ModelAPISessionCalculator"
+  output_side_packet: "SESSION:session"
+  node_options: {
+    [type.googleapis.com / mediapipe.ModelAPIOVMSSessionCalculatorOptions]: {
+      servable_name: "dummyUpper"
+      servable_version: "1"
+    }
+  }
+}
+node {
+  calculator: "ModelAPISideFeedCalculator"
+  input_side_packet: "SESSION:session"
+  input_stream: "B:in"
+  output_stream: "A:out"
+  )";
+    const std::string pbtxtPath = this->directoryPath + "/graphDummyUppercase.pbtxt";
+    createConfigFileWithContent(graphPbtxt, pbtxtPath);
+    configJson.replace(it, pathToReplace.size(), pbtxtPath);
+
+    const std::string configJsonPath = this->directoryPath + "/config.json";
+    createConfigFileWithContent(configJson, configJsonPath);
+    this->SetUpServer(configJsonPath.c_str());
+     // INFER
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string modelName = "mediapipeDummyUppercase";
+    request.Clear();
+    response.Clear();
+    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
+    preparePredictRequest(request, inputsMeta);
+    request.mutable_model_name()->assign(modelName);
+    ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
+    std::vector<float> requestData{0., 0., 0, 0., 0., 0., 0., 0, 0., 0.};
+    checkDummyResponse("out", requestData, request, response, 1, 1, modelName);
+}
+
 TEST_F(MediapipeConfig, MediapipeFullRelativePaths) {
     ConstructorEnabledModelManager manager;
     auto status = manager.startFromFile("/ovms/src/test/mediapipe/relative_paths/config_relative_dummy.json");

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -75,6 +75,7 @@ protected:
         server.setShutdownRequest(0);
     }
 };
+
 class MediapipeFlowAddTest : public MediapipeFlowTest {
 public:
     void SetUp() {
@@ -177,111 +178,46 @@ TEST_F(MediapipeConfig, MediapipeAdd) {
     ConstructorEnabledModelManager manager;
     auto status = manager.startFromFile("/ovms/src/test/mediapipe/config_mediapipe_add_adapter_full.json");
     EXPECT_EQ(status, ovms::StatusCode::OK);
-    // TODO add check for status
+
+    for (auto& graphName : mediaGraphsAdd) {
+        auto graphDefinition = manager.getMediapipeFactory().findDefinitionByName(graphName);
+        EXPECT_NE(graphDefinition, nullptr);
+        EXPECT_EQ(graphDefinition->getStatus().isAvailable(), true);
+    }
+
     manager.join();
 }
 
-class MediapipeNoTagMapping : public TestWithTempDir {
-protected:
-    ovms::Server& server = ovms::Server::instance();
-
-    const Precision precision = Precision::FP32;
-    std::unique_ptr<std::thread> t;
-    std::string port = "9178";
-    void SetUpServer(const char* configPath) {
-        server.setShutdownRequest(0);
-        randomizePort(this->port);
-        char* argv[] = {(char*)"ovms",
-            (char*)"--config_path",
-            (char*)configPath,
-            (char*)"--port",
-            (char*)port.c_str()};
-        int argc = 5;
-        t.reset(new std::thread([&argc, &argv, this]() {
-            EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
-        }));
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server.getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (!server.isReady()) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
-    }
-
-    void TearDown() {
-        server.setShutdownRequest(1);
-        t->join();
-        server.setShutdownRequest(0);
-        TestWithTempDir::TearDown();
-    }
-};
-
-TEST_F(MediapipeNoTagMapping, DummyUppercase) {
-    // Here we use dummy with uppercase input/output
-    // and we shouldn't need tag mapping
+TEST_F(MediapipeConfig, MediapipeFullRelativePaths) {
     ConstructorEnabledModelManager manager;
-    // create config file
-    std::string configJson = R"(
-{
-    "model_config_list": [
-        {"config": {
-                "name": "dummyUpper",
-                "base_path": "/ovms/src/test/dummyUppercase"
-        }
-        }
-    ],
-    "mediapipe_config_list": [
-    {
-        "name":"mediapipeDummyUppercase",
-        "graph_path":"PATH_TO_REPLACE"
-    }
-    ]
-})";
-    const std::string pathToReplace = "PATH_TO_REPLACE";
-    auto it = configJson.find(pathToReplace);
-    ASSERT_NE(it, std::string::npos);
-    const std::string graphPbtxt = R"(
-input_stream: "in"
-output_stream: "out"
-node {
-  calculator: "ModelAPISessionCalculator"
-  output_side_packet: "SESSION:session"
-  node_options: {
-    [type.googleapis.com / mediapipe.ModelAPIOVMSSessionCalculatorOptions]: {
-      servable_name: "dummyUpper"
-      servable_version: "1"
-    }
-  }
+    auto status = manager.startFromFile("/ovms/src/test/mediapipe/relative_paths/config_relative_dummy.json");
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+
+    auto definitionAdd = manager.getMediapipeFactory().findDefinitionByName("mediapipeAddADAPT");
+    EXPECT_NE(definitionAdd, nullptr);
+    EXPECT_EQ(definitionAdd->getStatus().isAvailable(), true);
+
+    auto definitionFull = manager.getMediapipeFactory().findDefinitionByName("mediapipeAddADAPTFULL");
+    EXPECT_NE(definitionFull, nullptr);
+    EXPECT_EQ(definitionFull->getStatus().isAvailable(), true);
+
+    manager.join();
 }
-node {
-  calculator: "ModelAPISideFeedCalculator"
-  input_side_packet: "SESSION:session"
-  input_stream: "B:in"
-  output_stream: "A:out"
-}
-)";
-    const std::string pbtxtPath = this->directoryPath + "/graphDummyUppercase.pbtxt";
-    createConfigFileWithContent(graphPbtxt, pbtxtPath);
-    configJson.replace(it, pathToReplace.size(), pbtxtPath);
 
-    const std::string configJsonPath = this->directoryPath + "/config.json";
-    createConfigFileWithContent(configJson, configJsonPath);
-    this->SetUpServer(configJsonPath.c_str());
+TEST_F(MediapipeConfig, MediapipeFullRelativePathsNegative) {
+    ConstructorEnabledModelManager manager;
+    auto status = manager.startFromFile("/ovms/src/test/mediapipe/relative_paths/config_relative_dummy_negative.json");
+    EXPECT_EQ(status, ovms::StatusCode::OK);
 
-    // INFER
-    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
-    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
-    ::KFSRequest request;
-    ::KFSResponse response;
+    auto definitionAdd = manager.getMediapipeFactory().findDefinitionByName("mediapipeAddADAPT");
+    EXPECT_NE(definitionAdd, nullptr);
+    EXPECT_EQ(definitionAdd->getStatus().isAvailable(), false);
 
-    const std::string modelName = "mediapipeDummyUppercase";
-    request.Clear();
-    response.Clear();
-    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
-    preparePredictRequest(request, inputsMeta);
-    request.mutable_model_name()->assign(modelName);
-    ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
-    std::vector<float> requestData{0., 0., 0, 0., 0., 0., 0., 0, 0., 0.};
-    checkDummyResponse("out", requestData, request, response, 1, 1, modelName);
+    auto definitionFull = manager.getMediapipeFactory().findDefinitionByName("mediapipeAddADAPTFULL");
+    EXPECT_NE(definitionFull, nullptr);
+    EXPECT_EQ(definitionFull->getStatus().isAvailable(), false);
+
+    manager.join();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/test/modelconfig_test.cpp
+++ b/src/test/modelconfig_test.cpp
@@ -40,6 +40,11 @@ TEST(ModelConfig, getters_setters) {
     auto path = config.getBasePath();
     EXPECT_EQ(path, "/path");
 
+    config.setRootDirectoryPath("/pathto/");
+    config.setBasePath("relative/path");
+    path = config.getBasePath();
+    EXPECT_EQ(path, "/pathto/relative/path");
+
     config.setTargetDevice("GPU");
     auto device = config.getTargetDevice();
     EXPECT_EQ(device, "GPU");

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -120,38 +120,6 @@ const char* relative_config_2_models = R"({
     }]
 })";
 
-const char* relative_config_1_model = R"({
-   "model_config_list": [
-    {
-      "config": {
-        "name": "resnet",
-        "base_path": "models/dummy1",
-        "target_device": "CPU",
-        "model_version_policy": {"all": {}}
-      }
-   }]
-})";
-
-const char* relative_config_2_models = R"({
-   "model_config_list": [
-    {
-      "config": {
-        "name": "resnet",
-        "base_path": "models/dummy1",
-        "target_device": "CPU",
-        "model_version_policy": {"all": {}}
-      }
-    },
-    {
-      "config": {
-        "name": "alpha",
-        "base_path": "models/dummy2",
-        "target_device": "CPU",
-        "model_version_policy": {"all": {}}
-      }
-    }]
-})";
-
 const std::string FIRST_MODEL_NAME = "resnet";
 const std::string SECOND_MODEL_NAME = "alpha";
 
@@ -805,6 +773,12 @@ TEST_F(ModelManager, ReadsVersionsFromDisk) {
 
         EXPECT_EQ(status, ovms::StatusCode::OK);
         EXPECT_THAT(versions, ::testing::UnorderedElementsAre(1, 5, 8, 10));
+
+        for (auto i : {1, 5, 8, 10}) {
+            std::filesystem::remove(path + std::to_string(i));
+        }
+
+        std::filesystem::remove(path + "unknown_dir11");  // invalid version directory
     } catch (...) {
         for (auto i : {1, 5, 8, 10}) {
             std::filesystem::remove(path + std::to_string(i));
@@ -830,6 +804,12 @@ TEST_F(ModelManager, ReadsVersionsFromDiskRelativePath) {
 
         EXPECT_EQ(status, ovms::StatusCode::OK);
         EXPECT_THAT(versions, ::testing::UnorderedElementsAre(1, 5, 8, 10));
+
+        for (auto i : {1, 5, 8, 10}) {
+            std::filesystem::remove(path + std::to_string(i));
+        }
+
+        std::filesystem::remove(path + "unknown_dir11");  // invalid version directory
     } catch (...) {
         for (auto i : {1, 5, 8, 10}) {
             std::filesystem::remove(path + std::to_string(i));

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -88,6 +88,70 @@ const char* config_2_models_new = R"({
     }]
 })";
 
+const char* relative_config_1_model = R"({
+   "model_config_list": [
+    {
+      "config": {
+        "name": "resnet",
+        "base_path": "models/dummy1",
+        "target_device": "CPU",
+        "model_version_policy": {"all": {}}
+      }
+   }]
+})";
+
+const char* relative_config_2_models = R"({
+   "model_config_list": [
+    {
+      "config": {
+        "name": "resnet",
+        "base_path": "models/dummy1",
+        "target_device": "CPU",
+        "model_version_policy": {"all": {}}
+      }
+    },
+    {
+      "config": {
+        "name": "alpha",
+        "base_path": "models/dummy2",
+        "target_device": "CPU",
+        "model_version_policy": {"all": {}}
+      }
+    }]
+})";
+
+const char* relative_config_1_model = R"({
+   "model_config_list": [
+    {
+      "config": {
+        "name": "resnet",
+        "base_path": "models/dummy1",
+        "target_device": "CPU",
+        "model_version_policy": {"all": {}}
+      }
+   }]
+})";
+
+const char* relative_config_2_models = R"({
+   "model_config_list": [
+    {
+      "config": {
+        "name": "resnet",
+        "base_path": "models/dummy1",
+        "target_device": "CPU",
+        "model_version_policy": {"all": {}}
+      }
+    },
+    {
+      "config": {
+        "name": "alpha",
+        "base_path": "models/dummy2",
+        "target_device": "CPU",
+        "model_version_policy": {"all": {}}
+      }
+    }]
+})";
+
 const std::string FIRST_MODEL_NAME = "resnet";
 const std::string SECOND_MODEL_NAME = "alpha";
 
@@ -523,13 +587,33 @@ void setupModelsDirs() {
     std::filesystem::create_directory("/tmp/models/dummy2");
 }
 
-TEST(ModelManagerWatcher, configRelodNotNeededManyThreads) {
+const std::vector<std::string> WATCHER_TEST_CONFIGS{
+    config_2_models,
+    relative_config_2_models,
+};
+
+class ModelManagerWatcher2Models : public ::testing::TestWithParam<std::string> {};
+
+std::string fromContentsToString(const std::string& configContents) {
+    return configContents.find("tmp") == std::string::npos ? "FullPath" : "RelativePath";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Test,
+    ModelManagerWatcher2Models,
+    ::testing::ValuesIn(WATCHER_TEST_CONFIGS),
+    [](const ::testing::TestParamInfo<ModelManagerWatcher2Models::ParamType>& info) {
+        return fromContentsToString(info.param);
+    });
+
+TEST_P(ModelManagerWatcher2Models, configRelodNotNeededManyThreads) {
     std::string configFile = "/tmp/config.json";
 
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
     setupModelsDirs();
-    createConfigFileWithContent(config_2_models, configFile);
+    std::string config_contents = GetParam();
+    createConfigFileWithContent(config_contents, configFile);
     auto status = manager.startFromFile(configFile);
     EXPECT_EQ(status, ovms::StatusCode::OK);
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -553,13 +637,14 @@ TEST(ModelManagerWatcher, configRelodNotNeededManyThreads) {
     modelMock.reset();
 }
 
-TEST(ModelManagerWatcher, configRelodNeededManyThreads) {
+TEST_P(ModelManagerWatcher2Models, configRelodNeededManyThreads) {
     std::string configFile = "/tmp/config.json";
 
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
     setupModelsDirs();
-    createConfigFileWithContent(config_2_models, configFile);
+    std::string config_contents = GetParam();
+    createConfigFileWithContent(config_contents, configFile);
     auto status = manager.startFromFile(configFile);
     EXPECT_EQ(status, ovms::StatusCode::OK);
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -589,13 +674,14 @@ TEST(ModelManagerWatcher, configRelodNeededManyThreads) {
     modelMock.reset();
 }
 
-TEST(ModelManagerWatcher, configReloadNeededChange) {
+TEST_P(ModelManagerWatcher2Models, configReloadNeededChange) {
     std::string configFile = "/tmp/config.json";
 
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
 
-    createConfigFileWithContent(config_2_models, configFile);
+    std::string config_contents = GetParam();
+    createConfigFileWithContent(config_contents, configFile);
     auto status = manager.startFromFile(configFile);
     EXPECT_EQ(status, ovms::StatusCode::OK);
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -612,13 +698,14 @@ TEST(ModelManagerWatcher, configReloadNeededChange) {
     modelMock.reset();
 }
 
-TEST(ModelManagerWatcher, loadConfigManyThreads) {
+TEST_P(ModelManagerWatcher2Models, loadConfigManyThreads) {
     std::string configFile = "/tmp/config.json";
 
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
     setupModelsDirs();
-    createConfigFileWithContent(config_2_models, configFile);
+    std::string config_contents = GetParam();
+    createConfigFileWithContent(config_contents, configFile);
 
     auto status = manager.startFromFile(configFile);
     EXPECT_EQ(status, ovms::StatusCode::OK);
@@ -641,13 +728,14 @@ TEST(ModelManagerWatcher, loadConfigManyThreads) {
     modelMock.reset();
 }
 
-TEST(ModelManagerWatcher, configReloadNeededBeforeConfigLoad) {
+TEST_P(ModelManagerWatcher2Models, configReloadNeededBeforeConfigLoad) {
     std::string configFile = "/tmp/config.json";
 
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
 
-    createConfigFileWithContent(config_2_models, configFile);
+    std::string config_contents = GetParam();
+    createConfigFileWithContent(config_contents, configFile);
     auto status = manager.startFromFile(configFile);
     EXPECT_EQ(status, ovms::StatusCode::OK);
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -704,22 +792,66 @@ TEST(ModelManagerWatcher, parseConfigWhenOnlyPipelineDefinitionProvided) {
 TEST_F(ModelManager, ReadsVersionsFromDisk) {
     const std::string path = "/tmp/test_model/";
 
-    for (auto i : {1, 5, 8, 10}) {
-        std::filesystem::create_directories(path + std::to_string(i));
-    }
+    try {
+        for (auto i : {1, 5, 8, 10}) {
+            std::filesystem::create_directories(path + std::to_string(i));
+        }
 
-    std::filesystem::create_directories(path + "unknown_dir11");  // invalid version directory
+        std::filesystem::create_directories(path + "unknown_dir11");  // invalid version directory
+        ovms::model_versions_t versions;
+        std::shared_ptr<ovms::FileSystem> fs = std::make_shared<ovms::LocalFileSystem>();
+
+        auto status = fixtureManager.readAvailableVersions(fs, path, versions);
+
+        EXPECT_EQ(status, ovms::StatusCode::OK);
+        EXPECT_THAT(versions, ::testing::UnorderedElementsAre(1, 5, 8, 10));
+    } catch (...) {
+        for (auto i : {1, 5, 8, 10}) {
+            std::filesystem::remove(path + std::to_string(i));
+        }
+
+        std::filesystem::remove(path + "unknown_dir11");  // invalid version directory
+    }
+}
+
+TEST_F(ModelManager, ReadsVersionsFromDiskRelativePath) {
+    const std::string path = "test_model/";
+
+    try {
+        for (auto i : {1, 5, 8, 10}) {
+            std::filesystem::create_directories(path + std::to_string(i));
+        }
+
+        std::filesystem::create_directories(path + "unknown_dir11");  // invalid version directory
+        ovms::model_versions_t versions;
+        std::shared_ptr<ovms::FileSystem> fs = std::make_shared<ovms::LocalFileSystem>();
+
+        auto status = fixtureManager.readAvailableVersions(fs, path, versions);
+
+        EXPECT_EQ(status, ovms::StatusCode::OK);
+        EXPECT_THAT(versions, ::testing::UnorderedElementsAre(1, 5, 8, 10));
+    } catch (...) {
+        for (auto i : {1, 5, 8, 10}) {
+            std::filesystem::remove(path + std::to_string(i));
+        }
+
+        std::filesystem::remove(path + "unknown_dir11");  // invalid version directory
+    }
+}
+
+TEST_F(ModelManager, PathEscapeError1) {
+    const std::string path = "/tmp/../test_model/";
+
     ovms::model_versions_t versions;
     std::shared_ptr<ovms::FileSystem> fs = std::make_shared<ovms::LocalFileSystem>();
 
     auto status = fixtureManager.readAvailableVersions(fs, path, versions);
 
-    EXPECT_EQ(status, ovms::StatusCode::OK);
-    EXPECT_THAT(versions, ::testing::UnorderedElementsAre(1, 5, 8, 10));
+    EXPECT_EQ(status, ovms::StatusCode::PATH_INVALID);
 }
 
-TEST_F(ModelManager, PathEscapeError1) {
-    const std::string path = "/tmp/../test_model/";
+TEST_F(ModelManager, PathEscapeError1RelativePath) {
+    const std::string path = "tmp/../test_model/";
 
     ovms::model_versions_t versions;
     std::shared_ptr<ovms::FileSystem> fs = std::make_shared<ovms::LocalFileSystem>();
@@ -754,11 +886,53 @@ TEST_F(ModelManager, ReadVersionsInvalidPath) {
     EXPECT_EQ(status, ovms::StatusCode::PATH_INVALID);
 }
 
+TEST_F(ModelManager, ReadVersionsInvalidPathRelativePath) {
+    const std::string path = "inexisting_path/8bt4kv";
+
+    try {
+        std::filesystem::remove(path);
+    } catch (const std::filesystem::filesystem_error&) {
+    }
+
+    std::vector<ovms::model_version_t> versions;
+    std::shared_ptr<ovms::FileSystem> fs = std::make_shared<ovms::LocalFileSystem>();
+    auto status = fixtureManager.readAvailableVersions(fs, path, versions);
+    EXPECT_EQ(status, ovms::StatusCode::PATH_INVALID);
+}
+
 TEST(ModelManagerWatcher, StartFromFile) {
-    std::filesystem::create_directories(model_1_path);
-    std::filesystem::create_directories(model_2_path);
     std::string fileToReload = "/tmp/ovms_config_file1.json";
     createConfigFileWithContent(config_1_model, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManager manager;
+
+    EXPECT_CALL(*modelMock, addVersion(_, _, _, _))
+        .Times(1)
+        .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
+    auto status = manager.startFromFile(fileToReload);
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+    manager.join();
+    modelMock.reset();
+}
+
+TEST(ModelManagerWatcher, StartFromFileRelativePath) {
+    std::string fileToReload = "/tmp/ovms_config_file1.json";
+    createConfigFileWithContent(relative_config_1_model, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManager manager;
+
+    EXPECT_CALL(*modelMock, addVersion(_, _, _, _))
+        .Times(1)
+        .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
+    auto status = manager.startFromFile(fileToReload);
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+    manager.join();
+    modelMock.reset();
+}
+
+TEST(ModelManagerWatcher, StartFromFileRelativePath) {
+    std::string fileToReload = "/tmp/ovms_config_file1.json";
+    createConfigFileWithContent(relative_config_1_model, fileToReload);
     modelMock = std::make_shared<MockModel>();
     MockModelManager manager;
 
@@ -782,9 +956,18 @@ TEST(ModelManagerWatcher, StartFromFileWhenModelFilesMissing) {
     manager.join();
 }
 
-TEST(ModelManagerWatcher, ConfigReloadingShouldAddNewModel) {
+TEST(ModelManagerWatcher, StartFromFileWhenModelFilesMissingRelativePath) {
     std::filesystem::create_directories(model_1_path);
-    std::filesystem::create_directories(model_2_path);
+    std::string fileToReload = "/tmp/ovms_config_file1.json";
+    createConfigFileWithContent(relative_config_1_model, fileToReload);
+    ConstructorEnabledModelManager manager;
+    ASSERT_TRUE(std::filesystem::is_empty(model_1_path));
+    auto status = manager.startFromFile(fileToReload);
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+    manager.join();
+}
+
+TEST(ModelManagerWatcher, ConfigReloadingShouldAddNewModel) {
     std::string fileToReload = "/tmp/ovms_config_file2.json";
     createConfigFileWithContent(config_1_model, fileToReload);
     modelMock = std::make_shared<MockModel>();
@@ -802,6 +985,68 @@ TEST(ModelManagerWatcher, ConfigReloadingShouldAddNewModel) {
     });
     t.join();
     createConfigFileWithContent(config_2_models, fileToReload);
+    bool isNeeded = false;
+    manager.configFileReloadNeeded(isNeeded);
+    ASSERT_EQ(isNeeded, true);
+    std::thread s([&manager]() {
+        waitForOVMSConfigReload(manager);
+    });
+    s.join();
+    models = manager.getModels().size();
+    EXPECT_EQ(models, 2);
+    manager.join();
+    modelMock.reset();
+}
+
+TEST(ModelManagerWatcher, ConfigReloadingShouldAddNewModelRelativePath) {
+    std::string fileToReload = "/tmp/ovms_config_file2.json";
+    createConfigFileWithContent(relative_config_1_model, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManager manager;
+    EXPECT_CALL(*modelMock, addVersion(_, _, _, _))
+        .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
+
+    auto status = manager.startFromFile(fileToReload);
+    manager.startWatcher(true);
+    auto models = manager.getModels().size();
+    EXPECT_EQ(models, 1);
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+    std::thread t([&manager]() {
+        waitForOVMSConfigReload(manager);
+    });
+    t.join();
+    createConfigFileWithContent(relative_config_2_models, fileToReload);
+    bool isNeeded = false;
+    manager.configFileReloadNeeded(isNeeded);
+    ASSERT_EQ(isNeeded, true);
+    std::thread s([&manager]() {
+        waitForOVMSConfigReload(manager);
+    });
+    s.join();
+    models = manager.getModels().size();
+    EXPECT_EQ(models, 2);
+    manager.join();
+    modelMock.reset();
+}
+
+TEST(ModelManagerWatcher, ConfigReloadingShouldAddNewModelRelativePath) {
+    std::string fileToReload = "/tmp/ovms_config_file2.json";
+    createConfigFileWithContent(relative_config_1_model, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManager manager;
+    EXPECT_CALL(*modelMock, addVersion(_, _, _, _))
+        .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
+
+    auto status = manager.startFromFile(fileToReload);
+    manager.startWatcher(true);
+    auto models = manager.getModels().size();
+    EXPECT_EQ(models, 1);
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+    std::thread t([&manager]() {
+        waitForOVMSConfigReload(manager);
+    });
+    t.join();
+    createConfigFileWithContent(relative_config_2_models, fileToReload);
     bool isNeeded = false;
     manager.configFileReloadNeeded(isNeeded);
     ASSERT_EQ(isNeeded, true);
@@ -1202,6 +1447,72 @@ TEST_F(ModelManager, ConfigReloadingWithTwoModelsWithTheSameName) {
     modelMock.reset();
 }
 
+TEST_F(ModelManager, ConfigReloadingWithTwoModelsWithTheSameNameRelativePath) {
+    const char* configWithTwoSameNames = R"({
+   "model_config_list": [
+    {
+      "config": {
+        "name": "same_name",
+        "base_path": "models/dummy1"
+      }
+    },
+    {
+      "config": {
+        "name": "same_name",
+        "base_path": "models/dummy2"
+      }
+    }]})";
+    std::filesystem::create_directories(model_1_path);
+    std::filesystem::create_directories(model_2_path);
+    std::string fileToReload = "/tmp/ovms_config_file2.json";
+    createConfigFileWithContent(configWithTwoSameNames, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManager manager;
+
+    EXPECT_CALL(*modelMock, addVersion(_, _, _, _))
+        .Times(1)
+        .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
+    auto status = manager.startFromFile(fileToReload);
+    auto models = manager.getModels().size();
+    EXPECT_EQ(models, 1);
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+    manager.join();
+    modelMock.reset();
+}
+
+TEST_F(ModelManager, ConfigReloadingWithTwoModelsWithTheSameNameRelativePath) {
+    const char* configWithTwoSameNames = R"({
+   "model_config_list": [
+    {
+      "config": {
+        "name": "same_name",
+        "base_path": "models/dummy1"
+      }
+    },
+    {
+      "config": {
+        "name": "same_name",
+        "base_path": "models/dummy2"
+      }
+    }]})";
+    std::filesystem::create_directories(model_1_path);
+    std::filesystem::create_directories(model_2_path);
+    std::string fileToReload = "/tmp/ovms_config_file2.json";
+    createConfigFileWithContent(configWithTwoSameNames, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManager manager;
+
+    EXPECT_CALL(*modelMock, addVersion(_, _, _, _))
+        .Times(1)
+        .WillRepeatedly(Return(ovms::Status(ovms::StatusCode::OK)));
+    auto status = manager.startFromFile(fileToReload);
+    auto models = manager.getModels().size();
+    EXPECT_EQ(models, 1);
+    EXPECT_EQ(status, ovms::StatusCode::OK);
+    manager.join();
+    modelMock.reset();
+}
+
 class MockModelManagerWithModelInstancesJustChangingStates : public ovms::ModelManager {
 public:
     std::shared_ptr<ovms::Model> modelFactory(const std::string& name, const bool isStateful) override {
@@ -1247,6 +1558,78 @@ TEST_F(ModelManager, ConfigReloadingShouldRetireModelInstancesOfModelRemovedFrom
     }
     // we remove SECOND_MODEL from config file and expect to have all versions of it retired
     createConfigFileWithContent(config_1_model, fileToReload);
+    waitForOVMSConfigReload(manager);
+    models = manager.getModels();
+    ASSERT_EQ(models.size(), 2);
+    for (auto& versionModelInstance : manager.getModels().at(FIRST_MODEL_NAME)->getModelVersions()) {
+        EXPECT_EQ(ovms::ModelVersionState::AVAILABLE, versionModelInstance.second->getStatus().getState());
+    }
+    for (auto& versionModelInstance : manager.getModels().at(SECOND_MODEL_NAME)->getModelVersions()) {
+        EXPECT_EQ(ovms::ModelVersionState::END, versionModelInstance.second->getStatus().getState());
+    }
+    manager.join();
+}
+
+TEST_F(ModelManager, ConfigReloadingShouldRetireModelInstancesOfModelRemovedFromJsonRelative) {
+    std::filesystem::create_directories(model_1_path);
+    std::filesystem::create_directories(model_2_path);
+    std::string fileToReload = "/tmp/ovms_config_file2.json";
+    createConfigFileWithContent(relative_config_2_models, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManagerWithModelInstancesJustChangingStates manager;
+    manager.registerVersionToLoad(1);
+    manager.registerVersionToLoad(2);
+    auto status = manager.startFromFile(fileToReload);
+    manager.startWatcher(true);
+    auto models = manager.getModels();
+    ASSERT_EQ(models.size(), 2);
+    ASSERT_EQ(status, ovms::StatusCode::OK);
+    waitForOVMSConfigReload(manager);
+    models = manager.getModels();
+    ASSERT_EQ(models.size(), 2);
+    for (auto& nameModel : models) {
+        for (auto& versionModelInstance : nameModel.second->getModelVersions()) {
+            ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, versionModelInstance.second->getStatus().getState());
+        }
+    }
+    // we remove SECOND_MODEL from config file and expect to have all versions of it retired
+    createConfigFileWithContent(relative_config_1_model, fileToReload);
+    waitForOVMSConfigReload(manager);
+    models = manager.getModels();
+    ASSERT_EQ(models.size(), 2);
+    for (auto& versionModelInstance : manager.getModels().at(FIRST_MODEL_NAME)->getModelVersions()) {
+        EXPECT_EQ(ovms::ModelVersionState::AVAILABLE, versionModelInstance.second->getStatus().getState());
+    }
+    for (auto& versionModelInstance : manager.getModels().at(SECOND_MODEL_NAME)->getModelVersions()) {
+        EXPECT_EQ(ovms::ModelVersionState::END, versionModelInstance.second->getStatus().getState());
+    }
+    manager.join();
+}
+
+TEST_F(ModelManager, ConfigReloadingShouldRetireModelInstancesOfModelRemovedFromJsonRelative) {
+    std::filesystem::create_directories(model_1_path);
+    std::filesystem::create_directories(model_2_path);
+    std::string fileToReload = "/tmp/ovms_config_file2.json";
+    createConfigFileWithContent(relative_config_2_models, fileToReload);
+    modelMock = std::make_shared<MockModel>();
+    MockModelManagerWithModelInstancesJustChangingStates manager;
+    manager.registerVersionToLoad(1);
+    manager.registerVersionToLoad(2);
+    auto status = manager.startFromFile(fileToReload);
+    manager.startWatcher(true);
+    auto models = manager.getModels();
+    ASSERT_EQ(models.size(), 2);
+    ASSERT_EQ(status, ovms::StatusCode::OK);
+    waitForOVMSConfigReload(manager);
+    models = manager.getModels();
+    ASSERT_EQ(models.size(), 2);
+    for (auto& nameModel : models) {
+        for (auto& versionModelInstance : nameModel.second->getModelVersions()) {
+            ASSERT_EQ(ovms::ModelVersionState::AVAILABLE, versionModelInstance.second->getStatus().getState());
+        }
+    }
+    // we remove SECOND_MODEL from config file and expect to have all versions of it retired
+    createConfigFileWithContent(relative_config_1_model, fileToReload);
     waitForOVMSConfigReload(manager);
     models = manager.getModels();
     ASSERT_EQ(models.size(), 2);
@@ -1603,7 +1986,7 @@ TEST_F(ReloadAvailableModelDueToConfigChange, SameConfig_ExpectNoReloads) {
 
 TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToBasePathChange) {
     mockModelVersionInstances = getMockedModelVersionInstances(initialVersions, *ieCore, config);
-    config.setBasePath("new/custom/path");
+    config.setBasePath("/new/custom/path");
     ovms::ModelManager::getVersionsToChange(config, mockModelVersionInstances, requestedVersions, versionsToStart, versionsToReload, versionsToRetire);
     EXPECT_THAT(*versionsToReload, UnorderedElementsAre(3));
 }

--- a/src/test/node_library_manager_test.cpp
+++ b/src/test/node_library_manager_test.cpp
@@ -28,6 +28,13 @@ TEST(NodeLibraryManagerTest, NewManagerExpectMissingLibrary) {
     EXPECT_EQ(status, StatusCode::NODE_LIBRARY_MISSING);
 }
 
+TEST(NodeLibraryManagerTest, UnSuccessfullLibraryLoading) {
+    CustomNodeLibraryManager manager;
+    NodeLibrary library;
+    auto status = manager.loadLibrary("random_name", "ovms/bazel-bin/src/lib_node_mock.so");
+    ASSERT_EQ(status, StatusCode::PATH_INVALID);
+}
+
 TEST(NodeLibraryManagerTest, SuccessfullLibraryLoadingAndExecution) {
     CustomNodeLibraryManager manager;
     NodeLibrary library;


### PR DESCRIPTION
Relative paths support in config.json

custom loader - library_path
mediapipe - add find definition
modelconfig - model relative path
modelmanager - directory path to config.json
mediapipe - graph_path relative
unit tests for above cases