### PR TITLE
Mediapipe adapter rt_info support

### DIFF
--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -60,7 +60,7 @@ if [ ${NO_WARNINGS_TEST_NOTUSED} -gt 0 ]; then
     echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_TEST_NOTUSED}";
     exit 1;
 fi
-if [ ${NO_WARNINGS} -gt  161 ]; then
+if [ ${NO_WARNINGS} -gt  160 ]; then
     echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
     exit 1
 fi

--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -19,15 +19,21 @@ CPPCLEAN_RESULTS_FILE_TEST="cppclean_test"
 cppclean ./src/ 2>&1 | grep -v "unable to find" | grep -v test > ${CPPCLEAN_RESULTS_FILE_SRC};
 cppclean ./src/ 2>&1 | grep -v "unable to find" | grep test > ${CPPCLEAN_RESULTS_FILE_TEST};
 NO_WARNINGS=$(wc -l ${CPPCLEAN_RESULTS_FILE_SRC} | awk '{print $1}')
-NO_WARNINGS_TEST=$(wc -l ${CPPCLEAN_RESULTS_FILE_TEST} | awk '{print $1}')
 NO_WARNINGS_FORWARD=$(grep "use a forward declaration instead" ${CPPCLEAN_RESULTS_FILE_SRC} | wc -l)
 NO_WARNINGS_DIRECT=$(grep "not found in any directly #included header" ${CPPCLEAN_RESULTS_FILE_SRC} | wc -l)
 NO_WARNINGS_NOTUSED=$(grep " not used$" ${CPPCLEAN_RESULTS_FILE_SRC} | wc -l)
+NO_WARNINGS_TEST=$(wc -l ${CPPCLEAN_RESULTS_FILE_TEST} | awk '{print $1}')
+NO_WARNINGS_TEST_FORWARD=$(grep "use a forward declaration instead" ${CPPCLEAN_RESULTS_FILE_TEST} | wc -l)
+NO_WARNINGS_TEST_DIRECT=$(grep "not found in any directly #included header" ${CPPCLEAN_RESULTS_FILE_TEST} | wc -l)
+NO_WARNINGS_TEST_NOTUSED=$(grep " not used$" ${CPPCLEAN_RESULTS_FILE_TEST} | wc -l)
 echo "Number of warnings:" ${NO_WARNINGS}
 echo "Number of warnings in tests:" ${NO_WARNINGS_TEST}
 echo "Number of warnings about not using forward delares:" ${NO_WARNINGS_FORWARD}
 echo "Number of warnings about not direct includes:" ${NO_WARNINGS_DIRECT}
 echo "Number of warnings about not used: " ${NO_WARNINGS_NOTUSED}
+echo "Number of warnings in tests about not using forward delares:" ${NO_WARNINGS_TEST_FORWARD}
+echo "Number of warnings in tests about not direct includes:" ${NO_WARNINGS_TEST_DIRECT}
+echo "Number of warnings in tests about not used: " ${NO_WARNINGS_TEST_NOTUSED}
 
 trap "cat ${CPPCLEAN_RESULTS_FILE_SRC}" err exit
 if [ ${NO_WARNINGS_FORWARD} -gt 7 ]; then
@@ -42,11 +48,23 @@ if [ ${NO_WARNINGS_NOTUSED} -gt 7 ]; then
     echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_NOTUSED}";
     exit 1;
 fi
-if [ ${NO_WARNINGS} -gt  162 ]; then
+if [ ${NO_WARNINGS_TEST_FORWARD} -gt 1 ]; then
+    echo "Failed due to not using forward declarations where possible: ${NO_WARNINGS_TEST_FORWARD}";
+    exit 1;
+fi
+if [ ${NO_WARNINGS_TEST_DIRECT} -gt 11 ]; then
+    echo "Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_TEST_DIRECT}";
+    exit 1;
+fi
+if [ ${NO_WARNINGS_TEST_NOTUSED} -gt 0 ]; then
+    echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_TEST_NOTUSED}";
+    exit 1;
+fi
+if [ ${NO_WARNINGS} -gt  161 ]; then
     echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
     exit 1
 fi
-if [ ${NO_WARNINGS_TEST} -gt  85 ]; then
+if [ ${NO_WARNINGS_TEST} -gt  52 ]; then
     echo "Failed due to higher than allowed number of issues in test code: ${NO_WARNINGS_TEST}"
     cat ${CPPCLEAN_RESULTS_FILE_TEST}
     exit 1

--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -60,7 +60,7 @@ if [ ${NO_WARNINGS_TEST_NOTUSED} -gt 0 ]; then
     echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_TEST_NOTUSED}";
     exit 1;
 fi
-if [ ${NO_WARNINGS} -gt  160 ]; then
+if [ ${NO_WARNINGS} -gt  158 ]; then
     echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
     exit 1
 fi

--- a/src/BUILD
+++ b/src/BUILD
@@ -731,6 +731,7 @@ cc_test(
     srcs = [
         "test/azurefilesystem_test.cpp",
         "test/tensor_conversion_test.cpp",
+        "test/c_api_test_utils.hpp",
         "test/c_api_tests.cpp",
         "test/custom_loader_test.cpp",
         "test/custom_node_output_allocator_test.cpp",

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -836,7 +836,7 @@ OVMS_Status* OVMS_ServableMetadataGetOutput(OVMS_ServableMetadata* servableMetad
     return nullptr;
 }
 
-OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* servableMetadata, void** info) {
+OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* servableMetadata, const void** info) {
     if (servableMetadata == nullptr) {
         return reinterpret_cast<OVMS_Status*>(new Status(StatusCode::NONEXISTENT_METADATA));
     }

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -745,7 +745,7 @@ OVMS_Status* OVMS_GetServableMetadata(OVMS_Server* serverPtr, const char* servab
         SPDLOG_INFO("Getting modelInstance or pipeline failed. {}", status.string());
         return reinterpret_cast<OVMS_Status*>(new Status(status));
     }
-    *servableMetadata = reinterpret_cast<OVMS_ServableMetadata*>(new ovms::ServableMetadata(servableName, servableVersion, modelInstance->getInputsInfo(), modelInstance->getOutputsInfo()));
+    *servableMetadata = reinterpret_cast<OVMS_ServableMetadata*>(new ovms::ServableMetadata(servableName, servableVersion, modelInstance->getInputsInfo(), modelInstance->getOutputsInfo(), modelInstance->getRTInfo()));
     return nullptr;
 }
 
@@ -835,6 +835,19 @@ OVMS_Status* OVMS_ServableMetadataGetOutput(OVMS_ServableMetadata* servableMetad
     *shapeMax = const_cast<int64_t*>(metadata->getOutputDimsMax().at(*name).data());
     return nullptr;
 }
+
+OVMS_Status* OVMS_ServableMetadataGetRTInfo(OVMS_ServableMetadata* servableMetadata, void** RTInfo) {
+    if (servableMetadata == nullptr) {
+        return reinterpret_cast<OVMS_Status*>(new Status(StatusCode::NONEXISTENT_METADATA));
+    }
+    if (RTInfo == nullptr) {
+        return reinterpret_cast<OVMS_Status*>(new Status(StatusCode::NONEXISTENT_DATA));
+    }
+    ovms::ServableMetadata* metadata = reinterpret_cast<ovms::ServableMetadata*>(servableMetadata);
+    *RTInfo = const_cast<void*>(reinterpret_cast<const void*>(&(metadata->getRTInfo())));
+    return nullptr;
+}
+
 void OVMS_ServableMetadataDelete(OVMS_ServableMetadata* metadata) {
     if (metadata == nullptr)
         return;

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -844,7 +844,7 @@ OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* servableMetadat
         return reinterpret_cast<OVMS_Status*>(new Status(StatusCode::NONEXISTENT_DATA));
     }
     ovms::ServableMetadata* metadata = reinterpret_cast<ovms::ServableMetadata*>(servableMetadata);
-    *info = const_cast<void*>(reinterpret_cast<const void*>(&(metadata->getExtraInfo())));
+    *info = const_cast<void*>(reinterpret_cast<const void*>(&(metadata->getInfo())));
     return nullptr;
 }
 

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -836,15 +836,15 @@ OVMS_Status* OVMS_ServableMetadataGetOutput(OVMS_ServableMetadata* servableMetad
     return nullptr;
 }
 
-OVMS_Status* OVMS_ServableMetadataGetRTInfo(OVMS_ServableMetadata* servableMetadata, void** RTInfo) {
+OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* servableMetadata, void** info) {
     if (servableMetadata == nullptr) {
         return reinterpret_cast<OVMS_Status*>(new Status(StatusCode::NONEXISTENT_METADATA));
     }
-    if (RTInfo == nullptr) {
+    if (info == nullptr) {
         return reinterpret_cast<OVMS_Status*>(new Status(StatusCode::NONEXISTENT_DATA));
     }
     ovms::ServableMetadata* metadata = reinterpret_cast<ovms::ServableMetadata*>(servableMetadata);
-    *RTInfo = const_cast<void*>(reinterpret_cast<const void*>(&(metadata->getRTInfo())));
+    *info = const_cast<void*>(reinterpret_cast<const void*>(&(metadata->getExtraInfo())));
     return nullptr;
 }
 

--- a/src/custom_nodes/tokenizer/test/detokenization_test.cpp
+++ b/src/custom_nodes/tokenizer/test/detokenization_test.cpp
@@ -127,7 +127,7 @@ TEST(DetokenizerTest, outputs_info) {
     ASSERT_EQ(ret, 0);
 }
 
-void prepare(std::vector<float> data, std::vector<size_t> shape, std::vector<std::vector<int64_t>> previousTokens, struct CustomNodeTensor* tensors) {
+static void prepare(std::vector<float> data, std::vector<size_t> shape, std::vector<std::vector<int64_t>> previousTokens, struct CustomNodeTensor* tensors) {
     // logits
     struct CustomNodeTensor* tensor = &tensors[0];
     tensor->dataBytes = data.size() * sizeof(float);

--- a/src/custom_nodes/tokenizer/test/tokenization_test.cpp
+++ b/src/custom_nodes/tokenizer/test/tokenization_test.cpp
@@ -125,7 +125,7 @@ TEST(TokenizerTest, outputs_info) {
     ASSERT_EQ(ret, 0);
 }
 
-void putStringsToTensor(std::vector<std::string> strings, struct CustomNodeTensor& tensor) {
+static void putStringsToTensor(std::vector<std::string> strings, struct CustomNodeTensor& tensor) {
     size_t maxStringLength = 0;
     for (auto& str : strings) {
         maxStringLength = std::max(str.size(), maxStringLength);

--- a/src/mediapipe_calculators/modelapiovmsadapter.cc
+++ b/src/mediapipe_calculators/modelapiovmsadapter.cc
@@ -176,7 +176,7 @@ void OVMSInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>& mod
         outputNames.emplace_back(tensorName);
     }
     const ov::AnyMap* servableMetadataRtInfo;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServableMetadataGetInfo(servableMetadata, const_cast<void**>(reinterpret_cast<const void**>(&servableMetadataRtInfo))));
+    ASSERT_CAPI_STATUS_NULL(OVMS_ServableMetadataGetInfo(servableMetadata, reinterpret_cast<const void**>(&servableMetadataRtInfo)));
     this->modelConfig = *servableMetadataRtInfo;
     OVMS_ServableMetadataDelete(servableMetadata);
 }

--- a/src/mediapipe_calculators/modelapiovmsadapter.cc
+++ b/src/mediapipe_calculators/modelapiovmsadapter.cc
@@ -62,13 +62,16 @@ using InferenceInput = std::map<std::string, ov::Tensor>;
 namespace ovms {
 static OVMS_DataType OVPrecision2CAPI(ov::element::Type_t datatype);
 static ov::element::Type_t CAPI2OVPrecision(OVMS_DataType datatype);
-static ov::Tensor* makeOvTensor(OVMS_DataType datatype, const int64_t* shape, size_t dimCount, const void* voutputData, size_t bytesize);
 static ov::Tensor makeOvTensorO(OVMS_DataType datatype, const int64_t* shape, size_t dimCount, const void* voutputData, size_t bytesize);
 
-OVMSInferenceAdapter::OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion) :
+OVMSInferenceAdapter::OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion, OVMS_Server* cserver) :
     servableName(servableName),
     servableVersion(servableVersion) {
-    OVMS_ServerNew(&this->cserver);  // TODO retcheck's;
+    if (nullptr != cserver) {
+        this->cserver = cserver;
+    } else {
+        OVMS_ServerNew(&this->cserver);
+    }
 }
 OVMSInferenceAdapter::~OVMSInferenceAdapter() {
 }
@@ -172,6 +175,9 @@ void OVMSInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>& mod
         ASSERT_CAPI_STATUS_NULL(OVMS_ServableMetadataGetOutput(servableMetadata, id, &tensorName, &datatype, &dimCount, &shapeMin, &shapeMax));
         outputNames.emplace_back(tensorName);
     }
+    const ov::AnyMap* servableMetadataRtInfo;
+    ASSERT_CAPI_STATUS_NULL(OVMS_ServableMetadataGetRTInfo(servableMetadata, const_cast<void**>(reinterpret_cast<const void**>(&servableMetadataRtInfo))));
+    this->modelConfig = *servableMetadataRtInfo;
     OVMS_ServableMetadataDelete(servableMetadata);
 }
 
@@ -265,17 +271,6 @@ static ov::element::Type_t CAPI2OVPrecision(OVMS_DataType datatype) {
         return ov::element::Type_t::undefined;
     }
     return it->second;
-}
-
-static ov::Tensor* makeOvTensor(OVMS_DataType datatype, const int64_t* shape, size_t dimCount, const void* voutputData, size_t bytesize) {
-    ov::Shape ovShape;
-    for (size_t i = 0; i < dimCount; ++i) {
-        ovShape.push_back(shape[i]);
-    }
-    // here we make copy of underlying OVMS repsonse tensor
-    ov::Tensor* output = new ov::Tensor(CAPI2OVPrecision(datatype), ovShape);
-    std::memcpy(output->data(), voutputData, bytesize);
-    return output;
 }
 
 static ov::Tensor makeOvTensorO(OVMS_DataType datatype, const int64_t* shape, size_t dimCount, const void* voutputData, size_t bytesize) {

--- a/src/mediapipe_calculators/modelapiovmsadapter.cc
+++ b/src/mediapipe_calculators/modelapiovmsadapter.cc
@@ -176,7 +176,7 @@ void OVMSInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>& mod
         outputNames.emplace_back(tensorName);
     }
     const ov::AnyMap* servableMetadataRtInfo;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServableMetadataGetRTInfo(servableMetadata, const_cast<void**>(reinterpret_cast<const void**>(&servableMetadataRtInfo))));
+    ASSERT_CAPI_STATUS_NULL(OVMS_ServableMetadataGetInfo(servableMetadata, const_cast<void**>(reinterpret_cast<const void**>(&servableMetadataRtInfo))));
     this->modelConfig = *servableMetadataRtInfo;
     OVMS_ServableMetadataDelete(servableMetadata);
 }

--- a/src/mediapipe_calculators/modelapiovmsadapter.hpp
+++ b/src/mediapipe_calculators/modelapiovmsadapter.hpp
@@ -54,7 +54,7 @@ class OVMSInferenceAdapter : public ::InferenceAdapter {
     ov::AnyMap modelConfig;
 
 public:
-    OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion = 0);
+    OVMSInferenceAdapter(const std::string& servableName, uint32_t servableVersion = 0, OVMS_Server* server = nullptr);
     virtual ~OVMSInferenceAdapter();
     InferenceOutput infer(const InferenceInput& input) override;
     void loadModel(const std::shared_ptr<const ov::Model>& model, ov::Core& core,

--- a/src/mediapipe_calculators/modelapiovmssessioncalculator.cc
+++ b/src/mediapipe_calculators/modelapiovmssessioncalculator.cc
@@ -78,8 +78,11 @@ public:
 
         const auto& options = cc->Options<ModelAPIOVMSSessionCalculatorOptions>();
         const std::string& servableName = options.servable_name();
-        const std::string& servableVersion = options.servable_version();
-        auto session = std::make_unique<AdapterWrapper>(new OVMSInferenceAdapter(servableName));
+        const std::string& servableVersionStr = options.servable_version();
+        auto servableVersionOpt = ::ovms::stou32(servableVersionStr);
+        // 0 means default
+        uint32_t servableVersion = servableVersionOpt.value_or(0);
+        auto session = std::make_unique<AdapterWrapper>(new OVMSInferenceAdapter(servableName, servableVersion));
         MLOG("Session create adapter");
         cc->OutputSidePackets().Tag(SESSION_TAG.c_str()).Set(Adopt(session.release()));
         MLOG("SessionOpen end");

--- a/src/mediapipe_internal/mediapipefactory.cpp
+++ b/src/mediapipe_internal/mediapipefactory.cpp
@@ -66,7 +66,7 @@ MediapipeGraphDefinition* MediapipeFactory::findDefinitionByName(const std::stri
 Status MediapipeFactory::reloadDefinition(const std::string& pipelineName,  // TODO
     const MediapipeGraphConfig& config,
     ModelManager& manager) {
-        SPDLOG_LOGGER_ERROR(modelmanager_logger, "reloading mediapipe graphs not implemented yet");
+    SPDLOG_LOGGER_ERROR(modelmanager_logger, "reloading mediapipe graphs not implemented yet");
     return StatusCode::OK;
 }
 

--- a/src/mediapipe_internal/mediapipefactory.cpp
+++ b/src/mediapipe_internal/mediapipefactory.cpp
@@ -29,6 +29,7 @@
 #include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
 #pragma GCC diagnostic pop
 #include "../kfs_frontend/kfs_grpc_inference_service.hpp"
+#include "../logging.hpp"
 #include "../modelmanager.hpp"
 #include "../status.hpp"
 #include "mediapipegraphdefinition.hpp"
@@ -65,6 +66,7 @@ MediapipeGraphDefinition* MediapipeFactory::findDefinitionByName(const std::stri
 Status MediapipeFactory::reloadDefinition(const std::string& pipelineName,  // TODO
     const MediapipeGraphConfig& config,
     ModelManager& manager) {
+        SPDLOG_LOGGER_ERROR(modelmanager_logger, "reloading mediapipe graphs not implemented yet");
     return StatusCode::OK;
 }
 
@@ -75,7 +77,7 @@ Status MediapipeFactory::create(std::shared_ptr<MediapipeGraphExecutor>& pipelin
     ModelManager& manager) const {
     auto it = definitions.find(name);
     if (it == definitions.end()) {
-        SPDLOG_DEBUG("Mediapipe graph with requested name: {} does not exist", name);  // TODO logger
+        SPDLOG_DEBUG("Mediapipe graph with requested name: {} does not exist", name);
         return StatusCode::NOT_IMPLEMENTED;
     }
     auto status = it->second->create(pipeline, request, response);
@@ -83,11 +85,11 @@ Status MediapipeFactory::create(std::shared_ptr<MediapipeGraphExecutor>& pipelin
 }
 
 void MediapipeFactory::retireOtherThan(std::set<std::string>&& pipelinesInConfigFile, ModelManager& manager) {
-    SPDLOG_ERROR("NOT_IMPLEMENTED");
+    SPDLOG_LOGGER_ERROR(modelmanager_logger, "retiring mediapipe graphs not implemented yet");
 }  // TODO
 Status MediapipeFactory::revalidatePipelines(ModelManager&) {
     // TODO
-    SPDLOG_ERROR("NOT_IMPLEMENTED");
+    SPDLOG_LOGGER_ERROR(modelmanager_logger, "revalidation of mediapipe graphs not implemented yet");
     return StatusCode::OK;
 }
 

--- a/src/mediapipe_internal/mediapipegraphexecutor.hpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.hpp
@@ -29,10 +29,6 @@
 #include "mediapipe/framework/port/status.h"
 
 namespace ovms {
-class MetricConfig;
-class MetricRegistry;
-class ModelManager;
-class MediapipeGraphExecutor;
 class Status;
 
 class MediapipeGraphExecutor {

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -321,6 +321,14 @@ static Status applyLayoutConfiguration(const ModelConfig& config, std::shared_pt
     return StatusCode::OK;
 }
 
+const std::string RT_INFO_KEY{"model_info"};
+
+void ModelInstance::loadRTInfo() {
+    if (this->model->has_rt_info(RT_INFO_KEY)) {
+        this->rt_info = model->get_rt_info<ov::AnyMap>(RT_INFO_KEY);
+    }
+}
+
 Status ModelInstance::loadTensors(const ModelConfig& config, bool needsToApplyLayoutConfiguration, const DynamicModelParameter& parameter) {
     Status status = validateConfigurationAgainstNetwork(config, this->model);
     if (!status.ok()) {
@@ -593,7 +601,7 @@ Status ModelInstance::loadOVModel() {
     auto& modelFile = modelFiles[0];
     SPDLOG_DEBUG("Try reading model file: {}", modelFile);
     try {
-        model = loadOVModelPtr(modelFile);
+        this->model = loadOVModelPtr(modelFile);
     } catch (std::exception& e) {
         SPDLOG_ERROR("Error: {}; occurred during loading ov::Model model: {} version: {}", e.what(), getName(), getVersion());
         return StatusCode::INTERNAL_ERROR;
@@ -839,6 +847,7 @@ Status ModelInstance::loadModelImpl(const ModelConfig& config, const DynamicMode
             this->status.setLoading(ModelVersionStatusErrorCode::UNKNOWN);
             return status;
         }
+        loadRTInfo();
         status = loadOVCompiledModel(this->config);
         if (!status.ok()) {
             this->status.setLoading(ModelVersionStatusErrorCode::UNKNOWN);

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -252,12 +252,16 @@ private:
          */
     std::unique_ptr<OVInferRequestsQueue> inferRequestsQueue;
 
+    ov::AnyMap rt_info;
+
     /**
          * @brief Holds current usage count in predict requests
          * 
          * Needed for gating model unloading.
          */
     std::atomic<uint64_t> predictRequestsHandlesCount = 0;
+
+    void loadRTInfo();
 
     /**
          * @brief Internal method for loading tensors
@@ -443,6 +447,10 @@ public:
          */
     virtual const tensor_map_t& getInputsInfo() const {
         return inputsInfo;
+    }
+
+    virtual ov::AnyMap getRTInfo() const {
+        return this->rt_info;
     }
 
     /**

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -501,13 +501,15 @@ OVMS_Status* OVMS_ServableMetadataGetInput(OVMS_ServableMetadata* metadata, uint
 // \return OVMS_Status object in case of failure
 OVMS_Status* OVMS_ServableMetadataGetOutput(OVMS_ServableMetadata* metadata, uint32_t id, const char** name, OVMS_DataType* datatype, size_t* dimCount, int64_t** shapeMinArray, int64_t** shapeMaxArray);
 
-// TODO
-// Get the RTInfo metadata of servable.
+
+// #ifdef EXPERIMENTAL / MEDIAPIPE
+// Get the additional info about servable.
 //
 // \param metadata The metadata object
-// \param rtinfo The ptr to the ov::AnyMap
+// \param info The ptr to the ov::AnyMap*
 // \return OVMS_Status object in case of failure
-OVMS_Status* OVMS_ServableMetadataGetRTInfo(OVMS_ServableMetadata* metadata, void** RTInfo);
+OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* metadata, void** info);
+// #endif
 
 // Deallocates a status object.
 //

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -502,14 +502,13 @@ OVMS_Status* OVMS_ServableMetadataGetInput(OVMS_ServableMetadata* metadata, uint
 OVMS_Status* OVMS_ServableMetadataGetOutput(OVMS_ServableMetadata* metadata, uint32_t id, const char** name, OVMS_DataType* datatype, size_t* dimCount, int64_t** shapeMinArray, int64_t** shapeMaxArray);
 
 
-// #ifdef EXPERIMENTAL / MEDIAPIPE
+// EXPERIMENTAL // TODO if declare specific type for underlying ov::AnyMap
 // Get the additional info about servable.
 //
 // \param metadata The metadata object
 // \param info The ptr to the ov::AnyMap*
 // \return OVMS_Status object in case of failure
 OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* metadata, const void** info);
-// #endif
 
 // Deallocates a status object.
 //

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -508,7 +508,7 @@ OVMS_Status* OVMS_ServableMetadataGetOutput(OVMS_ServableMetadata* metadata, uin
 // \param metadata The metadata object
 // \param info The ptr to the ov::AnyMap*
 // \return OVMS_Status object in case of failure
-OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* metadata, void** info);
+OVMS_Status* OVMS_ServableMetadataGetInfo(OVMS_ServableMetadata* metadata, const void** info);
 // #endif
 
 // Deallocates a status object.

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -501,6 +501,14 @@ OVMS_Status* OVMS_ServableMetadataGetInput(OVMS_ServableMetadata* metadata, uint
 // \return OVMS_Status object in case of failure
 OVMS_Status* OVMS_ServableMetadataGetOutput(OVMS_ServableMetadata* metadata, uint32_t id, const char** name, OVMS_DataType* datatype, size_t* dimCount, int64_t** shapeMinArray, int64_t** shapeMaxArray);
 
+// TODO
+// Get the RTInfo metadata of servable.
+//
+// \param metadata The metadata object
+// \param rtinfo The ptr to the ov::AnyMap
+// \return OVMS_Status object in case of failure
+OVMS_Status* OVMS_ServableMetadataGetRTInfo(OVMS_ServableMetadata* metadata, void** RTInfo);
+
 // Deallocates a status object.
 //
 //  \param metadata The metadata object

--- a/src/servablemanagermodule.cpp
+++ b/src/servablemanagermodule.cpp
@@ -38,7 +38,7 @@ ServableManagerModule::ServableManagerModule(ovms::Server& ovmsServer) {
 Status ServableManagerModule::start(const ovms::Config& config) {
     state = ModuleState::STARTED_INITIALIZE;
     SPDLOG_INFO("{} starting", SERVABLE_MANAGER_MODULE_NAME);
-    auto status = servableManager->start(config);
+    auto status = getServableManager().start(config);
     if (status.ok()) {
         state = ModuleState::INITIALIZED;
         SPDLOG_INFO("{} started", SERVABLE_MANAGER_MODULE_NAME);
@@ -52,7 +52,7 @@ void ServableManagerModule::shutdown() {
         return;
     state = ModuleState::STARTED_SHUTDOWN;
     SPDLOG_INFO("{} shutting down", SERVABLE_MANAGER_MODULE_NAME);
-    servableManager->join();
+    getServableManager().join();
     state = ModuleState::SHUTDOWN;
     SPDLOG_INFO("{} shutdown", SERVABLE_MANAGER_MODULE_NAME);
 }

--- a/src/servablemetadata.cpp
+++ b/src/servablemetadata.cpp
@@ -27,7 +27,7 @@ ServableMetadata::ServableMetadata(const std::string& name,
     version(version),
     inputsInfo(inputsInfo),
     outputsInfo(outputsInfo),
-    rtInfo(anyMap) {
+    extraInfo(anyMap) {
     for (auto& [key, tensorInfo] : this->inputsInfo) {
         auto& inDimsMin = this->inDimMin[key];
         auto& inDimsMax = this->inDimMax[key];

--- a/src/servablemetadata.cpp
+++ b/src/servablemetadata.cpp
@@ -16,14 +16,18 @@
 #include "servablemetadata.hpp"
 
 namespace ovms {
+
+const ov::AnyMap ServableMetadata::EMPTY_RT_INFO;
 ServableMetadata::ServableMetadata(const std::string& name,
     model_version_t version,
     const tensor_map_t& inputsInfo,
-    const tensor_map_t& outputsInfo) :
+    const tensor_map_t& outputsInfo,
+    const ov::AnyMap& anyMap) :
     name(name),
     version(version),
     inputsInfo(inputsInfo),
-    outputsInfo(outputsInfo) {
+    outputsInfo(outputsInfo),
+    rtInfo(anyMap) {
     for (auto& [key, tensorInfo] : this->inputsInfo) {
         auto& inDimsMin = this->inDimMin[key];
         auto& inDimsMax = this->inDimMax[key];

--- a/src/servablemetadata.cpp
+++ b/src/servablemetadata.cpp
@@ -27,7 +27,7 @@ ServableMetadata::ServableMetadata(const std::string& name,
     version(version),
     inputsInfo(inputsInfo),
     outputsInfo(outputsInfo),
-    extraInfo(anyMap) {
+    info(anyMap) {
     for (auto& [key, tensorInfo] : this->inputsInfo) {
         auto& inDimsMin = this->inDimMin[key];
         auto& inDimsMax = this->inDimMax[key];

--- a/src/servablemetadata.hpp
+++ b/src/servablemetadata.hpp
@@ -36,7 +36,7 @@ class ServableMetadata {
     capi_tensor_shapes_map_t inDimMax;
     capi_tensor_shapes_map_t outDimMin;
     capi_tensor_shapes_map_t outDimMax;
-    ov::AnyMap rtInfo;
+    ov::AnyMap extraInfo;
 
 public:
     ServableMetadata(const std::string& name,
@@ -50,8 +50,8 @@ public:
     const capi_tensor_shapes_map_t& getInputDimsMax() const { return this->inDimMax; }
     const capi_tensor_shapes_map_t& getOutputDimsMin() const { return this->outDimMin; }
     const capi_tensor_shapes_map_t& getOutputDimsMax() const { return this->outDimMax; }
-    const ov::AnyMap& getRTInfo() const {
-        return this->rtInfo;
+    const ov::AnyMap& getExtraInfo() const {
+        return this->extraInfo;
     }
 };
 }  // namespace ovms

--- a/src/servablemetadata.hpp
+++ b/src/servablemetadata.hpp
@@ -27,6 +27,7 @@ namespace ovms {
 using capi_tensor_shapes_map_t = std::unordered_map<std::string, std::vector<dimension_value_t>>;
 
 class ServableMetadata {
+    static const ov::AnyMap EMPTY_RT_INFO;
     const std::string name;
     const model_version_t version;
     tensor_map_t inputsInfo;
@@ -35,17 +36,22 @@ class ServableMetadata {
     capi_tensor_shapes_map_t inDimMax;
     capi_tensor_shapes_map_t outDimMin;
     capi_tensor_shapes_map_t outDimMax;
-    // 2nd for outputs
+    ov::AnyMap rtInfo;
+
 public:
     ServableMetadata(const std::string& name,
         model_version_t version,
         const tensor_map_t& inputsInfo,
-        const tensor_map_t& outputsInfo);
+        const tensor_map_t& outputsInfo,
+        const ov::AnyMap& anyMap = EMPTY_RT_INFO);
     const tensor_map_t& getInputsInfo() const { return inputsInfo; }
     const tensor_map_t& getOutputsInfo() const { return outputsInfo; }
     const capi_tensor_shapes_map_t& getInputDimsMin() const { return this->inDimMin; }
     const capi_tensor_shapes_map_t& getInputDimsMax() const { return this->inDimMax; }
     const capi_tensor_shapes_map_t& getOutputDimsMin() const { return this->outDimMin; }
     const capi_tensor_shapes_map_t& getOutputDimsMax() const { return this->outDimMax; }
+    const ov::AnyMap& getRTInfo() const {
+        return this->rtInfo;
+    }
 };
 }  // namespace ovms

--- a/src/servablemetadata.hpp
+++ b/src/servablemetadata.hpp
@@ -36,7 +36,8 @@ class ServableMetadata {
     capi_tensor_shapes_map_t inDimMax;
     capi_tensor_shapes_map_t outDimMin;
     capi_tensor_shapes_map_t outDimMax;
-    ov::AnyMap extraInfo;
+    // for now this returns ov::Model::get_rt_info("model_info")
+    ov::AnyMap info;
 
 public:
     ServableMetadata(const std::string& name,
@@ -50,8 +51,8 @@ public:
     const capi_tensor_shapes_map_t& getInputDimsMax() const { return this->inDimMax; }
     const capi_tensor_shapes_map_t& getOutputDimsMin() const { return this->outDimMin; }
     const capi_tensor_shapes_map_t& getOutputDimsMax() const { return this->outDimMax; }
-    const ov::AnyMap& getExtraInfo() const {
-        return this->extraInfo;
+    const ov::AnyMap& getInfo() const {
+        return this->info;
     }
 };
 }  // namespace ovms

--- a/src/test/c_api_test_utils.hpp
+++ b/src/test/c_api_test_utils.hpp
@@ -1,0 +1,61 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#pragma once
+#include <string>
+
+#include <gtest/gtest.h>
+
+#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)   \
+    {                                         \
+        auto* err = C_API_CALL;               \
+        if (err != nullptr) {                 \
+            uint32_t code = 0;                \
+            const char* msg = nullptr;        \
+            OVMS_StatusGetCode(err, &code);   \
+            OVMS_StatusGetDetails(err, &msg); \
+            std::string smsg(msg);            \
+            OVMS_StatusDelete(err);           \
+            EXPECT_EQ(0, code) << smsg;       \
+            ASSERT_EQ(err, nullptr) << smsg;  \
+        }                                     \
+    }
+
+#define ASSERT_CAPI_STATUS_NOT_NULL(C_API_CALL) \
+    {                                           \
+        auto* err = C_API_CALL;                 \
+        if (err != nullptr) {                   \
+            OVMS_StatusDelete(err);             \
+        } else {                                \
+            ASSERT_NE(err, nullptr);            \
+        }                                       \
+    }
+
+#define ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(C_API_CALL, EXPECTED_STATUS_CODE)                              \
+    {                                                                                                          \
+        auto* err = C_API_CALL;                                                                                \
+        if (err != nullptr) {                                                                                  \
+            uint32_t code = 0;                                                                                 \
+            const char* details = nullptr;                                                                     \
+            ASSERT_EQ(OVMS_StatusGetCode(err, &code), nullptr);                                                \
+            ASSERT_EQ(OVMS_StatusGetDetails(err, &details), nullptr);                                          \
+            ASSERT_NE(details, nullptr);                                                                       \
+            ASSERT_EQ(code, static_cast<uint32_t>(EXPECTED_STATUS_CODE))                                       \
+                << std::string{"wrong code: "} + std::to_string(code) + std::string{"; details: "} << details; \
+            OVMS_StatusDelete(err);                                                                            \
+        } else {                                                                                               \
+            ASSERT_NE(err, nullptr);                                                                           \
+        }                                                                                                      \
+    }

--- a/src/test/custom_node_buffersqueue_test.cpp
+++ b/src/test/custom_node_buffersqueue_test.cpp
@@ -51,7 +51,7 @@ TEST(CustomNodeBuffersQueue, GetAllBuffers) {
     }
 }
 
-void getBufferAndReturn(BuffersQueue& buffersQueue) {
+static void getBufferAndReturn(BuffersQueue& buffersQueue) {
     void* buffer = buffersQueue.getBuffer();
     ASSERT_NE(nullptr, buffer) << "Failed to get buffer";
 }

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1713,7 +1713,7 @@ enum class Method {
     MAXIMUM_AVERAGE,
 };
 
-std::vector<float> prepareGatherHighestExpectedOutput(std::vector<float> input, Method option) {
+static std::vector<float> prepareGatherHighestExpectedOutput(std::vector<float> input, Method option) {
     std::vector<float> expectedOutput(DUMMY_MODEL_OUTPUT_SIZE);
     size_t tensorsCount = input.size() / DUMMY_MODEL_OUTPUT_SIZE;
     // perform operations

--- a/src/test/localfilesystem_test.cpp
+++ b/src/test/localfilesystem_test.cpp
@@ -33,7 +33,7 @@ const std::string TMP_CONTENT = "filecontent123\r\n";
 const std::string TMP_DIR1 = "dir1";
 const std::string TMP_DIR2 = "dir2";
 
-void createTmpFiles() {
+static void createTmpFiles() {
     std::ofstream configFile(TMP_PATH + TMP_FILE);
     configFile << TMP_CONTENT << std::endl;
     configFile.close();

--- a/src/test/mediapipe/config_mediapipe_dummy_adapter_full_dag.json
+++ b/src/test/mediapipe/config_mediapipe_dummy_adapter_full_dag.json
@@ -13,10 +13,6 @@
         "graph_path":"/ovms/src/test/mediapipe/graphdummyadapterfull.pbtxt"
     },
     {
-        "name":"mediapipeDummyADAPT",
-        "graph_path":"/ovms/src/test/mediapipe/graphdummyadapter.pbtxt"
-    },
-    {
         "name":"mediapipeDummy",
         "graph_path":"/ovms/src/test/mediapipe/graphdummy.pbtxt"
     }

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -168,7 +168,7 @@ public:
         }
         ov::AnyMap configuration = {
             {"layout", "data:HWCN"},
-            {"resize_type", "unnatural"},  // fit_to_window
+            {"resize_type", "unnatural"},
             {"labels", mockLabels}};
         return configuration;
     }

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -36,6 +36,7 @@
 #include "../servablemanagermodule.hpp"
 #include "../server.hpp"
 #include "../shape.hpp"
+#include "../stringutils.hpp"
 #include "test_utils.hpp"
 
 using namespace ovms;
@@ -251,7 +252,10 @@ TEST(Mediapipe, AdapterRTInfo) {
     OVMS_ModelsSettings* modelsSettings = nullptr;
     ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsNew(&serverSettings));
     ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsNew(&modelsSettings));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, 5555));
+    std::string port{"5555"};
+    randomizePort(port);
+    uint32_t portNum = ovms::stou32(port).value();
+    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, portNum));
     // we will use dummy model that will have mocked rt_info
     ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsSetConfigPath(modelsSettings, "/ovms/src/test/c_api/config.json"));
 

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -265,7 +265,7 @@ TEST(Mediapipe, AdapterRTInfo) {
     const std::shared_ptr<const ov::Model> model;
     /*ov::AnyMap configuration = {
         {"layout", "data:HWCN"},
-        {"resize_type", "unnatural"}, //fit_to_window
+        {"resize_type", "unnatural"},
         {"labels", mockLabels}*/
     ov::Core unusedCore;
     ov::AnyMap notUsedAnyMap;

--- a/src/test/metrics_flow_test.cpp
+++ b/src/test/metrics_flow_test.cpp
@@ -41,7 +41,7 @@ using testing::HasSubstr;
 using testing::Not;
 
 // This checks for counter to be present with exact value and other remaining metrics of the family to be 0.
-void checkRequestsCounter(const std::string& collectedMetricData, const std::string& metricName, const std::string& endpointName, std::optional<model_version_t> endpointVersion, const std::string& interfaceName, const std::string& method, const std::string& api, int value) {
+static void checkRequestsCounter(const std::string& collectedMetricData, const std::string& metricName, const std::string& endpointName, std::optional<model_version_t> endpointVersion, const std::string& interfaceName, const std::string& method, const std::string& api, int value) {
     for (std::string _interface : std::set<std::string>{"gRPC", "REST"}) {
         for (std::string _api : std::set<std::string>{"TensorFlowServing", "KServe"}) {
             if (_api == "KServe") {

--- a/src/test/model_service_test.cpp
+++ b/src/test/model_service_test.cpp
@@ -65,12 +65,12 @@ using MyTypes = ::testing::Types<
 
 TYPED_TEST_SUITE(ModelServiceTest, MyTypes);
 
-void executeModelStatus(const TFSGetModelStatusRequest& modelStatusRequest, TFSGetModelStatusResponse& modelStatusResponse, ModelManager& manager, ExecutionContext context, ovms::StatusCode statusCode = StatusCode::OK) {
+static void executeModelStatus(const TFSGetModelStatusRequest& modelStatusRequest, TFSGetModelStatusResponse& modelStatusResponse, ModelManager& manager, ExecutionContext context, ovms::StatusCode statusCode = StatusCode::OK) {
     modelStatusResponse.Clear();
     ASSERT_EQ(GetModelStatusImpl::getModelStatus(&modelStatusRequest, &modelStatusResponse, manager, context), statusCode);
 }
 
-void setModelStatusRequest(TFSGetModelStatusRequest& modelStatusRequest, const std::string& name, int version) {
+static void setModelStatusRequest(TFSGetModelStatusRequest& modelStatusRequest, const std::string& name, int version) {
     modelStatusRequest.Clear();
     auto model_spec = modelStatusRequest.mutable_model_spec();
     model_spec->Clear();
@@ -80,7 +80,7 @@ void setModelStatusRequest(TFSGetModelStatusRequest& modelStatusRequest, const s
     }
 }
 
-void verifyModelStatusResponse(const TFSGetModelStatusResponse& modelStatusResponse, const std::vector<int>& versions = {1}) {
+static void verifyModelStatusResponse(const TFSGetModelStatusResponse& modelStatusResponse, const std::vector<int>& versions = {1}) {
     ASSERT_EQ(modelStatusResponse.model_version_status_size(), versions.size());
     for (size_t i = 0; i < versions.size(); i++) {
         auto& model_version_status = modelStatusResponse.model_version_status()[i];
@@ -92,16 +92,16 @@ void verifyModelStatusResponse(const TFSGetModelStatusResponse& modelStatusRespo
     }
 }
 
-void verifyModelStatusResponse(const KFSGetModelStatusResponse& modelStatusResponse, const std::vector<int>& versions = {1}) {
+static void verifyModelStatusResponse(const KFSGetModelStatusResponse& modelStatusResponse, const std::vector<int>& versions = {1}) {
     ASSERT_TRUE(modelStatusResponse.ready());
 }
 
-void executeModelStatus(const KFSGetModelStatusRequest& modelStatusRequest, KFSGetModelStatusResponse& modelStatusResponse, ModelManager& manager, ExecutionContext context, ovms::StatusCode statusCode = StatusCode::OK) {
+static void executeModelStatus(const KFSGetModelStatusRequest& modelStatusRequest, KFSGetModelStatusResponse& modelStatusResponse, ModelManager& manager, ExecutionContext context, ovms::StatusCode statusCode = StatusCode::OK) {
     modelStatusResponse.Clear();
     ASSERT_EQ(KFSInferenceServiceImpl::getModelReady(&modelStatusRequest, &modelStatusResponse, manager, context), statusCode);
 }
 
-void setModelStatusRequest(KFSGetModelStatusRequest& modelStatusRequest, const std::string& name, int version) {
+static void setModelStatusRequest(KFSGetModelStatusRequest& modelStatusRequest, const std::string& name, int version) {
     modelStatusRequest.Clear();
     modelStatusRequest.set_name(name);
     if (version)

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -556,7 +556,7 @@ TEST_F(ModelManager, parseConfigWhenPipelineDefinitionMatchSchema) {
     modelMock.reset();
 }
 
-void setupModelsDirs() {
+static void setupModelsDirs() {
     std::filesystem::create_directory("/tmp/models");
     std::filesystem::create_directory("/tmp/models/dummy1");
     std::filesystem::create_directory("/tmp/models/dummy2");
@@ -1525,7 +1525,7 @@ public:
     }
 };
 
-std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> getMockedModelVersionInstances(
+static std::map<ovms::model_version_t, std::shared_ptr<ovms::ModelInstance>> getMockedModelVersionInstances(
     std::map<ovms::ModelVersionState, ovms::model_versions_t> initialVersionStates,
     ov::Core& ieCore,
     const ovms::ModelConfig& modelConfig = ovms::ModelConfig{}) {
@@ -1970,8 +1970,6 @@ TEST_F(ReloadAvailableModelDueToConfigChange, ExpectReloadDueToShapeConfiguratio
 }
 
 class GetModelInstanceTest : public ::testing::Test {};
-
-class MockModel : public ovms::Model {};
 
 std::shared_ptr<ovms::Model> model;
 

--- a/src/test/ovinferrequestqueue_test.cpp
+++ b/src/test/ovinferrequestqueue_test.cpp
@@ -47,7 +47,7 @@ TEST(OVInferRequestQueue, ShortQueue) {
     EXPECT_EQ(reqid, 0);
 }
 
-void releaseStream(ovms::OVInferRequestsQueue& requestsQueue) {
+static void releaseStream(ovms::OVInferRequestsQueue& requestsQueue) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     requestsQueue.returnStream(3);
 }

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -1454,7 +1454,7 @@ INSTANTIATE_TEST_SUITE_P(
         return toString(info.param);
     });
 
-void prepareInferStringInputWithTwoDimensionShapeTensor(::KFSRequest& request, const std::string& name) {
+static void prepareInferStringInputWithTwoDimensionShapeTensor(::KFSRequest& request, const std::string& name) {
     KFSTensorInputProto* tensor = request.add_inputs();
     tensor->set_name(name);
     tensor->set_datatype("BYTES");
@@ -1463,7 +1463,7 @@ void prepareInferStringInputWithTwoDimensionShapeTensor(::KFSRequest& request, c
     tensor->add_shape(1);
 }
 
-void prepareInferStringInputWithTwoDimensionShapeTensor(tensorflow::serving::PredictRequest& request, const std::string& name) {
+static void prepareInferStringInputWithTwoDimensionShapeTensor(tensorflow::serving::PredictRequest& request, const std::string& name) {
     request.mutable_inputs()->clear();
     auto& input = (*request.mutable_inputs())[name];
     input.set_dtype(tensorflow::DataType::DT_STRING);
@@ -1471,7 +1471,7 @@ void prepareInferStringInputWithTwoDimensionShapeTensor(tensorflow::serving::Pre
     input.mutable_tensor_shape()->add_dim()->set_size(1);
 }
 
-void prepareInferStringInputWithNegativeShape(::KFSRequest& request, const std::string& name) {
+static void prepareInferStringInputWithNegativeShape(::KFSRequest& request, const std::string& name) {
     KFSTensorInputProto* tensor = request.add_inputs();
     tensor->set_name(name);
     tensor->set_datatype("BYTES");
@@ -1479,7 +1479,7 @@ void prepareInferStringInputWithNegativeShape(::KFSRequest& request, const std::
     tensor->add_shape(-5);
 }
 
-void prepareInferStringInputWithNegativeShape(tensorflow::serving::PredictRequest& request, const std::string& name) {
+static void prepareInferStringInputWithNegativeShape(tensorflow::serving::PredictRequest& request, const std::string& name) {
     request.mutable_inputs()->clear();
     auto& input = (*request.mutable_inputs())[name];
     input.set_dtype(tensorflow::DataType::DT_STRING);

--- a/src/test/rest_utils_test.cpp
+++ b/src/test/rest_utils_test.cpp
@@ -174,7 +174,7 @@ const char* rawPositiveFirstOrderResponseColumn = R"({
     }
 })";
 
-std::string getJsonResponseDependsOnOrder(ovms::Order order, const char* rowOrderResponse, const char* columnOrderResponse) {
+static std::string getJsonResponseDependsOnOrder(ovms::Order order, const char* rowOrderResponse, const char* columnOrderResponse) {
     switch (order) {
     case Order::ROW:
         return rowOrderResponse;
@@ -282,7 +282,7 @@ TEST_P(TFSMakeJsonFromPredictResponseRawTest, Positive_Noname) {
 
 std::vector<ovms::Order> SupportedOrders = {Order::ROW, Order::COLUMN};
 
-std::string toString(ovms::Order order) {
+static std::string toString(ovms::Order order) {
     switch (order) {
     case Order::ROW:
         return "ROW";

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -111,14 +111,15 @@ public:
     }
 };
 
-void requestServerAlive(const char* grpcPort, grpc::StatusCode status = grpc::StatusCode::OK, bool expectedStatus = true) {
+static void requestServerAlive(const char* grpcPort, grpc::StatusCode status = grpc::StatusCode::OK, bool expectedStatus = true) {
     grpc::ChannelArguments args;
     std::string address = std::string("localhost") + ":" + grpcPort;
     SPDLOG_INFO("Verifying if server is live on address: {}", address);
     ServingClient client(grpc::CreateCustomChannel(address, grpc::InsecureChannelCredentials(), args));
     client.verifyLive(status, expectedStatus);
 }
-void requestServerReady(const char* grpcPort, grpc::StatusCode status = grpc::StatusCode::OK, bool expectedStatus = true) {
+
+static void requestServerReady(const char* grpcPort, grpc::StatusCode status = grpc::StatusCode::OK, bool expectedStatus = true) {
     grpc::ChannelArguments args;
     std::string address = std::string("localhost") + ":" + grpcPort;
     SPDLOG_INFO("Veryfying if server is ready on address: {}", address);
@@ -126,7 +127,7 @@ void requestServerReady(const char* grpcPort, grpc::StatusCode status = grpc::St
     client.verifyReady(status, expectedStatus);
 }
 
-void requestModelReady(const char* grpcPort, const std::string& modelName, grpc::StatusCode status = grpc::StatusCode::OK, bool expectedStatus = true) {
+static void requestModelReady(const char* grpcPort, const std::string& modelName, grpc::StatusCode status = grpc::StatusCode::OK, bool expectedStatus = true) {
     grpc::ChannelArguments args;
     std::string address = std::string("localhost") + ":" + grpcPort;
     SPDLOG_INFO("Verifying if server is ready on address: {}", address);
@@ -134,7 +135,7 @@ void requestModelReady(const char* grpcPort, const std::string& modelName, grpc:
     client.verifyModelReady(modelName, status, expectedStatus);
 }
 
-void checkServerMetadata(const char* grpcPort, grpc::StatusCode status = grpc::StatusCode::OK) {
+static void checkServerMetadata(const char* grpcPort, grpc::StatusCode status = grpc::StatusCode::OK) {
     grpc::ChannelArguments args;
     std::string address = std::string("localhost") + ":" + grpcPort;
     SPDLOG_INFO("Verifying if server responds with correct metadata on address: {}", address);

--- a/src/test/status_test.cpp
+++ b/src/test/status_test.cpp
@@ -25,7 +25,7 @@
 #include "test_utils.hpp"
 
 namespace ovms {
-StatusCode& operator++(StatusCode& statusCode) {
+static StatusCode& operator++(StatusCode& statusCode) {
     if (statusCode == StatusCode::STATUS_CODE_END) {
         throw std::out_of_range("for E& operator ++ (E&)");
     }

--- a/src/test/threadsafequeue_test.cpp
+++ b/src/test/threadsafequeue_test.cpp
@@ -73,7 +73,7 @@ TEST(TestThreadSafeQueue, NoElementsPushed) {
 
 const uint ELEMENTS_TO_INSERT = 500;
 
-void producer(ThreadSafeQueue<int>& queue, std::future<void> startSignal) {
+static void producer(ThreadSafeQueue<int>& queue, std::future<void> startSignal) {
     startSignal.get();
     uint counter = 0;
     while (counter < ELEMENTS_TO_INSERT) {
@@ -82,7 +82,7 @@ void producer(ThreadSafeQueue<int>& queue, std::future<void> startSignal) {
     }
 }
 
-void consumer(ThreadSafeQueue<int>& queue, std::future<void> startSignal, std::vector<int>& consumed, const uint elementsToPull) {
+static void consumer(ThreadSafeQueue<int>& queue, std::future<void> startSignal, std::vector<int>& consumed, const uint elementsToPull) {
     startSignal.get();
     uint counter = 0;
     while (counter < elementsToPull) {


### PR DESCRIPTION
* Extract rt_info from OV::Model
* Add way to get rt_info through C-API
* Extract rt_info in OVMSAdapter
* Enhance cppclean check
* Fix missing static specifier in tests

JIRA:CVS-107510,107511