### PR TITLE
Support for reloading and removing mediapipe graphs

### DIFF
--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -44,7 +44,7 @@ if [ ${NO_WARNINGS_DIRECT} -gt 13 ]; then
     echo "Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_DIRECT}";
     exit 1;
 fi
-if [ ${NO_WARNINGS_NOTUSED} -gt 7 ]; then
+if [ ${NO_WARNINGS_NOTUSED} -gt 4 ]; then
     echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_NOTUSED}";
     exit 1;
 fi

--- a/src/mediapipe_calculators/modelapiovmsadapter.cc
+++ b/src/mediapipe_calculators/modelapiovmsadapter.cc
@@ -116,8 +116,10 @@ InferenceOutput OVMSInferenceAdapter::infer(const InferenceInput& input) {
     //  INFERENCE
     //////////////////
     OVMS_InferenceResponse* response = nullptr;
+    InferenceOutput output;
     if (nullptr != OVMS_Inference(cserver, request, &response)) {
         MLOG("Inference failed!");
+        return output;
     }
     CREATE_GUARD(responseGuard, OVMS_InferenceResponse, response);
     // verify GetOutputCount
@@ -136,7 +138,6 @@ InferenceOutput OVMSInferenceAdapter::infer(const InferenceInput& input) {
     OVMS_BufferType bufferType = (OVMS_BufferType)199;
     uint32_t deviceId = 42;
     const char* outputName{nullptr};
-    InferenceOutput output;
     for (size_t i = 0; i < outputCount; ++i) {
         OVMS_InferenceResponseGetOutput(response, outputId, &outputName, &datatype, &shape, &dimCount, &voutputData, &bytesize, &bufferType, &deviceId);
         output[outputName] = makeOvTensorO(datatype, shape, dimCount, voutputData, bytesize);  // TODO optimize FIXME

--- a/src/mediapipe_internal/mediapipefactory.cpp
+++ b/src/mediapipe_internal/mediapipefactory.cpp
@@ -39,6 +39,11 @@ namespace ovms {
 Status MediapipeFactory::createDefinition(const std::string& pipelineName,
     const MediapipeGraphConfig& config,
     ModelManager& manager) {
+    if (0 != pipelineName.rfind("mediapipe", 0)) {
+        // TODO need to enable reporter for mediapipe
+        SPDLOG_LOGGER_ERROR(modelmanager_logger, "Mediapipe graph not prefixed with \"mediapipe\": {}, will not work for now", pipelineName);
+        return StatusCode::NOT_IMPLEMENTED;
+    }
     if (definitionExists(pipelineName)) {
         SPDLOG_LOGGER_ERROR(modelmanager_logger, "Mediapipe graph definition: {} is already created", pipelineName);
         return StatusCode::PIPELINE_DEFINITION_ALREADY_EXIST;
@@ -55,6 +60,7 @@ bool MediapipeFactory::definitionExists(const std::string& name) const {
 }
 
 MediapipeGraphDefinition* MediapipeFactory::findDefinitionByName(const std::string& name) const {
+    // TODO thread safety
     auto it = definitions.find(name);
     if (it == std::end(definitions)) {
         return nullptr;
@@ -63,11 +69,16 @@ MediapipeGraphDefinition* MediapipeFactory::findDefinitionByName(const std::stri
     }
 }
 
-Status MediapipeFactory::reloadDefinition(const std::string& pipelineName,  // TODO
+Status MediapipeFactory::reloadDefinition(const std::string& name,
     const MediapipeGraphConfig& config,
     ModelManager& manager) {
-    SPDLOG_LOGGER_ERROR(modelmanager_logger, "reloading mediapipe graphs not implemented yet");
-    return StatusCode::OK;
+    auto mgd = findDefinitionByName(name);
+    if (mgd == nullptr) {
+        SPDLOG_LOGGER_ERROR(modelmanager_logger, "Requested to reload mediapipe graph definition but it does not exist: {}", name);
+        return StatusCode::INTERNAL_ERROR;
+    }
+    SPDLOG_LOGGER_INFO(modelmanager_logger, "Reloading mediapipe graph: {}", name);
+    return mgd->reload(manager, config);
 }
 
 Status MediapipeFactory::create(std::shared_ptr<MediapipeGraphExecutor>& pipeline,
@@ -84,12 +95,19 @@ Status MediapipeFactory::create(std::shared_ptr<MediapipeGraphExecutor>& pipelin
     return status;
 }
 
-void MediapipeFactory::retireOtherThan(std::set<std::string>&& pipelinesInConfigFile, ModelManager& manager) {
-    SPDLOG_LOGGER_ERROR(modelmanager_logger, "retiring mediapipe graphs not implemented yet");
-}  // TODO
+void MediapipeFactory::retireOtherThan(std::set<std::string>&& graphsInConfigFile, ModelManager& manager) {
+    std::for_each(definitions.begin(),
+        definitions.end(),
+        [&graphsInConfigFile, &manager](auto& nameDefinitionPair) {
+            if (graphsInConfigFile.find(nameDefinitionPair.second->getName()) == graphsInConfigFile.end() && nameDefinitionPair.second->getStateCode() != PipelineDefinitionStateCode::RETIRED) {
+                nameDefinitionPair.second->retire(manager);
+            }
+        });
+}
+
 Status MediapipeFactory::revalidatePipelines(ModelManager&) {
-    // TODO
-    SPDLOG_LOGGER_ERROR(modelmanager_logger, "revalidation of mediapipe graphs not implemented yet");
+    // TODO potentially not needed if we do not validate presence of models required in pbtxt
+    SPDLOG_LOGGER_WARN(modelmanager_logger, "revalidation of mediapipe graphs not implemented yet");
     return StatusCode::OK;
 }
 

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -135,4 +135,16 @@ Status MediapipeGraphDefinition::create(std::shared_ptr<MediapipeGraphExecutor>&
     pipeline = std::make_shared<MediapipeGraphExecutor>(getName(), std::to_string(getVersion()), this->config);
     return StatusCode::OK;
 }
+
+Status MediapipeGraphDefinition::reload(ModelManager& manager, const MediapipeGraphConfig& config) {
+    // TODO block creating new unloadGuards
+    // TODO thread safety
+    this->status.handle(ReloadEvent());
+    this->mgconfig = config;
+    return validate(manager);
+}
+
+void MediapipeGraphDefinition::retire(ModelManager& manager) {
+    this->status.handle(RetireEvent());
+}
 }  // namespace ovms

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -132,6 +132,10 @@ Status MediapipeGraphDefinition::createOutputsInfo() {
 }
 
 Status MediapipeGraphDefinition::create(std::shared_ptr<MediapipeGraphExecutor>& pipeline, const KFSRequest* request, KFSResponse* response) {
+    if (!this->getStatus().isAvailable()) {
+        SPDLOG_DEBUG("Failed to execute mediapipe graph: {} since it is not available", getName());
+        return StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET;
+    }
     pipeline = std::make_shared<MediapipeGraphExecutor>(getName(), std::to_string(getVersion()), this->config);
     return StatusCode::OK;
 }

--- a/src/mediapipe_internal/mediapipegraphdefinition.hpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.hpp
@@ -67,6 +67,7 @@ public:
         const MediapipeGraphConfig& config = MGC,
         MetricRegistry* registry = nullptr,
         const MetricConfig* metricConfig = nullptr);
+
     const std::string& getName() const { return name; }
     const PipelineDefinitionStatus& getStatus() const {
         return this->status;
@@ -79,7 +80,9 @@ public:
     // TODO simultaneous infer & reload handling
     Status create(std::shared_ptr<MediapipeGraphExecutor>& pipeline, const KFSRequest* request, KFSResponse* response);
 
+    Status reload(ModelManager& manager, const MediapipeGraphConfig& config);
     Status validate(ModelManager& manager);
+    void retire(ModelManager& manager);
 
     // Pipelines are not versioned and any available definition has constant version equal 1.
     static constexpr model_version_t VERSION = 1;

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -411,7 +411,7 @@ node {
   input_side_packet: "SESSION:session"
   input_stream: "B:in"
   output_stream: "A:out"
-  )";
+})";
     const std::string pbtxtPath = this->directoryPath + "/graphDummyUppercase.pbtxt";
     createConfigFileWithContent(graphPbtxt, pbtxtPath);
     configJson.replace(it, pathToReplace.size(), pbtxtPath);

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -28,6 +28,7 @@
 #include "../http_rest_api_handler.hpp"
 #include "../kfs_frontend/kfs_grpc_inference_service.hpp"
 #include "../mediapipe_calculators/modelapiovmsadapter.hpp"
+#include "../mediapipe_internal/mediapipefactory.hpp"
 #include "../mediapipe_internal/mediapipegraphdefinition.hpp"
 #include "../metric_config.hpp"
 #include "../metric_module.hpp"
@@ -463,6 +464,148 @@ TEST_F(MediapipeConfig, MediapipeFullRelativePathsNegative) {
     EXPECT_EQ(definitionFull->getStatus().isAvailable(), false);
 
     manager.join();
+}
+
+class MediapipeConfigChanges : public TestWithTempDir {
+    void SetUp() override {
+        TestWithTempDir::SetUp();
+    }
+    void performWrongPipelineConfigTest(const char* configFileContent) {
+        std::string fileToReload = directoryPath + "/ovms_config_file1.json";
+        createConfigFileWithContent(configFileContent, fileToReload);
+        ConstructorEnabledModelManager modelManager;
+        modelManager.loadConfig(fileToReload);
+        const MediapipeFactory& factory = modelManager.getMediapipeFactory();
+        auto definition = factory.findDefinitionByName("mediapipeGraph");
+        ASSERT_NE(nullptr, definition);
+        ASSERT_EQ(definition->getStatus().getStateCode(), PipelineDefinitionStateCode::LOADING_PRECONDITION_FAILED);
+    }
+
+public:
+    static const std::string configFileWithGraphPathToReplace;
+    static const std::string configFileWithoutGraph;
+    static const std::string pbtxtContent;
+};
+const std::string MediapipeConfigChanges::configFileWithGraphPathToReplace = R"(
+{
+    "model_config_list": [
+        {"config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy"
+        }
+        }
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"mediapipeGraph",
+        "graph_path":"XYZ"
+    }
+    ]
+}
+)";
+
+const std::string MediapipeConfigChanges::configFileWithoutGraph = R"(
+{
+    "model_config_list": [
+        {"config": {
+                "name": "dummy",
+                "base_path": "/ovms/src/test/dummy"
+        }
+        }
+    ]
+}
+)";
+
+const std::string MediapipeConfigChanges::pbtxtContent = R"(
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "ModelAPISessionCalculator"
+  output_side_packet: "SESSION:session"
+  node_options: {
+    [type.googleapis.com / mediapipe.ModelAPIOVMSSessionCalculatorOptions]: {
+      servable_name: "dummy"
+      servable_version: "1"
+    }
+  }
+}
+node {
+  calculator: "ModelAPISideFeedCalculator"
+  input_side_packet: "SESSION:session"
+  input_stream: "B:in"
+  output_stream: "A:out"
+  node_options: {
+    [type.googleapis.com / mediapipe.ModelAPIInferenceCalculatorOptions]: {
+      tag_to_input_tensor_names {
+        key: "B"
+        value: "b"
+      }
+      tag_to_output_tensor_names {
+        key: "A"
+        value: "a"
+      }
+    }
+  }
+}
+)";
+
+TEST_F(MediapipeConfigChanges, AddProperGraphThenRetire) {
+    std::string configFileContent = configFileWithGraphPathToReplace;
+    std::string configFilePath = directoryPath + "/config.json";
+    std::string graphFilePath = directoryPath + "/graph.pbtxt";
+    const std::string modelPathToReplace{"XYZ"};
+    configFileContent.replace(configFileContent.find(modelPathToReplace), modelPathToReplace.size(), graphFilePath);
+    createConfigFileWithContent(configFileContent, configFilePath);
+    createConfigFileWithContent(pbtxtContent, graphFilePath);
+    ConstructorEnabledModelManager modelManager;
+    modelManager.loadConfig(configFilePath);
+    const MediapipeFactory& factory = modelManager.getMediapipeFactory();
+    auto definition = factory.findDefinitionByName("mediapipeGraph");
+    ASSERT_NE(nullptr, definition);
+    ASSERT_EQ(definition->getStatus().getStateCode(), PipelineDefinitionStateCode::AVAILABLE);
+    // now we retire
+    configFileContent = configFileWithoutGraph;
+    createConfigFileWithContent(configFileContent, configFilePath);
+    modelManager.loadConfig(configFilePath);
+    definition = factory.findDefinitionByName("mediapipeGraph");
+    ASSERT_NE(nullptr, definition);
+    ASSERT_EQ(definition->getStatus().getStateCode(), PipelineDefinitionStateCode::RETIRED);
+    // now we add again
+    configFileContent = configFileWithGraphPathToReplace;
+    configFileContent.replace(configFileContent.find(modelPathToReplace), modelPathToReplace.size(), graphFilePath);
+    createConfigFileWithContent(configFileContent, configFilePath);
+    modelManager.loadConfig(configFilePath);
+    definition = factory.findDefinitionByName("mediapipeGraph");
+    ASSERT_NE(nullptr, definition);
+    ASSERT_EQ(definition->getStatus().getStateCode(), PipelineDefinitionStateCode::AVAILABLE);
+}
+
+TEST_F(MediapipeConfigChanges, AddImroperGraphThenFixWithReloadThenBreakAgain) {
+    std::string configFileContent = configFileWithGraphPathToReplace;
+    std::string configFilePath = directoryPath + "/config.json";
+    std::string graphFilePath = directoryPath + "/graph.pbtxt";
+    createConfigFileWithContent(configFileContent, configFilePath);
+    createConfigFileWithContent(pbtxtContent, graphFilePath);
+    ConstructorEnabledModelManager modelManager;
+    modelManager.loadConfig(configFilePath);
+    const MediapipeFactory& factory = modelManager.getMediapipeFactory();
+    auto definition = factory.findDefinitionByName("mediapipeGraph");
+    ASSERT_NE(nullptr, definition);
+    ASSERT_EQ(definition->getStatus().getStateCode(), PipelineDefinitionStateCode::LOADING_PRECONDITION_FAILED);
+    // now we fix the config
+    const std::string modelPathToReplace{"XYZ"};
+    configFileContent.replace(configFileContent.find(modelPathToReplace), modelPathToReplace.size(), graphFilePath);
+    createConfigFileWithContent(configFileContent, configFilePath);
+    modelManager.loadConfig(configFilePath);
+    ASSERT_NE(nullptr, definition);
+    ASSERT_EQ(definition->getStatus().getStateCode(), PipelineDefinitionStateCode::AVAILABLE);
+    // now we break
+    configFileContent = configFileWithGraphPathToReplace;
+    createConfigFileWithContent(configFileContent, configFilePath);
+    modelManager.loadConfig(configFilePath);
+    definition = factory.findDefinitionByName("mediapipeGraph");
+    ASSERT_NE(nullptr, definition);
+    ASSERT_EQ(definition->getStatus().getStateCode(), PipelineDefinitionStateCode::LOADING_PRECONDITION_FAILED);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
* temporarily lock creation of graph definition without
   mediapipe suffix
* void segfault when inference fail