### PR TITLE
Mediapipe GetModelStatus/ModelReady support

### DIFF
--- a/ci/check_coverage.bat
+++ b/ci/check_coverage.bat
@@ -5,7 +5,7 @@ MIN_LINES_COV=76.8
 MIN_FUNCTION_COV=87.6
 
 #Rhel
-MIN_LINES_COV=75.1
+MIN_LINES_COV=75.6
 MIN_FUNCTION_COV=75.4
 
 LINES_COV=`cat genhtml/index.html | grep "headerCovTableEntry.*%" | grep -oP  ">\K(\d*.\d*) " | head -n 1`

--- a/src/kfs_frontend/kfs_grpc_inference_service.hpp
+++ b/src/kfs_frontend/kfs_grpc_inference_service.hpp
@@ -42,6 +42,7 @@ using KFSOutputTensorIteratorType = google::protobuf::internal::RepeatedPtrItera
 
 namespace ovms {
 class ExecutionContext;
+class MediapipeGraphDefinition;
 class Model;
 class ModelInstance;
 class ModelInstanceUnloadGuard;
@@ -73,6 +74,7 @@ public:
     static Status buildResponse(PipelineDefinition& pipelineDefinition, KFSModelMetadataResponse* response);
     static Status buildResponse(std::shared_ptr<ModelInstance> instance, KFSGetModelStatusResponse* response);
     static Status buildResponse(PipelineDefinition& pipelineDefinition, KFSGetModelStatusResponse* response);
+    static Status buildResponse(MediapipeGraphDefinition& pipelineDefinition, KFSGetModelStatusResponse* response);
     static void convert(const std::pair<std::string, std::shared_ptr<const TensorInfo>>& from, KFSModelMetadataResponse::TensorMetadata* to);
     static Status getModelReady(const KFSGetModelStatusRequest* request, KFSGetModelStatusResponse* response, const ModelManager& manager, ExecutionContext executionContext);
 

--- a/src/model_service.cpp
+++ b/src/model_service.cpp
@@ -34,8 +34,10 @@
 #include "dags/pipelinedefinition.hpp"
 #include "execution_context.hpp"
 #include "grpc_utils.hpp"
+#if (MEDIAPIPE_DISABLE == 0)
 #include "mediapipe_internal/mediapipefactory.hpp"
 #include "mediapipe_internal/mediapipegraphdefinition.hpp"
+#endif
 #include "modelinstance.hpp"
 #include "modelmanager.hpp"
 #include "servablemanagermodule.hpp"
@@ -109,6 +111,7 @@ Status GetModelStatusImpl::getModelStatus(
         SPDLOG_DEBUG("GetModelStatus: Model {} is missing, trying to find pipeline with such name", requested_model_name);
         auto pipelineDefinition = manager.getPipelineFactory().findDefinitionByName(requested_model_name);
         if (!pipelineDefinition) {
+#if (MEDIAPIPE_DISABLE == 0)
             auto mediapipeGraphDefinition = manager.getMediapipeFactory().findDefinitionByName(requested_model_name);
             if (!mediapipeGraphDefinition) {
                 return StatusCode::MODEL_NAME_MISSING;
@@ -117,6 +120,9 @@ Status GetModelStatusImpl::getModelStatus(
             SPDLOG_DEBUG("model_service: response: {}", response->DebugString());
             SPDLOG_DEBUG("MODEL_STATUS created a response for {} - {}", requested_model_name, requested_version);
             return StatusCode::OK;
+#else
+            return StatusCode::MODEL_NAME_MISSING;
+#endif
         }
         INCREMENT_IF_ENABLED(pipelineDefinition->getMetricReporter().getGetModelStatusRequestSuccessMetric(context));
 

--- a/src/test/model_service_test.cpp
+++ b/src/test/model_service_test.cpp
@@ -187,6 +187,7 @@ TYPED_TEST(ModelServiceTest, pipeline) {
     verifyModelStatusResponse(this->modelStatusResponse);
 }
 
+#if (MEDIAPIPE_DISABLE == 0)
 TYPED_TEST(ModelServiceTest, MediapipeGraph) {
     std::string fileToReload = "/ovms/src/test/mediapipe/config_mediapipe_dummy_adapter_full.json";
     ASSERT_EQ(this->manager.startFromFile(fileToReload), StatusCode::OK);
@@ -211,6 +212,7 @@ TYPED_TEST(ModelServiceTest, MediapipeGraph) {
     executeModelStatus(this->modelStatusRequest, this->modelStatusResponse, this->manager, DEFAULT_TEST_CONTEXT);
     verifyModelStatusResponse(this->modelStatusResponse);
 }
+#endif
 
 TYPED_TEST(ModelServiceTest, non_existing_model) {
     const std::string name = "non_existing_model";

--- a/src/test/model_service_test.cpp
+++ b/src/test/model_service_test.cpp
@@ -187,6 +187,31 @@ TYPED_TEST(ModelServiceTest, pipeline) {
     verifyModelStatusResponse(this->modelStatusResponse);
 }
 
+TYPED_TEST(ModelServiceTest, MediapipeGraph) {
+    std::string fileToReload = "/ovms/src/test/mediapipe/config_mediapipe_dummy_adapter_full.json";
+    ASSERT_EQ(this->manager.startFromFile(fileToReload), StatusCode::OK);
+
+    const std::string name = "mediapipeDummyADAPTFULL";
+
+    // existing version
+    int version = 1;
+    setModelStatusRequest(this->modelStatusRequest, name, version);
+    executeModelStatus(this->modelStatusRequest, this->modelStatusResponse, this->manager, DEFAULT_TEST_CONTEXT);
+    verifyModelStatusResponse(this->modelStatusResponse);
+
+    // No version specified - with 0 version value is not set in helper function
+    version = 0;
+    setModelStatusRequest(this->modelStatusRequest, name, version);
+    executeModelStatus(this->modelStatusRequest, this->modelStatusResponse, this->manager, DEFAULT_TEST_CONTEXT);
+    verifyModelStatusResponse(this->modelStatusResponse);
+
+    // Any version
+    version = 5;
+    setModelStatusRequest(this->modelStatusRequest, name, version);
+    executeModelStatus(this->modelStatusRequest, this->modelStatusResponse, this->manager, DEFAULT_TEST_CONTEXT);
+    verifyModelStatusResponse(this->modelStatusResponse);
+}
+
 TYPED_TEST(ModelServiceTest, non_existing_model) {
     const std::string name = "non_existing_model";
     int version = 0;


### PR DESCRIPTION
Request will ignore version - the same behavior as in DAG's

JIRA:CVS-109640,CVS-109643