### PR TITLE
Fix mediapipe disablement flag

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -333,8 +333,9 @@ RUN bazel build --jobs=$JOBS ${debug_bazel_flags} ${minitrace_flags} //src:ovms
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:libsampleloader.so
 
 # C-api C/C++ app with gcc
-COPY MakefileCapi .
-RUN make -f MakefileCapi cpp && make -f MakefileCapi c
+COPY MakefileCapi /ovms/
+RUN make -f MakefileCapi cpp BAZEL_DEBUG_FLAGS="${debug_bazel_flags}" && \
+    make -f MakefileCapi c BAZEL_DEBUG_FLAGS="${debug_bazel_flags}"
 
 ARG ovms_metadata_file
 COPY ${ovms_metadata_file} metadata.json

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -259,7 +259,6 @@ RUN curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHT
 WORKDIR /ovms
 COPY .bazelrc WORKSPACE /ovms/
 COPY external /ovms/external/
-COPY MakefileCapi /ovms/
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/runtime/lib/intel64/:/opt/opencv/lib/:/opt/intel/openvino/runtime/3rdparty/tbb/lib/
 
@@ -330,7 +329,9 @@ RUN bazel build --jobs=$JOBS ${debug_bazel_flags} ${minitrace_flags} //src:ovms
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:libsampleloader.so
 
 # C-api C/C++ app with gcc
-RUN make -f MakefileCapi cpp && make -f MakefileCapi c
+COPY MakefileCapi /ovms/
+RUN make -f MakefileCapi cpp BAZEL_DEBUG_FLAGS="${debug_bazel_flags}" && \
+    make -f MakefileCapi c BAZEL_DEBUG_FLAGS="${debug_bazel_flags}"
 
 ARG ovms_metadata_file
 COPY ${ovms_metadata_file} metadata.json

--- a/MakefileCapi
+++ b/MakefileCapi
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 cpp:
-	bazel build //src:ovms_shared
+	bazel build ${BAZEL_DEBUG_FLAGS} //src:ovms_shared
 	g++ src/main_capi.cpp -I/ovms/src/ -L/ovms/bazel-bin/src/ -lovms_shared -fPIC --std=c++17 -o /ovms/bazel-bin/src/capi_cpp_example
 	LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/ovms/bazel-bin/src/ /ovms/bazel-bin/src/capi_cpp_example
 
 c:
-	bazel build //src:ovms_shared
+	bazel build ${BAZEL_DEBUG_FLAGS} //src:ovms_shared
 	gcc -c src/main_capi.c -o /ovms/bazel-bin/src/main_capi.o -std=c99
 	gcc -o /ovms/bazel-bin/src/capi_c_example /ovms/bazel-bin/src/main_capi.o -lovms_shared -L/ovms/bazel-bin/src/
 	LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/ovms/bazel-bin/src/ /ovms/bazel-bin/src/capi_c_example


### PR DESCRIPTION
There was an issue with last C-API test recompiling entire ovms with mediapipe due to lacking bazel build flags.