### PR TITLE
Improved OVMS Mediapipe calculators logging and error handling

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -109,8 +109,8 @@ void configure_logger(const std::string& log_level, const std::string& log_path)
     if (log_level == "DEBUG" || log_level == "TRACE")
         FLAGS_minloglevel = google::INFO;
     else if (log_level == "WARNING")
-        FLAGS_minloglevel = google::INFO;
-    else  // ERROR, WARNING, FATAL
+        FLAGS_minloglevel = google::WARNING;
+    else  // ERROR, FATAL
         FLAGS_minloglevel = google::ERROR;
 #endif
 }

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -34,6 +34,6 @@ extern std::shared_ptr<spdlog::logger> capi_logger;
 #if (MEDIAPIPE_DISABLE == 0)
 extern std::shared_ptr<spdlog::logger> mediapipe_logger;
 #endif
-void configure_logger(const std::string log_level, const std::string log_path);
+void configure_logger(const std::string& log_level, const std::string& log_path);
 
 }  // namespace ovms

--- a/src/mediapipe_calculators/modelapiovmsadapter.cc
+++ b/src/mediapipe_calculators/modelapiovmsadapter.cc
@@ -32,23 +32,22 @@
 // here we need to decide if we have several calculators (1 for OVMS repository, 1-N inside mediapipe)
 // for the one inside OVMS repo it makes sense to reuse code from ovms lib
 namespace mediapipe {
-#define MLOG(A) LOG(ERROR) << __FILE__ << ":" << __LINE__ << " " << A << std::endl;
 
 using std::endl;
 
-#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)                                                  \
-    {                                                                                        \
-        auto* err = C_API_CALL;                                                              \
-        if (err != nullptr) {                                                                \
-            uint32_t code = 0;                                                               \
-            const char* msg = nullptr;                                                       \
-            OVMS_StatusGetCode(err, &code);                                                  \
-            OVMS_StatusGetDetails(err, &msg);                                                \
-            LOG(ERROR) << "Error encountred in OVMSCalculator:" << msg << " code: " << code; \
-            std::runtime_error exc(msg);                                                     \
-            OVMS_StatusDelete(err);                                                          \
-            throw exc;                                                                       \
-        }                                                                                    \
+#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)                                                 \
+    {                                                                                       \
+        auto* err = C_API_CALL;                                                             \
+        if (err != nullptr) {                                                               \
+            uint32_t code = 0;                                                              \
+            const char* msg = nullptr;                                                      \
+            OVMS_StatusGetCode(err, &code);                                                 \
+            OVMS_StatusGetDetails(err, &msg);                                               \
+            LOG(INFO) << "Error encountred in OVMSCalculator:" << msg << " code: " << code; \
+            std::runtime_error exc(msg);                                                    \
+            OVMS_StatusDelete(err);                                                         \
+            throw exc;                                                                      \
+        }                                                                                   \
     }
 #define CREATE_GUARD(GUARD_NAME, CAPI_TYPE, CAPI_PTR) \
     std::unique_ptr<CAPI_TYPE, decltype(&(CAPI_TYPE##Delete))> GUARD_NAME(CAPI_PTR, &(CAPI_TYPE##Delete));
@@ -77,7 +76,7 @@ OVMSInferenceAdapter::OVMSInferenceAdapter(const std::string& servableName, uint
 }
 
 OVMSInferenceAdapter::~OVMSInferenceAdapter() {
-    LOG(ERROR) << "OVMSAdapter destr";
+    LOG(INFO) << "OVMSAdapter destr";
 }
 
 InferenceOutput OVMSInferenceAdapter::infer(const InferenceInput& input) {
@@ -104,7 +103,7 @@ InferenceOutput OVMSInferenceAdapter::infer(const InferenceInput& input) {
             ss << input_tensor_access[x] << " ";
         }
         ss << " ]";
-        MLOG(ss.str());
+        LOG(INFO) << ss.str();
 #endif
         const auto& ovinputShape = input_tensor.get_shape();
         std::vector<int64_t> inputShape{ovinputShape.begin(), ovinputShape.end()};  // TODO error handling shape conversion
@@ -132,7 +131,7 @@ InferenceOutput OVMSInferenceAdapter::infer(const InferenceInput& input) {
         std::stringstream ss;
         ss << "Inference in OVMSAdapter failed: ";
         ss << msg << " code: " << code;
-        MLOG(ss.str());
+        LOG(INFO) << ss.str();
         OVMS_StatusDelete(status);
         return output;
     }
@@ -199,9 +198,8 @@ void OVMSInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>& mod
 ov::Shape OVMSInferenceAdapter::getInputShape(const std::string& inputName) const {
     auto it = inShapesMinMaxes.find(inputName);
     if (it == inShapesMinMaxes.end()) {
-        MLOG("Could not find input");
-        MLOG(inputName);
-        throw std::runtime_error(std::string("Adapter could not find input:") + inputName);  // TODO error handling
+        LOG(INFO) << "Could not find input:" << inputName;
+        throw std::runtime_error(std::string("Adapter could not find input:") + inputName);
     }
 
     ov::Shape ovShape;

--- a/src/mediapipe_calculators/modelapiovmssessioncalculator.cc
+++ b/src/mediapipe_calculators/modelapiovmssessioncalculator.cc
@@ -29,7 +29,6 @@
 // here we need to decide if we have several calculators (1 for OVMS repository, 1-N inside mediapipe)
 // for the one inside OVMS repo it makes sense to reuse code from ovms lib
 namespace mediapipe {
-#define MLOG(A) LOG(ERROR) << __FILE__ << ":" << __LINE__ << " " << A << std::endl;
 
 using ovms::OVMSInferenceAdapter;
 using std::endl;
@@ -43,25 +42,25 @@ class ModelAPISessionCalculator : public CalculatorBase {
 
 public:
     static absl::Status GetContract(CalculatorContract* cc) {
-        MLOG("Session GetContract start");
+        LOG(INFO) << "Session GetContract start";
         RET_CHECK(cc->Inputs().GetTags().empty());
         RET_CHECK(cc->Outputs().GetTags().empty());
         cc->OutputSidePackets().Tag(SESSION_TAG.c_str()).Set<std::shared_ptr<::InferenceAdapter>>();
         const auto& options = cc->Options<ModelAPIOVMSSessionCalculatorOptions>();
         RET_CHECK(!options.servable_name().empty());
-        MLOG("Session GetContract middle");
         // TODO validate version from string
         // TODO validate service url format
         // this is for later support for remote server inference
-        MLOG("Session GetContract end");
+        LOG(INFO) << "Session GetContract end";
         return absl::OkStatus();
     }
 
     absl::Status Close(CalculatorContext* cc) final {
+        LOG(INFO) << "Session Close";
         return absl::OkStatus();
     }
     absl::Status Open(CalculatorContext* cc) final {
-        MLOG("Session Open start");
+        LOG(INFO) << "Session Open start";
         for (CollectionItemId id = cc->Inputs().BeginId();
              id < cc->Inputs().EndId(); ++id) {
             if (!cc->Inputs().Get(id).Header().IsEmpty()) {
@@ -86,21 +85,20 @@ public:
         try {
             session->loadModel(nullptr, UNUSED_OV_CORE, "UNUSED", {});
         } catch (const std::exception& e) {
-            MLOG("Catched exception with message:");
-            MLOG(e.what());
+            LOG(INFO) << "Catched exception with message: " << e.what();
             RET_CHECK(false);
         } catch (...) {
-            MLOG("Catched unknown exception");
+            LOG(INFO) << "Catched unknown exception";
             RET_CHECK(false);
         }
-        MLOG("Session create adapter");
+        LOG(INFO) << "Session create adapter";
         cc->OutputSidePackets().Tag(SESSION_TAG.c_str()).Set(MakePacket<std::shared_ptr<InferenceAdapter>>(session));
-        MLOG("SessionOpen end");
+        LOG(INFO) << "Session Open end";
         return absl::OkStatus();
     }
 
     absl::Status Process(CalculatorContext* cc) final {
-        MLOG("SessionProcess");
+        LOG(INFO) << "Session Process";
         return absl::OkStatus();
     }
 };

--- a/src/mediapipe_calculators/ovms_calculator.cc
+++ b/src/mediapipe_calculators/ovms_calculator.cc
@@ -27,23 +27,21 @@
 // here we need to decide if we have several calculators (1 for OVMS repository, 1-N inside mediapipe)
 // for the one inside OVMS repo it makes sense to reuse code from ovms lib
 namespace mediapipe {
-#define MLOG(A) LOG(ERROR) << __FILE__ << ":" << __LINE__ << " " << A << std::endl;
-
 using std::endl;
 
 namespace {
-#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)                                                  \
-    {                                                                                        \
-        auto* err = C_API_CALL;                                                              \
-        if (err != nullptr) {                                                                \
-            uint32_t code = 0;                                                               \
-            const char* msg = nullptr;                                                       \
-            OVMS_StatusGetCode(err, &code);                                                  \
-            OVMS_StatusGetDetails(err, &msg);                                                \
-            LOG(ERROR) << "Error encountred in OVMSCalculator:" << msg << " code: " << code; \
-            OVMS_StatusDelete(err);                                                          \
-            RET_CHECK(err == nullptr);                                                       \
-        }                                                                                    \
+#define ASSERT_CAPI_STATUS_NULL(C_API_CALL)                                                 \
+    {                                                                                       \
+        auto* err = C_API_CALL;                                                             \
+        if (err != nullptr) {                                                               \
+            uint32_t code = 0;                                                              \
+            const char* msg = nullptr;                                                      \
+            OVMS_StatusGetCode(err, &code);                                                 \
+            OVMS_StatusGetDetails(err, &msg);                                               \
+            LOG(INFO) << "Error encountred in OVMSCalculator:" << msg << " code: " << code; \
+            OVMS_StatusDelete(err);                                                         \
+            RET_CHECK(err == nullptr);                                                      \
+        }                                                                                   \
     }
 #define CREATE_GUARD(GUARD_NAME, CAPI_TYPE, CAPI_PTR) \
     std::unique_ptr<CAPI_TYPE, decltype(&(CAPI_TYPE##Delete))> GUARD_NAME(CAPI_PTR, &(CAPI_TYPE##Delete));
@@ -230,7 +228,7 @@ public:
                 ss << input_tensor_access[x] << " ";
             }
             ss << " ] timestamp: " << cc->InputTimestamp().DebugString();
-            MLOG(ss.str());
+            LOG(INFO) << ss.str();
             const auto& ovInputShape = input_tensor.get_shape();
             std::vector<int64_t> inputShape(ovInputShape.begin(), ovInputShape.end());  // TODO ensure ov tensors shapes conversions return error in all calcs
             OVMS_DataType inputDataType = OVPrecision2CAPI(input_tensor.get_element_type());


### PR DESCRIPTION
* Remove doubled filename & line number in MP log lines
* Catch possible C-API infer errors inside OVMS Calculators While those exceptions are catched at higher level, we can log additional information in lower stack. Final error handling is yet to be implemented together with C++ Model API
* Added warning about double loggers configuring for easier debug
* OVMS will set Mediapipe log level to INFO when OVMS is in DEBUG/TRACE This is due to Glog not having compiled in debug log level when in build is debug.

Note:
Ideally we could format Glog logs in the same way as SPDLOG however this requires glog to be comiled with flag enabling custom prefix GLOG_CUSTOM_PREFIX_SUPPORT and forcing this flag through MP. Calling InitGoogleLogging for some reason breaks appropiate log level setting so it is skipped now.

JIRA:CVS-109174