### PR TITLE
Fix docker clipping build logs of unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+# workaround for docker clipping build step logs
+BUILDKIT_STEP_LOG_MAX_SIZE=500000000
+BUILDKIT_STEP_LOG_MAX_SPEED=10000000
+
 VIRTUALENV_EXE := python3 -m virtualenv -p python3
 VIRTUALENV_DIR := .venv
 ACTIVATE="$(VIRTUALENV_DIR)/bin/activate"


### PR DESCRIPTION
With recent docker update it changed the builder to use buildkit:
https://docs.docker.com/build/buildkit/
The issue with that update is that it automatically cuts the build step logs to 2mb which is not sufficient when we have failure in UT's.

CVS-312114