### PR TITLE
REST/Metadata fixes and tests for Scalar Tensors

### DIFF
--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -492,6 +492,7 @@ Status HttpRestApiHandler::processModelMetadataKFSRequest(const HttpRequestCompo
     }
     std::string output;
     google::protobuf::util::JsonPrintOptions opts;
+    opts.always_print_primitive_fields = true;
     google::protobuf::util::Status status = google::protobuf::util::MessageToJsonString(grpc_response, &output, opts);
     if (!status.ok()) {
         return StatusCode::JSON_SERIALIZATION_ERROR;

--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -492,6 +492,7 @@ Status HttpRestApiHandler::processModelMetadataKFSRequest(const HttpRequestCompo
     }
     std::string output;
     google::protobuf::util::JsonPrintOptions opts;
+    // This parameter forces JSON writer to not omit empty shape in case of scalar tensor
     opts.always_print_primitive_fields = true;
     google::protobuf::util::Status status = google::protobuf::util::MessageToJsonString(grpc_response, &output, opts);
     if (!status.ok()) {

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -342,7 +342,7 @@ void OVMS_InferenceRequestDelete(OVMS_InferenceRequest* response);
 // \param request The request object
 // \param inputName The name of the input
 // \param datatype The data type of the input
-// \param shape The shape of the input
+// \param shape The shape of the input (ignored for scalars)
 // \param dimCount The number of dimensions of the shape
 // \return OVMS_Status object in case of failure
 OVMS_Status* OVMS_InferenceRequestAddInput(OVMS_InferenceRequest* request, const char* inputName, OVMS_DataType datatype, const int64_t* shape, size_t dimCount);

--- a/src/rest_parser.cpp
+++ b/src/rest_parser.cpp
@@ -354,8 +354,7 @@ static bool addNumber(tensorflow::TensorProto& proto, const rapidjson::Value& va
 Status TFSRestParser::parseColumnFormat(rapidjson::Value& node) {
     order = Order::COLUMN;
     // no named scalar
-    if (node.IsNumber() && requestProto.inputs_size() == 1)
-    {
+    if (node.IsNumber() && requestProto.inputs_size() == 1) {
         addNumber(requestProto.mutable_inputs()->begin()->second, node);
         format = Format::NONAMED;
         return StatusCode::OK;
@@ -390,8 +389,7 @@ Status TFSRestParser::parseColumnFormat(rapidjson::Value& node) {
         // scalar
         if (kv.value.IsNumber()) {
             addNumber(proto, kv.value);
-        }
-        else if (!parseArray(kv.value, 0, proto, tensorName)) {
+        } else if (!parseArray(kv.value, 0, proto, tensorName)) {
             return StatusCode::REST_COULD_NOT_PARSE_INPUT;
         }
     }

--- a/src/rest_parser.hpp
+++ b/src/rest_parser.hpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #pragma once
 
+#include <set>
 #include <string>
 #include <unordered_map>
 
@@ -71,6 +72,8 @@ class TFSRestParser : RestParser {
      * @brief Request proto
      */
     tensorflow::serving::PredictRequest requestProto;
+
+    std::set<std::string> inputsFoundInRequest;
 
     /**
      * @brief Request content precision

--- a/src/test/get_model_metadata_signature_test.cpp
+++ b/src/test/get_model_metadata_signature_test.cpp
@@ -45,6 +45,10 @@ protected:
                                              ovms::Precision::I64,
                                              {1, 6, 128, 128, 16},
                                          }},
+            {"Input_U8_Scalar", {
+                                    ovms::Precision::U8,
+                                    {},
+                                }},
         };
 
         for (const auto& pair : tensors) {
@@ -58,25 +62,28 @@ protected:
 
 TEST_F(GetModelMetadataSignature, ConvertCorrectNumberOfInputs) {
     ovms::GetModelMetadataImpl::convert(inputs, &signature);
-    EXPECT_EQ(signature.size(), 2);
+    EXPECT_EQ(signature.size(), 3);
 }
 
 TEST_F(GetModelMetadataSignature, ConvertInputsExist) {
     ovms::GetModelMetadataImpl::convert(inputs, &signature);
     EXPECT_NE(signature.find("Input_FP32_1_3_224_224"), signature.end());
     EXPECT_NE(signature.find("Input_I64_1_6_128_128_16"), signature.end());
+    EXPECT_NE(signature.find("Input_U8_Scalar"), signature.end());
 }
 
 TEST_F(GetModelMetadataSignature, ConvertCorrectInputNames) {
     ovms::GetModelMetadataImpl::convert(inputs, &signature);
     EXPECT_EQ(signature["Input_FP32_1_3_224_224"].name(), "Input_FP32_1_3_224_224");
     EXPECT_EQ(signature["Input_I64_1_6_128_128_16"].name(), "Input_I64_1_6_128_128_16");
+    EXPECT_EQ(signature["Input_U8_Scalar"].name(), "Input_U8_Scalar");
 }
 
 TEST_F(GetModelMetadataSignature, ConvertCorrectPrecision) {
     ovms::GetModelMetadataImpl::convert(inputs, &signature);
     EXPECT_EQ(signature["Input_FP32_1_3_224_224"].dtype(), tensorflow::DT_FLOAT);
     EXPECT_EQ(signature["Input_I64_1_6_128_128_16"].dtype(), tensorflow::DT_INT64);
+    EXPECT_EQ(signature["Input_U8_Scalar"].dtype(), tensorflow::DT_UINT8);
 }
 
 TEST_F(GetModelMetadataSignature, ConvertCorrectTensorShape) {
@@ -89,4 +96,8 @@ TEST_F(GetModelMetadataSignature, ConvertCorrectTensorShape) {
     EXPECT_TRUE(isShapeTheSame(
         signature["Input_I64_1_6_128_128_16"].tensor_shape(),
         {1, 6, 128, 128, 16}));
+
+    EXPECT_TRUE(isShapeTheSame(
+        signature["Input_U8_Scalar"].tensor_shape(),
+        {}));
 }

--- a/src/test/kfs_metadata_test.cpp
+++ b/src/test/kfs_metadata_test.cpp
@@ -112,7 +112,11 @@ public:
                     {"Input_U8_1_3_62_62", {
                                                ovms::Precision::U8,
                                                {1, 3, 62, 62},
-                                           }}}),
+                                           }},
+                    {"Input_I64_Scalar", {
+                                             ovms::Precision::I64,
+                                             {},
+                                         }}}),
             tensor_desc_map_t({{"Output_I32_1_2000", {
                                                          ovms::Precision::I32,
                                                          {1, 2000},
@@ -120,7 +124,11 @@ public:
                 {"Output_FP32_2_20_3", {
                                            ovms::Precision::FP32,
                                            {2, 20, 3},
-                                       }}}));
+                                       }},
+                {"Output_I64_Scalar", {
+                                          ovms::Precision::I64,
+                                          {},
+                                      }}}));
     }
 
 protected:
@@ -246,6 +254,28 @@ TEST_F(ModelMetadataResponseBuild, DoubleInputDoubleOutputValidResponse) {
     EXPECT_EQ(secondOutput.datatype(), "FP32");
     EXPECT_EQ(secondOutput.shape_size(), 4);
     EXPECT_TRUE(isShapeTheSame(secondOutput.shape(), {1, 3, 400, 400}));
+}
+
+TEST_F(ModelMetadataResponseBuild, ScalarsValidResponse) {
+    tensor_desc_map_t inputs = tensor_desc_map_t({{"SingleInput", {ovms::Precision::FP32, {}}}});
+    tensor_desc_map_t outputs = tensor_desc_map_t({{"SingleOutput", {ovms::Precision::I32, {}}}});
+    prepare(inputs, outputs);
+
+    ASSERT_EQ(ovms::KFSInferenceServiceImpl::buildResponse(*model, *instance, &response), ovms::StatusCode::OK);
+
+    EXPECT_EQ(response.inputs_size(), 1);
+    auto input = response.inputs().at(0);
+    EXPECT_EQ(input.name(), "SingleInput");
+    EXPECT_EQ(input.datatype(), "FP32");
+    EXPECT_EQ(input.shape_size(), 0);
+    EXPECT_TRUE(isShapeTheSame(input.shape(), {}));
+
+    EXPECT_EQ(response.outputs_size(), 1);
+    auto output = response.outputs().at(0);
+    EXPECT_EQ(output.name(), "SingleOutput");
+    EXPECT_EQ(output.datatype(), "INT32");
+    EXPECT_EQ(output.shape_size(), 0);
+    EXPECT_TRUE(isShapeTheSame(output.shape(), {}));
 }
 
 class PipelineMetadataResponseBuild : public ::testing::Test {

--- a/src/test/kfs_rest_test.cpp
+++ b/src/test/kfs_rest_test.cpp
@@ -390,7 +390,7 @@ TEST_F(HttpRestApiHandlerTest, inferRequest) {
 
 TEST_F(HttpRestApiHandlerWithScalarModelTest, inferRequestScalar) {
     std::string request = "/v2/models/scalar/versions/1/infer";
-    std::string request_body = "{\"inputs\":[{\"name\":\"scalar_model_input\",\"shape\":[],\"datatype\":\"FP32\",\"data\":[4.1]}], \"id\":\"1\"}";
+    std::string request_body = "{\"inputs\":[{\"name\":\"model_scalar_input\",\"shape\":[],\"datatype\":\"FP32\",\"data\":[4.1]}], \"id\":\"1\"}";
     ovms::HttpRequestComponents comp;
 
     ASSERT_EQ(handler->parseRequestComponents(comp, "POST", request), ovms::StatusCode::OK);
@@ -402,9 +402,12 @@ TEST_F(HttpRestApiHandlerWithScalarModelTest, inferRequestScalar) {
     doc.Parse(response.c_str());
     ASSERT_EQ(doc["model_name"].GetString(), std::string("scalar"));
     ASSERT_EQ(doc["id"].GetString(), std::string("1"));
-    auto output = doc["outputs"].GetArray()[0].GetObject()["scalar_model_output"].GetArray();
+    ASSERT_TRUE(doc["outputs"].GetArray()[0].GetObject().HasMember("data"));
+    ASSERT_TRUE(doc["outputs"].GetArray()[0].GetObject().HasMember("shape"));
+    auto output = doc["outputs"].GetArray()[0].GetObject()["data"].GetArray();
     ASSERT_EQ(output.Size(), 1);
     ASSERT_EQ(output[0].GetFloat(), 4.1f);
+    ASSERT_EQ(doc["outputs"].GetArray()[0].GetObject()["shape"].GetArray().Size(), 0);
 }
 
 TEST_F(HttpRestApiHandlerTest, inferPreprocess) {

--- a/src/test/tfs_rest_parser_column_test.cpp
+++ b/src/test/tfs_rest_parser_column_test.cpp
@@ -109,6 +109,19 @@ TEST(TFSRestParserColumn, ParseValid2Inputs) {
                                                               14.0, 15.0, 16.0));
 }
 
+TEST(TFSRestParserColumn, ValidShape_1d_vector_1elem) {
+    TFSRestParser parser(prepareTensors({{"i", {1}}}));
+
+    ASSERT_EQ(parser.parse(R"({"signature_name":"","inputs":{
+        "i":[155.0]
+    }})"),
+        StatusCode::OK);
+    EXPECT_EQ(parser.getOrder(), Order::COLUMN);
+    EXPECT_EQ(parser.getFormat(), Format::NAMED);
+    EXPECT_THAT(asVector(parser.getProto().inputs().at("i").tensor_shape()), ElementsAre(1));
+    EXPECT_THAT(asVector<float>(parser.getProto().inputs().at("i").tensor_content()), ElementsAre(155.0));
+}
+
 TEST(TFSRestParserColumn, ValidShape_1x1) {
     TFSRestParser parser(prepareTensors({{"i", {1, 1}}}));
 
@@ -233,6 +246,19 @@ TEST(TFSRestParserColumn, ValidShape_2x1x3x1x5) {
                                                                                           1.9, 2.9, 3.9, 4.9, 5.9,
                                                                                           1.9, 2.9, 3.9, 4.9, 5.9,
                                                                                           1.9, 2.9, 3.9, 4.9, 5.9));
+}
+
+TEST(TFSRestParserColumn, ValidScalar) {
+    TFSRestParser parser(prepareTensors({{"i", {}}}));
+
+    ASSERT_EQ(parser.parse(R"({"signature_name":"","inputs":{
+        "i":155.0
+    }})"),
+        StatusCode::OK);
+    EXPECT_EQ(parser.getOrder(), Order::COLUMN);
+    EXPECT_EQ(parser.getFormat(), Format::NAMED);
+    EXPECT_THAT(asVector(parser.getProto().inputs().at("i").tensor_shape()), ElementsAre());
+    EXPECT_THAT(asVector<float>(parser.getProto().inputs().at("i").tensor_content()), ElementsAre(155.0));
 }
 
 TEST(TFSRestParserColumn, AllowsDifferent0thDimension) {

--- a/src/test/tfs_rest_parser_column_test.cpp
+++ b/src/test/tfs_rest_parser_column_test.cpp
@@ -257,7 +257,9 @@ TEST(TFSRestParserColumn, ValidScalar) {
         StatusCode::OK);
     EXPECT_EQ(parser.getOrder(), Order::COLUMN);
     EXPECT_EQ(parser.getFormat(), Format::NAMED);
+    ASSERT_EQ(parser.getProto().inputs().count("i"), 1);
     EXPECT_THAT(asVector(parser.getProto().inputs().at("i").tensor_shape()), ElementsAre());
+    EXPECT_EQ(parser.getProto().inputs().at("i").dtype(), tensorflow::DT_FLOAT);
     EXPECT_THAT(asVector<float>(parser.getProto().inputs().at("i").tensor_content()), ElementsAre(155.0));
 }
 
@@ -417,7 +419,6 @@ TEST(TFSRestParserColumn, NoInputsFound) {
 TEST(TFSRestParserColumn, CannotParseInput) {
     TFSRestParser parser(prepareTensors({{"i", {2, 1}}}));
 
-    EXPECT_EQ(parser.parse(R"({"signature_name":"","inputs":{"i":2}})"), StatusCode::REST_COULD_NOT_PARSE_INPUT);
     EXPECT_EQ(parser.parse(R"({"signature_name":"","inputs":{"i":null}})"), StatusCode::REST_COULD_NOT_PARSE_INPUT);
     EXPECT_EQ(parser.parse(R"({"signature_name":"","inputs":{"i":[1,null]}})"), StatusCode::REST_COULD_NOT_PARSE_INPUT);
     EXPECT_EQ(parser.parse(R"({"signature_name":"","inputs":{"i":[[1,2],[3,"str"]]}})"), StatusCode::REST_COULD_NOT_PARSE_INPUT);

--- a/src/test/tfs_rest_parser_nonamed_test.cpp
+++ b/src/test/tfs_rest_parser_nonamed_test.cpp
@@ -115,6 +115,7 @@ TEST(TFSRestParserNoNamed, ColumnOrder_1d_5elements) {
     EXPECT_EQ(parser.getFormat(), Format::NONAMED);
     ASSERT_EQ(parser.getProto().inputs().count("my_input"), 1);
     const auto& my_input = parser.getProto().inputs().at("my_input");
+    EXPECT_THAT(my_input.dtype(), tensorflow::DT_FLOAT);
     EXPECT_THAT(asVector(my_input.tensor_shape()), ElementsAre(5));
     EXPECT_THAT(asVector<float>(my_input.tensor_content()), ElementsAre(1, 2, 3, 4, 5));
 }
@@ -128,6 +129,7 @@ TEST(TFSRestParserNoNamed, ColumnOrder_Scalar) {
     EXPECT_EQ(parser.getFormat(), Format::NONAMED);
     ASSERT_EQ(parser.getProto().inputs().count("my_input"), 1);
     const auto& my_input = parser.getProto().inputs().at("my_input");
+    EXPECT_THAT(my_input.dtype(), tensorflow::DT_FLOAT);
     EXPECT_THAT(asVector(my_input.tensor_shape()), ElementsAre());
     EXPECT_THAT(asVector<float>(my_input.tensor_content()), ElementsAre(5));
 }

--- a/src/test/tfs_rest_parser_nonamed_test.cpp
+++ b/src/test/tfs_rest_parser_nonamed_test.cpp
@@ -106,7 +106,7 @@ TEST(TFSRestParserNoNamed, ColumnOrder_2x1x3x1x5) {
                                                                 1, 2, 3, 4, 5));
 }
 
-TEST(TFSRestParserNoNamed, ColumnOrder_5) {
+TEST(TFSRestParserNoNamed, ColumnOrder_1d_5elements) {
     TFSRestParser parser(prepareTensors({{"my_input", {5}}}));
 
     ASSERT_EQ(parser.parse(R"({"signature_name":"","inputs":[1,2,3,4,5]})"),
@@ -117,4 +117,17 @@ TEST(TFSRestParserNoNamed, ColumnOrder_5) {
     const auto& my_input = parser.getProto().inputs().at("my_input");
     EXPECT_THAT(asVector(my_input.tensor_shape()), ElementsAre(5));
     EXPECT_THAT(asVector<float>(my_input.tensor_content()), ElementsAre(1, 2, 3, 4, 5));
+}
+
+TEST(TFSRestParserNoNamed, ColumnOrder_Scalar) {
+    TFSRestParser parser(prepareTensors({{"my_input", {}}}));
+
+    ASSERT_EQ(parser.parse(R"({"signature_name":"","inputs":5})"),
+        StatusCode::OK);
+    EXPECT_EQ(parser.getOrder(), Order::COLUMN);
+    EXPECT_EQ(parser.getFormat(), Format::NONAMED);
+    ASSERT_EQ(parser.getProto().inputs().count("my_input"), 1);
+    const auto& my_input = parser.getProto().inputs().at("my_input");
+    EXPECT_THAT(asVector(my_input.tensor_shape()), ElementsAre());
+    EXPECT_THAT(asVector<float>(my_input.tensor_content()), ElementsAre(5));
 }


### PR DESCRIPTION
- change way how TFSParser drops unnecessary inputs (previously based reserved dimension count 0 - which conflicts with scalars, changed to store information in std::set)
- added scalar parsing for column named and nonamed format: `{"inputs": 14.2}` (unnamed) `{"inputs": {"b": 14.2}}` (named) - TFS row format does not support scalars by design
- fixed KFS metadata GRPC=>REST conversion with missing shape for dim=0 shapes
- added unit tests 