### PR TITLE
Fix sporadic timeout issue in test

### DIFF
--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -16,6 +16,7 @@
 #include "modelmanager.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -67,7 +68,7 @@
 
 namespace ovms {
 
-static constexpr uint16_t MAX_CONFIG_JSON_READ_RETRY_COUNT = 2;
+static constexpr uint16_t MAX_CONFIG_JSON_READ_RETRY_COUNT = 3;
 const std::string DEFAULT_MODEL_CACHE_DIRECTORY = "/opt/cache";
 
 ModelManager::ModelManager(const std::string& modelCacheDirectory, MetricRegistry* registry) :
@@ -155,7 +156,7 @@ ModelManager::~ModelManager() {
 }
 
 Status ModelManager::start(const Config& config) {
-    watcherIntervalSec = config.filesystemPollWaitSeconds();
+    this->watcherIntervalMillisec = config.filesystemPollWaitSeconds() * 1000;
     sequenceCleaupIntervalMinutes = config.sequenceCleanerPollWaitMinutes();
     resourcesCleanupIntervalSec = config.resourcesCleanerPollWaitSeconds();
     if (resourcesCleanupIntervalSec < 1) {
@@ -179,7 +180,7 @@ Status ModelManager::start(const Config& config) {
 }
 
 void ModelManager::startWatcher(bool watchConfigFile) {
-    if ((!watcherStarted) && (watcherIntervalSec > 0)) {
+    if ((!watcherStarted) && (this->watcherIntervalMillisec > 0)) {
         std::future<void> exitSignal = exitTrigger.get_future();
         std::thread t(std::thread(&ModelManager::watcher, this, std::move(exitSignal), watchConfigFile));
         watcherStarted = true;
@@ -888,7 +889,7 @@ Status ModelManager::loadConfig(const std::string& jsonFilename) {
             SPDLOG_LOGGER_ERROR(modelmanager_logger, "Configuration file is invalid {}", jsonFilename);
             intermediateStatus = StatusCode::CONFIG_FILE_INVALID;
             loud.log();
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            std::this_thread::sleep_for(std::chrono::milliseconds(WRONG_CONFIG_FILE_RETRY_DELAY_MS));
             continue;
         }
         rapidjson::IStreamWrapper isw(ifs);
@@ -898,21 +899,21 @@ Status ModelManager::loadConfig(const std::string& jsonFilename) {
                 rapidjson::GetParseError_En(parseResult.Code()));
             intermediateStatus = StatusCode::JSON_INVALID;
             loud.log();
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            std::this_thread::sleep_for(std::chrono::milliseconds(WRONG_CONFIG_FILE_RETRY_DELAY_MS));
             continue;
         }
         intermediateStatus = StatusCode::OK;
         break;
     } while (++counter < MAX_CONFIG_JSON_READ_RETRY_COUNT && !intermediateStatus.ok());
     if (!intermediateStatus.ok()) {
-        lastLoadConfigStatus = intermediateStatus;
-        return lastLoadConfigStatus;
+        this->lastLoadConfigStatus = intermediateStatus;
+        return this->lastLoadConfigStatus;
     }
 
     if (validateJsonAgainstSchema(configJson, MODELS_CONFIG_SCHEMA.c_str()) != StatusCode::OK) {
         SPDLOG_LOGGER_ERROR(modelmanager_logger, "Configuration file is not in valid configuration format");
-        lastLoadConfigStatus = StatusCode::JSON_INVALID;
-        return lastLoadConfigStatus;
+        this->lastLoadConfigStatus = StatusCode::JSON_INVALID;
+        return this->lastLoadConfigStatus;
     }
     Status status;
 
@@ -975,7 +976,7 @@ Status ModelManager::loadConfig(const std::string& jsonFilename) {
         IF_ERROR_NOT_OCCURRED_EARLIER_THEN_SET_FIRST_ERROR(status);
     }
 
-    lastLoadConfigStatus = firstErrorStatus;
+    this->lastLoadConfigStatus = firstErrorStatus;
     return firstErrorStatus;
 }
 
@@ -1071,10 +1072,9 @@ Status ModelManager::configFileReloadNeeded(bool& isNeeded) {
     if (lastConfigFileMD5 != newmd5) {
         configFileModified = true;
     }
-
     if (configFilename == "" || !configFileModified) {
         isNeeded = false;
-        return lastLoadConfigStatus;
+        return this->lastLoadConfigStatus;
     } else {
         isNeeded = true;
     }
@@ -1084,9 +1084,9 @@ Status ModelManager::configFileReloadNeeded(bool& isNeeded) {
 
 void ModelManager::watcher(std::future<void> exitSignal, bool watchConfigFile) {
     SPDLOG_LOGGER_INFO(modelmanager_logger, "Started model manager thread");
-    while (exitSignal.wait_for(std::chrono::seconds(watcherIntervalSec)) == std::future_status::timeout) {
+    while (exitSignal.wait_for(std::chrono::milliseconds(this->watcherIntervalMillisec)) == std::future_status::timeout) {
         SPDLOG_LOGGER_TRACE(modelmanager_logger, "Models configuration and filesystem check cycle begin");
-        std::lock_guard<std::recursive_mutex> loadingLock(configMtx);
+        std::unique_lock<std::recursive_mutex> loadingLock(configMtx);
         if (watchConfigFile) {
             bool isNeeded;
             configFileReloadNeeded(isNeeded);
@@ -1095,6 +1095,8 @@ void ModelManager::watcher(std::future<void> exitSignal, bool watchConfigFile) {
             }
         }
         updateConfigurationWithoutConfigFile();
+        // FIXME CHECK
+        loadingLock.unlock();
         SPDLOG_LOGGER_TRACE(modelmanager_logger, "Models configuration and filesystem check cycle end");
     }
     SPDLOG_LOGGER_INFO(modelmanager_logger, "Stopped model manager thread");

--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -1095,7 +1095,6 @@ void ModelManager::watcher(std::future<void> exitSignal, bool watchConfigFile) {
             }
         }
         updateConfigurationWithoutConfigFile();
-        // FIXME CHECK
         loadingLock.unlock();
         SPDLOG_LOGGER_TRACE(modelmanager_logger, "Models configuration and filesystem check cycle end");
     }

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -89,7 +89,6 @@ protected:
 
     GlobalSequencesViewer globalSequencesViewer;
 
-protected:
     uint32_t waitForModelLoadedTimeoutMs;
 
 private:

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -88,8 +88,10 @@ protected:
     std::vector<std::shared_ptr<CNLIMWrapper>> resources = {};
 
     GlobalSequencesViewer globalSequencesViewer;
+
 protected:
     uint32_t waitForModelLoadedTimeoutMs;
+
 private:
     bool watcherStarted = false;
     bool cleanerStarted = false;
@@ -191,14 +193,15 @@ private:
      * @brief Mutex for protecting concurrent reloading config
      */
     mutable std::recursive_mutex configMtx;
+
 protected:
     /**
      * Time interval between each config file check
      */
     uint watcherIntervalMillisec = 1000;
     const int WRONG_CONFIG_FILE_RETRY_DELAY_MS = 10;
-private:
 
+private:
     /**
      * Time interval between two consecutive sequence cleanup scans (in minutes)
      */

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -88,11 +88,12 @@ protected:
     std::vector<std::shared_ptr<CNLIMWrapper>> resources = {};
 
     GlobalSequencesViewer globalSequencesViewer;
+protected:
     uint32_t waitForModelLoadedTimeoutMs;
+private:
     bool watcherStarted = false;
     bool cleanerStarted = false;
 
-private:
     /**
      * @brief 
      * 
@@ -190,11 +191,13 @@ private:
      * @brief Mutex for protecting concurrent reloading config
      */
     mutable std::recursive_mutex configMtx;
-
+protected:
     /**
      * Time interval between each config file check
      */
-    uint watcherIntervalSec = 1;
+    uint watcherIntervalMillisec = 1000;
+    const int WRONG_CONFIG_FILE_RETRY_DELAY_MS = 10;
+private:
 
     /**
      * Time interval between two consecutive sequence cleanup scans (in minutes)
@@ -256,8 +259,8 @@ public:
     /**
      *  @brief Gets the watcher interval timestep in seconds
      */
-    uint getWatcherIntervalSec() {
-        return watcherIntervalSec;
+    uint getWatcherIntervalMillisec() {
+        return watcherIntervalMillisec;
     }
 
     /**

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -147,7 +147,8 @@ std::shared_ptr<MockModel> modelMock;
 
 class MockModelManager : public ovms::ModelManager {
 public:
-    MockModelManager() : ModelManager() {
+    MockModelManager() :
+        ModelManager() {
         this->watcherIntervalMillisec = 100;
     }
     std::shared_ptr<ovms::Model> modelFactory(const std::string& name, const bool isStateful) override {

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -147,6 +147,9 @@ std::shared_ptr<MockModel> modelMock;
 
 class MockModelManager : public ovms::ModelManager {
 public:
+    MockModelManager() : ModelManager() {
+        this->watcherIntervalMillisec = 100;
+    }
     std::shared_ptr<ovms::Model> modelFactory(const std::string& name, const bool isStateful) override {
         return modelMock;
     }
@@ -629,7 +632,7 @@ TEST_P(ModelManagerWatcher2Models, configRelodNotNeededManyThreads) {
     modelMock.reset();
 }
 
-TEST_P(ModelManagerWatcher2Models, configRelodNeededManyThreads) {
+TEST_P(ModelManagerWatcher2Models, configReloadNeededManyThreads) {
     std::string configFile = "/tmp/config.json";
 
     modelMock = std::make_shared<MockModel>();
@@ -980,7 +983,6 @@ TEST_F(ModelManagerWatcher, ConfigReloadingShouldAddNewModel) {
     auto models = manager.getModels().size();
     EXPECT_EQ(models, 1);
     EXPECT_EQ(status, ovms::StatusCode::OK);
-
     createConfigFileWithContent(getConfig2Models(this->getFilePath("/models/dummy1"), this->getFilePath("/models/dummy2")), fileToReload);
     bool isNeeded = false;
     manager.configFileReloadNeeded(isNeeded);
@@ -1300,6 +1302,7 @@ TEST_F(ModelManager, HandlingInvalidLastVersion) {
     config.setName(modelDirectory.name);
     config.setNireq(1);
     ConstructorEnabledModelManager manager;
+    manager.setWaitForModelLoadedTimeoutMs(50);
     manager.reloadModelWithVersions(config);
     std::shared_ptr<ovms::ModelInstance> modelInstance1;
     std::shared_ptr<ovms::ModelInstance> modelInstance2;

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -16,6 +16,7 @@
 #include "test_utils.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <functional>
 
 #include "../capi_frontend/capi_utils.hpp"
@@ -106,11 +107,19 @@ void preparePredictRequest(tensorflow::serving::PredictRequest& request, inputs_
 }
 
 void waitForOVMSConfigReload(ovms::ModelManager& manager) {
-    // This is effectively multiplying by 1.8 to have 1 config reload in between
-    // two test steps
-    const float WAIT_MULTIPLIER_FACTOR = 1.8;
-    const uint waitTime = WAIT_MULTIPLIER_FACTOR * manager.getWatcherIntervalSec() * 1000;
-    std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
+    // This is effectively multiplying by 5 to have at least 1 config reload in between
+    // two test steps, but we check if config files changed to exit earlier if changes are already applied
+    const float WAIT_MULTIPLIER_FACTOR = 5;
+    const uint waitTime = WAIT_MULTIPLIER_FACTOR * manager.getWatcherIntervalMillisec() * 1000;
+    bool reloadIsNeeded = true;
+    int timestepMs = 10;
+    
+    auto start = std::chrono::high_resolution_clock::now();
+     while (reloadIsNeeded &&
+            (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count() < waitTime)) {
+         std::this_thread::sleep_for(std::chrono::milliseconds(timestepMs));
+         manager.configFileReloadNeeded(reloadIsNeeded);
+     }
 }
 
 void waitForOVMSResourcesCleanup(ovms::ModelManager& manager) {
@@ -123,13 +132,13 @@ void waitForOVMSResourcesCleanup(ovms::ModelManager& manager) {
 
 std::string createConfigFileWithContent(const std::string& content, std::string filename) {
     std::ofstream configFile{filename};
-    spdlog::info("Creating config file: {}\n with content:\n{}", filename, content);
+    SPDLOG_INFO("Creating config file: {}\n with content:\n{}", filename, content);
     configFile << content << std::endl;
     configFile.close();
     if (configFile.fail()) {
-        spdlog::info("Closing configFile failed");
+        SPDLOG_INFO("Closing configFile failed");
     } else {
-        spdlog::info("Closing configFile succeed");
+        SPDLOG_INFO("Closing configFile succeed");
     }
     return filename;
 }

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -113,13 +113,13 @@ void waitForOVMSConfigReload(ovms::ModelManager& manager) {
     const uint waitTime = WAIT_MULTIPLIER_FACTOR * manager.getWatcherIntervalMillisec() * 1000;
     bool reloadIsNeeded = true;
     int timestepMs = 10;
-    
+
     auto start = std::chrono::high_resolution_clock::now();
-     while (reloadIsNeeded &&
-            (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count() < waitTime)) {
-         std::this_thread::sleep_for(std::chrono::milliseconds(timestepMs));
-         manager.configFileReloadNeeded(reloadIsNeeded);
-     }
+    while (reloadIsNeeded &&
+           (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count() < waitTime)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(timestepMs));
+        manager.configFileReloadNeeded(reloadIsNeeded);
+    }
 }
 
 void waitForOVMSResourcesCleanup(ovms::ModelManager& manager) {

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -420,6 +420,9 @@ public:
     void updateConfigurationWithoutConfigFile() {
         ModelManager::updateConfigurationWithoutConfigFile();
     }
+    void setWaitForModelLoadedTimeoutMs(int value) {
+        this->waitForModelLoadedTimeoutMs = value;
+    }
 };
 
 class MockedMetadataModelIns : public ovms::ModelInstance {
@@ -469,6 +472,9 @@ protected:
     std::string directoryPath;
 };
 
+/**
+ * Wait until ModelManager::configFileReloadNeeded returns false or timeout is reached
+ */
 void waitForOVMSConfigReload(ovms::ModelManager& manager);
 void waitForOVMSResourcesCleanup(ovms::ModelManager& manager);
 


### PR DESCRIPTION
Issue was that on particularly slow or overloaded machine the config reload could not happen within 1.8s window. 
Threshold was increased to 5s but at the same time test utility function to check for config reload exits as soon as the config is already loaded. ModelManager::configFileReloadNeeded method is tested separately.

* set watcher check interval for tests to lower value.
* increase retry count for invalid json file reading but lowered the time step between retries

JIRA:CVS-109709