### PR TITLE
Fix sporadic test

### DIFF
--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -987,7 +987,6 @@ TEST_F(ModelManagerWatcher, ConfigReloadingShouldAddNewModel) {
     createConfigFileWithContent(getConfig2Models(this->getFilePath("/models/dummy1"), this->getFilePath("/models/dummy2")), fileToReload);
     bool isNeeded = false;
     manager.configFileReloadNeeded(isNeeded);
-    ASSERT_EQ(isNeeded, true);
     std::thread s([&manager]() {
         waitForOVMSConfigReload(manager);
     });


### PR DESCRIPTION
Failure occured when the watcher thread from ModelManager managed to detect that config file reload is needed before test thread creating the file managed to call ModelManager::configFileReloadNeeded. Watcher thread blocked shared mutex so the test check occured only after the whole config was reloaded which changed the result of configFileReloadNeeded and made test fail.

Check was introduced in #472.

JIRA:CVS-