### PR TITLE
Add MP errors reporting through grpc

### DIFF
--- a/src/grpc_utils.cpp
+++ b/src/grpc_utils.cpp
@@ -96,6 +96,13 @@ const grpc::Status grpc(const Status& status) {
         {StatusCode::MODEL_VERSION_NOT_LOADED_YET, grpc::StatusCode::UNAVAILABLE},
         {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET, grpc::StatusCode::UNAVAILABLE},
         {StatusCode::MEDIAPIPE_DEFINITION_NOT_LOADED_YET, grpc::StatusCode::UNAVAILABLE},
+        // UNKNOWN
+        {StatusCode::MEDIAPIPE_EXECUTION_ERROR, grpc::StatusCode::UNKNOWN},
+        {StatusCode::MEDIAPIPE_GRAPH_START_ERROR, grpc::StatusCode::UNKNOWN},
+        {StatusCode::MEDIAPIPE_GRAPH_ADD_OUTPUT_STREAM_ERROR, grpc::StatusCode::UNKNOWN},
+        {StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR, grpc::StatusCode::UNKNOWN},
+        {StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM, grpc::StatusCode::UNKNOWN},
+        {StatusCode::MEDIAPIPE_GRAPH_CLOSE_INPUT_STREAM_ERROR, grpc::StatusCode::UNKNOWN},
     };
     auto it = grpcStatusMap.find(status.getCode());
     if (it != grpcStatusMap.end()) {

--- a/src/grpc_utils.cpp
+++ b/src/grpc_utils.cpp
@@ -48,6 +48,11 @@ const grpc::Status grpc(const Status& status) {
         {StatusCode::RESHAPE_ERROR, grpc::StatusCode::FAILED_PRECONDITION},
         {StatusCode::CANNOT_COMPILE_MODEL_INTO_TARGET_DEVICE, grpc::StatusCode::FAILED_PRECONDITION},
         {StatusCode::SEQUENCE_TERMINATED, grpc::StatusCode::FAILED_PRECONDITION},
+        {StatusCode::MEDIAPIPE_GRAPH_START_ERROR, grpc::StatusCode::FAILED_PRECONDITION},
+        {StatusCode::MEDIAPIPE_GRAPH_ADD_OUTPUT_STREAM_ERROR, grpc::StatusCode::FAILED_PRECONDITION},
+        {StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR, grpc::StatusCode::FAILED_PRECONDITION},
+        {StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM, grpc::StatusCode::FAILED_PRECONDITION},
+        {StatusCode::MEDIAPIPE_GRAPH_CLOSE_INPUT_STREAM_ERROR, grpc::StatusCode::FAILED_PRECONDITION},
         // NOT_FOUND
         {StatusCode::MODEL_MISSING, grpc::StatusCode::NOT_FOUND},
         {StatusCode::MODEL_NAME_MISSING, grpc::StatusCode::NOT_FOUND},
@@ -67,6 +72,7 @@ const grpc::Status grpc(const Status& status) {
         {StatusCode::SEQUENCE_ID_BAD_TYPE, grpc::StatusCode::INVALID_ARGUMENT},
         {StatusCode::SEQUENCE_CONTROL_INPUT_BAD_TYPE, grpc::StatusCode::INVALID_ARGUMENT},
         {StatusCode::SPECIAL_INPUT_NO_TENSOR_SHAPE, grpc::StatusCode::INVALID_ARGUMENT},
+        {StatusCode::MEDIAPIPE_EXECUTION_ERROR, grpc::StatusCode::INVALID_ARGUMENT},
         // Predict request validation
         {StatusCode::INVALID_NO_OF_INPUTS, grpc::StatusCode::INVALID_ARGUMENT},
         {StatusCode::INVALID_MISSING_INPUT, grpc::StatusCode::INVALID_ARGUMENT},
@@ -97,12 +103,6 @@ const grpc::Status grpc(const Status& status) {
         {StatusCode::PIPELINE_DEFINITION_NOT_LOADED_YET, grpc::StatusCode::UNAVAILABLE},
         {StatusCode::MEDIAPIPE_DEFINITION_NOT_LOADED_YET, grpc::StatusCode::UNAVAILABLE},
         // UNKNOWN
-        {StatusCode::MEDIAPIPE_EXECUTION_ERROR, grpc::StatusCode::UNKNOWN},
-        {StatusCode::MEDIAPIPE_GRAPH_START_ERROR, grpc::StatusCode::UNKNOWN},
-        {StatusCode::MEDIAPIPE_GRAPH_ADD_OUTPUT_STREAM_ERROR, grpc::StatusCode::UNKNOWN},
-        {StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR, grpc::StatusCode::UNKNOWN},
-        {StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM, grpc::StatusCode::UNKNOWN},
-        {StatusCode::MEDIAPIPE_GRAPH_CLOSE_INPUT_STREAM_ERROR, grpc::StatusCode::UNKNOWN},
     };
     auto it = grpcStatusMap.find(status.getCode());
     if (it != grpcStatusMap.end()) {


### PR DESCRIPTION
Add MP ret codes mapping. Execution error should occur when during calculator processing issue is detected so it points in the direction of invalid input data.

Other return codes suggests issue on configuration side of pbtxt file.

JIRA:CVS-119596,CVS-119597