### PR TITLE
Add MediaPipe & C-API tests

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -325,7 +325,7 @@ COPY ci/check_coverage.bat /ovms/
 ARG CHECK_COVERAGE=0
 
 ARG RUN_TESTS=1
-RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" = "1" ] ; then bazel coverage --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
+RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" = "1" ] ; then bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
     bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:ovms_test > ${TEST_LOG} 2>&1 || (cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; ) && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ;  \ 
     bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:test_python_binding; fi ;
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -338,7 +338,7 @@ ARG CHECK_COVERAGE=0
 
 ARG RUN_TESTS=1
 RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" == "1" ] ; then \
-    bazel coverage --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
+    bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
     bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:ovms_test > ${TEST_LOG} 2>&1 || (cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; ) && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ; \ 
     bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:test_python_binding; fi ;
 

--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -52,7 +52,7 @@ if [ ${NO_WARNINGS_TEST_FORWARD} -gt 1 ]; then
     echo "Failed due to not using forward declarations where possible: ${NO_WARNINGS_TEST_FORWARD}";
     exit 1;
 fi
-if [ ${NO_WARNINGS_TEST_DIRECT} -gt 14 ]; then
+if [ ${NO_WARNINGS_TEST_DIRECT} -gt 15 ]; then
     echo "Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_TEST_DIRECT}";
     exit 1;
 fi
@@ -64,7 +64,7 @@ if [ ${NO_WARNINGS} -gt  160 ]; then
     echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
     exit 1
 fi
-if [ ${NO_WARNINGS_TEST} -gt  56 ]; then
+if [ ${NO_WARNINGS_TEST} -gt  57 ]; then
     echo "Failed due to higher than allowed number of issues in test code: ${NO_WARNINGS_TEST}"
     cat ${CPPCLEAN_RESULTS_FILE_TEST}
     exit 1

--- a/src/BUILD
+++ b/src/BUILD
@@ -868,6 +868,7 @@ cc_test(
                 "test/get_mediapipe_graph_metadata_response_test.cpp",
                 "test/mediapipe/inputsidepacketusertestcalc.cc",
                 "test/mediapipeflow_test.cpp",
+                "test/mediapipe_framework_test.cpp",
                 "test/mediapipe_validation_test.cpp",
                 "test/mediapipe/ovms_kfs_calculator.cc",
                 "test/mediapipe/ovms_image_input_calculator.cc",
@@ -933,6 +934,10 @@ cc_test(
         "test/mediapipe/graphdummyadapterfull_dummyinputnames.pbtxt",
         "test/mediapipe/graphadapterfull_two_outputs_dag.pbtxt",
         "test/mediapipe/graphdummyadapterfull_two_outputs.pbtxt",
+        "test/mediapipe/negative/config_exception_during_process.json",
+        "test/mediapipe/negative/config_no_calc_output_stream.json",
+        "test/mediapipe/negative/graph_exception_during_process.pbtxt",
+        "test/mediapipe/negative/graph_no_calc_output_stream.pbtxt",
         "test/mediapipe/relative_paths/config_mp_passthrough.json",
         "test/mediapipe/relative_paths/config_relative_dummy_negative.json",
         "test/mediapipe/relative_paths/config_relative_add_subconfig_negative.json",
@@ -984,6 +989,7 @@ cc_test(
         "@com_google_googletest//:gtest",
         ] + select({
             "//conditions:default": [
+                "//src/test/mediapipe/calculators:mediapipe_test_calculators",
                 "@mediapipe//mediapipe/calculators/ovms:ovms_calculator",
             ],
             "//src:disable_mediapipe" : [],

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -752,12 +752,9 @@ static Status getModelManager(Server& server, ModelManager** modelManager) {
     if (!server.isLive()) {
         return ovms::Status(ovms::StatusCode::SERVER_NOT_READY, "not live");
     }
-    if (!server.isReady()) {
-        return ovms::Status(ovms::StatusCode::SERVER_NOT_READY, "not ready");
-    }
     const ovms::Module* servableModule = server.getModule(ovms::SERVABLE_MANAGER_MODULE_NAME);
     if (!servableModule) {
-        return ovms::Status(ovms::StatusCode::INTERNAL_ERROR, "missing servable manager");
+        return ovms::Status(ovms::StatusCode::SERVER_NOT_READY, "not ready - missing servable manager");
     }
     *modelManager = &dynamic_cast<const ServableManagerModule*>(servableModule)->getServableManager();
     return StatusCode::OK;

--- a/src/kfs_frontend/kfs_grpc_inference_service.cpp
+++ b/src/kfs_frontend/kfs_grpc_inference_service.cpp
@@ -274,7 +274,7 @@ Status KFSInferenceServiceImpl::ModelMetadataImpl(::grpc::ServerContext* context
     return grpc(status);
 }
 
-::grpc::Status KFSInferenceServiceImpl::ModelStreamInfer(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::inference::ModelStreamInferResponse, ::inference::ModelInferRequest>* stream) {
+::grpc::Status KFSInferenceServiceImpl::ModelStreamInfer(::grpc::ServerContext* context, ::grpc::ServerReaderWriter<::inference::ModelStreamInferResponse, ::inference::ModelInferRequest>* stream) {
     SPDLOG_DEBUG("KFSInferenceServiceImpl::ModelStreamInfer");
     return grpc(StatusCode::NOT_IMPLEMENTED);
 }

--- a/src/kfs_frontend/kfs_grpc_inference_service.hpp
+++ b/src/kfs_frontend/kfs_grpc_inference_service.hpp
@@ -71,7 +71,7 @@ public:
     ::grpc::Status ServerMetadata(::grpc::ServerContext* context, const KFSServerMetadataRequest* request, KFSServerMetadataResponse* response) override;
     ::grpc::Status ModelMetadata(::grpc::ServerContext* context, const KFSModelMetadataRequest* request, KFSModelMetadataResponse* response) override;
     ::grpc::Status ModelInfer(::grpc::ServerContext* context, const KFSRequest* request, KFSResponse* response) override;
-    ::grpc::Status ModelStreamInfer(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::inference::ModelStreamInferResponse, ::inference::ModelInferRequest>* stream) override;
+    ::grpc::Status ModelStreamInfer(::grpc::ServerContext* context, ::grpc::ServerReaderWriter<::inference::ModelStreamInferResponse, ::inference::ModelInferRequest>* stream) override;
     static Status buildResponse(Model& model, ModelInstance& instance, KFSModelMetadataResponse* response);
     static Status buildResponse(PipelineDefinition& pipelineDefinition, KFSModelMetadataResponse* response);
     static Status buildResponse(std::shared_ptr<ModelInstance> instance, KFSGetModelStatusResponse* response);

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -93,11 +93,19 @@ Status MediapipeGraphDefinition::validateForConfigLoadableness() {
 
 Status MediapipeGraphDefinition::dryInitializeTest() {
     ::mediapipe::CalculatorGraph graph;
-    auto absStatus = graph.Initialize(this->config);
-    if (!absStatus.ok()) {
-        const std::string absMessage = absStatus.ToString();
-        SPDLOG_LOGGER_ERROR(modelmanager_logger, "Mediapipe graph: {} initialization failed with message: {}. Check if all required calculators are registered in OVMS", this->getName(), absMessage);
-        return Status(StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR, std::move(absMessage));
+    try {
+        auto absStatus = graph.Initialize(this->config);
+        if (!absStatus.ok()) {
+            const std::string absMessage = absStatus.ToString();
+            SPDLOG_LOGGER_ERROR(modelmanager_logger, "Mediapipe graph: {} initialization failed with message: {}. Check if all required calculators are registered in OVMS", this->getName(), absMessage);
+            return Status(StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR, std::move(absMessage));
+        }
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("Exception caught whilie trying to initialize MediaPipe graph: {}", e.what());
+        return StatusCode::UNKNOWN_ERROR;
+    } catch (...) {
+        SPDLOG_ERROR("Exception caught whilie trying to initialize MediaPipe graph.");
+        return StatusCode::UNKNOWN_ERROR;
     }
     return StatusCode::OK;
 }

--- a/src/test/c_api_stress_tests.cpp
+++ b/src/test/c_api_stress_tests.cpp
@@ -60,7 +60,7 @@ public:
         return modelName;
     }
     void SetUp() override {
-        SetUpServerInstance(initialClearConfig);
+        SetUpCAPIServerInstance(initialClearConfig);
     }
 };
 

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -153,7 +153,7 @@ public:
         return modelName;
     }
     void SetUp() override {
-        SetUpServerInstance(initialClearConfig);
+        SetUpCAPIServerInstance(initialClearConfig);
     }
 };
 
@@ -607,7 +607,7 @@ public:
         return modelName;
     }
     void SetUp() override {
-        SetUpServerInstance(createStressTestPipelineOneDummyConfig());
+        SetUpCAPIServerInstance(createStressTestPipelineOneDummyConfig());
     }
 };
 TEST_F(StressMediapipeChanges, AddGraphDuringPredictLoad) {

--- a/src/test/mediapipe/calculators/BUILD
+++ b/src/test/mediapipe/calculators/BUILD
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#config_setting(
+#    name = "linux_distribution_family",
+#    constraint_values = [
+#        ":debian", # like Ubuntu
+#        ":fedora", # like RHEL/CentOS
+#    ],
+#)
+
+cc_library(
+    name = "mediapipe_test_calculators",
+    linkstatic = 1,
+    alwayslink = 1,
+    srcs = [
+        "nooutputstreamsproducedcalculator.cpp",
+        "exceptionduringprocesscalculator.cpp",
+        "exceptionduringopencalculator.cpp",
+        "exceptionduringclosecalculator.cpp",
+        "exceptionduringgetcontractcalculator.cpp",
+    ],
+    copts = [
+        "-Wall",
+        "-Wno-unknown-pragmas",
+        "-Werror",
+        "-Wno-sign-compare",
+        ] + select({
+            "//conditions:default": [
+            ],
+            "//src:fuzzer_build" : [
+                "-fsanitize=address",
+                "-fprofile-generate",
+                "-ftest-coverage",
+            ],
+        }),
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//src:ovmscalculatoroptions_cc_proto", # ovmscalculatoroptions_proto - just mediapipe stuff with mediapipe_proto_library adding nonvisible target
+        "@mediapipe_calculators//:mediapipe_calculators", # Need this dependencies here because we use ovms/src - cannot add in ovms_dependencies because we copy src directory later in Dockerfile
+        "@linux_openvino//:openvino",
+    ],
+    linkopts = select({
+        "//conditions:default": [
+        ],
+        "//src:fuzzer_build" : [
+            "-fprofile-generate",
+            "-fsanitize=address",
+            "-fsanitize-coverage=trace-pc",
+            "-static-libasan",
+        ],
+    }),
+)
+

--- a/src/test/mediapipe/calculators/exceptionduringclosecalculator.cpp
+++ b/src/test/mediapipe/calculators/exceptionduringclosecalculator.cpp
@@ -1,0 +1,83 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+#include <openvino/openvino.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
+#include "src/mediapipe_calculators/ovmscalculator.pb.h"
+// here we need to decide if we have several calculators (1 for OVMS repository, 1-N inside mediapipe)
+// for the one inside OVMS repo it makes sense to reuse code from ovms lib
+namespace mediapipe {
+using std::endl;
+
+class ExceptionDuringCloseCalculator : public CalculatorBase {
+    std::unordered_map<std::string, std::string> outputNameToTag;
+
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        RET_CHECK(!cc->Inputs().GetTags().empty());
+        RET_CHECK(!cc->Outputs().GetTags().empty());
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            cc->Inputs().Tag(tag).Set<ov::Tensor>();
+        }
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            cc->Outputs().Tag(tag).Set<ov::Tensor>();
+        }
+        return absl::OkStatus();
+    }
+
+    absl::Status Close(CalculatorContext* cc) final {
+        LOG(INFO) << "Throwing exception from ExceptionDuringCloseCalculator";
+        throw std::runtime_error("Throwing exception from ExceptionDuringCloseCalculator");
+        return absl::OkStatus();
+    }
+    absl::Status Open(CalculatorContext* cc) final {
+        for (CollectionItemId id = cc->Inputs().BeginId(); id < cc->Inputs().EndId(); ++id) {
+            if (!cc->Inputs().Get(id).Header().IsEmpty()) {
+                cc->Outputs().Get(id).SetHeader(cc->Inputs().Get(id).Header());
+            }
+        }
+        if (cc->OutputSidePackets().NumEntries() != 0) {
+            for (CollectionItemId id = cc->InputSidePackets().BeginId(); id < cc->InputSidePackets().EndId(); ++id) {
+                cc->OutputSidePackets().Get(id).Set(cc->InputSidePackets().Get(id));
+            }
+        }
+        cc->SetOffset(TimestampDiff(0));
+        const auto& options = cc->Options<OVMSCalculatorOptions>();
+        for (const auto& [key, value] : options.tag_to_output_tensor_names()) {
+            outputNameToTag[value] = key;
+        }
+        return absl::OkStatus();
+    }
+
+    absl::Status Process(CalculatorContext* cc) final {
+        ov::Shape ovShape{1, 10};
+        ov::Tensor* output = new ov::Tensor(ov::element::Type_t::f32, ovShape);
+        cc->Outputs().Tag(outputNameToTag.at("a")).Add(output, cc->InputTimestamp());
+        return absl::OkStatus();
+    }
+};
+#pragma GCC diagnostic pop
+REGISTER_CALCULATOR(ExceptionDuringCloseCalculator);
+}  // namespace mediapipe

--- a/src/test/mediapipe/calculators/exceptionduringgetcontractcalculator.cpp
+++ b/src/test/mediapipe/calculators/exceptionduringgetcontractcalculator.cpp
@@ -1,0 +1,55 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <stdexcept>
+
+#include <openvino/openvino.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
+namespace mediapipe {
+
+class ExceptionDuringGetContractCalculator : public CalculatorBase {
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        RET_CHECK(!cc->Inputs().GetTags().empty());
+        RET_CHECK(!cc->Outputs().GetTags().empty());
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            cc->Inputs().Tag(tag).Set<ov::Tensor>();
+        }
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            cc->Outputs().Tag(tag).Set<ov::Tensor>();
+        }
+        LOG(ERROR) << "Throwing answer to everything from calculator GetContract()!";
+        throw std::runtime_error("42");
+        return absl::OkStatus();
+    }
+
+    absl::Status Close(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Open(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Process(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+};
+REGISTER_CALCULATOR(ExceptionDuringGetContractCalculator);
+}  // namespace mediapipe

--- a/src/test/mediapipe/calculators/exceptionduringopencalculator.cpp
+++ b/src/test/mediapipe/calculators/exceptionduringopencalculator.cpp
@@ -1,0 +1,55 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <stdexcept>
+
+#include <openvino/openvino.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
+namespace mediapipe {
+
+class ExceptionDuringOpenCalculator : public CalculatorBase {
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        RET_CHECK(!cc->Inputs().GetTags().empty());
+        RET_CHECK(!cc->Outputs().GetTags().empty());
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            cc->Inputs().Tag(tag).Set<ov::Tensor>();
+        }
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            cc->Outputs().Tag(tag).Set<ov::Tensor>();
+        }
+        return absl::OkStatus();
+    }
+
+    absl::Status Close(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Open(CalculatorContext* cc) final {
+        LOG(ERROR) << "Throwing answer to everything from calculator Open()!";
+        throw std::runtime_error("42");
+        return absl::OkStatus();
+    }
+
+    absl::Status Process(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+};
+REGISTER_CALCULATOR(ExceptionDuringOpenCalculator);
+}  // namespace mediapipe

--- a/src/test/mediapipe/calculators/exceptionduringprocess.cpp
+++ b/src/test/mediapipe/calculators/exceptionduringprocess.cpp
@@ -1,0 +1,56 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <stdexcept>
+
+#include <openvino/openvino.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
+namespace mediapipe {
+
+class ExceptionDuringProcessCalculator : public CalculatorBase {
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        RET_CHECK(!cc->Inputs().GetTags().empty());
+        RET_CHECK(!cc->Outputs().GetTags().empty());
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            cc->Inputs().Tag(tag).Set<ov::Tensor>();
+        }
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            cc->Outputs().Tag(tag).Set<ov::Tensor>();
+        }
+        return absl::OkStatus();
+    }
+
+    absl::Status Close(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Open(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Process(CalculatorContext* cc) final {
+        LOG(ERROR) << "Throwing answer to everything from calculator Process()!";
+        throw std::runtime_error("42");
+        return absl::OkStatus();
+    }
+};
+#pragma GCC diagnostic pop
+REGISTER_CALCULATOR(ExceptionDuringProcessCalculator);
+}  // namespace mediapipe

--- a/src/test/mediapipe/calculators/exceptionduringprocesscalculator.cpp
+++ b/src/test/mediapipe/calculators/exceptionduringprocesscalculator.cpp
@@ -1,0 +1,56 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <stdexcept>
+
+#include <openvino/openvino.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
+namespace mediapipe {
+
+class ExceptionDuringProcessCalculator : public CalculatorBase {
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        RET_CHECK(!cc->Inputs().GetTags().empty());
+        RET_CHECK(!cc->Outputs().GetTags().empty());
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            cc->Inputs().Tag(tag).Set<ov::Tensor>();
+        }
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            cc->Outputs().Tag(tag).Set<ov::Tensor>();
+        }
+        return absl::OkStatus();
+    }
+
+    absl::Status Close(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Open(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Process(CalculatorContext* cc) final {
+        LOG(ERROR) << "Throwing answer to everything from calculator Process()!";
+        throw std::runtime_error("42");
+        throw 42;
+        return absl::OkStatus();
+    }
+};
+REGISTER_CALCULATOR(ExceptionDuringProcessCalculator);
+}  // namespace mediapipe

--- a/src/test/mediapipe/calculators/nooutputstreamsproducedcalculator.cpp
+++ b/src/test/mediapipe/calculators/nooutputstreamsproducedcalculator.cpp
@@ -1,0 +1,52 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <openvino/openvino.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
+namespace mediapipe {
+
+class NoOutputStreamsProducedCalculator : public CalculatorBase {
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        RET_CHECK(!cc->Inputs().GetTags().empty());
+        RET_CHECK(!cc->Outputs().GetTags().empty());
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            cc->Inputs().Tag(tag).Set<ov::Tensor>();
+        }
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            cc->Outputs().Tag(tag).Set<ov::Tensor>();
+        }
+        return absl::OkStatus();
+    }
+
+    absl::Status Close(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Open(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+
+    absl::Status Process(CalculatorContext* cc) final {
+        LOG(ERROR) << "Exiting process without producing packets!";
+        return absl::OkStatus();
+    }
+};
+REGISTER_CALCULATOR(NoOutputStreamsProducedCalculator);
+}  // namespace mediapipe

--- a/src/test/mediapipe/negative/config_exception_during_close.json
+++ b/src/test/mediapipe/negative/config_exception_during_close.json
@@ -1,0 +1,10 @@
+{
+    "model_config_list": [
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"graph_exception_during_close",
+        "graph_path":"./graph_exception_during_close.pbtxt"
+    }
+    ]
+}

--- a/src/test/mediapipe/negative/config_exception_during_getcontract.json
+++ b/src/test/mediapipe/negative/config_exception_during_getcontract.json
@@ -1,0 +1,10 @@
+{
+    "model_config_list": [
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"graph_exception_during_getcontract",
+        "graph_path":"./graph_exception_during_getcontract.pbtxt"
+    }
+    ]
+}

--- a/src/test/mediapipe/negative/config_exception_during_open.json
+++ b/src/test/mediapipe/negative/config_exception_during_open.json
@@ -1,0 +1,10 @@
+{
+    "model_config_list": [
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"graph_exception_during_open",
+        "graph_path":"./graph_exception_during_open.pbtxt"
+    }
+    ]
+}

--- a/src/test/mediapipe/negative/config_exception_during_process.json
+++ b/src/test/mediapipe/negative/config_exception_during_process.json
@@ -1,0 +1,10 @@
+{
+    "model_config_list": [
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"graph_exception_during_process",
+        "graph_path":"./graph_exception_during_process.pbtxt"
+    }
+    ]
+}

--- a/src/test/mediapipe/negative/config_no_calc_output_stream.json
+++ b/src/test/mediapipe/negative/config_no_calc_output_stream.json
@@ -1,0 +1,10 @@
+{
+    "model_config_list": [
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"graph_no_calc_output_stream",
+        "graph_path":"./graph_no_calc_output_stream.pbtxt"
+    }
+    ]
+}

--- a/src/test/mediapipe/negative/graph_exception_during_close.pbtxt
+++ b/src/test/mediapipe/negative/graph_exception_during_close.pbtxt
@@ -1,0 +1,36 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "ExceptionDuringCloseCalculator"
+  input_stream: "B:in"
+  output_stream: "A:out"
+  node_options: {
+        [type.googleapis.com / mediapipe.OVMSCalculatorOptions]: {
+          servable_name: "dummy"
+          servable_version: "1"
+          tag_to_input_tensor_names {
+            key: "B"
+            value: "b"
+          }
+          tag_to_output_tensor_names {
+            key: "A"
+            value: "a"
+          }
+        }
+  }
+}

--- a/src/test/mediapipe/negative/graph_exception_during_getcontract.pbtxt
+++ b/src/test/mediapipe/negative/graph_exception_during_getcontract.pbtxt
@@ -1,0 +1,22 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "ExceptionDuringGetContractCalculator"
+  input_stream: "B:in"
+  output_stream: "A:out"
+}

--- a/src/test/mediapipe/negative/graph_exception_during_open.pbtxt
+++ b/src/test/mediapipe/negative/graph_exception_during_open.pbtxt
@@ -1,0 +1,22 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "ExceptionDuringOpenCalculator"
+  input_stream: "B:in"
+  output_stream: "A:out"
+}

--- a/src/test/mediapipe/negative/graph_exception_during_process.pbtxt
+++ b/src/test/mediapipe/negative/graph_exception_during_process.pbtxt
@@ -1,0 +1,22 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "ExceptionDuringProcessCalculator"
+  input_stream: "B:in"
+  output_stream: "A:out"
+}

--- a/src/test/mediapipe/negative/graph_long_loading.pbtxt
+++ b/src/test/mediapipe/negative/graph_long_loading.pbtxt
@@ -1,0 +1,22 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "LongLoadingCalculator"
+  input_stream: "B:in"
+  output_stream: "A:out"
+}

--- a/src/test/mediapipe/negative/graph_no_calc_output_stream.pbtxt
+++ b/src/test/mediapipe/negative/graph_no_calc_output_stream.pbtxt
@@ -1,0 +1,22 @@
+#
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "in"
+output_stream: "out"
+node {
+  calculator: "NoOutputStreamsProducedCalculator"
+  input_stream: "B:in"
+  output_stream: "A:out"
+}

--- a/src/test/mediapipe_framework_test.cpp
+++ b/src/test/mediapipe_framework_test.cpp
@@ -1,0 +1,190 @@
+//*****************************************************************************
+// Copyright 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <openvino/openvino.hpp>
+
+#include "../config.hpp"
+#include "../dags/pipelinedefinition.hpp"
+#include "../grpcservermodule.hpp"
+#include "../http_rest_api_handler.hpp"
+#include "../kfs_frontend/kfs_grpc_inference_service.hpp"
+#include "../mediapipe_internal/mediapipefactory.hpp"
+#include "../mediapipe_internal/mediapipegraphdefinition.hpp"
+#include "../metric_config.hpp"
+#include "../metric_module.hpp"
+#include "../model_service.hpp"
+#include "../precision.hpp"
+#include "../servablemanagermodule.hpp"
+#include "../server.hpp"
+#include "../shape.hpp"
+#include "../stringutils.hpp"
+#include "../tfs_frontend/tfs_utils.hpp"
+#include "c_api_test_utils.hpp"
+#include "mediapipe/calculators/ovms/modelapiovmsadapter.hpp"
+#include "opencv2/opencv.hpp"
+#include "test_utils.hpp"
+
+using namespace ovms;
+
+using testing::HasSubstr;
+using testing::Not;
+
+/***
+ * Test assumptions about MP framework
+ * */
+class MediapipeFrameworkTest : public TestWithTempDir {
+protected:
+    ovms::Server& server = ovms::Server::instance();
+
+    const Precision precision = Precision::FP32;
+    std::unique_ptr<std::thread> t;
+    std::string port = "9178";
+
+    void SetUpServer(const char* configPath) {
+        ::SetUpServer(this->t, this->server, this->port, configPath);
+    }
+
+    void SetUp() override {
+    }
+    void TearDown() {
+        if (server.isLive()) {
+            server.setShutdownRequest(1);
+            t->join();
+            server.setShutdownRequest(0);
+        }
+    }
+};
+
+class MediapipeNegativeFrameworkTest : public MediapipeFrameworkTest {
+};
+
+// purpose of this test is to ensure there is no hang in case of one of the graph nodes
+// not producing output packet
+TEST_F(MediapipeNegativeFrameworkTest, NoOutputPacketProduced) {
+    SetUpServer("/ovms/src/test/mediapipe/negative/config_no_calc_output_stream.json");
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string modelName{"graph_no_calc_output_stream"};
+    request.Clear();
+    response.Clear();
+    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
+    std::vector<float> requestData{13.5, 0., 0, 0., 0., 0., 0., 0, 3., 67.};
+    preparePredictRequest(request, inputsMeta, requestData);
+    request.mutable_model_name()->assign(modelName);
+    auto status = impl.ModelInfer(nullptr, &request, &response);
+    ASSERT_EQ(status.error_code(), grpc::StatusCode::INVALID_ARGUMENT) << status.error_message();
+}
+
+TEST_F(MediapipeNegativeFrameworkTest, ExceptionDuringProcess) {
+    GTEST_SKIP() << "Terminate called otherwise";
+    SetUpServer("/ovms/src/test/mediapipe/negative/config_exception_during_process.json");
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string modelName{"graph_exception_during_process"};
+    request.Clear();
+    response.Clear();
+    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
+    std::vector<float> requestData{13.5, 0., 0, 0., 0., 0., 0., 0, 3., 67.};
+    preparePredictRequest(request, inputsMeta, requestData);
+    request.mutable_model_name()->assign(modelName);
+    try {
+        auto status = impl.ModelInfer(nullptr, &request, &response);
+        ASSERT_EQ(status.error_code(), grpc::StatusCode::INVALID_ARGUMENT) << status.error_message();
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("ERs");
+    } catch (...) {
+        SPDLOG_ERROR("ER");
+    }
+}
+TEST_F(MediapipeNegativeFrameworkTest, ExceptionDuringGetContract) {
+    SetUpServer("/ovms/src/test/mediapipe/negative/config_exception_during_getcontract.json");
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string modelName{"graph_exception_during_getcontract"};
+    request.Clear();
+    response.Clear();
+    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
+    std::vector<float> requestData{13.5, 0., 0, 0., 0., 0., 0., 0, 3., 67.};
+    preparePredictRequest(request, inputsMeta, requestData);
+    request.mutable_model_name()->assign(modelName);
+    try {
+        auto status = impl.ModelInfer(nullptr, &request, &response);
+        ASSERT_EQ(status.error_code(), grpc::StatusCode::UNAVAILABLE) << status.error_message();
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("ERs");
+    } catch (...) {
+        SPDLOG_ERROR("ER");
+    }
+}
+TEST_F(MediapipeNegativeFrameworkTest, ExceptionDuringGetOpen) {
+    GTEST_SKIP() << "Terminate called otherwise";
+    SetUpServer("/ovms/src/test/mediapipe/negative/config_exception_during_open.json");
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string modelName{"graph_exception_during_open"};
+    request.Clear();
+    response.Clear();
+    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
+    std::vector<float> requestData{13.5, 0., 0, 0., 0., 0., 0., 0, 3., 67.};
+    preparePredictRequest(request, inputsMeta, requestData);
+    request.mutable_model_name()->assign(modelName);
+    try {
+        auto status = impl.ModelInfer(nullptr, &request, &response);
+        ASSERT_EQ(status.error_code(), grpc::StatusCode::INVALID_ARGUMENT) << status.error_message();
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("ERs");
+    } catch (...) {
+        SPDLOG_ERROR("ER");
+    }
+}
+TEST_F(MediapipeNegativeFrameworkTest, ExceptionDuringClose) {
+    GTEST_SKIP() << "Terminate called otherwise";
+    SetUpServer("/ovms/src/test/mediapipe/negative/config_exception_during_close.json");
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string modelName{"graph_exception_during_close"};
+    request.Clear();
+    response.Clear();
+    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
+    std::vector<float> requestData{13.5, 0., 0, 0., 0., 0., 0., 0, 3., 67.};
+    preparePredictRequest(request, inputsMeta, requestData);
+    request.mutable_model_name()->assign(modelName);
+    try {
+        auto status = impl.ModelInfer(nullptr, &request, &response);
+        ASSERT_EQ(status.error_code(), grpc::StatusCode::INVALID_ARGUMENT) << status.error_message();
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("ERs");
+    } catch (...) {
+        SPDLOG_ERROR("ER");
+    }
+}

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -13,9 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
+#include <chrono>
 #include <fstream>
 #include <set>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -23,6 +25,12 @@
 #include <gtest/gtest.h>
 #include <openvino/openvino.hpp>
 #include <sys/stat.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
 
 #include "../config.hpp"
 #include "../dags/pipelinedefinition.hpp"
@@ -64,23 +72,9 @@ protected:
     const Precision precision = Precision::FP32;
     std::unique_ptr<std::thread> t;
     std::string port = "9178";
+
     void SetUpServer(const char* configPath) {
-        server.setShutdownRequest(0);
-        randomizePort(this->port);
-        char* argv[] = {(char*)"ovms",
-            (char*)"--config_path",
-            (char*)configPath,
-            (char*)"--port",
-            (char*)port.c_str()};
-        int argc = 5;
-        t.reset(new std::thread([&argc, &argv, this]() {
-            EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
-        }));
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server.getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (!server.isReady()) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        ::SetUpServer(this->t, this->server, this->port, configPath);
     }
 
     void SetUp() override {
@@ -971,7 +965,8 @@ TEST_P(MediapipeFlowAddTest, Infer) {
     std::vector<float> requestData2{0., 0., 0., 0., 0., 0., 0, 0., 0., 0};
     preparePredictRequest(request, inputsMeta, requestData1);
     request.mutable_model_name()->assign(modelName);
-    ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
+    auto status = impl.ModelInfer(nullptr, &request, &response);
+    ASSERT_EQ(status.error_code(), grpc::StatusCode::OK) << status.error_message();
     checkAddResponse("out", requestData1, requestData2, request, response, 1, 1, modelName);
 }
 
@@ -2096,6 +2091,141 @@ TEST(MediapipeStreamTypes, Recognition) {
 //     EXPECT_EQ(status, ovms::StatusCode::JSON_INVALID);
 //     manager.join();
 // }
+//
+
+std::promise<void> unblockLoading2ndGraph;
+namespace mediapipe {
+class LongLoadingCalculator : public CalculatorBase {
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        auto signal = unblockLoading2ndGraph.get_future();
+        signal.get();
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            cc->Inputs().Tag(tag).Set<ov::Tensor>();
+        }
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            cc->Outputs().Tag(tag).Set<ov::Tensor>();
+        }
+        return absl::OkStatus();
+    }
+    absl::Status Close(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+    absl::Status Open(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+    absl::Status Process(CalculatorContext* cc) final {
+        return absl::OkStatus();
+    }
+};
+REGISTER_CALCULATOR(LongLoadingCalculator);
+}  // namespace mediapipe
+class MediapipeFlowStartTest : public TestWithTempDir {
+protected:
+    bool isMpReady(const std::string name) {
+        ovms::Server& server = ovms::Server::instance();
+        SPDLOG_ERROR("serverReady:{}", server.isReady());
+        const ovms::Module* servableModule = server.getModule(ovms::SERVABLE_MANAGER_MODULE_NAME);
+        if (!servableModule) {
+            return false;
+        }
+        ModelManager* manager = &dynamic_cast<const ServableManagerModule*>(servableModule)->getServableManager();
+        auto mediapipeGraphDefinition = manager->getMediapipeFactory().findDefinitionByName(name);
+        if (!mediapipeGraphDefinition) {
+            return false;
+        }
+        return mediapipeGraphDefinition->getStatus().isAvailable();
+    }
+    void stopServer() {
+        OVMS_Server* cserver;
+        ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
+        ovms::Server& server = ovms::Server::instance();
+        server.setShutdownRequest(1);
+    }
+    void TearDown() {
+        OVMS_Server* cserver = nullptr;
+        ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
+        bool serverLive = false;
+        ASSERT_CAPI_STATUS_NULL(OVMS_ServerLive(cserver, &serverLive));
+        if (serverLive) {
+            stopServer();
+        }
+        ovms::Server& server = ovms::Server::instance();
+        server.setShutdownRequest(0);
+    }
+};
+
+TEST_F(MediapipeFlowStartTest, AsSoonAsMediaPipeGraphDefinitionReadyInferShouldPass) {
+    // 1st thread starts to load OVMS with C-API but we make it stuck on 2nd graph
+    // 2nd thread as soon as sees that 1st MP graph is ready executest inference
+    std::string configFilePath = directoryPath + "/config.json";
+    const std::string configContent = R"(
+{
+    "model_config_list": [
+        {"config": {
+            "name": "dummy",
+            "base_path": "/ovms/src/test/dummy"
+            }
+        }
+    ],
+    "mediapipe_config_list": [
+    {
+        "name":"mediapipeDummy",
+        "graph_path": "/ovms/src/test/mediapipe/graphdummyadapterfull.pbtxt"
+    },
+    {
+        "name": "mediapipeLongLoading",
+        "graph_path": "/ovms/src/test/mediapipe/negative/graph_long_loading.pbtxt"
+    }
+    ]
+}
+)";
+
+    createConfigFileWithContent(configContent, configFilePath);
+    ovms::Server& server = ovms::Server::instance();
+    server.setShutdownRequest(0);
+    std::string port{"9000"};
+    randomizePort(port);
+    char* argv[] = {(char*)"ovms",
+        (char*)"--config_path",
+        (char*)configFilePath.c_str(),
+        (char*)"--port",
+        (char*)port.c_str()};
+    int argc = 5;
+    std::thread t([&argc, &argv, &server]() {
+        EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
+    });
+
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string servableName{"mediapipeDummy"};
+    request.Clear();
+    response.Clear();
+    const Precision precision = Precision::FP32;
+    inputs_info_t inputsMeta{{"in", {DUMMY_MODEL_SHAPE, precision}}};
+    std::vector<float> requestData{13.5, 0., 0, 0., 0., 0., 0., 0, 3., 67.};
+    preparePredictRequest(request, inputsMeta, requestData);
+    request.mutable_model_name()->assign(servableName);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    while (!isMpReady(servableName) &&
+           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS)) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    if (!grpcModule) {
+        this->stopServer();
+        t.join();
+        throw 42;
+    }
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
+    unblockLoading2ndGraph.set_value();
+    size_t dummysInTheGraph = 1;
+    checkDummyResponse("out", requestData, request, response, dummysInTheGraph, 1, servableName);
+    this->stopServer();
+    t.join();
+}
 
 INSTANTIATE_TEST_SUITE_P(
     Test,

--- a/src/test/stress_test_utils.hpp
+++ b/src/test/stress_test_utils.hpp
@@ -1088,7 +1088,7 @@ public:
             std::tuple<ovms::signed_shape_t, ovms::Precision>{{1, DUMMY_MODEL_INPUT_SIZE}, ovms::Precision::FP32}}};
     }
     // we setup the OVMS so that it does not have any models loaded but also prepare the fixture to have ovmsConfig & configFilePath set up
-    void SetUpServerInstance(const std::string& initialConfigContent) {
+    void SetUpCAPIServerInstance(const std::string& initialConfigContent) {
         TestWithTempDir::SetUp();
         std::string port = "9178";
         std::string restPort = "9178";
@@ -1114,7 +1114,7 @@ public:
         manager = &(dynamic_cast<const ovms::ServableManagerModule*>(server.getModule(SERVABLE_MANAGER_MODULE_NAME))->getServableManager());
     }
     void SetUp() override {
-        SetUpServerInstance(createStressTestPipelineOneDummyConfig());
+        SetUpCAPIServerInstance(createStressTestPipelineOneDummyConfig());
     }
     void TearDown() override {
         OVMS_Server* cserver;

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -692,6 +693,10 @@ static const std::vector<ovms::Precision> UNSUPPORTED_CAPI_INPUT_PRECISIONS_TENS
 
 void randomizePort(std::string& port);
 void randomizePorts(std::string& port1, std::string& port2);
+
+extern const int64_t SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS;
+
+void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath);
 
 class ConstructorEnabledConfig : public ovms::Config {
 public:


### PR DESCRIPTION
* Add tests documenting OVMS handling of exceptions from calculators
* Multiple threads starting OVMS via C-API at the same time
* C-API requests responsiveness test during start
* move SetUpServer test utility
* Cppclean threshold increase 
due to 
 ./src/test/test_utils.cpp:774: 'SetUpServer' not found in any directly #included header
even tough it is coming from test_utils.hpp

JIRA:CVS-120394
