### PR TITLE
rework sphinx markdown directives

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -1,39 +1,38 @@
 # Demos {#ovms_docs_demos}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_demo_age_gender_guide
-   ovms_demo_horizontal_text_detection
-   ovms_demo_optical_character_recognition
-   ovms_demo_face_detection
-   ovms_demo_face_blur_pipeline
-   ovms_demo_capi_inference_demo
-   ovms_demo_single_face_analysis_pipeline
-   ovms_demo_multi_faces_analysis_pipeline
-   ovms_docs_demo_ensemble
-   ovms_docs_demo_mediapipe_image_classification
-   ovms_docs_demo_mediapipe_multi_model
-   ovms_docs_demo_mediapipe_object_detection
-   ovms_docs_demo_mediapipe_holistic
-   ovms_docs_image_classification
-   ovms_demo_using_onnx_model
-   ovms_demo_tf_classification
-   ovms_demo_person_vehicle_bike_detection
-   ovms_demo_vehicle_analysis_pipeline
-   ovms_demo_real_time_stream_analysis
-   ovms_demo_bert
-   ovms_demo_gptj_causal_lm
-   ovms_demo_llama_2_chat
-   ovms_demo_stable_diffusion
-   ovms_demo_universal-sentence-encoder
-   ovms_demo_speech_recognition
-   ovms_demo_benchmark_client
-
-@endsphinxdirective
+ovms_demo_age_gender_guide
+ovms_demo_horizontal_text_detection
+ovms_demo_optical_character_recognition
+ovms_demo_face_detection
+ovms_demo_face_blur_pipeline
+ovms_demo_capi_inference_demo
+ovms_demo_single_face_analysis_pipeline
+ovms_demo_multi_faces_analysis_pipeline
+ovms_docs_demo_ensemble
+ovms_docs_demo_mediapipe_image_classification
+ovms_docs_demo_mediapipe_multi_model
+ovms_docs_demo_mediapipe_object_detection
+ovms_docs_demo_mediapipe_holistic
+ovms_docs_image_classification
+ovms_demo_using_onnx_model
+ovms_demo_tf_classification
+ovms_demo_person_vehicle_bike_detection
+ovms_demo_vehicle_analysis_pipeline
+ovms_demo_real_time_stream_analysis
+ovms_demo_bert
+ovms_demo_gptj_causal_lm
+ovms_demo_llama_2_chat
+ovms_demo_stable_diffusion
+ovms_demo_universal-sentence-encoder
+ovms_demo_speech_recognition
+ovms_demo_benchmark_client
+```
 
 OpenVINO Model Server demos have been created to showcase the usage of the model server as well as demonstrate it’s capabilities. Check out the list below to see complete step-by-step examples of using OpenVINO Model Server with real world use cases:
 

--- a/demos/benchmark/README.md
+++ b/demos/benchmark/README.md
@@ -1,15 +1,14 @@
 # Benchmark Client {#ovms_demo_benchmark_client}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_demo_benchmark_app
-   ovms_demo_benchmark_app_cpp
-
-@endsphinxdirective
+ovms_demo_benchmark_app
+ovms_demo_benchmark_app_cpp
+```
 
 ## Python
 | Demo | Description |

--- a/demos/image_classification/README.md
+++ b/demos/image_classification/README.md
@@ -1,16 +1,15 @@
 # Image Classification Demos {#ovms_docs_image_classification}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_demo_image_classification
-   ovms_demo_image_classification_cpp
-   ovms_demo_image_classification_go
-
-@endsphinxdirective
+ovms_demo_image_classification
+ovms_demo_image_classification_cpp
+ovms_demo_image_classification_go
+```
 
 ## Python 
 | Demo | Description |

--- a/docs/accelerators.md
+++ b/docs/accelerators.md
@@ -26,35 +26,26 @@ Before using GPU as OpenVINO Model Server target device, you need to:
 
 Running inference on GPU requires the model server process security context account to have correct permissions. It must belong to the render group identified by the command:
 
-@sphinxdirective
-.. code-block:: sh
-
-    stat -c "group_name=%G group_id=%g" /dev/dri/render*
-
-@endsphinxdirective
+```bash
+stat -c "group_name=%G group_id=%g" /dev/dri/render*
+```
 
 The default account in the docker image is preconfigured. If you change the security context, use the following command to start the model server container:
 
-@sphinxdirective
-.. code-block:: sh
-
-    docker run --rm -it  --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
-    -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
-    --model_path /opt/model --model_name resnet --port 9001 --target_device GPU
-
-@endsphinxdirective
+```bash
+docker run --rm -it  --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
+-v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
+--model_path /opt/model --model_name resnet --port 9001 --target_device GPU
+```
 
 GPU device can be used also on Windows hosts with Windows Subsystem for Linux 2 (WSL2). In such scenario, there are needed extra docker parameters. See the command below.
 Use device `/dev/dxg` instead of `/dev/dri` and mount the volume `/usr/lib/wsl`:
 
-@sphinxdirective
-.. code-block:: sh
-
-    docker run --rm -it  --device=/dev/dxg --volume /usr/lib/wsl:/usr/lib/wsl -u $(id -u):$(id -g) \
-    -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
-    --model_path /opt/model --model_name resnet --port 9001 --target_device GPU
-
-@endsphinxdirective
+```bash
+docker run --rm -it  --device=/dev/dxg --volume /usr/lib/wsl:/usr/lib/wsl -u $(id -u):$(id -g) \
+-v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
+--model_path /opt/model --model_name resnet --port 9001 --target_device GPU
+```
 
 > **NOTE**:
 > The public docker image includes the OpenCL drivers for GPU in version 22.28 (RedHat) and 22.35 (Ubuntu).
@@ -136,15 +127,12 @@ Make sure you have passed the devices and access to the devices you want to use 
 
 Below is an example of the command with AUTO Plugin as target device. It includes extra docker parameters to enable GPU (/dev/dri) , beside CPU.
 
-@sphinxdirective
-.. code-block:: sh
-
-    docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) \
-    -u $(id -u):$(id -g) -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
-    --model_path /opt/model --model_name resnet --port 9001 \
-    --target_device AUTO
-
-@endsphinxdirective
+```bash
+docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) \
+-u $(id -u):$(id -g) -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
+--model_path /opt/model --model_name resnet --port 9001 \
+--target_device AUTO
+```
 
 The `Auto Device` plugin can also use the [PERFORMANCE_HINT](performance_tuning.md) plugin config property that enables you to specify a performance mode for the plugin.
 
@@ -154,29 +142,23 @@ To enable Performance Hints for your application, use the following command:
 
 LATENCY
 
-@sphinxdirective
-.. code-block:: sh
-
-    docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
-    -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
-    --model_path /opt/model --model_name resnet --port 9001 \
-    --plugin_config '{"PERFORMANCE_HINT": "LATENCY"}' \
-    --target_device AUTO
-
-@endsphinxdirective
+```bash
+docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
+-v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
+--model_path /opt/model --model_name resnet --port 9001 \
+--plugin_config '{"PERFORMANCE_HINT": "LATENCY"}' \
+--target_device AUTO
+```
 
 THROUGHPUT
 
-@sphinxdirective
-.. code-block:: sh
-
-    docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
-    -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
-    --model_path /opt/model --model_name resnet --port 9001 \
-    --plugin_config '{"PERFORMANCE_HINT": "THROUGHPUT"}' \
-    --target_device AUTO
-
-@endsphinxdirective
+```bash
+docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
+-v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
+--model_path /opt/model --model_name resnet --port 9001 \
+--plugin_config '{"PERFORMANCE_HINT": "THROUGHPUT"}' \
+--target_device AUTO
+```
 
 > **NOTE**: currently, AUTO plugin cannot be used with `--shape auto` parameter while GPU device is enabled.
 
@@ -186,22 +168,22 @@ OpenVINO Model Server can be used also with NVIDIA GPU cards by using NVIDIA plu
 The docker image of OpenVINO Model Server including support for NVIDIA can be built from sources
 
 ```bash
-   git clone https://github.com/openvinotoolkit/model_server.git
-   cd model_server
-   make docker_build NVIDIA=1 OV_USE_BINARY=0
-   cd ..
+git clone https://github.com/openvinotoolkit/model_server.git
+cd model_server
+make docker_build NVIDIA=1 OV_USE_BINARY=0
+cd ..
 ```
 Check also [building from sources](https://github.com/openvinotoolkit/model_server/blob/main/docs/build_from_source.md).
 
 Example command to run container with NVIDIA support:
 
 ```bash
-   docker run -it --gpus all -p 9000:9000 -v ${PWD}/models/public/resnet-50-tf:/opt/model openvino/model_server:latest-cuda --model_path /opt/model --model_name resnet --port 9000 --target_device NVIDIA
+docker run -it --gpus all -p 9000:9000 -v ${PWD}/models/public/resnet-50-tf:/opt/model openvino/model_server:latest-cuda --model_path /opt/model --model_name resnet --port 9000 --target_device NVIDIA
 ```
 
 For models with layers not supported on NVIDIA plugin, you can use a virtual plugin `HETERO` which can use multiple devices listed after the colon:
 ```bash
-   docker run -it --gpus all -p 9000:9000 -v ${PWD}/models/public/resnet-50-tf:/opt/model openvino/model_server:latest-cuda --model_path /opt/model --model_name resnet --port 9000 --target_device HETERO:NVIDIA,CPU
+docker run -it --gpus all -p 9000:9000 -v ${PWD}/models/public/resnet-50-tf:/opt/model openvino/model_server:latest-cuda --model_path /opt/model --model_name resnet --port 9000 --target_device HETERO:NVIDIA,CPU
 ```
 
 Check the supported [configuration parameters](https://github.com/openvinotoolkit/openvino_contrib/tree/master/modules/nvidia_plugin#supported-configuration-parameters) and [supported layers](https://github.com/openvinotoolkit/openvino_contrib/tree/master/modules/nvidia_plugin#supported-layers-and-limitations)

--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -1,17 +1,16 @@
 # Advanced Features {#ovms_docs_advanced}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_sample_cpu_extension
-   ovms_docs_model_cache
-   ovms_docs_custom_loader
-   ovms_extras_nginx-mtls-auth-readme
-
-@endsphinxdirective
+ovms_sample_cpu_extension
+ovms_docs_model_cache
+ovms_docs_custom_loader
+ovms_extras_nginx-mtls-auth-readme
+```
 
 ## CPU Extensions
 Implement any CPU layer, that is not support by OpenVINO yet, as a shared library.

--- a/docs/api_reference_guide.md
+++ b/docs/api_reference_guide.md
@@ -1,18 +1,17 @@
 # API Reference Guide {#ovms_docs_server_api}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_grpc_api_tfs
-   ovms_docs_grpc_api_kfs
-   ovms_docs_rest_api_tfs
-   ovms_docs_rest_api_kfs
-   ovms_docs_c_api
-
-@endsphinxdirective
+ovms_docs_grpc_api_tfs
+ovms_docs_grpc_api_kfs
+ovms_docs_rest_api_tfs
+ovms_docs_rest_api_kfs
+ovms_docs_c_api
+```
 
 ## Introduction
 

--- a/docs/binary_input.md
+++ b/docs/binary_input.md
@@ -1,17 +1,16 @@
 # Support for Binary Encoded Image Input Data {#ovms_docs_binary_input}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_binary_input_layout_and_shape
-   ovms_docs_binary_input_tfs
-   ovms_docs_binary_input_kfs
-   ovms_docs_demo_tensorflow_conversion
-
-@endsphinxdirective
+ovms_docs_binary_input_layout_and_shape
+ovms_docs_binary_input_tfs
+ovms_docs_binary_input_kfs
+ovms_docs_demo_tensorflow_conversion
+```
 
 While OpenVINO models don't have the ability to process images directly in their binary format, the model server can accept them and convert
 automatically from JPEG/PNG to OpenVINO friendly format using built-in [OpenCV](https://opencv.org/) library. To take advantage of this feature, there are two requirements:

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,14 +1,14 @@
 # Clients {#ovms_docs_clients}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_clients_tfs
-   ovms_docs_clients_kfs
-@endsphinxdirective
+ovms_docs_clients_tfs
+ovms_docs_clients_kfs
+```
 
 In this section you can find short code samples to interact with OpenVINO Model Server endpoints via:
 - [TensorFlow Serving API](./clients_tfs.md)

--- a/docs/clients_kfs.md
+++ b/docs/clients_kfs.md
@@ -6,879 +6,808 @@ When creating a Python-based client application, you can use Triton client libra
 
 ### Install the Package
 
-@sphinxdirective
-
-.. code-block:: sh
-
-        pip3 install tritonclient[all] 
-
-@endsphinxdirective
+```bash
+pip3 install tritonclient[all] 
+```
 
 ### Request Health Endpoints
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} python [GRPC] 
+:sync: python-grpc
+```{code} python
+import tritonclient.grpc as grpcclient
 
-.. tab-set::
+client = grpcclient.InferenceServerClient("localhost:9000")
 
-   .. tab-item::  python [GRPC]
-      :sync: python-grpc
-   
-      .. code-block:: python
-            
-         import tritonclient.grpc as grpcclient
-                     
-         client = grpcclient.InferenceServerClient("localhost:9000")
-               
-         server_live = client.is_server_live()
-                 
-         server_ready = client.is_server_ready()
-                 
-         model_ready = client.is_model_ready("model_name")
-   
-   .. tab-item::  python [REST]
-      :sync: python-rest
-   
-      .. code-block:: python
-                       
-         import tritonclient.http as httpclient
-                    
-         client = httpclient.InferenceServerClient("localhost:9000")
-                          
-         server_live = client.is_server_live()
-                     
-         server_ready = client.is_server_ready()
-                      
-         model_ready = client.is_model_ready("model_name")
-   
-   .. tab-item::  cpp [GRPC]
-      :sync: cpp-grpc
-   
-      .. code-block:: cpp
-                          
-         #include "grpc_client.h"
-                        
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerGrpcClient> client;
-             tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
-                     
-             bool serverLive = client->IsServerLive(&serverLive);
-                         
-             bool serverReady = client->IsServerReady(&serverReady);
-                            
-             bool modelReady = client->IsModelReady(&modelReady, "model_name", "model_version");
-         }
-   
-   .. tab-item::  cpp [REST]
-      :sync: cpp-rest
-   
-      .. code-block:: cpp
-                    
-         #include "http_client.h"
-                      
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerHttpClient> client;
-             tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
-                     
-             bool serverLive = client->IsServerLive(&serverLive);
-                     
-             bool serverReady = client->IsServerReady(&serverReady);
-                       
-             bool modelReady = client->IsModelReady(&modelReady, "model_name", "model_version");
-         }
-   
-   .. tab-item::  java
-      :sync: java
-   
-      .. code-block:: java
-                        
-         public static void main(String[] args) {
-             ManagedChannel channel = ManagedChannelBuilder
-                             .forAddress("localhost", 9000)
-                             .usePlaintext().build();
-             GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
-                      
-             ServerLiveRequest.Builder serverLiveRequest = ServerLiveRequest.newBuilder();
-             ServerLiveResponse serverLiveResponse = grpc_stub.serverLive(serverLiveRequest.build());
-                   
-             bool serverLive = serverLiveResponse.getLive();
-                    
-             ServerReadyRequest.Builder serverReadyRequest = ServerReadyRequest.newBuilder();
-             ServerReadyResponse serverReadyResponse = grpc_stub.serverReady(serverReadyRequest.build());
-                     
-             bool serverReady = serverReadyResponse.getReady();
-                       
-             ModelReadyRequest.Builder modelReadyRequest = ModelReadyRequest.newBuilder();
-             modelReadyRequest.setName("model_name");
-             modelReadyRequest.setVersion("version");
-             ModelReadyResponse modelReadyResponse = grpc_stub.modelReady(modelReadyRequest.build());
-                                    
-             bool modelReady = modelReadyResponse.getReady();
-             
-             channel.shutdownNow();
-         }
-   
-   
-   .. tab-item::  golang
-      :sync: golang
-   
-      .. code-block:: cpp
-               
-         func main() {
-             grpc.Dial("localhost:9000", grpc.WithInsecure())
-             client := grpc_client.NewGRPCInferenceServiceClient(conn)
-                   
-             serverLiveRequest := grpc_client.ServerLiveRequest{}
-             serverLiveResponse, err := client.ServerLive(ctx, &serverLiveRequest)
-                    
-             serverReadyRequest := grpc_client.ServerReadyRequest{}
-             serverReadyResponse, err := client.ServerReady(ctx, &serverReadyRequest)
-                            
-             modelReadyRequest := grpc_client.ModelReadyRequest{
-                     Name:    "modelName",
-                     Version: "modelVersion",
-             }
-             modelReadyResponse, err := client.ModelReady(ctx, &modelReadyRequest)
-         }
-   
-   .. tab-item::  curl   
-      :sync: curl  
-   
-      .. code-block:: sh  
-                     
-         curl http://localhost:8000/v2/health/live
-         curl http://localhost:8000/v2/health/ready
-         curl http://localhost:8000/v2/models/model_name/ready
+server_live = client.is_server_live()
 
-@endsphinxdirective
+server_ready = client.is_server_ready()
+
+model_ready = client.is_model_ready("model_name")
+```
+:::
+:::{tab-item} python [REST]
+:sync: python-rest
+```{code} python
+import tritonclient.http as httpclient
+
+client = httpclient.InferenceServerClient("localhost:9000")
+
+server_live = client.is_server_live()
+
+server_ready = client.is_server_ready()
+
+model_ready = client.is_model_ready("model_name")
+```
+:::
+:::{tab-item} cpp [GRPC]
+:sync: cpp-grpc
+```{code} cpp
+#include "grpc_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerGrpcClient> client;
+    tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
+
+    bool serverLive = client->IsServerLive(&serverLive);
+
+    bool serverReady = client->IsServerReady(&serverReady);
+
+    bool modelReady = client->IsModelReady(&modelReady, "model_name", "model_version");
+}
+```
+:::
+:::{tab-item} cpp [REST]
+:sync: cpp-rest
+```{code} cpp
+#include "http_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerHttpClient> client;
+    tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
+
+    bool serverLive = client->IsServerLive(&serverLive);
+
+    bool serverReady = client->IsServerReady(&serverReady);
+
+    bool modelReady = client->IsModelReady(&modelReady, "model_name", "model_version");
+}
+```
+:::
+:::{tab-item} java
+:sync: java
+```{code} java
+public static void main(String[] args) {
+    ManagedChannel channel = ManagedChannelBuilder
+                    .forAddress("localhost", 9000)
+                    .usePlaintext().build();
+    GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
+
+    ServerLiveRequest.Builder serverLiveRequest = ServerLiveRequest.newBuilder();
+    ServerLiveResponse serverLiveResponse = grpc_stub.serverLive(serverLiveRequest.build());
+
+    bool serverLive = serverLiveResponse.getLive();
+
+    ServerReadyRequest.Builder serverReadyRequest = ServerReadyRequest.newBuilder();
+    ServerReadyResponse serverReadyResponse = grpc_stub.serverReady(serverReadyRequest.build());
+
+    bool serverReady = serverReadyResponse.getReady();
+
+    ModelReadyRequest.Builder modelReadyRequest = ModelReadyRequest.newBuilder();
+    modelReadyRequest.setName("model_name");
+    modelReadyRequest.setVersion("version");
+    ModelReadyResponse modelReadyResponse = grpc_stub.modelReady(modelReadyRequest.build());
+
+    bool modelReady = modelReadyResponse.getReady();
+    
+    channel.shutdownNow();
+}
+```
+:::
+:::{tab-item} golang
+:sync: golang
+```{code} cpp
+func main() {
+    grpc.Dial("localhost:9000", grpc.WithInsecure())
+    client := grpc_client.NewGRPCInferenceServiceClient(conn)
+
+    serverLiveRequest := grpc_client.ServerLiveRequest{}
+    serverLiveResponse, err := client.ServerLive(ctx, &serverLiveRequest)
+
+    serverReadyRequest := grpc_client.ServerReadyRequest{}
+    serverReadyResponse, err := client.ServerReady(ctx, &serverReadyRequest)
+    
+    modelReadyRequest := grpc_client.ModelReadyRequest{
+            Name:    "modelName",
+            Version: "modelVersion",
+    }
+    modelReadyResponse, err := client.ModelReady(ctx, &modelReadyRequest)
+}
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} bash
+curl http://localhost:8000/v2/health/live
+curl http://localhost:8000/v2/health/ready
+curl http://localhost:8000/v2/models/model_name/ready
+```
+:::
+::::
 
 ### Request Server Metadata
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} python [GRPC] 
+:sync: python-grpc
+```{code} python
+import tritonclient.grpc as grpcclient
 
-.. tab-set::
+client = grpcclient.InferenceServerClient("localhost:9000")
+server_metadata = client.get_server_metadata()
+```
+:::
+:::{tab-item} python [REST]
+:sync: python-rest
+```{code} python
+import tritonclient.http as httpclient
 
-   .. tab-item::  python [GRPC]
-      :sync: python-grpc
-   
-      .. code-block:: python
-                
-         import tritonclient.grpc as grpcclient
-               
-         client = grpcclient.InferenceServerClient("localhost:9000")
-         server_metadata = client.get_server_metadata()
-   
-   .. tab-item::  python [REST]
-      :sync: python-rest
-   
-      .. code-block:: python
-                 
-         import tritonclient.http as httpclient
-             
-         client = httpclient.InferenceServerClient("localhost:9000")
-         server_metadata = client.get_server_metadata()
-   
-   .. tab-item::  cpp [GRPC]
-      :sync: cpp-grpc
-   
-      .. code-block:: cpp
-                         
-         #include "grpc_client.h"
-                         
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerGrpcClient> client;
-             tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
-                             
-             inference::ServerMetadataResponse server_metadata;
-             client->ServerMetadata(&server_metadata);
-                                      
-             std::string name = server_metadata.name();
-             std::string version = server_metadata.version();
-         }
-   
-   .. tab-item::  cpp [REST]
-      :sync: cpp-rest
-   
-      .. code-block:: cpp
-                         
-         #include "http_client.h"
-                
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerHttpClient> client;
-             tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
-                               
-             std::string server_metadata;
-             client->ServerMetadata(&server_metadata);
-         }
-   
-   .. tab-item::  java
-      :sync: java
-   
-      .. code-block:: java
-                 
-         public static void main(String[] args) {
-             ManagedChannel channel = ManagedChannelBuilder
-                             .forAddress("localhost", 9000)
-                             .usePlaintext().build();
-             GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
-                         
-             ServerMetadataRequest.Builder request = ServerMetadataRequest.newBuilder();
-             ServerMetadataResponse response = grpc_stub.serverMetadata(request.build());
-             
-             channel.shutdownNow();
-         }
-   
-   
-   .. tab-item::  golang
-      :sync: golang
-   
-      .. code-block:: cpp
-                          
-         grpc.Dial("localhost:9000", grpc.WithInsecure())
-         client := grpc_client.NewGRPCInferenceServiceClient(conn)
-                             
-         serverMetadataRequest := grpc_client.ServerMetadataRequest{}
-         serverMetadataResponse, err := client.ServerMetadata(ctx, &serverMetadataRequest)
-   
-   .. tab-item::  curl    
-      :sync: curl  
-                                
-      .. code-block:: sh  
-                                  
-         curl http://localhost:8000/v2
-           
-@endsphinxdirective
+client = httpclient.InferenceServerClient("localhost:9000")
+server_metadata = client.get_server_metadata()
+```
+:::
+:::{tab-item} cpp [GRPC]
+:sync: cpp-grpc
+```{code} cpp
+#include "grpc_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerGrpcClient> client;
+    tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
+
+    inference::ServerMetadataResponse server_metadata;
+    client->ServerMetadata(&server_metadata);
+
+    std::string name = server_metadata.name();
+    std::string version = server_metadata.version();
+}
+```
+:::
+:::{tab-item} cpp [REST]
+:sync: cpp-rest
+```{code} cpp
+#include "http_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerHttpClient> client;
+    tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
+
+    std::string server_metadata;
+    client->ServerMetadata(&server_metadata);
+}
+```
+:::
+:::{tab-item} java
+:sync: java
+```{code} java
+public static void main(String[] args) {
+    ManagedChannel channel = ManagedChannelBuilder
+                    .forAddress("localhost", 9000)
+                    .usePlaintext().build();
+    GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
+
+    ServerMetadataRequest.Builder request = ServerMetadataRequest.newBuilder();
+    ServerMetadataResponse response = grpc_stub.serverMetadata(request.build());
+    
+    channel.shutdownNow();
+}
+```
+:::
+:::{tab-item} golang
+:sync: golang
+```{code} cpp
+grpc.Dial("localhost:9000", grpc.WithInsecure())
+client := grpc_client.NewGRPCInferenceServiceClient(conn)
+
+serverMetadataRequest := grpc_client.ServerMetadataRequest{}
+serverMetadataResponse, err := client.ServerMetadata(ctx, &serverMetadataRequest)
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} bash
+curl http://localhost:8000/v2
+```
+:::
+::::
 
 ### Request Model Metadata
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} python [GRPC] 
+:sync: python-grpc
+```{code} python
+import tritonclient.grpc as grpcclient
 
-.. tab-set::
+client = grpcclient.InferenceServerClient("localhost:9000")
+model_metadata = client.get_model_metadata("model_name")
+```
+:::
+:::{tab-item} python [REST]
+:sync: python-rest
+```{code} python
+import tritonclient.http as httpclient
 
-   .. tab-item::  python [GRPC]
-      :sync: python-grpc
-   
-      .. code-block:: python
-                            
-         import tritonclient.grpc as grpcclient
-                             
-         client = grpcclient.InferenceServerClient("localhost:9000")
-         model_metadata = client.get_model_metadata("model_name")
-   
-   .. tab-item::  python [REST]
-      :sync: python-rest
-                     
-      .. code-block:: python
-                     
-         import tritonclient.http as httpclient
-                            
-         client = httpclient.InferenceServerClient("localhost:9000")
-         model_metadata = client.get_model_metadata("model_name")
-   
-   .. tab-item::  cpp [GRPC]
-      :sync: cpp-grpc
-   
-      .. code-block:: cpp
-                              
-         #include "grpc_client.h"
-                                
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerGrpcClient> client;
-             tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
-                                 
-             inference::ModelMetadataResponse model_metadata;
-             client->ModelMetadata(&model_metadata, "model_name", "model_version");
-         }
-   
-   .. tab-item::  cpp [REST]
-      :sync: cpp-rest
-   
-      .. code-block:: cpp
-                          
-         #include "http_client.h"
-                                  
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerHttpClient> client;
-             tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
-                                       
-             std::string model_metadata;
-             client->ModelMetadata(&model_metadata, "model_name", "model_version")
-         }
-   
-   .. tab-item::  java
-      :sync: java
-   
-      .. code-block:: java
-                         
-         public static void main(String[] args) {
-             ManagedChannel channel = ManagedChannelBuilder
-                             .forAddress("localhost", 9000)
-                             .usePlaintext().build();
-             GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
-                                        
-             ModelMetadataRequest.Builder request = ModelMetadataRequest.newBuilder();
-             request.setName("model_name");
-             request.setVersion("model_version");
-             ModelMetadataResponse response = grpc_stub.modelMetadata(request.build());
-             
-             channel.shutdownNow();
-         }
-   
-   
-   .. tab-item::  golang
-      :sync: golang
-   
-      .. code-block:: cpp
-                          
-         grpc.Dial("localhost:9000", grpc.WithInsecure())
-         client := grpc_client.NewGRPCInferenceServiceClient(conn)
-                            
-         modelMetadataRequest := grpc_client.ModelMetadataRequest{
-             Name:    "modelName",
-             Version: "modelVersion",
-         }
-         modelMetadataResponse, err := client.ModelMetadata(ctx, &modelMetadataRequest)
-   
-   .. tab-item::  curl    
-      :sync: curl  
-   
-      .. code-block:: sh  
-                   
-         curl http://localhost:8000/v2/models/model_name
-        
-@endsphinxdirective
+client = httpclient.InferenceServerClient("localhost:9000")
+model_metadata = client.get_model_metadata("model_name")
+```
+:::
+:::{tab-item} cpp [GRPC]
+:sync: cpp-grpc
+```{code} cpp
+#include "grpc_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerGrpcClient> client;
+    tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
+
+    inference::ModelMetadataResponse model_metadata;
+    client->ModelMetadata(&model_metadata, "model_name", "model_version");
+}
+```
+:::
+:::{tab-item} cpp [REST]
+:sync: cpp-rest
+```{code} cpp
+#include "http_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerHttpClient> client;
+    tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
+
+    std::string model_metadata;
+    client->ModelMetadata(&model_metadata, "model_name", "model_version")
+}
+```
+:::
+:::{tab-item} java
+:sync: java
+```{code} java
+public static void main(String[] args) {
+    ManagedChannel channel = ManagedChannelBuilder
+                    .forAddress("localhost", 9000)
+                    .usePlaintext().build();
+    GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
+
+    ModelMetadataRequest.Builder request = ModelMetadataRequest.newBuilder();
+    request.setName("model_name");
+    request.setVersion("model_version");
+    ModelMetadataResponse response = grpc_stub.modelMetadata(request.build());
+    
+    channel.shutdownNow();
+}
+```
+:::
+:::{tab-item} golang
+:sync: golang
+```{code} cpp
+grpc.Dial("localhost:9000", grpc.WithInsecure())
+client := grpc_client.NewGRPCInferenceServiceClient(conn)
+
+modelMetadataRequest := grpc_client.ModelMetadataRequest{
+    Name:    "modelName",
+    Version: "modelVersion",
+}
+modelMetadataResponse, err := client.ModelMetadata(ctx, &modelMetadataRequest)
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} bash
+curl http://localhost:8000/v2/models/model_name
+```
+:::
+::::
 
 ### Request Prediction on an Encoded Image
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} python [GRPC] 
+:sync: python-grpc
+```{code} python
+import tritonclient.grpc as grpcclient
 
-.. tab-set::
+triton_client = grpcclient.InferenceServerClient(
+    url="address",
+    ssl=False,
+    verbose=False)
 
-   .. tab-item::  python [GRPC]
-      :sync: python-grpc
-   
-      .. code-block:: python
-                          
-         import tritonclient.grpc as grpcclient
-                    
-         triton_client = grpcclient.InferenceServerClient(
-             url="address",
-             ssl=False,
-             verbose=False)
-                          
-         image_data = []
-         with open("image_path", 'rb') as f:
-             image_data.append(f.read())
-         inputs = []
-         inputs.append(grpcclient.InferInput('input_name', 1, "BYTES"))
-         nmpy = np.array(image_data , dtype=np.object_)
-         inputs[0].set_data_from_numpy(nmpy)
-                      
-         outputs = []
-         outputs.append(grpcclient.InferRequestedOutput("output_name"))
-                                  
-         results = triton_client.infer(model_name="model_name",
-                                   inputs=inputs,
-                                   outputs=outputs)
-   
-   .. tab-item::  python [REST]
-      :sync: python-rest
-   
-      .. code-block:: python
-                  
-         import tritonclient.http as httpclient
-                     
-         triton_client = httpclient.InferenceServerClient(
-                     url="address",
-                     ssl=False,
-                     ssl_options=None,
-                     verbose=False)
-                 
-         image_data = []
-         with open("image_path", 'rb') as f:
-             image_data.append(f.read())
-         inputs = []
-         inputs.append(httpclient.InferInput('input_name', 1, "BYTES"))
-         nmpy = np.array(image_data , dtype=np.object_)
-         inputs[0].set_data_from_numpy(nmpy)
-                                    
-         outputs = []
-         outputs.append(httpclient.InferRequestedOutput("output_name"))
-                             
-         results = triton_client.infer(model_name="model_name",
-                                   inputs=inputs,
-                                   outputs=outputs)
-   
-   .. tab-item::  cpp [GRPC]
-      :sync: cpp-grpc
-   
-      .. code-block:: cpp
-                    
-         #include "grpc_client.h"
-                      
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerGrpcClient> client;
-             tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
-                        
-             std::vector<int64_t> shape{1};
-             tc::InferInput* input;
-             tc::InferInput::Create(&input, "input_name", shape, "BYTES");
-             std::shared_ptr<tc::InferInput> input_ptr;
-             input_ptr.reset(input)
-                        
-             std::ifstream file(fileName, std::ios::binary);
-             file.unsetf(std::ios::skipws);
-             std::streampos fileSize;
-                           
-             file.seekg(0, std::ios::end);
-             fileSize = file.tellg();
-             file.seekg(0, std::ios::beg);
-             std::ostringstream oss;
-             oss << file.rdbuf();
-             input_ptr->AppendFromString({oss.str()});
-                                  
-             tc::InferOptions options("model_name");
-             tc::InferResult* result;
-             client->Infer(&result, options, inputs);
-         }
-   
-   .. tab-item::  cpp [REST]
-      :sync: cpp-rest
-   
-      .. code-block:: cpp
-             
-         #include "http_client.h"
-                          
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerHttpClient> client;
-             tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
-                            
-             std::vector<int64_t> shape{1};
-             tc::InferInput* input;
-             tc::InferInput::Create(&input, "input_name", shape, "BYTES");
-             std::shared_ptr<tc::InferInput> input_ptr;
-             input_ptr.reset(input)
-                       
-             std::ifstream file(fileName, std::ios::binary);
-             file.unsetf(std::ios::skipws);
-             std::streampos fileSize;
-                             
-             file.seekg(0, std::ios::end);
-             fileSize = file.tellg();
-             file.seekg(0, std::ios::beg);
-             std::ostringstream oss;
-             oss << file.rdbuf();
-             input_ptr->AppendFromString({oss.str()});
-                                    
-             tc::InferOptions options("model_name");
-             tc::InferResult* result;
-             client->Infer(&result, options, inputs);
-         }
-   
-   .. tab-item::  java
-      :sync: java
-   
-      .. code-block:: java
-                          
-         public static void main(String[] args) {
-             ManagedChannel channel = ManagedChannelBuilder
-                             .forAddress("localhost", 9000)
-                             .usePlaintext().build();
-             GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
-                             
-             ModelInferRequest.Builder request = ModelInferRequest.newBuilder();
-             request.setModelName("model_name");
-             request.setModelVersion("model_version");
-                                  
-             ModelInferRequest.InferInputTensor.Builder input = ModelInferRequest.InferInputTensor
-                     .newBuilder();
-             String defaultInputName = "b";
-             input.setName("input_name");
-             input.setDatatype("BYTES");
-             input.addShape(1);
-                                     
-             FileInputStream imageStream = new FileInputStream("image_path");
-             InferTensorContents.Builder input_data = InferTensorContents.newBuilder();
-             input_data.addBytesContents(ByteString.readFrom(imageStream));
-             input.setContents(input_data);
-             request.addInputs(0, input);
-                                    
-             ModelInferResponse response = grpc_stub.modelInfer(request.build());
-                                           
-             channel.shutdownNow();
-         }
-   
-   
-   .. tab-item::  golang
-      :sync: golang
-   
-      .. code-block:: cpp
-                         
-         grpc.Dial("localhost:9000", grpc.WithInsecure())
-         client := grpc_client.NewGRPCInferenceServiceClient(conn)
-                        
-         ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-                                 
-         bytes, err := ioutil.ReadFile(fileName)
-         contents := grpc_client.InferTensorContents{}
-         contents.BytesContents = append(contents.BytesContents, bytes) 
-                       
-         inferInput := grpc_client.ModelInferRequest_InferInputTensor{
-             Name:     "0",
-             Datatype: "BYTES",
-             Shape:    []int64{1},
-             Contents: &contents,
-         }
-                             
-         inferInputs := []*grpc_client.ModelInferRequest_InferInputTensor{
-             &inferInput,
-         }
-                                   
-         modelInferRequest := grpc_client.ModelInferRequest{
-             ModelName:    modelName,
-             ModelVersion: modelVersion,
-             Inputs:       inferInputs,
-         }
-                              
-         modelInferResponse, err := client.ModelInfer(ctx, &modelInferRequest)
-   
-   .. tab-item::  curl  
-      :sync: curl    
-   
-      .. code-block:: sh  
-                 
-         echo -n '{"inputs” : [{"name" : "0", "shape" : [1], "datatype" : "BYTES"}]}' > request.json
-         stat --format=%s request.json
-         66
-         printf "%x\n" `stat -c "%s" ./image.jpeg`
-         1c21
-         echo -n -e '\x21\x1c\x00\x00' >> request.json
-         cat ./image.jpeg >> request.json
-         curl --data-binary "@./request.json" -X POST http://localhost:8000/v2/models/resnet/versions/0/infer -H "Inference-Header-Content-Length: 66"
+image_data = []
+with open("image_path", 'rb') as f:
+    image_data.append(f.read())
+inputs = []
+inputs.append(grpcclient.InferInput('input_name', 1, "BYTES"))
+nmpy = np.array(image_data , dtype=np.object_)
+inputs[0].set_data_from_numpy(nmpy)
 
-@endsphinxdirective
+outputs = []
+outputs.append(grpcclient.InferRequestedOutput("output_name"))
+
+results = triton_client.infer(model_name="model_name",
+                            inputs=inputs,
+                            outputs=outputs)
+```
+:::
+:::{tab-item} python [REST]
+:sync: python-rest
+```{code} python
+import tritonclient.http as httpclient
+
+triton_client = httpclient.InferenceServerClient(
+            url="address",
+            ssl=False,
+            ssl_options=None,
+            verbose=False)
+
+image_data = []
+with open("image_path", 'rb') as f:
+    image_data.append(f.read())
+inputs = []
+inputs.append(httpclient.InferInput('input_name', 1, "BYTES"))
+nmpy = np.array(image_data , dtype=np.object_)
+inputs[0].set_data_from_numpy(nmpy)
+
+outputs = []
+outputs.append(httpclient.InferRequestedOutput("output_name"))
+
+results = triton_client.infer(model_name="model_name",
+                            inputs=inputs,
+                            outputs=outputs)
+```
+:::
+:::{tab-item} cpp [GRPC]
+:sync: cpp-grpc
+```{code} cpp
+#include "grpc_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerGrpcClient> client;
+    tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
+
+    std::vector<int64_t> shape{1};
+    tc::InferInput* input;
+    tc::InferInput::Create(&input, "input_name", shape, "BYTES");
+    std::shared_ptr<tc::InferInput> input_ptr;
+    input_ptr.reset(input)
+
+    std::ifstream file(fileName, std::ios::binary);
+    file.unsetf(std::ios::skipws);
+    std::streampos fileSize;
+
+    file.seekg(0, std::ios::end);
+    fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::ostringstream oss;
+    oss << file.rdbuf();
+    input_ptr->AppendFromString({oss.str()});
+
+    tc::InferOptions options("model_name");
+    tc::InferResult* result;
+    client->Infer(&result, options, inputs);
+}
+```
+:::
+:::{tab-item} cpp [REST]
+:sync: cpp-rest
+```{code} cpp
+#include "http_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerHttpClient> client;
+    tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
+
+    std::vector<int64_t> shape{1};
+    tc::InferInput* input;
+    tc::InferInput::Create(&input, "input_name", shape, "BYTES");
+    std::shared_ptr<tc::InferInput> input_ptr;
+    input_ptr.reset(input)
+
+    std::ifstream file(fileName, std::ios::binary);
+    file.unsetf(std::ios::skipws);
+    std::streampos fileSize;
+
+    file.seekg(0, std::ios::end);
+    fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::ostringstream oss;
+    oss << file.rdbuf();
+    input_ptr->AppendFromString({oss.str()});
+
+    tc::InferOptions options("model_name");
+    tc::InferResult* result;
+    client->Infer(&result, options, inputs);
+}
+```
+:::
+:::{tab-item} java
+:sync: java
+```{code} java
+public static void main(String[] args) {
+    ManagedChannel channel = ManagedChannelBuilder
+                    .forAddress("localhost", 9000)
+                    .usePlaintext().build();
+    GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
+
+    ModelInferRequest.Builder request = ModelInferRequest.newBuilder();
+    request.setModelName("model_name");
+    request.setModelVersion("model_version");
+
+    ModelInferRequest.InferInputTensor.Builder input = ModelInferRequest.InferInputTensor
+            .newBuilder();
+    String defaultInputName = "b";
+    input.setName("input_name");
+    input.setDatatype("BYTES");
+    input.addShape(1);
+
+    FileInputStream imageStream = new FileInputStream("image_path");
+    InferTensorContents.Builder input_data = InferTensorContents.newBuilder();
+    input_data.addBytesContents(ByteString.readFrom(imageStream));
+    input.setContents(input_data);
+    request.addInputs(0, input);
+
+    ModelInferResponse response = grpc_stub.modelInfer(request.build());
+    
+    channel.shutdownNow();
+}
+```
+:::
+:::{tab-item} golang
+:sync: golang
+```{code} cpp
+grpc.Dial("localhost:9000", grpc.WithInsecure())
+client := grpc_client.NewGRPCInferenceServiceClient(conn)
+
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+bytes, err := ioutil.ReadFile(fileName)
+contents := grpc_client.InferTensorContents{}
+contents.BytesContents = append(contents.BytesContents, bytes) 
+
+inferInput := grpc_client.ModelInferRequest_InferInputTensor{
+    Name:     "0",
+    Datatype: "BYTES",
+    Shape:    []int64{1},
+    Contents: &contents,
+}
+
+inferInputs := []*grpc_client.ModelInferRequest_InferInputTensor{
+    &inferInput,
+}
+
+modelInferRequest := grpc_client.ModelInferRequest{
+    ModelName:    modelName,
+    ModelVersion: modelVersion,
+    Inputs:       inferInputs,
+}
+
+modelInferResponse, err := client.ModelInfer(ctx, &modelInferRequest)
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} bash
+echo -n '{"inputs” : [{"name" : "0", "shape" : [1], "datatype" : "BYTES"}]}' > request.json
+stat --format=%s request.json
+66
+printf "%x\n" `stat -c "%s" ./image.jpeg`
+1c21
+echo -n -e '\x21\x1c\x00\x00' >> request.json
+cat ./image.jpeg >> request.json
+curl --data-binary "@./request.json" -X POST http://localhost:8000/v2/models/resnet/versions/0/infer -H "Inference-Header-Content-Length: 66"
+```
+:::
+::::
 
 ### Request Prediction on a Numpy Array
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} python [GRPC] 
+:sync: python-grpc
+```{code} python
+import numpy as np
+import tritonclient.grpc as grpcclient
 
-.. tab-set::
-   
-   .. tab-item::  python [GRPC]
-      :sync: python-grpc
-   
-      .. code-block:: python
-                   
-         import numpy as np
-         import tritonclient.grpc as grpcclient
-                   
-         client = grpcclient.InferenceServerClient("localhost:9000")
-         data = np.array([1.0, 2.0, ..., 1000.0])
-         infer_input = grpcclient.InferInput("input_name", data.shape, "FP32")
-         infer_input.set_data_from_numpy(data)
-         results = client.infer("model_name", [infer_input])
-   
-   .. tab-item::  python [REST]
-      :sync: python-rest
-   
-      .. code-block:: python
-                   
-         import numpy as np
-         import tritonclient.http as httpclient
-                     
-         client = httpclient.InferenceServerClient("localhost:9000")
-         data = np.array([1.0, 2.0, ..., 1000.0])
-         infer_input = httpclient.InferInput("input_name", data.shape, "FP32")
-         infer_input.set_data_from_numpy(data)
-         results = client.infer("model_name", [infer_input])
-   
-   .. tab-item::  cpp [GRPC]
-      :sync: cpp-grpc
-   
-      .. code-block:: cpp
-                      
-         #include "grpc_client.h"
-                      
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerGrpcClient> client;
-             tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
-                             
-             std::vector<int64_t> shape{1, 10};
-             tc::InferInput* input;
-             tc::InferInput::Create(&input, "input_name", shape, "FP32");
-             std::shared_ptr<tc::InferInput> input_ptr;
-             input_ptr.reset(input);
-                             
-             std::vector<float> input_data(10);
-             for (size_t i = 0; i < 10; ++i) {
-                 input_data[i] = i;
-             }
-             std::vector<tc::InferInput*> inputs = {input_ptr.get()};
-             tc::InferOptions options("model_name");
-             tc::InferResult* result;
-             input_ptr->AppendRaw(input_data);
-             client->Infer(&result, options, inputs);
-             input->Reset();
-         }
-   
-   .. tab-item::  cpp [REST]
-      :sync: cpp-rest
-   
-      .. code-block:: cpp
-                 
-         #include "http_client.h"
-                    
-         namespace tc = triton::client;
-         int main() {
-             std::unique_ptr<tc::InferenceServerHttpClient> client;
-             tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
-                       
-             std::vector<int64_t> shape{1, 10};
-             tc::InferInput* input;
-             tc::InferInput::Create(&input, "input_name", shape, "FP32");
-             std::shared_ptr<tc::InferInput> input_ptr;
-             input_ptr.reset(input);
-                        
-             std::vector<float> input_data(10);
-             for (size_t i = 0; i < 10; ++i) {
-                 input_data[i] = i;
-             }
-             std::vector<tc::InferInput*> inputs = {input_ptr.get()};
-             tc::InferOptions options("model_name");
-             tc::InferResult* result;
-             input_ptr->AppendRaw(input_data);
-             client->Infer(&result, options, inputs);
-             input->Reset();
-         }
-   
-   .. tab-item::  java
-      :sync: java
-   
-      .. code-block:: java
-                      
-         public static void main(String[] args) {
-             ManagedChannel channel = ManagedChannelBuilder
-                             .forAddress("localhost", 9000)
-                             .usePlaintext().build();
-             GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
-                     
-             ModelInferRequest.Builder request = ModelInferRequest.newBuilder();
-             request.setModelName("model_name");
-             request.setModelVersion("model_version");
-                      
-             List<Float> lst = Arrays.asList(0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f);
-             InferTensorContents.Builder input_data = InferTensorContents.newBuilder();
-             input_data.addAllFp32Contents(lst);
-                       
-             ModelInferRequest.InferInputTensor.Builder input = ModelInferRequest.InferInputTensor
-                     .newBuilder();
-             String defaultInputName = "b";
-             input.setName("input_name");
-             input.setDatatype("FP32");
-             input.addShape(1);
-             input.addShape(10);
-             input.setContents(input_data);
-                      
-             request.addInputs(0, input);
-                         
-             ModelInferResponse response = grpc_stub.modelInfer(request.build());
-             
-             channel.shutdownNow();
-         }
-   
-   
-   .. tab-item::  golang
-      :sync: golang
-   
-      .. code-block:: cpp
-                           
-         grpc.Dial("localhost:9000", grpc.WithInsecure())
-         client := grpc_client.NewGRPCInferenceServiceClient(conn)
-                                
-         ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-                                   
-         inputData := make([]float32, inputSize)
-         for i := 0; i < inputSize; i++ {
-             inputData[i] = float32(i)
-         }
-                                     
-         inferInputs := []*grpc_client.ModelInferRequest_InferInputTensor{
-             &grpc_client.ModelInferRequest_InferInputTensor{
-                 Name:     "b",
-                 Datatype: "FP32",
-                 Shape:    []int64{1, 10},
-                 Contents: &grpc_client.InferTensorContents{
-                     Fp32Contents: inputData,
-                 },
-             },
-         }
-                                 
-         modelInferRequest := grpc_client.ModelInferRequest{
-             ModelName:    "model_name",
-             ModelVersion: "model_version",
-             Inputs:       inferInputs,
-         }
-                            
-         modelInferResponse, err := client.ModelInfer(ctx, &modelInferRequest)
-   
-   .. tab-item::  curl    
-      :sync: curl   
-   
-      .. code-block:: sh  
-                      
-         curl -X POST http://localhost:8000/v2/models/model_name/infer
-         -H 'Content-Type: application/json'
-         -d '{"inputs" : [ {"name" : "input_name", "shape" : [ 1, 10 ], "datatype"  : "FP32", "data" : [1,2,3,4,5,6,7,8,9,10]} ]}'
+client = grpcclient.InferenceServerClient("localhost:9000")
+data = np.array([1.0, 2.0, ..., 1000.0])
+infer_input = grpcclient.InferInput("input_name", data.shape, "FP32")
+infer_input.set_data_from_numpy(data)
+results = client.infer("model_name", [infer_input])
+```
+:::
+:::{tab-item} python [REST]
+:sync: python-rest
+```{code} python
+import numpy as np
+import tritonclient.http as httpclient
 
-@endsphinxdirective
+client = httpclient.InferenceServerClient("localhost:9000")
+data = np.array([1.0, 2.0, ..., 1000.0])
+infer_input = httpclient.InferInput("input_name", data.shape, "FP32")
+infer_input.set_data_from_numpy(data)
+results = client.infer("model_name", [infer_input])
+```
+:::
+:::{tab-item} cpp [GRPC]
+:sync: cpp-grpc
+```{code} cpp
+#include "grpc_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerGrpcClient> client;
+    tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
+
+    std::vector<int64_t> shape{1, 10};
+    tc::InferInput* input;
+    tc::InferInput::Create(&input, "input_name", shape, "FP32");
+    std::shared_ptr<tc::InferInput> input_ptr;
+    input_ptr.reset(input);
+
+    std::vector<float> input_data(10);
+    for (size_t i = 0; i < 10; ++i) {
+        input_data[i] = i;
+    }
+    std::vector<tc::InferInput*> inputs = {input_ptr.get()};
+    tc::InferOptions options("model_name");
+    tc::InferResult* result;
+    input_ptr->AppendRaw(input_data);
+    client->Infer(&result, options, inputs);
+    input->Reset();
+}
+```
+:::
+:::{tab-item} cpp [REST]
+:sync: cpp-rest
+```{code} cpp
+#include "http_client.h"
+
+namespace tc = triton::client;
+int main() {
+    std::unique_ptr<tc::InferenceServerHttpClient> client;
+    tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
+
+    std::vector<int64_t> shape{1, 10};
+    tc::InferInput* input;
+    tc::InferInput::Create(&input, "input_name", shape, "FP32");
+    std::shared_ptr<tc::InferInput> input_ptr;
+    input_ptr.reset(input);
+
+    std::vector<float> input_data(10);
+    for (size_t i = 0; i < 10; ++i) {
+        input_data[i] = i;
+    }
+    std::vector<tc::InferInput*> inputs = {input_ptr.get()};
+    tc::InferOptions options("model_name");
+    tc::InferResult* result;
+    input_ptr->AppendRaw(input_data);
+    client->Infer(&result, options, inputs);
+    input->Reset();
+}
+```
+:::
+:::{tab-item} java
+:sync: java
+```{code} java
+public static void main(String[] args) {
+    ManagedChannel channel = ManagedChannelBuilder
+                    .forAddress("localhost", 9000)
+                    .usePlaintext().build();
+    GRPCInferenceServiceBlockingStub grpc_stub = GRPCInferenceServiceGrpc.newBlockingStub(channel);
+
+    ModelInferRequest.Builder request = ModelInferRequest.newBuilder();
+    request.setModelName("model_name");
+    request.setModelVersion("model_version");
+
+    List<Float> lst = Arrays.asList(0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f);
+    InferTensorContents.Builder input_data = InferTensorContents.newBuilder();
+    input_data.addAllFp32Contents(lst);
+
+    ModelInferRequest.InferInputTensor.Builder input = ModelInferRequest.InferInputTensor
+            .newBuilder();
+    String defaultInputName = "b";
+    input.setName("input_name");
+    input.setDatatype("FP32");
+    input.addShape(1);
+    input.addShape(10);
+    input.setContents(input_data);
+
+    request.addInputs(0, input);
+
+    ModelInferResponse response = grpc_stub.modelInfer(request.build());
+    
+    channel.shutdownNow();
+}
+```
+:::
+:::{tab-item} golang
+:sync: golang
+```{code} cpp
+grpc.Dial("localhost:9000", grpc.WithInsecure())
+client := grpc_client.NewGRPCInferenceServiceClient(conn)
+
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+inputData := make([]float32, inputSize)
+for i := 0; i < inputSize; i++ {
+    inputData[i] = float32(i)
+}
+
+inferInputs := []*grpc_client.ModelInferRequest_InferInputTensor{
+    &grpc_client.ModelInferRequest_InferInputTensor{
+        Name:     "b",
+        Datatype: "FP32",
+        Shape:    []int64{1, 10},
+        Contents: &grpc_client.InferTensorContents{
+            Fp32Contents: inputData,
+        },
+    },
+}
+
+modelInferRequest := grpc_client.ModelInferRequest{
+    ModelName:    "model_name",
+    ModelVersion: "model_version",
+    Inputs:       inferInputs,
+}
+
+modelInferResponse, err := client.ModelInfer(ctx, &modelInferRequest)
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} bash
+curl -X POST http://localhost:8000/v2/models/model_name/infer
+-H 'Content-Type: application/json'
+-d '{"inputs" : [ {"name" : "input_name", "shape" : [ 1, 10 ], "datatype"  : "FP32", "data" : [1,2,3,4,5,6,7,8,9,10]} ]}'
+```
+:::
+::::
 
 ### Request Prediction on a string
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} python [GRPC] 
+:sync: python-grpc
+```{code} python
+import numpy as np
+import tritonclient.grpc as grpcclient
 
-.. tab-set::
+client = grpcclient.InferenceServerClient("localhost:9000")
+data = "<string>"
+input = np.array([data.encode('utf-8')], dtype=np.object_)
+infer_input = grpcclient.InferInput("input_name", [1], "BYTES")
+infer_input.set_data_from_numpy(input)
+results = client.infer("model_name", [infer_input])
+```
+:::
+:::{tab-item} python [REST]
+:sync: python-rest
+```{code} python
+import numpy as np
+import tritonclient.http as httpclient
 
-   .. tab-item::  python [GRPC]
-      :sync: python-grpc
-   
-      .. code-block:: python
-                    
-         import numpy as np
-         import tritonclient.grpc as grpcclient
-                      
-         client = grpcclient.InferenceServerClient("localhost:9000")
-         data = "<string>"
-         input = np.array([data.encode('utf-8')], dtype=np.object_)
-         infer_input = grpcclient.InferInput("input_name", [1], "BYTES")
-         infer_input.set_data_from_numpy(input)
-         results = client.infer("model_name", [infer_input])
-   
-   .. tab-item::  python [REST]
-      :sync: python-rest
-   
-      .. code-block:: python
-                           
-         import numpy as np
-         import tritonclient.http as httpclient
-                        
-         client = httpclient.InferenceServerClient("localhost:9000")
-         data = "<string>"
-         input = np.array([data.encode('utf-8')], dtype=np.object_)
-         infer_input = httpclient.InferInput("input_name", [1], "BYTES")
-         infer_input.set_data_from_numpy(input)
-         results = client.infer("model_name", [infer_input])
-   
-   .. tab-item::  cpp [GRPC]
-      :sync: cpp-grpc
-   
-      .. code-block:: cpp
-                    
-         #include "grpc_client.h"
-                         
-         namespace tc = triton::client;
-                               
-         int main(int argc, char** argv) {
-             std::unique_ptr<tc::InferenceServerGrpcClient> client;
-             tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
-             
-             tc::InferInput* input;
-             tc::InferInput::Create(&input, "input_name", {1}, "BYTES");
-             std::shared_ptr<tc::InferInput> input_ptr;
-             input_ptr.reset(input);
-             input_ptr->AppendFromString({std::string("<string>")});
-             std::vector<tc::InferInput*> inputs = {input_ptr.get()};
-             
-             tc::InferOptions options("model_name");
-             tc::InferResult* results;
-             client->Infer(&results, options, inputs);
-             std::shared_ptr<tc::InferResult> results_ptr;
-             results_ptr.reset(results);
-             return 0;
-         }
-           
-   .. tab-item::  cpp [REST]
-      :sync: cpp-rest
-   
-      .. code-block:: cpp
-                         
-         #include "http_client.h"
-                       
-         namespace tc = triton::client;
-                              
-         int main(int argc, char** argv) {
-             std::unique_ptr<tc::InferenceServerHttpClient> client;
-             tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
-             
-             tc::InferInput* input;
-             tc::InferInput::Create(&input, "input_name", {1}, "BYTES");
-             std::shared_ptr<tc::InferInput> input_ptr;
-             input_ptr.reset(input);
-             input_ptr->AppendFromString({std::string("<string>")});    
-             std::vector<tc::InferInput*> inputs = {input_ptr.get()};
-             
-             tc::InferOptions options("model_name");
-             tc::InferResult* results;
-             client->Infer(&results, options, inputs);
-             std::shared_ptr<tc::InferResult> results_ptr;
-             results_ptr.reset(results);
-             return 0;
-         }
-           
-   .. tab-item::  curl    
-      :sync: curl  
-   
-      .. code-block:: sh  
-                          
-         curl -X POST http://localhost:9000/v2/models/model_name/infer
-         -H 'Content-Type: application/json'
-         -d '{"inputs" : [ {"name" : "input_name", "shape" : [ 1 ], "datatype"  : "BYTES", "data" : ["<string>"]} ]}'
-   
-@endsphinxdirective
+client = httpclient.InferenceServerClient("localhost:9000")
+data = "<string>"
+input = np.array([data.encode('utf-8')], dtype=np.object_)
+infer_input = httpclient.InferInput("input_name", [1], "BYTES")
+infer_input.set_data_from_numpy(input)
+results = client.infer("model_name", [infer_input])
+```
+:::
+:::{tab-item} cpp [GRPC]
+:sync: cpp-grpc
+```{code} cpp
+#include "grpc_client.h"
+
+namespace tc = triton::client;
+
+int main(int argc, char** argv) {
+    std::unique_ptr<tc::InferenceServerGrpcClient> client;
+    tc::InferenceServerGrpcClient::Create(&client, "localhost:9000");
+    
+    tc::InferInput* input;
+    tc::InferInput::Create(&input, "input_name", {1}, "BYTES");
+    std::shared_ptr<tc::InferInput> input_ptr;
+    input_ptr.reset(input);
+    input_ptr->AppendFromString({std::string("<string>")});
+    std::vector<tc::InferInput*> inputs = {input_ptr.get()};
+    
+    tc::InferOptions options("model_name");
+    tc::InferResult* results;
+    client->Infer(&results, options, inputs);
+    std::shared_ptr<tc::InferResult> results_ptr;
+    results_ptr.reset(results);
+    return 0;
+}
+```
+:::
+:::{tab-item} cpp [REST]
+:sync: cpp-rest
+```{code} cpp
+#include "http_client.h"
+
+namespace tc = triton::client;
+
+int main(int argc, char** argv) {
+    std::unique_ptr<tc::InferenceServerHttpClient> client;
+    tc::InferenceServerHttpClient::Create(&client, "localhost:9000");
+    
+    tc::InferInput* input;
+    tc::InferInput::Create(&input, "input_name", {1}, "BYTES");
+    std::shared_ptr<tc::InferInput> input_ptr;
+    input_ptr.reset(input);
+    input_ptr->AppendFromString({std::string("<string>")});    
+    std::vector<tc::InferInput*> inputs = {input_ptr.get()};
+    
+    tc::InferOptions options("model_name");
+    tc::InferResult* results;
+    client->Infer(&results, options, inputs);
+    std::shared_ptr<tc::InferResult> results_ptr;
+    results_ptr.reset(results);
+    return 0;
+}
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} bash
+curl -X POST http://localhost:9000/v2/models/model_name/infer
+-H 'Content-Type: application/json'
+-d '{"inputs" : [ {"name" : "input_name", "shape" : [ 1 ], "datatype"  : "BYTES", "data" : ["<string>"]} ]}
+```
+:::
+::::
 
 ### Request Streaming Prediction
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} python [GRPC] 
+:sync: python-grpc
+```{code} python
+import numpy as np
+import tritonclient.grpc as grpcclient
 
-.. tab-set::
-   
-   .. tab-item::  python [GRPC]
-      :sync: python-grpc
-   
-      .. code-block:: python
-                   
-         import numpy as np
-         import tritonclient.grpc as grpcclient
-         
-         def callback(result, error):
-            if error:
-                raise error
-            # ... process result
-            timestamp = result.get_response().parameters['OVMS_MP_TIMESTAMP'].int64_param  # optional
+def callback(result, error):
+    if error:
+        raise error
+    # ... process result
+    timestamp = result.get_response().parameters['OVMS_MP_TIMESTAMP'].int64_param  # optional
 
-         client = grpcclient.InferenceServerClient("localhost:9000")
-         
-         data = np.array([1.0, 2.0, ..., 1000.0])
-         infer_input = grpcclient.InferInput("input_name", data.shape, "FP32")
-         infer_input.set_data_from_numpy(data)
+client = grpcclient.InferenceServerClient("localhost:9000")
 
-         client.start_stream(callback=callback)
+data = np.array([1.0, 2.0, ..., 1000.0])
+infer_input = grpcclient.InferInput("input_name", data.shape, "FP32")
+infer_input.set_data_from_numpy(data)
 
-         for _ in range(5):  # re-use opened stream
-             client.async_stream_infer(
-                model_name="model_name",
-                inputs=[infer_input],
-                parameters={'OVMS_MP_TIMESTAMP': 43166520112})  # optional
+client.start_stream(callback=callback)
 
-         client.stop_stream()
+for _ in range(5):  # re-use opened stream
+    client.async_stream_infer(
+        model_name="model_name",
+        inputs=[infer_input],
+        parameters={'OVMS_MP_TIMESTAMP': 43166520112})  # optional
 
-@endsphinxdirective
+client.stop_stream()
+```
+:::
+::::
 
 For complete usage examples see [Kserve samples](https://github.com/openvinotoolkit/model_server/tree/main/client/python/kserve-api/samples).

--- a/docs/clients_tfs.md
+++ b/docs/clients_tfs.md
@@ -1,391 +1,326 @@
 # TensorFlow Serving API Clients {#ovms_docs_clients_tfs}
 
-@sphinxdirective
-
--  `Python Client <#-python-client>`__
--  `C++ and Go Clients <#-cpp-go-clients>`__
-
-.. raw:: html
-
-   <a name='-python-client' id='-python-client'/>
-
-`Python Client`_
-================
-
-@endsphinxdirective
+## Python Client
 
 When creating a Python-based client application, there are two packages on PyPi that can be used with OpenVINO Model Server:
 - [tensorflow-serving-api](https://pypi.org/project/tensorflow-serving-api/)
 - [ovmsclient](https://pypi.org/project/ovmsclient/)
 
 ### Install the Package
-@sphinxdirective
 
-.. tab-set::
-
-   .. tab-item::  ovmsclient  
-      :sync: ovmsclient
-   
-      .. code-block:: sh
-      
-         pip3 install ovmsclient 
-   
-   .. tab-item::  tensorflow-serving-api  
-      :sync: tensorflow-serving-api  
-   
-      .. code-block:: sh  
-      
-         pip3 install tensorflow-serving-api 
-
-@endsphinxdirective
+::::{tab-set}
+:::{tab-item} ovmsclient
+:sync: ovmsclient
+```{code} sh
+pip3 install ovmsclient
+```
+:::
+:::{tab-item} tensorflow-serving-api
+:sync: tensorflow-serving-api
+```{code} sh
+pip3 install tensorflow-serving-api
+```
+:::
+::::
 
 ### Request Model Status
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} ovmsclient [GRPC]
+:sync: ovmsclient-grpc
+```{code} python
+from ovmsclient import make_grpc_client
 
-.. tab-set::
+client = make_grpc_client("localhost:9000")
+status = client.get_model_status(model_name="my_model")
+```
+:::
+:::{tab-item} ovmsclient [REST]
+:sync: ovmsclient-rest
+```{code} python
+from ovmsclient import make_http_client
 
-   .. tab-item::  ovmsclient [GRPC]
-      :sync: ovmsclient-grpc
-   
-      .. code-block:: python
-      
-         from ovmsclient import make_grpc_client
-     
-         client = make_grpc_client("localhost:9000")
-         status = client.get_model_status(model_name="my_model")
-   
-   
-   .. tab-item::  ovmsclient [REST]
-      :sync: ovmsclient-rest
-   
-      .. code-block:: python
-      
-         from ovmsclient import make_http_client
-      
-         client = make_http_client("localhost:8000")
-         status = client.get_model_status(model_name="my_model")
-   
-   
-   .. tab-item::  tensorflow-serving-api  
-      :sync: tensorflow-serving-api  
-   
-      .. code-block:: python
-     
-         import grpc
-         from tensorflow_serving.apis import model_service_pb2_grpc, get_model_status_pb2
-         from tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus
-     
-         channel = grpc.insecure_channel("localhost:9000")
-         model_service_stub = model_service_pb2_grpc.ModelServiceStub(channel)
-               
-         status_request = get_model_status_pb2.GetModelStatusRequest()
-         status_request.model_spec.name = "my_model"
-         status_response = model_service_stub.GetModelStatus(status_request, 10.0)
-                 
-         model_status = {}
-         model_version_status = status_response.model_version_status
-         for model_version in model_version_status:
-             model_status[model_version.version] = dict([
-                 ('state', ModelVersionStatus.State.Name(model_version.state)),
-                 ('error_code', model_version.status.error_code),
-                 ('error_message', model_version.status.error_message),
-             ])
-   
-   .. tab-item::  curl    
-      :sync: curl   
-   
-      .. code-block:: sh  
+client = make_http_client("localhost:8000")
+status = client.get_model_status(model_name="my_model")
+```
+:::
+:::{tab-item} tensorflow-serving-api
+:sync: tensorflow-serving-api
+```{code} python
+import grpc
+from tensorflow_serving.apis import model_service_pb2_grpc, get_model_status_pb2
+from tensorflow_serving.apis.get_model_status_pb2 import ModelVersionStatus
 
-         curl http://localhost:8000/v1/models/my_model
-       
-@endsphinxdirective
+channel = grpc.insecure_channel("localhost:9000")
+model_service_stub = model_service_pb2_grpc.ModelServiceStub(channel)
+
+status_request = get_model_status_pb2.GetModelStatusRequest()
+status_request.model_spec.name = "my_model"
+status_response = model_service_stub.GetModelStatus(status_request, 10.0)
+        
+model_status = {}
+model_version_status = status_response.model_version_status
+for model_version in model_version_status:
+    model_status[model_version.version] = dict([
+        ('state', ModelVersionStatus.State.Name(model_version.state)),
+        ('error_code', model_version.status.error_code),
+        ('error_message', model_version.status.error_message),
+    ])
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} sh
+curl http://localhost:8000/v1/models/my_model
+```
+:::
+::::
 
 ### Request Model Metadata
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} ovmsclient [GRPC]
+:sync: ovmsclient-grpc
+```{code} python
+from ovmsclient import make_grpc_client
 
-.. tab-set::
+client = make_grpc_client("localhost:9000")
+model_metadata = client.get_model_metadata(model_name="my_model")
+```
+:::
+:::{tab-item} ovmsclient [REST]
+:sync: ovmsclient-rest
+```{code} python
+from ovmsclient import make_http_client
 
-   .. tab-item::  ovmsclient [GRPC]
-      :sync: ovmsclient-grpc
-   
-      .. code-block:: python
-           
-         from ovmsclient import make_grpc_client
-             
-         client = make_grpc_client("localhost:9000")
-         model_metadata = client.get_model_metadata(model_name="my_model")
-   
-   
-   .. tab-item::  ovmsclient [REST]
-      :sync: ovmsclient-rest
-   
-      .. code-block:: python
-               
-         from ovmsclient import make_http_client
-         
-         client = make_http_client("localhost:8000")
-         model_metadata = client.get_model_metadata(model_name="my_model")
-   
-   
-   .. tab-item::  tensorflow-serving-api
-      :sync: tensorflow-serving-api 
-   
-      .. code-block:: python
-                 
-         import grpc
-         from tensorflow_serving.apis import prediction_service_pb2_grpc, get_model_metadata_pb2
-         from tensorflow.core.framework.types_pb2 import DataType
-                  
-         channel = grpc.insecure_channel("localhost:9000")
-         prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
-                 
-         metadata_request = get_model_metadata_pb2.GetModelMetadataRequest()
-         metadata_request.model_spec.name = "my_model"
-         metadata_response = prediction_service_stub.GetModelMetadata(metadata_request, 10.0)
-                
-         model_metadata = {}
-                 
-         signature_def = metadata_response.metadata['signature_def']
-         signature_map = get_model_metadata_pb2.SignatureDefMap()
-         signature_map.ParseFromString(signature_def.value)
-         model_signature = signature_map.ListFields()[0][1]['serving_default']
-                    
-         inputs_metadata = {}
-         for input_name, input_info in model_signature.inputs.items():
-             input_shape = [d.size for d in input_info.tensor_shape.dim]
-             inputs_metadata[input_name] = dict([
-                 ("shape", input_shape),
-                 ("dtype", DataType.Name(input_info.dtype))
-             ])
-                      
-         outputs_metadata = {}
-         for output_name, output_info in model_signature.outputs.items():
-             output_shape = [d.size for d in output_info.tensor_shape.dim]
-             outputs_metadata[output_name] = dict([
-                 ("shape", output_shape),
-                 ("dtype", DataType.Name(output_info.dtype))
-             ])
-                          
-         version = metadata_response.model_spec.version.value
-         model_metadata = dict([
-             ("model_version", version),
-             ("inputs", inputs_metadata),
-             ("outputs", outputs_metadata)
-         ])
-   
-   .. tab-item::  curl
-      :sync: curl   
-   
-      .. code-block:: sh  
-            
-         curl http://localhost:8000/v1/models/my_model/metadata
-   
+client = make_http_client("localhost:8000")
+model_metadata = client.get_model_metadata(model_name="my_model")
+```
+:::
+:::{tab-item} tensorflow-serving-api
+:sync: tensorflow-serving-api
+```{code} python
+import grpc
+from tensorflow_serving.apis import prediction_service_pb2_grpc, get_model_metadata_pb2
+from tensorflow.core.framework.types_pb2 import DataType
 
-@endsphinxdirective
+channel = grpc.insecure_channel("localhost:9000")
+prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
+
+metadata_request = get_model_metadata_pb2.GetModelMetadataRequest()
+metadata_request.model_spec.name = "my_model"
+metadata_response = prediction_service_stub.GetModelMetadata(metadata_request, 10.0)
+
+model_metadata = {}
+
+signature_def = metadata_response.metadata['signature_def']
+signature_map = get_model_metadata_pb2.SignatureDefMap()
+signature_map.ParseFromString(signature_def.value)
+model_signature = signature_map.ListFields()[0][1]['serving_default']
+
+inputs_metadata = {}
+for input_name, input_info in model_signature.inputs.items():
+    input_shape = [d.size for d in input_info.tensor_shape.dim]
+    inputs_metadata[input_name] = dict([
+        ("shape", input_shape),
+        ("dtype", DataType.Name(input_info.dtype))
+    ])
+
+outputs_metadata = {}
+for output_name, output_info in model_signature.outputs.items():
+    output_shape = [d.size for d in output_info.tensor_shape.dim]
+    outputs_metadata[output_name] = dict([
+        ("shape", output_shape),
+        ("dtype", DataType.Name(output_info.dtype))
+    ])
+
+version = metadata_response.model_spec.version.value
+model_metadata = dict([
+    ("model_version", version),
+    ("inputs", inputs_metadata),
+    ("outputs", outputs_metadata)
+])
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} sh
+curl http://localhost:8000/v1/models/my_model/metadata
+```
+:::
+::::
 
 ### Request Prediction on a Binary Input
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} ovmsclient [GRPC]
+:sync: ovmsclient-grpc
+```{code} python
+from ovmsclient import make_grpc_client
 
-.. tab-set::
+client = make_grpc_client("localhost:9000")
+with open("img.jpeg", "rb") as f:
+    data = f.read()
+inputs = {"input_name": data}    
+results = client.predict(inputs=inputs, model_name="my_model")
+```
+:::
+:::{tab-item} ovmsclient [REST]
+:sync: ovmsclient-rest
+```{code} python
+from ovmsclient import make_http_client
 
-   .. tab-item::  ovmsclient [GRPC]
-      :sync: ovmsclient-grpc
-   
-      .. code-block:: python
-                 
-         from ovmsclient import make_grpc_client
-              
-         client = make_grpc_client("localhost:9000")
-         with open("img.jpeg", "rb") as f:
-             data = f.read()
-         inputs = {"input_name": data}    
-         results = client.predict(inputs=inputs, model_name="my_model")
-   
-   .. tab-item::  ovmsclient [REST]
-      :sync: ovmsclient-rest
-   
-      .. code-block:: python
-                  
-         from ovmsclient import make_http_client
-              
-         client = make_http_client("localhost:8000")
-                 
-         with open("img.jpeg", "rb") as f:
-             data = f.read()
-         inputs = {"input_name": data}    
-         results = client.predict(inputs=inputs, model_name="my_model")
-   
-   
-   .. tab-item::  tensorflow-serving-api
-      :sync: tensorflow-serving-api 
-   
-      .. code-block:: python
-                  
-         import grpc
-         from tensorflow_serving.apis import prediction_service_pb2_grpc, predict_pb2
-         from tensorflow import make_tensor_proto, make_ndarray
-                   
-         channel = grpc.insecure_channel("localhost:9000")
-         prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
-                     
-         with open("img.jpeg", "rb") as f:
-             data = f.read()
-         predict_request = predict_pb2.PredictRequest()
-         predict_request.model_spec.name = "my_model"
-         predict_request.inputs["input_name"].CopyFrom(make_tensor_proto(data))
-         predict_response = prediction_service_stub.Predict(predict_request, 10.0)
-         results = make_ndarray(predict_response.outputs["output_name"])
-   
-   .. tab-item::  curl
-      :sync: curl   
-   
-      .. code-block:: sh  
-                 
-         curl -X POST http://localhost:8000/v1/models/my_model:predict
-         -H 'Content-Type: application/json'
-         -d '{"instances": [{"input_name": {"b64":"YXdlc29tZSBpbWFnZSBieXRlcw=="}}]}'
+client = make_http_client("localhost:8000")
 
-@endsphinxdirective
+with open("img.jpeg", "rb") as f:
+    data = f.read()
+inputs = {"input_name": data}    
+results = client.predict(inputs=inputs, model_name="my_model")
+```
+:::
+:::{tab-item} tensorflow-serving-api
+:sync: tensorflow-serving-api
+```{code} python
+import grpc
+from tensorflow_serving.apis import prediction_service_pb2_grpc, predict_pb2
+from tensorflow import make_tensor_proto, make_ndarray
+
+channel = grpc.insecure_channel("localhost:9000")
+prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
+
+with open("img.jpeg", "rb") as f:
+    data = f.read()
+predict_request = predict_pb2.PredictRequest()
+predict_request.model_spec.name = "my_model"
+predict_request.inputs["input_name"].CopyFrom(make_tensor_proto(data))
+predict_response = prediction_service_stub.Predict(predict_request, 10.0)
+results = make_ndarray(predict_response.outputs["output_name"])
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} sh
+curl -X POST http://localhost:8000/v1/models/my_model:predict
+-H 'Content-Type: application/json'
+-d '{"instances": [{"input_name": {"b64":"YXdlc29tZSBpbWFnZSBieXRlcw=="}}]}'
+```
+:::
+::::
 
 ### Request Prediction on a Numpy Array
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} ovmsclient [GRPC]
+:sync: ovmsclient-grpc
+```{code} python
+import numpy as np
+from ovmsclient import make_grpc_client
 
-.. tab-set::
+client = make_grpc_client("localhost:9000")
+data = np.array([1.0, 2.0, ..., 1000.0])
+inputs = {"input_name": data}
+results = client.predict(inputs=inputs, model_name="my_model")
+```
+:::
+:::{tab-item} ovmsclient [REST]
+:sync: ovmsclient-rest
+```{code} python
+import numpy as np
+from ovmsclient import make_http_client
 
-   .. tab-item::  ovmsclient [GRPC]
-      :sync: ovmsclient-grpc
-   
-      .. code-block:: python
-               
-         import numpy as np
-         from ovmsclient import make_grpc_client
-             
-         client = make_grpc_client("localhost:9000")
-         data = np.array([1.0, 2.0, ..., 1000.0])
-         inputs = {"input_name": data}
-         results = client.predict(inputs=inputs, model_name="my_model")
-   
-   .. tab-item::  ovmsclient [REST]
-      :sync: ovmsclient-rest
-   
-      .. code-block:: python
-               
-         import numpy as np
-         from ovmsclient import make_http_client
-               
-         client = make_http_client("localhost:8000")
-             
-         data = np.array([1.0, 2.0, ..., 1000.0])
-         inputs = {"input_name": data}
-         results = client.predict(inputs=inputs, model_name="my_model")
-   
-   .. tab-item::  tensorflow-serving-api  
-      :sync: tensorflow-serving-api 
-   
-      .. code-block:: python
-          
-         import grpc
-         from tensorflow_serving.apis import prediction_service_pb2_grpc, predict_pb2
-         from tensorflow import make_tensor_proto
-              
-         channel = grpc.insecure_channel("localhost:9000")
-         prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
-                     
-         data = np.array([1.0, 2.0, ..., 1000.0])
-         predict_request = predict_pb2.PredictRequest()
-         predict_request.model_spec.name = "my_model"
-         predict_request.inputs["input_name"].CopyFrom(make_tensor_proto(data))
-         predict_response = prediction_service_stub.Predict(predict_request, 10.0)
-         results = make_ndarray(predict_response.outputs["output_name"])
-   
-   .. tab-item::  curl
-      :sync: curl 
-   
-      .. code-block:: sh  
-                     
-         curl -X POST http://localhost:8000/v1/models/my_model:predict
-         -H 'Content-Type: application/json'
-         -d '{"instances": [{"input_name": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}]}'
+client = make_http_client("localhost:8000")
 
-@endsphinxdirective
+data = np.array([1.0, 2.0, ..., 1000.0])
+inputs = {"input_name": data}
+results = client.predict(inputs=inputs, model_name="my_model")
+```
+:::
+:::{tab-item} tensorflow-serving-api
+:sync: tensorflow-serving-api
+```{code} python
+import grpc
+from tensorflow_serving.apis import prediction_service_pb2_grpc, predict_pb2
+from tensorflow import make_tensor_proto
+
+channel = grpc.insecure_channel("localhost:9000")
+prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
+
+data = np.array([1.0, 2.0, ..., 1000.0])
+predict_request = predict_pb2.PredictRequest()
+predict_request.model_spec.name = "my_model"
+predict_request.inputs["input_name"].CopyFrom(make_tensor_proto(data))
+predict_response = prediction_service_stub.Predict(predict_request, 10.0)
+results = make_ndarray(predict_response.outputs["output_name"])
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} sh
+curl -X POST http://localhost:8000/v1/models/my_model:predict
+-H 'Content-Type: application/json'
+-d '{"instances": [{"input_name": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}]}'
+```
+:::
+::::
 
 ### Request Prediction on a string
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} ovmsclient [GRPC]
+:sync: ovmsclient-grpc
+```{code} python
+from ovmsclient import make_grpc_client
 
-.. tab-set::
+client = make_grpc_client("localhost:9000")
+data = ["<string>"]
+inputs = {"input_name": data}
+results = client.predict(inputs=inputs, model_name="my_model")
+```
+:::
+:::{tab-item} ovmsclient [REST]
+:sync: ovmsclient-rest
+```{code} python
+from ovmsclient import make_http_client
 
-   .. tab-item::  ovmsclient [GRPC]
-      :sync: ovmsclient-grpc
-   
-      .. code-block:: python
-               
-         from ovmsclient import make_grpc_client
-                
-         client = make_grpc_client("localhost:9000")
-         data = ["<string>"]
-         inputs = {"input_name": data}
-         results = client.predict(inputs=inputs, model_name="my_model")
-   
-   .. tab-item::  ovmsclient [REST]
-      :sync: ovmsclient-rest
-   
-      .. code-block:: python
-             
-         from ovmsclient import make_http_client
-               
-         client = make_http_client("localhost:8000")
-               
-         data = ["<string>"]
-         inputs = {"input_name": data}
-         results = client.predict(inputs=inputs, model_name="my_model")
-   
-   .. tab-item::  tensorflow-serving-api  
-      :sync: tensorflow-serving-api 
-   
-      .. code-block:: python
-                   
-         import grpc
-         from tensorflow_serving.apis import prediction_service_pb2_grpc, predict_pb2
-         from tensorflow import make_tensor_proto
-              
-         channel = grpc.insecure_channel("localhost:9000")
-         prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
-               
-         data = ["<string>"]
-         predict_request = predict_pb2.PredictRequest()
-         predict_request.model_spec.name = "my_model"
-         predict_request.inputs["input_name"].CopyFrom(make_tensor_proto(data))
-         predict_response = prediction_service_stub.Predict(predict_request, 1)
-         results = predict_response.outputs["output_name"]
-   
-   .. tab-item::  curl
-      :sync: curl
-   
-      .. code-block:: sh  
-                 
-         curl -X POST http://localhost:8000/v1/models/my_model:predict
-         -H 'Content-Type: application/json'
-         -d '{"instances": [{"input_name": "<string>"}]}'
-   
-@endsphinxdirective
+client = make_http_client("localhost:8000")
+
+data = ["<string>"]
+inputs = {"input_name": data}
+results = client.predict(inputs=inputs, model_name="my_model")
+```
+:::
+:::{tab-item} tensorflow-serving-api
+:sync: tensorflow-serving-api
+```{code} python
+import grpc
+from tensorflow_serving.apis import prediction_service_pb2_grpc, predict_pb2
+from tensorflow import make_tensor_proto
+
+channel = grpc.insecure_channel("localhost:9000")
+prediction_service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
+
+data = ["<string>"]
+predict_request = predict_pb2.PredictRequest()
+predict_request.model_spec.name = "my_model"
+predict_request.inputs["input_name"].CopyFrom(make_tensor_proto(data))
+predict_response = prediction_service_stub.Predict(predict_request, 1)
+results = predict_response.outputs["output_name"]
+```
+:::
+:::{tab-item} curl
+:sync: curl
+```{code} sh
+curl -X POST http://localhost:8000/v1/models/my_model:predict
+-H 'Content-Type: application/json'
+-d '{"instances": [{"input_name": "<string>"}]}'
+```
+:::
+::::
+
 
 For complete usage examples see [ovmsclient samples](https://github.com/openvinotoolkit/model_server/tree/main/client/python/ovmsclient/samples).
 
-@sphinxdirective
-
-.. raw:: html
-
-   <a name='-cpp-go-clients' id='-cpp-go-clients'/>
-
-`C++ and Go Clients`_
-=====================
-
-@endsphinxdirective
+## C++ and Go Clients
 
 Creating a client application in C++ or [Go](https://go.dev/) follows the same principles as Python, but using them adds some complexity. There is no package or library available for them with convenient functions to interact with OpenVINO Model Server.
 

--- a/docs/dag_scheduler.md
+++ b/docs/dag_scheduler.md
@@ -1,16 +1,14 @@
 # Directed Acyclic Graph (DAG) Scheduler {#ovms_docs_dag}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_demultiplexing
-   ovms_docs_custom_node_development
-
-
-@endsphinxdirective
+ovms_docs_demultiplexing
+ovms_docs_custom_node_development
+```
 
 ## Introduction
 The Directed Acyclic Graph (DAG) Scheduler makes it possible to create a pipeline of models for execution in a single client request. 

--- a/docs/deploying_server.md
+++ b/docs/deploying_server.md
@@ -76,92 +76,86 @@ If everything is set up correctly, you will see 'zebra' prediction in the output
 It is possible to deploy Model Server outside of container.
 To deploy Model Server on baremetal, use pre-compiled binaries for Ubuntu20, Ubuntu22 or RHEL8.
 
-@sphinxdirective
+::::{tab-set}
+:::{tab-item} Ubuntu 20.04
+:sync: ubuntu-20-04
+Download precomiled package:
 
-.. tab-set::
+```{code} sh
+wget https://github.com/openvinotoolkit/model_server/releases/download/v2023.1/ovms_ubuntu20.tar.gz
+```
 
-   .. tab-item::  Ubuntu 20.04  
-      :sync: ubuntu-20-04
-   
-      Download precompiled package:
-      
-      .. code-block:: sh
-   
-         wget https://github.com/openvinotoolkit/model_server/releases/download/v2023.2/ovms_ubuntu20.tar.gz
-      
-      or build it yourself:
-      
-      .. code-block:: sh
-   
-         # Clone the model server repository
-         git clone https://github.com/openvinotoolkit/model_server
-         cd model_server
-         # Build docker images (the binary is one of the artifacts)
-         make docker_build
-         # Unpack the package
-         tar -xzvf dist/ubuntu/ovms.tar.gz
-   
-      Install required libraries:
-   
-      .. code-block:: sh
-   
-         sudo apt update -y && apt install -y libpugixml1v5 libtbb2
-   
-   .. tab-item::  Ubuntu 22.04  
-      :sync: ubuntu-22-04
-   
-      Download precompiled package:
-      
-      .. code-block:: sh
-   
-         wget https://github.com/openvinotoolkit/model_server/releases/download/v2023.2/ovms_ubuntu22.tar.gz
-      
-      or build it yourself:
-      
-      .. code-block:: sh
-   
-         # Clone the model server repository
-         git clone https://github.com/openvinotoolkit/model_server
-         cd model_server
-         # Build docker images (the binary is one of the artifacts)
-         make docker_build BASE_OS_TAG_UBUNTU=22.04
-         # Unpack the package
-         tar -xzvf dist/ubuntu/ovms.tar.gz
-   
-      Install required libraries:
-   
-      .. code-block:: sh
-   
-         sudo apt update -y && apt install -y libpugixml1v5
-   
-   .. tab-item::  RHEL 8.8
-      :sync: rhel-8-8
-   
-      Download precompiled package:
-      
-      .. code-block:: sh
-   
-         wget https://github.com/openvinotoolkit/model_server/releases/download/v2023.2/ovms_redhat.tar.gz
-      
-      or build it yourself:
-   
-      .. code-block:: sh  
-   
-         # Clone the model server repository
-         git clone https://github.com/openvinotoolkit/model_server
-         cd model_server
-         # Build docker images (the binary is one of the artifacts)
-         make docker_build BASE_OS=redhat
-         # Unpack the package
-         tar -xzvf dist/redhat/ovms.tar.gz
-   
-      Install required libraries:
-   
-      .. code-block:: sh
-   
-         sudo dnf install -y pkg-config && sudo rpm -ivh https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm
+or build it yourself:
 
-@endsphinxdirective
+```{code} sh
+# Clone the model server repository
+git clone https://github.com/openvinotoolkit/model_server
+cd model_server
+# Build docker images (the binary is one of the artifacts)
+make docker_build
+# Unpack the package
+tar -xzvf dist/ubuntu/ovms.tar.gz
+```
+
+Install required libraries:
+
+```{code} sh
+sudo apt update -y && apt install -y libpugixml1v5 libtbb2
+```
+:::
+:::{tab-item} Ubuntu 22.04
+:sync: ubuntu-22-04
+Download precomiled package:
+
+```{code} sh
+wget https://github.com/openvinotoolkit/model_server/releases/download/v2023.1/ovms_ubuntu22.tar.gz
+```
+
+or build it yourself:
+
+```{code} sh
+# Clone the model server repository
+git clone https://github.com/openvinotoolkit/model_server
+cd model_server
+# Build docker images (the binary is one of the artifacts)
+make docker_build BASE_OS_TAG_UBUNTU=22.04
+# Unpack the package
+tar -xzvf dist/ubuntu/ovms.tar.gz
+```
+
+Install required libraries:
+
+```{code} sh
+sudo apt update -y && apt install -y libpugixml1v5
+```
+:::
+:::{tab-item} RHEL 8.7
+:sync: rhel-8-7
+Download precomiled package:
+
+```{code} sh
+wget https://github.com/openvinotoolkit/model_server/releases/download/v2023.1/ovms_redhat.tar.gz
+```
+
+or build it yourself:
+
+```{code} sh
+# Clone the model server repository
+git clone https://github.com/openvinotoolkit/model_server
+cd model_server
+# Build docker images (the binary is one of the artifacts)
+make docker_build BASE_OS=redhat
+# Unpack the package
+tar -xzvf dist/redhat/ovms.tar.gz
+```
+
+Install required libraries:
+
+```{code} sh
+sudo dnf install -y pkg-config && sudo rpm -ivh https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm
+```
+:::
+::::
 
 Start the server:
 

--- a/docs/dynamic_input.md
+++ b/docs/dynamic_input.md
@@ -1,20 +1,18 @@
 # Dynamic Input Parameters {#ovms_docs_dynamic_input}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_dynamic_bs_demultiplexer
-   ovms_docs_dynamic_bs_auto_reload
-   ovms_docs_dynamic_shape_auto_reload
-   ovms_docs_dynamic_shape_custom_node
-   ovms_docs_dynamic_shape_binary_inputs
-   ovms_docs_dynamic_shape_dynamic_model
-
-
-@endsphinxdirective
+ovms_docs_dynamic_bs_demultiplexer
+ovms_docs_dynamic_bs_auto_reload
+ovms_docs_dynamic_shape_auto_reload
+ovms_docs_dynamic_shape_custom_node
+ovms_docs_dynamic_shape_binary_inputs
+ovms_docs_dynamic_shape_dynamic_model
+```
 
 Models served by the OpenVINO Model Server can be configured to accept data with different batch sizes and in different shapes.
 There are multiple ways of enabling dynamic inputs for the model:

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,26 +1,25 @@
 # Model Server Features {#ovms_docs_features}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_dag
-   ovms_docs_mediapipe
-   ovms_docs_streaming_endpoints
-   ovms_docs_stateful_models
-   ovms_docs_binary_input
-   ovms_docs_text
-   ovms_docs_shape_batch_layout
-   ovms_docs_dynamic_input
-   ovms_docs_online_config_changes
-   ovms_docs_model_version_policy
-   ovms_docs_metrics
-   ovms_docs_c_api
-   ovms_docs_advanced
-
-@endsphinxdirective
+ovms_docs_dag
+ovms_docs_mediapipe
+ovms_docs_streaming_endpoints
+ovms_docs_stateful_models
+ovms_docs_binary_input
+ovms_docs_text
+ovms_docs_shape_batch_layout
+ovms_docs_dynamic_input
+ovms_docs_online_config_changes
+ovms_docs_model_version_policy
+ovms_docs_metrics
+ovms_docs_c_api
+ovms_docs_advanced
+```
 
 ## Serving Pipelines of Models
 Connect multiple models in a pipeline and reduce data transfer overhead with Directed Acyclic Graph (DAG) Scheduler. 

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,22 +1,21 @@
 # OpenVINO&trade; Model Server {#ovms_what_is_openvino_model_server}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_quick_start_guide
-   ovms_docs_models_repository
-   ovms_docs_deploying_server
-   ovms_docs_serving_model
-   ovms_docs_server_app
-   ovms_docs_features
-   ovms_docs_performance_tuning
-   ovms_docs_demos
-   ovms_docs_troubleshooting
-
-@endsphinxdirective
+ovms_docs_quick_start_guide
+ovms_docs_models_repository
+ovms_docs_deploying_server
+ovms_docs_serving_model
+ovms_docs_server_app
+ovms_docs_features
+ovms_docs_performance_tuning
+ovms_docs_demos
+ovms_docs_troubleshooting
+```
 
 Model Server hosts models and makes them accessible to software components over standard network protocols: a client sends a request to the model server, which performs model inference and sends a response back to the client. Model Server offers many advantages for efficient model deployment: 
 - Remote inference enables using lightweight clients with only the necessary functions to perform API calls to edge or cloud deployments.

--- a/docs/mediapipe.md
+++ b/docs/mediapipe.md
@@ -1,12 +1,11 @@
 # Integration with mediapipe {#ovms_docs_mediapipe}
 
-@sphinxdirective
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-@endsphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
+```
 
 ## Introduction
 MediaPipe is an open-source framework for building pipelines to perform inference over arbitrary sensory data. Using MediaPipe in the OpenVINO Model Server enables user to define a powerful graph from a lot of ready calculators/nodes that come with the MediaPipe which support all the needed features for running a stable graph like e.g. flow limiter node. User can also run the graph in a server or run it inside application host. Here can be found more information about [MediaPipe framework ](https://developers.google.com/mediapipe/framework/framework_concepts/overview)

--- a/docs/model_cache.md
+++ b/docs/model_cache.md
@@ -51,13 +51,10 @@ $ curl --create-dirs https://storage.openvinotoolkit.org/repositories/open_model
 
 ### Starting the service
 
-@sphinxdirective
-.. code-block:: sh
-
-    $ mkdir cache
-    $ docker run -p 9000:9000 -d -u $(id -u):$(id -g) --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -v ${PWD}/model/fdsample:/model:ro -v ${PWD}/cache:/opt/cache:rw openvino/model_server:latest-gpu --model_name model --model_path /model --target_device GPU --port 9000
-
-@endsphinxdirective
+```{code} sh
+$ mkdir cache
+$ docker run -p 9000:9000 -d -u $(id -u):$(id -g) --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -v ${PWD}/model/fdsample:/model:ro -v ${PWD}/cache:/opt/cache:rw openvino/model_server:latest-gpu --model_name model --model_path /model --target_device GPU --port 9000
+```
 
 Expected message in the logs `Model cache is enabled: /opt/cache`.
 

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -25,25 +25,22 @@ To enable Performance Hints for your application, use the following command:
 
 CPU
 
-   ```bash
-         docker run --rm -d -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest \
-               --model_path /opt/model --model_name resnet --port 9001 \
-               --plugin_config '{"PERFORMANCE_HINT": "THROUGHPUT"}' \
-               --target_device CPU
-   ```
+```bash
+docker run --rm -d -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest \
+      --model_path /opt/model --model_name resnet --port 9001 \
+      --plugin_config '{"PERFORMANCE_HINT": "THROUGHPUT"}' \
+      --target_device CPU
+```
 
 GPU
 
-@sphinxdirective
-.. code-block:: sh
-
-         docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
-               -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
-               --model_path /opt/model --model_name resnet --port 9001 \
-               --plugin_config '{"PERFORMANCE_HINT": "THROUGHPUT"}' \
-               --target_device GPU
-
-@endsphinxdirective
+```bash
+docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
+      -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
+      --model_path /opt/model --model_name resnet --port 9001 \
+      --plugin_config '{"PERFORMANCE_HINT": "THROUGHPUT"}' \
+      --target_device GPU
+```
 
 #### LATENCY
 This mode prioritizes low latency, providing short response time for each inference job. It performs best for tasks where inference is required for a single input image, like a medical analysis of an ultrasound scan image. It also fits the tasks of real-time or nearly real-time applications, such as an industrial robot's response to actions in its environment or obstacle avoidance for autonomous vehicles.
@@ -53,22 +50,22 @@ To enable Performance Hints for your application, use the following command:
 
 CPU
 
-   ```bash
-         docker run --rm -d -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest \
-               --model_path /opt/model --model_name resnet --port 9001 \
-               --plugin_config '{"PERFORMANCE_HINT": "LATENCY"}' \
-               --target_device CPU
-   ```
+```bash
+docker run --rm -d -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest \
+      --model_path /opt/model --model_name resnet --port 9001 \
+      --plugin_config '{"PERFORMANCE_HINT": "LATENCY"}' \
+      --target_device CPU
+```
 
 GPU
    
-   ```bash
-         docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
-               -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
-               --model_path /opt/model --model_name resnet --port 9001 \
-               --plugin_config '{"PERFORMANCE_HINT": "LATENCY"}' \
-               --target_device GPU
-   ```
+```bash
+docker run --rm -d --device=/dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
+      -v ${PWD}/models/public/resnet-50-tf:/opt/model -p 9001:9001 openvino/model_server:latest-gpu \
+      --model_path /opt/model --model_name resnet --port 9001 \
+      --plugin_config '{"PERFORMANCE_HINT": "LATENCY"}' \
+      --target_device GPU
+```
 
 > **NOTE**: NUM_STREAMS and PERFORMANCE_HINT should not be used together.
 

--- a/docs/starting_server.md
+++ b/docs/starting_server.md
@@ -1,17 +1,16 @@
 # Starting Model Server {#ovms_docs_serving_model}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_parameters
-   ovms_docs_target_devices
-   ovms_docs_cloud_storage
-   ovms_docs_security
-
-@endsphinxdirective
+ovms_docs_parameters
+ovms_docs_target_devices
+ovms_docs_cloud_storage
+ovms_docs_security
+```
 
 Serving a single model is the simplest way to deploy OpenVINO™ Model Server. Only one model is served and the whole configuration is passed via CLI parameters.
 Note that changing configuration in runtime while serving a single model is not possible. Serving multiple models requires a configuration file that stores settings for all served models. 
@@ -41,34 +40,25 @@ docker run -d --rm -v ${PWD}/models:/models -p 9000:9000 -p 8000:8000 openvino/m
 
 The required Model Server parameters are listed below. For additional configuration options, see the [Model Server Parameters](parameters.md) section.
 
-@sphinxdirective
+| option                         | description                                                            |
+|--------------------------------|------------------------------------------------------------------------|
+| `--rm`                         | remove the container when exiting the Docker container                 |
+| `-d`                           | runs the container in the background                                   |
+| `-v`                           | defines how to mount the model folder in the Docker container          |
+| `-p`                           | exposes the model serving port outside the Docker container            |
+| `openvino/model_server:latest` | represents the image name; the ovms binary is the Docker entry point   |
+| `--model_path`                 | model location                                                         |
+| `--model_name`                 | the name of the model in the model_path                                |
+| `--port`                       | the gRPC server port                                                   |
+| `--rest_port`                  | the REST server port                                                   |
 
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `--rm`                         | | remove the container when exiting the Docker container                                                                        |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `-d`                           | | runs the container in the background                                                                                          |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `-v`                           | | defines how to mount the model folder in the Docker container                                                                 |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `-p`                           | | exposes the model serving port outside the Docker container                                                                   |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `openvino/model_server:latest` | | represents the image name; the ovms binary is the Docker entry point                                                          |
-|                                | | varies by tag and build process - see tags: https://hub.docker.com/r/openvino/model_server/tags/ for a full tag list.         |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `--model_path`                 | | model location, which can be:                                                                                                 |
-|                                | | a Docker container path that is mounted during start-up                                                                       |
-|                                | | a Google Cloud Storage path `gs://<bucket>/<model_path>`                                                                      |
-|                                | | an AWS S3 path `s3://<bucket>/<model_path>`                                                                                   |
-|                                | | an Azure blob path `az://<container>/<model_path>`                                                                            |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `--model_name`                 | | the name of the model in the model_path                                                                                       |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `--port`                       | | the gRPC server port                                                                                                          |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| `--rest_port`                  | | the REST server port                                                                                                          |
-+--------------------------------+---------------------------------------------------------------------------------------------------------------------------------+
+Possible model locations (`--model_path`):
+* Docker container path that is mounted during start-up
+* Google Cloud Storage path `gs://<bucket>/<model_path>`
+* AWS S3 path `s3://<bucket>/<model_path>`   
+* Azure blob path `az://<container>/<model_path>`
 
-@endsphinxdirective
+`openvino/model_server:latest` varies by tag and build process - see tags: https://hub.docker.com/r/openvino/model_server/tags/ for a full tag list.
 
 - Expose the container ports to **open ports** on your host or virtual machine. 
 - In the command above, port 9000 is exposed for gRPC and port 8000 is exposed for REST API calls.

--- a/docs/using_cloud_storage.md
+++ b/docs/using_cloud_storage.md
@@ -4,20 +4,7 @@
 
 OpenVINO Model Server supports a range of cloud storage options. In general, "read" and "list" permissions are required for a model repository.
 
-@sphinxdirective
-
--  `Azure Cloud Storage <#-azure>`__
--  `Google Cloud Storage <#-gcs>`__
--  `Amazon S3 and MinIO Storage <#-s3>`__
-
-.. raw:: html
-
-   <a name='-azure' id='-azure'/>
-
-`Azure Cloud Storage`_
-======================
-
-@endsphinxdirective
+### Azure Cloud Storage
 
 Add the Azure Storage path as the model_path and pass the Azure Storage credentials to the Docker container.
 
@@ -48,16 +35,7 @@ Add `-e "http_proxy=$http_proxy" -e "https_proxy=$https_proxy"` to docker run co
 
 By default, the `https_proxy` variable will be used. If you want to use `http_proxy` please set the `AZURE_STORAGE_USE_HTTP_PROXY` environment variable to any value and pass it to the container.
 
-@sphinxdirective
-
-.. raw:: html
-
-   <a name='-gcs' id='-gcs'/>
-
-`Google Cloud Storage`_
-=======================
-
-@endsphinxdirective
+### Google Cloud Storage
 
 Add the Google Cloud Storage path as the model_path and pass the Google Cloud Storage credentials to the Docker container.
 Exception: This is not required if you use GKE Kubernetes cluster. GKE Kubernetes clusters handle authorization.
@@ -73,16 +51,7 @@ openvino/model_server:latest \
 --model_path gs://bucket/model_path --model_name gs_model --port 9001
 ```
 
-@sphinxdirective
-
-.. raw:: html
-
-   <a name='-s3' id='-s3'/>
-
-`Amazon S3 and MinIO Storage`_
-==============================
-
-@endsphinxdirective
+### Amazon S3 and MinIO Storage
 
 Add the S3 path as the model_path and pass the credentials as environment variables to the Docker container.
 `S3_ENDPOINT` is optional for Amazon S3 storage and mandatory for MinIO and other S3-compatible storage types.

--- a/docs/writing_app.md
+++ b/docs/writing_app.md
@@ -1,15 +1,14 @@
 # Writing a Client Application {#ovms_docs_server_app}
 
-@sphinxdirective
+```{toctree}
+---
+maxdepth: 1
+hidden:
+---
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   ovms_docs_clients
-   ovms_docs_server_api
-
-@endsphinxdirective
+ovms_docs_clients
+ovms_docs_server_api
+```
 
 OpenVINO&trade; Model Server exposes two sets of APIs: one compatible with TensorFlow Serving and another one, with KServe API, for inference. Both APIs work on gRPC and REST interfaces. Supporting two sets of APIs makes OpenVINO Model Server easier to plug into existing systems the already leverage one of these APIs for inference. Learn more about supported APIs:
 


### PR DESCRIPTION
Rework of articles used in OV docs generation in order to match https://mystmd.org/ conventions and work with [myst-parser](https://myst-parser.readthedocs.io/en/latest/) sphinx extension.

Related to https://github.com/openvinotoolkit/openvino/pull/21239