### PR TITLE
Fix azure patch

### DIFF
--- a/third_party/azure/azure_sdk.patch
+++ b/third_party/azure/azure_sdk.patch
@@ -38,7 +38,7 @@ index d775d23..850046e 100644
  add_library(${AZURESTORAGE_LIBRARY} ${SOURCES})
  
 -target_link_libraries(${AZURESTORAGE_LIBRARIES})
-+target_link_libraries(${AZURESTORAGE_LIBRARY} PRIVATE "-Wl,--exclude-libs,ALL")
++target_link_libraries(${AZURESTORAGE_LIBRARIES} PRIVATE "-Wl,--exclude-libs,ALL")
  
  if(WIN32)
    target_link_libraries(${AZURESTORAGE_LIBRARY} Ws2_32.lib rpcrt4.lib xmllite.lib bcrypt.lib)

--- a/third_party/azure/azure_sdk.patch
+++ b/third_party/azure/azure_sdk.patch
@@ -38,7 +38,7 @@ index d775d23..850046e 100644
  add_library(${AZURESTORAGE_LIBRARY} ${SOURCES})
  
 -target_link_libraries(${AZURESTORAGE_LIBRARIES})
-+target_link_libraries(${AZURESTORAGE_LIBRARIES} PRIVATE "-Wl,--exclude-libs,ALL")
++target_link_libraries(${AZURESTORAGE_LIBRARIES} "-Wl,--exclude-libs,ALL")
  
  if(WIN32)
    target_link_libraries(${AZURESTORAGE_LIBRARY} Ws2_32.lib rpcrt4.lib xmllite.lib bcrypt.lib)


### PR DESCRIPTION
Added back the boost static libs that are linked in libazurestorage.so
All symbols are required during python import in mediapipe python solutions.
Previously we were adding the symbols to ovms binary not to libazurestorage.so because we had conflicts in different versions of boost. Tested azfs models loading in additional tests.