### PR TITLE
Mediapipe gRPC streaming deserialization

### DIFF
--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 #
 # Copyright 2022 Intel Corporation
 #
@@ -35,38 +35,37 @@ echo "Number of warnings in tests about not using forward delares:" ${NO_WARNING
 echo "Number of warnings in tests about not direct includes:" ${NO_WARNINGS_TEST_DIRECT}
 echo "Number of warnings in tests about not used: " ${NO_WARNINGS_TEST_NOTUSED}
 
-trap "cat ${CPPCLEAN_RESULTS_FILE_SRC}" err exit
+errors=""
 if [ ${NO_WARNINGS_FORWARD} -gt 7 ]; then
-    echo "Failed due to not using forward declarations where possible: ${NO_WARNINGS_FORWARD}";
-    exit 1;
+    errors+="Failed due to not using forward declarations where possible: ${NO_WARNINGS_FORWARD}"$'\n'
 fi
-if [ ${NO_WARNINGS_DIRECT} -gt 19 ]; then
-    echo "Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_DIRECT}";
-    exit 1;
+if [ ${NO_WARNINGS_DIRECT} -gt 18 ]; then
+    errors+="Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_DIRECT}"$'\n'
 fi
 if [ ${NO_WARNINGS_NOTUSED} -gt 4 ]; then
-    echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_NOTUSED}";
-    exit 1;
+    errors+="Failed probably due to unnecessary forward includes: ${NO_WARNINGS_NOTUSED}"$'\n'
 fi
 if [ ${NO_WARNINGS_TEST_FORWARD} -gt 1 ]; then
-    echo "Failed due to not using forward declarations where possible: ${NO_WARNINGS_TEST_FORWARD}";
-    exit 1;
+    errors+="Failed due to not using forward declarations where possible: ${NO_WARNINGS_TEST_FORWARD}"$'\n'
 fi
 if [ ${NO_WARNINGS_TEST_DIRECT} -gt 15 ]; then
-    echo "Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_TEST_DIRECT}";
-    exit 1;
+    errors+="Failed probably due to not using static keyword with functions definitions: ${NO_WARNINGS_TEST_DIRECT}"$'\n'
 fi
 if [ ${NO_WARNINGS_TEST_NOTUSED} -gt 0 ]; then
-    echo "Failed probably due to unnecessary forward includes: ${NO_WARNINGS_TEST_NOTUSED}";
-    exit 1;
+    errors+="Failed probably due to unnecessary forward includes: ${NO_WARNINGS_TEST_NOTUSED}"$'\n'
 fi
-if [ ${NO_WARNINGS} -gt  160 ]; then
-    echo "Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"
-    exit 1
+if [ ${NO_WARNINGS} -gt  156 ]; then
+    errors+="Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"$'\n'
 fi
 if [ ${NO_WARNINGS_TEST} -gt  51 ]; then
-    echo "Failed due to higher than allowed number of issues in test code: ${NO_WARNINGS_TEST}"
-    cat ${CPPCLEAN_RESULTS_FILE_TEST}
-    exit 1
+    errors+="Failed due to higher than allowed number of issues in test code: ${NO_WARNINGS_TEST}"$'\n'
 fi
-exit 0
+if [ -n "$errors" ]; then
+    cat ${CPPCLEAN_RESULTS_FILE_SRC}
+    cat ${CPPCLEAN_RESULTS_FILE_TEST}
+    echo "$errors"
+    echo "Compare results with clean main branch to narrow down where the issues lie"
+    exit 1
+else
+    exit 0
+fi

--- a/external/tf.patch
+++ b/external/tf.patch
@@ -47,10 +47,10 @@ index 3542c8ae3e8..ea7b8e4db8f 100644
  
 diff --git a/tensorflow/tsl/platform/default/log_macros.h b/tensorflow/tsl/platform/default/log_macros.h
 new file mode 100644
-index 00000000000..31ba58594cc
+index 00000000000..05dba0a2f7a
 --- /dev/null
 +++ b/tensorflow/tsl/platform/default/log_macros.h
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,101 @@
 +#pragma once
 +#define LOG(severity) _TF_LOG_##severity
 +
@@ -87,7 +87,9 @@ index 00000000000..31ba58594cc
 +// `DVLOG` behaves like `VLOG` in debug mode (i.e. `#ifndef NDEBUG`).
 +// Otherwise, it compiles away and does nothing.
 +#ifndef NDEBUG
++#ifndef DVLOG
 +#define DVLOG VLOG
++#endif
 +#else
 +#ifndef DVLOG
 +#define DVLOG(verbose_level) \

--- a/src/grpc_utils.cpp
+++ b/src/grpc_utils.cpp
@@ -77,6 +77,7 @@ const grpc::Status grpc(const Status& status) {
         // Predict request validation
         {StatusCode::INVALID_NO_OF_INPUTS, grpc::StatusCode::INVALID_ARGUMENT},
         {StatusCode::INVALID_MISSING_INPUT, grpc::StatusCode::INVALID_ARGUMENT},
+        {StatusCode::INVALID_UNEXPECTED_INPUT, grpc::StatusCode::INVALID_ARGUMENT},
         {StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS, grpc::StatusCode::INVALID_ARGUMENT},
         {StatusCode::INVALID_BATCH_SIZE, grpc::StatusCode::INVALID_ARGUMENT},
         {StatusCode::INVALID_SHAPE, grpc::StatusCode::INVALID_ARGUMENT},

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -110,6 +110,7 @@ static const net_http::HTTPStatusCode http(const ovms::Status& status) {
         // Predict request validation
         {StatusCode::INVALID_NO_OF_INPUTS, net_http::HTTPStatusCode::BAD_REQUEST},
         {StatusCode::INVALID_MISSING_INPUT, net_http::HTTPStatusCode::BAD_REQUEST},
+        {StatusCode::INVALID_UNEXPECTED_INPUT, net_http::HTTPStatusCode::BAD_REQUEST},
         {StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS, net_http::HTTPStatusCode::BAD_REQUEST},
         {StatusCode::INVALID_BATCH_SIZE, net_http::HTTPStatusCode::BAD_REQUEST},
         {StatusCode::INVALID_SHAPE, net_http::HTTPStatusCode::BAD_REQUEST},

--- a/src/mediapipe_internal/mediapipegraphexecutor.cpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.cpp
@@ -697,7 +697,7 @@ public:
 template <typename T>
 class HolderWithNoRequestOwnership : public ::mediapipe::packet_internal::Holder<T> {
 public:
-    explicit HolderWithNoRequestOwnership(const T* barePtr, const std::shared_ptr<const ::inference::ModelInferRequest>& req) :
+    explicit HolderWithNoRequestOwnership(const T* barePtr, const std::shared_ptr<const KFSRequest>& req) :
         ::mediapipe::packet_internal::Holder<T>(barePtr) {}
 };
 template <>
@@ -735,7 +735,7 @@ static Status createPacketAndPushIntoGraph(const std::string& inputName, std::sh
 
 Status MediapipeGraphExecutor::infer(const KFSRequest* requestPtr, KFSResponse* response, ExecutionContext executionContext, ServableMetricReporter*& reporterOut) const {
     Timer<TIMER_END> timer;
-    SPDLOG_DEBUG("Start KServe request mediapipe graph: {} execution", requestPtr->model_name());
+    SPDLOG_DEBUG("Start unary KServe request mediapipe graph: {} execution", requestPtr->model_name());
     ::mediapipe::CalculatorGraph graph;
     auto absStatus = graph.Initialize(this->config);
     if (!absStatus.ok()) {
@@ -916,6 +916,7 @@ Status MediapipeGraphExecutor::partialDeserialize(std::shared_ptr<const KFSReque
 
 Status MediapipeGraphExecutor::inferStream(const KFSRequest& firstRequest, ::grpc::ServerReaderWriterInterface<::inference::ModelStreamInferResponse, KFSRequest>& stream) {
     const std::string& servableName = firstRequest.model_name();  // TODO: Validate subsequent requests to match first servable name
+    SPDLOG_DEBUG("Start streaming KServe request mediapipe graph: {} execution", servableName);
     try {
         // Init
         ::mediapipe::CalculatorGraph graph;

--- a/src/mediapipe_internal/mediapipegraphexecutor.cpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.cpp
@@ -693,7 +693,7 @@ class HolderWithNoRequestOwnership : public ::mediapipe::packet_internal::Holder
 public:
     explicit HolderWithNoRequestOwnership(const T* barePtr, const std::shared_ptr<const ::inference::ModelInferRequest>& req) :
     //HolderWithNoRequestOwnership(const T* barePtr, const std::shared_ptr<const KFSRequest>& req) :
-        ::mediapipe::packet_internal::Holder<T>(barePtr) { SPDLOG_ERROR("ER"); }
+        ::mediapipe::packet_internal::Holder<T>(barePtr) {}
 };
 template <>
 class HolderWithNoRequestOwnership<const KFSRequest*> : public ::mediapipe::packet_internal::ForeignHolder<const KFSRequest*> {
@@ -702,7 +702,7 @@ public:
     //explicit HolderWithRequestOwnership(const T* barePtr, const std::shared_ptr<const ::inference::ModelInferRequest>& req) :
 // TODO work with barePtr
     HolderWithNoRequestOwnership(const KFSRequest* barePtr, const std::shared_ptr<const KFSRequest>& req) :
-        ::mediapipe::packet_internal::ForeignHolder<const KFSRequest*>(&hiddenPtr), hiddenPtr(barePtr) { SPDLOG_ERROR("ER"); }
+        ::mediapipe::packet_internal::ForeignHolder<const KFSRequest*>(&hiddenPtr), hiddenPtr(barePtr) {}
 };
 
 template <template<typename X> typename Holder>
@@ -775,7 +775,7 @@ Status MediapipeGraphExecutor::infer(const KFSRequest* requestPtr, KFSResponse* 
 
     ovms::Status status;
     size_t insertedStreamPackets = 0;
-    std::shared_ptr<const KFSRequest> request(requestPtr, [](const KFSRequest* r){ SPDLOG_ERROR("ERper"); return;});  // here we don't actually own nor delete the request
+    std::shared_ptr<const KFSRequest> request(requestPtr, [](const KFSRequest* r){});  // here we don't actually own nor delete the request
     for (auto& inputName : this->inputNames) {
         status = selectPacketType<HolderWithNoRequestOwnership>(inputName, request, graph, this->currentStreamTimestamp, this->inputTypes);
         if (!status.ok()) {

--- a/src/mediapipe_internal/mediapipegraphexecutor.cpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.cpp
@@ -891,7 +891,7 @@ Status MediapipeGraphExecutor::deserializeTimestamp(const KFSRequest& request) {
     }
     return StatusCode::OK;
 }
-// TODO write test that request contains not existing stream
+
 Status MediapipeGraphExecutor::partialDeserialize(std::shared_ptr<const KFSRequest> request, ::mediapipe::CalculatorGraph& graph) {
     auto status = deserializeTimestamp(*request);
     if (!status.ok()) {
@@ -902,7 +902,7 @@ Status MediapipeGraphExecutor::partialDeserialize(std::shared_ptr<const KFSReque
         const auto& inputName = input.name();
         if (std::find_if(this->inputNames.begin(), this->inputNames.end(), [&inputName](auto streamName) { return streamName == inputName; }) == this->inputNames.end()) {
             SPDLOG_DEBUG("Request for {}, contains not expected input name: {}", request->model_name(), inputName);
-            return Status(StatusCode::INVALID_UNEXPECTED_INPUT, std::string(inputName) + "is unexpected");
+            return Status(StatusCode::INVALID_UNEXPECTED_INPUT, std::string(inputName) + " is unexpected");
         }
         status = createPacketAndPushIntoGraph<HolderWithRequestOwnership>(inputName, request, graph, this->currentStreamTimestamp, this->inputTypes);
         if (!status.ok()) {

--- a/src/mediapipe_internal/mediapipegraphexecutor.cpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.cpp
@@ -499,7 +499,7 @@ static Status createPacketAndPushIntoGraph(const std::string& name, std::shared_
 }
 
 template <template <typename X> typename Holder>
-Status createPacketAndPushIntoGraph(const std::string& name, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph, const ::mediapipe::Timestamp& timestamp) {
+static Status createPacketAndPushIntoGraph(const std::string& name, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph, const ::mediapipe::Timestamp& timestamp) {
     if (name.empty()) {
         SPDLOG_DEBUG("Creating Mediapipe graph inputs name failed for: {}", name);
         return StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM;
@@ -519,7 +519,7 @@ Status createPacketAndPushIntoGraph(const std::string& name, std::shared_ptr<con
     return StatusCode::OK;
 }
 
-Status closeInputStream(const std::string& name, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph) {
+static Status closeInputStream(const std::string& name, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph) {
     auto absStatus = graph.CloseInputStream(name);
     if (!absStatus.ok()) {
         const std::string absMessage = absStatus.ToString();
@@ -710,7 +710,7 @@ public:
 };
 
 template <template <typename X> typename Holder>
-Status createPacketAndPushIntoGraph(const std::string& inputName, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph, const ::mediapipe::Timestamp& timestamp, const stream_types_mapping_t& inputTypes) {
+static Status createPacketAndPushIntoGraph(const std::string& inputName, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph, const ::mediapipe::Timestamp& timestamp, const stream_types_mapping_t& inputTypes) {
     auto inputPacketType = inputTypes.at(inputName);
     ovms::Status status;
     if (inputPacketType == mediapipe_packet_type_enum::KFS_REQUEST) {

--- a/src/mediapipe_internal/mediapipegraphexecutor.cpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.cpp
@@ -872,7 +872,7 @@ Status MediapipeGraphExecutor::infer(const KFSRequest* requestPtr, KFSResponse* 
         }                                                             \
     }
 
-Status MediapipeGraphExecutor::acquireTimestamp(const KFSRequest& request) {
+Status MediapipeGraphExecutor::deserializeTimestamp(const KFSRequest& request) {
     if (!request.id().empty()) {
         auto requestTimestamp = stoi64(request.id());  // TODO: Decide if deserialize from id or int parameter
         if (requestTimestamp.has_value()) {
@@ -891,11 +891,9 @@ Status MediapipeGraphExecutor::acquireTimestamp(const KFSRequest& request) {
     }
     return StatusCode::OK;
 }
-// TODO: Add support for other types CVS-122328/CVS-122329
 // TODO write test that request contains not existing stream
-// TODO create test for streaming with KFS passthrough
 Status MediapipeGraphExecutor::partialDeserialize(std::shared_ptr<const KFSRequest> request, ::mediapipe::CalculatorGraph& graph) {
-    auto status = acquireTimestamp(*request);
+    auto status = deserializeTimestamp(*request);
     if (!status.ok()) {
         return status;
     }

--- a/src/mediapipe_internal/mediapipegraphexecutor.cpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.cpp
@@ -258,49 +258,6 @@ static Status deserializeTensor(const std::string& requestedName, const KFSReque
     return StatusCode::OK;
 }
 
-static Status deserializeTensor(const std::string& requestedName, const KFSRequest& request, TfLiteTensor** outTensor, const std::unique_ptr<tflite::Interpreter>& interpreter, size_t tfLiteTensorIdx) {
-    auto requestInputItr = request.inputs().begin();
-    auto status = getRequestInput(requestInputItr, requestedName, request);
-    if (!status.ok()) {
-        return status;
-    }
-    auto inputIndex = requestInputItr - request.inputs().begin();
-    auto& bufferLocation = request.raw_input_contents().at(inputIndex);
-    try {
-        auto datatype = getPrecisionAsTfLiteDataType(KFSPrecisionToOvmsPrecision(requestInputItr->datatype()));
-        if (datatype == kTfLiteNoType) {
-            std::stringstream ss;
-            ss << "Not supported precision for Tensorflow Lite tensor deserialization: " << requestInputItr->datatype();
-            const std::string details = ss.str();
-            SPDLOG_DEBUG(details);
-            return Status(StatusCode::INVALID_PRECISION, std::move(details));
-        }
-        std::vector<int> rawShape;
-        for (int i = 0; i < requestInputItr->shape().size(); i++) {
-            if (requestInputItr->shape()[i] < 0) {
-                std::stringstream ss;
-                ss << "Negative dimension size is not acceptable: " << tensorShapeToString(requestInputItr->shape()) << "; input name: " << requestedName;
-                const std::string details = ss.str();
-                SPDLOG_DEBUG("[servable name: {} version: {}] Invalid shape - {}", request.model_name(), request.model_version(), details);
-                return Status(StatusCode::INVALID_SHAPE, details);
-            }
-            rawShape.emplace_back(requestInputItr->shape()[i]);
-        }
-        interpreter->SetTensorParametersReadWrite(
-            tfLiteTensorIdx,
-            datatype,
-            requestedName.c_str(),
-            rawShape,
-            TfLiteQuantization());
-        // we shouldn't need to allocate tensors since we use buffer from request
-        auto tensor = interpreter->tensor(tfLiteTensorIdx);
-        tensor->data.data = reinterpret_cast<void*>(const_cast<char*>((bufferLocation.data())));
-        *outTensor = tensor;
-    }
-    HANDLE_DESERIALIZATION_EXCEPTION("Tensorflow Lite tensor")
-    return StatusCode::OK;
-}
-
 static Status deserializeTensor(const std::string& requestedName, const KFSRequest& request, std::unique_ptr<ov::Tensor>& outTensor) {
     auto requestInputItr = request.inputs().begin();
     auto status = getRequestInput(requestInputItr, requestedName, request);
@@ -502,111 +459,82 @@ static std::map<std::string, mediapipe::Packet> createInputSidePackets(const KFS
     return inputSidePackets;
 }
 
-template <typename T>
-static Status createPacketAndPushIntoGraph(const std::string& name, const KFSRequest& request, ::mediapipe::CalculatorGraph& graph) {
+template <typename T, template<typename X> typename Holder>
+static Status createPacketAndPushIntoGraph(const std::string& name, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph, const ::mediapipe::Timestamp& timestamp) {
     if (name.empty()) {
         SPDLOG_DEBUG("Creating Mediapipe graph inputs name failed for: {}", name);
         return StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM;
     }
     SPDLOG_DEBUG("Tensor to deserialize:\"{}\"", name);
-    if (request.raw_input_contents().size() == 0) {
+    if (request->raw_input_contents().size() == 0) {
         const std::string details = "Invalid message structure - raw_input_content is empty";
-        SPDLOG_DEBUG("[servable name: {} version: {}] {}", request.model_name(), request.model_version(), details);
+        SPDLOG_DEBUG("[servable name: {} version: {}] {}", request->model_name(), request->model_version(), details);
         return Status(StatusCode::INVALID_MESSAGE_STRUCTURE, details);
     }
-    if (request.raw_input_contents().size() != request.inputs().size()) {
+    if (request->raw_input_contents().size() != request->inputs().size()) {
         std::stringstream ss;
-        ss << "Size of raw_input_contents: " << request.raw_input_contents().size() << " is different than number of inputs: " << request.inputs().size();
+        ss << "Size of raw_input_contents: " << request->raw_input_contents().size() << " is different than number of inputs: " << request->inputs().size();
         const std::string details = ss.str();
-        SPDLOG_DEBUG("[servable name: {} version: {}] Invalid message structure - {}", request.model_name(), request.model_version(), details);
+        SPDLOG_DEBUG("[servable name: {} version: {}] Invalid message structure - {}", request->model_name(), request->model_version(), details);
         return Status(StatusCode::INVALID_MESSAGE_STRUCTURE, details);
     }
-    std::unique_ptr<T> input_tensor;
-    auto status = deserializeTensor(name, request, input_tensor);
+    std::unique_ptr<T> inputTensor;
+    auto status = deserializeTensor(name, *request, inputTensor);
     if (!status.ok()) {
         SPDLOG_DEBUG("Failed to deserialize tensor: {}", name);
         return status;
     }
     auto absStatus = graph.AddPacketToInputStream(
-        name, ::mediapipe::Adopt<T>(input_tensor.release()).At(::mediapipe::Timestamp(STARTING_TIMESTAMP)));
+                              name,
+                              //::mediapipe::packet_internal::Create(new ::mediapipe::packet_internal::Holder<T>(inputTensor.release())
+                              ::mediapipe::packet_internal::Create(new Holder<T>(inputTensor.release(), request))
+//                              ::mediapipe::Adopt<T>(inputTensor.release())
+                              .At(timestamp));
+ /*   absStatus = graph.AddPacketToInputStream(
+                              input.name(),
+                              ::mediapipe::packet_internal::Create(
+                                  new HolderWithRequestOwnership<T>(inputTensor.release(), request))
+                                  .At(timestamp)),*/
     if (!absStatus.ok()) {
         const std::string absMessage = absStatus.ToString();
         SPDLOG_DEBUG("Failed to add stream: {} packet to mediapipe graph: {} with error: {}",
-            name, request.model_name(), absStatus.message(), absStatus.raw_code());
+            name, request->model_name(), absStatus.message(), absStatus.raw_code());
         return Status(StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM, std::move(absMessage));
-    }
-    absStatus = graph.CloseInputStream(name);
-    if (!absStatus.ok()) {
-        const std::string absMessage = absStatus.ToString();
-        SPDLOG_DEBUG("Failed to close stream: {} of mediapipe graph: {} with error: {}",
-            name, request.model_name(), absMessage);
-        return Status(StatusCode::MEDIAPIPE_GRAPH_CLOSE_INPUT_STREAM_ERROR, std::move(absMessage));
     }
     return StatusCode::OK;
 }
 
-static Status createPacketAndPushIntoGraphTfLiteTensor(const std::string& name, const KFSRequest& request, ::mediapipe::CalculatorGraph& graph, const std::unique_ptr<tflite::Interpreter>& interpreter, size_t tfLiteTensorIdx) {
-    if (name.empty()) {
-        SPDLOG_DEBUG("Creating Mediapipe graph inputs name failed for: {}", name);
-        return StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM;
-    }
-    SPDLOG_DEBUG("Tensor to deserialize:\"{}\"", name);
-    if (request.raw_input_contents().size() == 0) {
-        const std::string details = "Invalid message structure - raw_input_content is empty";
-        SPDLOG_DEBUG("[servable name: {} version: {}] {}", request.model_name(), request.model_version(), details);
-        return Status(StatusCode::INVALID_MESSAGE_STRUCTURE, details);
-    }
-    if (request.raw_input_contents().size() != request.inputs().size()) {
-        std::stringstream ss;
-        ss << "Size of raw_input_contents: " << request.raw_input_contents().size() << " is different than number of inputs: " << request.inputs().size();
-        const std::string details = ss.str();
-        SPDLOG_DEBUG("[servable name: {} version: {}] Invalid message structure - {}", request.model_name(), request.model_version(), details);
-        return Status(StatusCode::INVALID_MESSAGE_STRUCTURE, details);
-    }
-    TfLiteTensor* input_tensor = nullptr;
-    auto status = deserializeTensor(name, request, &input_tensor, interpreter, tfLiteTensorIdx);
-    if (!status.ok() || (!input_tensor)) {
-        SPDLOG_DEBUG("Failed to deserialize tensor: {}", name);
-        return status;
-    }
-    auto absStatus = graph.AddPacketToInputStream(  // potential need for fix when TfLite tensors enabled
-        name, ::mediapipe::Adopt<TfLiteTensor>(input_tensor).At(::mediapipe::Timestamp(STARTING_TIMESTAMP)));
-    if (!absStatus.ok()) {
-        const std::string absMessage = absStatus.ToString();
-        SPDLOG_DEBUG("Failed to add stream: {} packet to mediapipe graph: {} with error: {}",
-            name, request.model_name(), absStatus.message(), absStatus.raw_code());
-        return Status(StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM, std::move(absMessage));
-    }
-    absStatus = graph.CloseInputStream(name);
-    if (!absStatus.ok()) {
-        const std::string absMessage = absStatus.ToString();
-        SPDLOG_DEBUG("Failed to close stream: {} of mediapipe graph: {} with error: {}",
-            name, request.model_name(), absMessage);
-        return Status(StatusCode::MEDIAPIPE_GRAPH_CLOSE_INPUT_STREAM_ERROR, std::move(absMessage));
-    }
-    return StatusCode::OK;
-}
-
-template <>
-Status createPacketAndPushIntoGraph<KFSRequest*>(const std::string& name, const KFSRequest& request, ::mediapipe::CalculatorGraph& graph) {
+template <template<typename X> typename Holder>
+Status createPacketAndPushIntoGraph(const std::string& name, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph, const ::mediapipe::Timestamp& timestamp) {
     if (name.empty()) {
         SPDLOG_DEBUG("Creating Mediapipe graph inputs name failed for: {}", name);
         return StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM;
     }
     SPDLOG_DEBUG("Request to passthrough:\"{}\"", name);
     auto absStatus = graph.AddPacketToInputStream(
-        name, ::mediapipe::MakePacket<const KFSRequest*>(&request).At(::mediapipe::Timestamp(STARTING_TIMESTAMP)));
+        name, 
+              //::mediapipe::MakePacket<const KFSRequest*>(&request).At(timestamp));
+              ::mediapipe::packet_internal::Create(new Holder<const KFSRequest>(static_cast<const KFSRequest*>(request.get()), request)).At(timestamp));
+    /*auto absStatus = graph.AddPacketToInputStream(
+                              name,
+                              ::mediapipe::packet_internal::Create(new Holder<KFSRequest*>(inputTensor.release()))
+//                              ::mediapipe::Adopt<T>(inputTensor.release())
+                              .At(timestamp));*/
     if (!absStatus.ok()) {
         const std::string absMessage = absStatus.ToString();
         SPDLOG_DEBUG("Failed to add stream: {} packet to mediapipe graph: {} with error: {}",
-            name, request.model_name(), absStatus.message(), absStatus.raw_code());
+            name, request->model_name(), absStatus.message(), absStatus.raw_code());
         return Status(StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM, std::move(absMessage));
     }
-    absStatus = graph.CloseInputStream(name);
+    return StatusCode::OK;
+}
+
+Status closeInputStream(const std::string& name, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph) {
+    auto absStatus = graph.CloseInputStream(name);
     if (!absStatus.ok()) {
         const std::string absMessage = absStatus.ToString();
         SPDLOG_DEBUG("Failed to close stream: {} of mediapipe graph: {} with error: {}",
-            name, request.model_name(), absMessage);
+            name, request->model_name(), absMessage);
         return Status(StatusCode::MEDIAPIPE_GRAPH_CLOSE_INPUT_STREAM_ERROR, std::move(absMessage));
     }
     return StatusCode::OK;
@@ -751,14 +679,61 @@ Status receiveAndSerializePacket<mediapipe::ImageFrame>(const ::mediapipe::Packe
     HANDLE_PACKET_RECEIVAL_EXCEPTIONS();
 }
 
-Status MediapipeGraphExecutor::infer(const KFSRequest* request, KFSResponse* response, ExecutionContext executionContext, ServableMetricReporter*& reporterOut) const {
+// Two types of holders
+// One is required for streaming where it is OVMS who creates the request and we have to clean up
+template <typename T>
+class HolderWithRequestOwnership : public ::mediapipe::packet_internal::Holder<T> {
+    std::shared_ptr<const KFSRequest> req;
+
+public:
+    //explicit HolderWithRequestOwnership(const T* ptr, const std::shared_ptr<const ::inference::ModelInferRequest>& req) :
+    HolderWithRequestOwnership(const T* ptr, const std::shared_ptr<const KFSRequest>& req) :
+        ::mediapipe::packet_internal::Holder<T>(ptr),
+        req(req) {}
+};
+// Second is required for unary-unary where it is gRPC who creates the request and musn't clean up
+template <typename T>
+class HolderWithNoRequestOwnership : public ::mediapipe::packet_internal::Holder<T> {
+public:
+    //explicit HolderWithNoRequestOwnership(const T* ptr, const std::shared_ptr<const ::inference::ModelInferRequest>& req) :
+    HolderWithNoRequestOwnership(const T* ptr, const std::shared_ptr<const KFSRequest>& req) :
+        ::mediapipe::packet_internal::Holder<T>(ptr) {}
+};
+
+auto someL = [](const KFSRequest*){ return;};
+
+template <template<typename X> typename Holder>
+Status selectPacketType(const std::string& inputName, std::shared_ptr<const KFSRequest>& request, ::mediapipe::CalculatorGraph& graph, const ::mediapipe::Timestamp& timestamp, const stream_types_mapping_t& inputTypes) {
+    auto inputPacketType = inputTypes.at(inputName);
+    ovms::Status status;
+    if (inputPacketType == mediapipe_packet_type_enum::KFS_REQUEST) {
+        SPDLOG_DEBUG("Request processing KFS passthrough: {}", inputName);
+        status = createPacketAndPushIntoGraph<Holder>(inputName, request, graph, timestamp);
+    } else if (inputPacketType == mediapipe_packet_type_enum::TFTENSOR) {
+        SPDLOG_DEBUG("Request processing TF tensor: {}", inputName);
+        status = createPacketAndPushIntoGraph<tensorflow::Tensor, Holder>(inputName, request, graph, timestamp);
+    } else if (inputPacketType == mediapipe_packet_type_enum::MPTENSOR) {
+        SPDLOG_DEBUG("Request processing MP tensor: {}", inputName);
+        status = createPacketAndPushIntoGraph<mediapipe::Tensor, Holder>(inputName, request, graph, timestamp);
+    } else if (inputPacketType == mediapipe_packet_type_enum::MEDIAPIPE_IMAGE) {
+        SPDLOG_DEBUG("Request processing Mediapipe ImageFrame: {}", inputName);
+        status = createPacketAndPushIntoGraph<mediapipe::ImageFrame, Holder>(inputName, request, graph, timestamp);
+    } else if ((inputPacketType == mediapipe_packet_type_enum::OVTENSOR) ||
+               (inputPacketType == mediapipe_packet_type_enum::UNKNOWN)) {
+        SPDLOG_DEBUG("Request processing OVTensor: {}", inputName);
+        status = createPacketAndPushIntoGraph<ov::Tensor, Holder>(inputName, request, graph, timestamp);
+    }
+    return StatusCode::OK;
+}
+
+Status MediapipeGraphExecutor::infer(const KFSRequest* requestPtr, KFSResponse* response, ExecutionContext executionContext, ServableMetricReporter*& reporterOut) const {
     Timer<TIMER_END> timer;
-    SPDLOG_DEBUG("Start KServe request mediapipe graph: {} execution", request->model_name());
+    SPDLOG_DEBUG("Start KServe request mediapipe graph: {} execution", requestPtr->model_name());
     ::mediapipe::CalculatorGraph graph;
     auto absStatus = graph.Initialize(this->config);
     if (!absStatus.ok()) {
         const std::string absMessage = absStatus.ToString();
-        SPDLOG_DEBUG("KServe request for mediapipe graph: {} initialization failed with message: {}", request->model_name(), absMessage);
+        SPDLOG_DEBUG("KServe request for mediapipe graph: {} initialization failed with message: {}", requestPtr->model_name(), absMessage);
         return Status(StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR, std::move(absMessage));
     }
 
@@ -771,24 +746,24 @@ Status MediapipeGraphExecutor::infer(const KFSRequest* request, KFSResponse* res
         auto absStatusOrPoller = graph.AddOutputStreamPoller(name);
         if (!absStatusOrPoller.ok()) {
             const std::string absMessage = absStatusOrPoller.status().ToString();
-            SPDLOG_DEBUG("Failed to add mediapipe graph output stream poller: {} with error: {}", request->model_name(), absMessage);
+            SPDLOG_DEBUG("Failed to add mediapipe graph output stream poller: {} with error: {}", requestPtr->model_name(), absMessage);
             return Status(StatusCode::MEDIAPIPE_GRAPH_ADD_OUTPUT_STREAM_ERROR, std::move(absMessage));
         }
         outputPollers.emplace(name, std::move(absStatusOrPoller).value());
     }
 
-    std::map<std::string, mediapipe::Packet> inputSidePackets{createInputSidePackets(request)};
+    std::map<std::string, mediapipe::Packet> inputSidePackets{createInputSidePackets(requestPtr)};
     absStatus = graph.StartRun(inputSidePackets);
     if (!absStatus.ok()) {
         const std::string absMessage = absStatus.ToString();
-        SPDLOG_DEBUG("Failed to start mediapipe graph: {} with error: {}", request->model_name(), absMessage);
+        SPDLOG_DEBUG("Failed to start mediapipe graph: {} with error: {}", requestPtr->model_name(), absMessage);
         return Status(StatusCode::MEDIAPIPE_GRAPH_START_ERROR, std::move(absMessage));
     }
-    if (static_cast<int>(this->inputNames.size()) != request->inputs().size()) {
+    if (static_cast<int>(this->inputNames.size()) != requestPtr->inputs().size()) {
         std::stringstream ss;
-        ss << "Expected: " << this->inputNames.size() << "; Actual: " << request->inputs().size();
+        ss << "Expected: " << this->inputNames.size() << "; Actual: " << requestPtr->inputs().size();
         const std::string details = ss.str();
-        SPDLOG_DEBUG("[servable name: {} version: {}] Invalid number of inputs - {}", request->model_name(), version, details);
+        SPDLOG_DEBUG("[servable name: {} version: {}] Invalid number of inputs - {}", requestPtr->model_name(), version, details);
         return Status(StatusCode::INVALID_NO_OF_INPUTS, details);
     }
 
@@ -796,38 +771,16 @@ Status MediapipeGraphExecutor::infer(const KFSRequest* request, KFSResponse* res
     std::set<std::string> outputPollersWithReceivedPacket;
 
     ovms::Status status;
-    size_t tfLiteTensors = std::count_if(this->inputTypes.begin(), this->inputTypes.end(), [](const auto& pair) {
-        return pair.second == mediapipe_packet_type_enum::TFLITETENSOR;
-    });
-    std::unique_ptr<tflite::Interpreter> interpreter = nullptr;
-    if (tfLiteTensors) {
-        interpreter = std::make_unique<tflite::Interpreter>();
-        interpreter->AddTensors(tfLiteTensors);
-    }
-    size_t tfLiteTensorIdx = 0;
     size_t insertedStreamPackets = 0;
-    for (auto& name : this->inputNames) {
-        if (this->inputTypes.at(name) == mediapipe_packet_type_enum::KFS_REQUEST) {
-            SPDLOG_DEBUG("Request processing KFS passthrough: {}", name);
-            status = createPacketAndPushIntoGraph<KFSRequest*>(name, *request, graph);
-        } else if (this->inputTypes.at(name) == mediapipe_packet_type_enum::TFTENSOR) {
-            SPDLOG_DEBUG("Request processing TF tensor: {}", name);
-            status = createPacketAndPushIntoGraph<tensorflow::Tensor>(name, *request, graph);
-        } else if (this->inputTypes.at(name) == mediapipe_packet_type_enum::TFLITETENSOR) {
-            SPDLOG_DEBUG("Request processing TfLite tensor: {}", name);
-            status = createPacketAndPushIntoGraphTfLiteTensor(name, *request, graph, interpreter, tfLiteTensorIdx);
-            ++tfLiteTensorIdx;
-        } else if (this->inputTypes.at(name) == mediapipe_packet_type_enum::MPTENSOR) {
-            SPDLOG_DEBUG("Request processing MP tensor: {}", name);
-            status = createPacketAndPushIntoGraph<mediapipe::Tensor>(name, *request, graph);
-        } else if (this->inputTypes.at(name) == mediapipe_packet_type_enum::MEDIAPIPE_IMAGE) {
-            SPDLOG_DEBUG("Request processing Mediapipe ImageFrame: {}", name);
-            status = createPacketAndPushIntoGraph<mediapipe::ImageFrame>(name, *request, graph);
-        } else if ((this->inputTypes.at(name) == mediapipe_packet_type_enum::OVTENSOR) ||
-                   (this->inputTypes.at(name) == mediapipe_packet_type_enum::UNKNOWN)) {
-            SPDLOG_DEBUG("Request processing OVTensor: {}", name);
-            status = createPacketAndPushIntoGraph<ov::Tensor>(name, *request, graph);
+    //std::shared_ptr<const KFSRequest> request(requestPtr, [](const KFSRequest* r){ return;});  // here we don't actually own nor delete the request
+    std::shared_ptr<const KFSRequest> request(requestPtr, someL);  // here we don't actually own nor delete the request
+    const mediapipe::Timestamp timestamp(DEFAULT_STARTING_STREAM_TIMESTAMP);
+    for (auto& inputName : this->inputNames) {
+        status = selectPacketType<HolderWithNoRequestOwnership>(inputName, request, graph, timestamp, this->inputTypes);
+        if (!status.ok()) {
+            return status;
         }
+        status = closeInputStream(inputName, request, graph);
         if (!status.ok()) {
             return status;
         }
@@ -914,21 +867,9 @@ Status MediapipeGraphExecutor::infer(const KFSRequest* request, KFSResponse* res
         }                                                             \
     }
 
-template <typename T>
-class HolderWithRequestOwnership : public ::mediapipe::packet_internal::Holder<T> {
-    std::shared_ptr<const ::inference::ModelInferRequest> req;
-
-public:
-    explicit HolderWithRequestOwnership(const T* ptr, const std::shared_ptr<const ::inference::ModelInferRequest>& req) :
-        ::mediapipe::packet_internal::Holder<T>(ptr),
-        req(req) {}
-};
-
-// TODO: Add support for other types CVS-122328/CVS-122329
-Status MediapipeGraphExecutor::partialDeserialize(std::shared_ptr<const ::inference::ModelInferRequest> request, ::mediapipe::CalculatorGraph& graph) {
-    // Deserialize optional manual timestamp
-    if (!request->id().empty()) {
-        auto requestTimestamp = stoi64(request->id());  // TODO: Decide if deserialize from id or int parameter
+Status MediapipeGraphExecutor::acquireTimestamp(const KFSRequest& request) {
+    if (!request.id().empty()) {
+        auto requestTimestamp = stoi64(request.id());  // TODO: Decide if deserialize from id or int parameter
         if (requestTimestamp.has_value()) {
             // Cannot create with error checking since error check = abseil death test
             currentStreamTimestamp = ::mediapipe::Timestamp::CreateNoErrorChecking(requestTimestamp.value());
@@ -938,33 +879,56 @@ Status MediapipeGraphExecutor::partialDeserialize(std::shared_ptr<const ::infere
             return status;
         }
     }
-
     // Validate current timestamp (can be manual or automatic at this point)
     if (!currentStreamTimestamp.IsRangeValue()) {
         SPDLOG_DEBUG("Timestamp not in range: {}", currentStreamTimestamp.DebugString());
         return Status(StatusCode::MEDIAPIPE_INVALID_TIMESTAMP, currentStreamTimestamp.DebugString());
     }
-
+    return StatusCode::OK;
+}
+// TODO: Add support for other types CVS-122328/CVS-122329
+Status MediapipeGraphExecutor::partialDeserialize(std::shared_ptr<const KFSRequest> request, ::mediapipe::CalculatorGraph& graph) {
+    auto status = acquireTimestamp(*request);
+    if (!status.ok()){
+        return status;
+    }
     // Deserialize each input separately
     for (const auto& input : request->inputs()) {
-        std::unique_ptr<ov::Tensor> tensor;
-        OVMS_RETURN_ON_FAIL(deserializeTensor(input.name(), *request, tensor), "ov::Tensor deserialization");
-        MP_RETURN_ON_FAIL(graph.AddPacketToInputStream(
-                              input.name(),
-                              ::mediapipe::packet_internal::Create(
-                                  new HolderWithRequestOwnership<ov::Tensor>(
-                                      tensor.release(),
-                                      request))
-                                  .At(currentStreamTimestamp)),
-            "adding packet to input stream", StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM);
+        const auto& inputName = input.name();
+        // TODO write test that request contains not existing stream
+        if (std::find_if(this->inputNames.begin(), this->inputNames.end(), [&inputName](auto e){ return e == inputName;}) == this->inputNames.end()) {
+            SPDLOG_DEBUG("Request for {}, contains not expected input name: {}", request->model_name(), inputName);
+            return Status(StatusCode::INVALID_UNEXPECTED_INPUT, std::string(inputName) + "is unexpected");
+        }
+        auto inputPacketType = this->inputTypes.at(inputName);
+        ovms::Status status;
+        if (inputPacketType == mediapipe_packet_type_enum::KFS_REQUEST) {
+            SPDLOG_DEBUG("Request processing KFS passthrough: {}", inputName);
+            status = createPacketAndPushIntoGraph<HolderWithRequestOwnership>(inputName, request, graph, currentStreamTimestamp);
+        } else if (inputPacketType == mediapipe_packet_type_enum::TFTENSOR) {
+            SPDLOG_DEBUG("Request processing TF tensor: {}", inputName);
+            status = createPacketAndPushIntoGraph<tensorflow::Tensor, HolderWithRequestOwnership>(inputName, request, graph, currentStreamTimestamp);
+        } else if (inputPacketType == mediapipe_packet_type_enum::MPTENSOR) {
+            SPDLOG_DEBUG("Request processing MP tensor: {}", inputName);
+            status = createPacketAndPushIntoGraph<mediapipe::Tensor, HolderWithRequestOwnership>(inputName, request, graph, currentStreamTimestamp);
+        } else if (inputPacketType == mediapipe_packet_type_enum::MEDIAPIPE_IMAGE) {
+            SPDLOG_DEBUG("Request processing Mediapipe ImageFrame: {}", inputName);
+            status = createPacketAndPushIntoGraph<mediapipe::ImageFrame, HolderWithRequestOwnership>(inputName, request, graph, currentStreamTimestamp);
+        } else if ((inputPacketType == mediapipe_packet_type_enum::OVTENSOR) ||
+                   (inputPacketType == mediapipe_packet_type_enum::UNKNOWN)) {
+            SPDLOG_DEBUG("Request processing OVTensor: {}", inputName);
+            status = createPacketAndPushIntoGraph<ov::Tensor, HolderWithRequestOwnership>(inputName, request, graph, currentStreamTimestamp);
+        }
+        if (!status.ok()) {
+            return status;
+        }
     }
-
     // Increment timestamp automatically for next request
     currentStreamTimestamp = currentStreamTimestamp.NextAllowedInStream();
     return StatusCode::OK;
 }
 
-Status MediapipeGraphExecutor::inferStream(const ::inference::ModelInferRequest& firstRequest, ::grpc::ServerReaderWriterInterface<::inference::ModelStreamInferResponse, ::inference::ModelInferRequest>& stream) {
+Status MediapipeGraphExecutor::inferStream(const KFSRequest& firstRequest, ::grpc::ServerReaderWriterInterface<::inference::ModelStreamInferResponse, KFSRequest>& stream) {
     const std::string& servableName = firstRequest.model_name();  // TODO: Validate subsequent requests to match first servable name
     try {
         // Init

--- a/src/mediapipe_internal/mediapipegraphexecutor.hpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.hpp
@@ -48,6 +48,7 @@ class MediapipeGraphExecutor {
 
     ::mediapipe::Timestamp currentStreamTimestamp;
 
+    Status acquireTimestamp(const KFSRequest& request);
     Status partialDeserialize(std::shared_ptr<const ::inference::ModelInferRequest> request, ::mediapipe::CalculatorGraph& graph);
 
 protected:

--- a/src/mediapipe_internal/mediapipegraphexecutor.hpp
+++ b/src/mediapipe_internal/mediapipegraphexecutor.hpp
@@ -48,7 +48,7 @@ class MediapipeGraphExecutor {
 
     ::mediapipe::Timestamp currentStreamTimestamp;
 
-    Status acquireTimestamp(const KFSRequest& request);
+    Status deserializeTimestamp(const KFSRequest& request);
     Status partialDeserialize(std::shared_ptr<const ::inference::ModelInferRequest> request, ::mediapipe::CalculatorGraph& graph);
 
 protected:

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -91,6 +91,7 @@ const std::unordered_map<const StatusCode, const std::string> Status::statusMess
     // Predict request validation
     {StatusCode::INVALID_NO_OF_INPUTS, "Invalid number of inputs"},
     {StatusCode::INVALID_MISSING_INPUT, "Missing input with specific name"},
+    {StatusCode::INVALID_UNEXPECTED_INPUT, "Unexpected input"},
     {StatusCode::INVALID_MISSING_OUTPUT, "Missing output with specific name"},
     {StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS, "Invalid number of shape dimensions"},
     {StatusCode::INVALID_BATCH_SIZE, "Invalid input batch size"},

--- a/src/status.hpp
+++ b/src/status.hpp
@@ -90,6 +90,7 @@ enum class StatusCode {
     // Predict request validation
     INVALID_NO_OF_INPUTS,             /*!< Invalid number of inputs */
     INVALID_MISSING_INPUT,            /*!< Missing one or more of inputs */
+    INVALID_UNEXPECTED_INPUT,         /*!< Unexpected one or more of inputs */
     INVALID_MISSING_OUTPUT,           /*!< Missing one or more of outputs */
     INVALID_NO_OF_SHAPE_DIMENSIONS,   /*!< Invalid number of shape dimensions */
     INVALID_BATCH_SIZE,               /*!< Input batch size other than required */

--- a/src/test/c_api_tests.cpp
+++ b/src/test/c_api_tests.cpp
@@ -1755,11 +1755,12 @@ TEST(CAPI, MultipleThreadsStarting) {
         ss << retCodes[i] << ", ";
     }
     ss << "]";
-    SPDLOG_ERROR("ER: {}", ss.str());
-    SPDLOG_ERROR("ER");
+    SPDLOG_ERROR("Error codes: {}", ss.str());
+    SPDLOG_DEBUG("Will close server now");
     OVMS_Server* cserver = nullptr;
     ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
     OVMS_ServerDelete(cserver);
+    SPDLOG_DEBUG("Closed server now");
     auto started = std::count_if(retCodes.begin(), retCodes.end(),
         [](const uint32_t v) {
             return v == (uint32_t)(ovms::StatusCode::OK);

--- a/src/test/mediapipe/ovms_kfs_calculator.cc
+++ b/src/test/mediapipe/ovms_kfs_calculator.cc
@@ -72,7 +72,7 @@ public:
             response->add_raw_output_contents()->assign(request->raw_input_contents()[i].data(), request->raw_input_contents()[i].size());
         }
 
-        cc->Outputs().Tag("RESPONSE").AddPacket(::mediapipe::MakePacket<KFSResponse*>(response.get()).At(::mediapipe::Timestamp(0)));
+        cc->Outputs().Tag("RESPONSE").AddPacket(::mediapipe::MakePacket<KFSResponse*>(response.get()).At(cc->InputTimestamp()));
 
         return absl::OkStatus();
     }

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -1241,7 +1241,7 @@ TEST_F(MediapipeStreamFlowAddTest, InferOnReloadedGraph) {
             [&msg]() {
                 const auto& outputs = msg.infer_response().outputs();
                 ASSERT_EQ(outputs.size(), 0);
-                ASSERT_EQ(msg.error_message(), Status(StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM).string() + " - INTERNAL: ; partial deserialization of first request");
+                ASSERT_EQ(msg.error_message(), Status(StatusCode::INVALID_UNEXPECTED_INPUT).string() + " - in1 is unexpected; partial deserialization of first request");
             }();
             canDisconnect.set_value();
             return true;

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -150,13 +150,6 @@ TEST_F(MediapipeFlowKfsTest, Infer) {
     preparePredictRequest(request, inputsMeta, requestData1);
     request.mutable_model_name()->assign(modelName);
     ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
-    auto outputs = response.outputs();
-    ASSERT_EQ(outputs.size(), 1);
-    ASSERT_EQ(outputs[0].name(), "out");
-    ASSERT_EQ(outputs[0].shape().size(), 2);
-    ASSERT_EQ(outputs[0].shape()[0], 1);
-    ASSERT_EQ(outputs[0].shape()[1], 10);
-
     // Checking that KFSPASS calculator copies requestData1 to the reponse so that we expect requestData1 on output
     checkAddResponse("out", requestData1, requestData2, request, response, 1, 1, modelName);
 }

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -653,12 +653,12 @@ node {
 
     std::mutex mtx[3];
 
-    // Mock receiving 3 requests, the last one malicious
+    // Mock receiving 4 requests, the last two malicious
     prepareRequest(this->firstRequest, {{"in", 3.5f}}, 0);  // correct request
     EXPECT_CALL(this->stream, Read(_))
         .WillOnce(ReceiveWithTimestamp({{"in", 7.2f}}, 1))                                             // correct request
         .WillOnce(ReceiveInvalidWithTimestampWhenNotified({"in"}, 2, mtx[0]))                          // invalid request - missing data in buffer
-        .WillOnce(ReceiveWithTimestampWhenNotified({{"NONEXISTING", 13.f}, {"in", 2.3f}}, 2, mtx[1]))  // invalid request - missing data in buffer
+        .WillOnce(ReceiveWithTimestampWhenNotified({{"NONEXISTING", 13.f}, {"in", 2.3f}}, 2, mtx[1]))  // invalid request - non existing input
         .WillOnce(DisconnectWhenNotified(mtx[2]));
 
     // Expect 2 responses, no more due to error


### PR DESCRIPTION
Add handling all supported packet types in gRPC KFS streaming

Added test for KFSRequest* as this is specific case. Other deserializations should be covered by existing tests.

* Cppclean enhancement
Cppclean scan will now print all broken thresholds not only the first one
* Minor tweaks in tests logs
* Fixed debug build