### PR TITLE
Fixed not failing CI with UT failure

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -312,10 +312,9 @@ ARG minitrace_flags
 # Test Coverage
 COPY ci/check_coverage.bat /ovms/
 ARG CHECK_COVERAGE=0
-
 ARG RUN_TESTS=1
 RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" = "1" ] ; then bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
-    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || (cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; ) && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ;  \ 
+    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || {cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ;  \ 
     bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:test_python_binding; fi ;
 
 # Set OVMS version strings

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -313,9 +313,8 @@ ARG minitrace_flags
 COPY ci/check_coverage.bat /ovms/
 ARG CHECK_COVERAGE=0
 ARG RUN_TESTS=1
-RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" = "1" ] ; then bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
-    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ;  \
-    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:test_python_binding; fi ;
+COPY rununittest.sh /ovms/
+RUN ./rununittest.sh
 
 # Set OVMS version strings
 RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/version.hpp" && \

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -314,7 +314,7 @@ COPY ci/check_coverage.bat /ovms/
 ARG CHECK_COVERAGE=0
 ARG RUN_TESTS=1
 RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" = "1" ] ; then bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
-    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || {cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ;  \ 
+    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ;  \
     bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* //src:test_python_binding; fi ;
 
 # Set OVMS version strings

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -347,7 +347,7 @@ ARG CHECK_COVERAGE=0
 
 RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" == "1" ] ; then \
     bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
-    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || (cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; ) && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ; fi ;
+    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ; fi ;
 
 # C api shared library
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:ovms_shared

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -344,10 +344,8 @@ RUN bash -c "sed -i -e 's|REPLACE_PROJECT_NAME|${PROJECT_NAME}|g' /ovms/src/vers
 # Test Coverage
 COPY ci/check_coverage.bat /ovms/
 ARG CHECK_COVERAGE=0
-
-RUN if [ "$RUN_TESTS" == "1" ] ; then if [ "$CHECK_COVERAGE" == "1" ] ; then \
-    bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" ; fi ; \
-    bazel test --jobs=$JOBS ${debug_bazel_flags} --test_timeout=1800 --test_summary=detailed --test_output=streamed --test_filter=* --test_env PYTHONPATH=$PYTHONPATH //src:ovms_test > ${TEST_LOG} 2>&1 || { cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1 ; } && tail -n 100 ${TEST_LOG} && rm -rf ${TEST_LOG} ; fi ;
+COPY rununittest.sh /ovms/
+RUN ./rununittest.sh
 
 # C api shared library
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:ovms_shared

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -348,6 +348,7 @@ COPY rununittest.sh /ovms/
 RUN ./rununittest.sh
 
 # C api shared library
+# hadolint ignore=DL3059
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:ovms_shared
 
 ARG FUZZER_BUILD=0

--- a/rununittest.sh
+++ b/rununittest.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -x
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script should be used inside build image to run unit tests
+TEST_FILTER="--test_filter=*CAPI*:*OvmsConfigDeathTest*"
+SHARED_OPTIONS="
+--jobs=$JOBS \
+${debug_bazel_flags} \
+--test_timeout=1800 \
+--test_summary=detailed \
+--test_output=streamed \
+--test_env PYTHONPATH=\"$PYTHONPATH\""
+GENEREATE_COVERAGE_REPORT_COMMAND="genhtml --output genhtml \"$(bazel info output_path)/_coverage/_coverage_report.dat\""
+TESTS_FAIL_PROCEDURE="cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1"
+test_fail_procedure() {
+    cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1
+}
+echo $RUN_TEST
+echo $CHECK_COVERAGE
+if [ "$RUN_TESTS" == "1" ] ; then
+    if [ "$CHECK_COVERAGE" == "1" ] ; then
+        { bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov \
+            ${SHARED_OPTIONS} ${TEST_FILTER} \
+            //src:ovms_test > ${TEST_LOG} 2>&1 || \
+            test_fail_procedure; } && \
+            $(${GENEREATE_COVERAGE_REPORT_COMMAND});
+    fi
+    { bazel test \
+        ${SHARED_OPTIONS} "${TEST_FILTER}" \
+        //src:ovms_test > ${TEST_LOG} 2>&1 || \
+        test_fail_procedure; } && \
+        tail -n 15 ${TEST_LOG} && \
+        rm -rf ${TEST_LOG};
+fi

--- a/rununittest.sh
+++ b/rununittest.sh
@@ -15,7 +15,7 @@
 #
 
 # This script should be used inside build image to run unit tests
-TEST_FILTER="--test_filter=*"
+TEST_FILTER="--test_filter=*:-PythonFlowTest.InitializationPass:PythonFlowTest.FinalizationPass:PythonFlowTest.PythonNodePassArgumentsToConstructor:PythonFlowTest.PythonCalculatorTestSingleInSingleOut:PythonFlowTest.PythonCalculatorTestMultiInMultiOut:PythonFlowTest.PythonCalculatorTestSingleInSingleOutMultiRunWithErrors"
 SHARED_OPTIONS=" \
 --jobs=$JOBS \
 ${debug_bazel_flags} \
@@ -43,6 +43,6 @@ if [ "$RUN_TESTS" == "1" ] ; then
         ${SHARED_OPTIONS} "${TEST_FILTER}" \
         //src:ovms_test > ${TEST_LOG} 2>&1 || \
         test_fail_procedure; } && \
-        tail -n 15 ${TEST_LOG} && \
+        tail -n 100 ${TEST_LOG} && \
         rm -rf ${TEST_LOG};
 fi

--- a/rununittest.sh
+++ b/rununittest.sh
@@ -15,7 +15,7 @@
 #
 
 # This script should be used inside build image to run unit tests
-TEST_FILTER="--test_filter=*CAPI*:*OvmsConfigDeathTest*"
+TEST_FILTER="--test_filter=*"
 SHARED_OPTIONS=" \
 --jobs=$JOBS \
 ${debug_bazel_flags} \

--- a/rununittest.sh
+++ b/rununittest.sh
@@ -16,27 +16,28 @@
 
 # This script should be used inside build image to run unit tests
 TEST_FILTER="--test_filter=*CAPI*:*OvmsConfigDeathTest*"
-SHARED_OPTIONS="
+SHARED_OPTIONS=" \
 --jobs=$JOBS \
 ${debug_bazel_flags} \
 --test_timeout=1800 \
 --test_summary=detailed \
 --test_output=streamed \
 --test_env PYTHONPATH=\"$PYTHONPATH\""
-GENEREATE_COVERAGE_REPORT_COMMAND="genhtml --output genhtml \"$(bazel info output_path)/_coverage/_coverage_report.dat\""
-TESTS_FAIL_PROCEDURE="cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1"
+generate_coverage_report() {
+    genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
+}
 test_fail_procedure() {
     cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1
 }
-echo $RUN_TEST
-echo $CHECK_COVERAGE
+echo "Run test: ${RUN_TESTS}"
+echo "Run coverage: ${CHECK_COVERAGE}"
 if [ "$RUN_TESTS" == "1" ] ; then
     if [ "$CHECK_COVERAGE" == "1" ] ; then
         { bazel coverage --instrumentation_filter="-src/test" --combined_report=lcov \
             ${SHARED_OPTIONS} ${TEST_FILTER} \
             //src:ovms_test > ${TEST_LOG} 2>&1 || \
             test_fail_procedure; } && \
-            $(${GENEREATE_COVERAGE_REPORT_COMMAND});
+            generate_coverage_report;
     fi
     { bazel test \
         ${SHARED_OPTIONS} "${TEST_FILTER}" \

--- a/rununittest.sh
+++ b/rununittest.sh
@@ -22,7 +22,7 @@ ${debug_bazel_flags} \
 --test_timeout=1800 \
 --test_summary=detailed \
 --test_output=streamed \
---test_env PYTHONPATH=\"$PYTHONPATH\""
+--test_env PYTHONPATH=${PYTHONPATH}"
 generate_coverage_report() {
     genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
 }

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -60,7 +60,6 @@ public:
 };
 
 TEST_F(OvmsConfigDeathTest, bufferTest) {
-    ASSERT_TRUE(false);
     std::string input{"Test buffer"};
     std::cout << input;
     std::string check{buffer.str()};

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -60,6 +60,7 @@ public:
 };
 
 TEST_F(OvmsConfigDeathTest, bufferTest) {
+    ASSERT_TRUE(false);
     std::string input{"Test buffer"};
     std::cout << input;
     std::string check{buffer.str()};


### PR DESCRIPTION
The issue was caused by launching exit 1 in subshell instead of current shell in case of unit tests failures.

Moved test logic to separate script for readability.