### PR TITLE
Python streaming support

### DIFF
--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -49,6 +49,8 @@ using grpc::ServerBuilder;
 
 namespace ovms {
 static const int GIGABYTE = 1024 * 1024 * 1024;
+// Default server shutdown deadline set to 5 seconds,
+// so it happens before docker container graceful stop.
 static const int SERVER_SHUTDOWN_DEADLINE_SECONDS = 5;
 
 static bool isPortAvailable(uint64_t port) {

--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -49,6 +49,7 @@ using grpc::ServerBuilder;
 
 namespace ovms {
 static const int GIGABYTE = 1024 * 1024 * 1024;
+static const int SERVER_SHUTDOWN_DEADLINE_SECONDS = 5;
 
 static bool isPortAvailable(uint64_t port) {
     struct sockaddr_in addr;
@@ -195,8 +196,10 @@ void GRPCServerModule::shutdown() {
         return;
     state = ModuleState::STARTED_SHUTDOWN;
     SPDLOG_INFO("{} shutting down", GRPC_SERVER_MODULE_NAME);
+    std::chrono::time_point serverDeadline = std::chrono::system_clock::now() +
+                                             std::chrono::seconds(SERVER_SHUTDOWN_DEADLINE_SECONDS);
     for (const auto& server : servers) {
-        server->Shutdown();
+        server->Shutdown(serverDeadline);
         SPDLOG_INFO("Shutdown gRPC server");
     }
     servers.clear();

--- a/src/mediapipe_calculators/python_executor_calculator.cc
+++ b/src/mediapipe_calculators/python_executor_calculator.cc
@@ -43,7 +43,7 @@ class PythonExecutorCalculator : public CalculatorBase {
     // this way we can support timestamp continuity for more than one request in streaming scenario.
     mediapipe::Timestamp outputTimestamp;
 
-    void prepareInputs(CalculatorContext* cc, std::vector<py::object> * pyInputs) {
+    void prepareInputs(CalculatorContext* cc, std::vector<py::object>* pyInputs) {
         for (const std::string& tag : cc->Inputs().GetTags()) {
             if (tag != "LOOPBACK") {
                 const py::object& pyInput = cc->Inputs().Tag(tag).Get<PyObjectWrapper<py::object>>().getObject();
@@ -92,7 +92,7 @@ class PythonExecutorCalculator : public CalculatorBase {
     void generate(CalculatorContext* cc, mediapipe::Timestamp& timestamp) {
         py::list pyOutputs = py::cast<py::list>(*pyIteratorPtr->getObject());
         pushOutputs(cc, pyOutputs, timestamp, true);
-        ++(pyIteratorPtr->getObject()); // increment iterator
+        ++(pyIteratorPtr->getObject());  // increment iterator
     }
 
     void initializeGenerator(py::object generator) {
@@ -113,7 +113,6 @@ class PythonExecutorCalculator : public CalculatorBase {
             throw UnexpectedPythonObjectError(executionResult, "list or generator");
         }
     }
-
 
 public:
     static absl::Status GetContract(CalculatorContract* cc) {
@@ -179,8 +178,7 @@ public:
                     LOG(INFO) << "PythonExecutorCalculator [Node: " << cc->NodeName() << "] finished generating. Reseting the generator.";
                     resetGenerator();
                 }
-            } else {  // Generator not initialized, either first iteration or execute is not yielding
-
+            } else {
                 // If execute yields, first request sets initial timestamp to input timestamp, then each cycle increments it.
                 // If execute returns, input timestamp is also output timestamp.
                 outputTimestamp = cc->InputTimestamp();

--- a/src/mediapipe_calculators/python_executor_calculator.cc
+++ b/src/mediapipe_calculators/python_executor_calculator.cc
@@ -37,15 +37,13 @@ namespace mediapipe {
 const std::string INPUT_SIDE_PACKET_TAG = "PYTHON_NODE_RESOURCES";
 
 class PythonExecutorCalculator : public CalculatorBase {
-    /* 
-    TODO: Streaming support:
-        - timestamping
-        - loopback input
-    */
     std::shared_ptr<PythonNodeResource> nodeResources;
     std::unique_ptr<PyObjectWrapper<py::iterator>> pyIteratorPtr;
+    // The calculator manages timestamp for outputs to work independently of inputs
+    // this way we can support timestamp continuity for more than one request in streaming scenario.
+    mediapipe::Timestamp outputTimestamp;
 
-    void pushOutputs(CalculatorContext* cc, py::list pyOutputs) {
+    void pushOutputs(CalculatorContext* cc, py::list pyOutputs, mediapipe::Timestamp& timestamp, bool pushLoopback) {
         py::gil_scoped_acquire acquire;
         for (py::handle pyOutputHandle : pyOutputs) {
             py::object pyOutput = pyOutputHandle.cast<py::object>();
@@ -53,9 +51,24 @@ class PythonExecutorCalculator : public CalculatorBase {
             std::string outputName = pyOutput.attr("name").cast<std::string>();
             if (cc->Outputs().HasTag(outputName)) {
                 std::unique_ptr<PyObjectWrapper<py::object>> outputPtr = std::make_unique<PyObjectWrapper<py::object>>(pyOutput);
-                cc->Outputs().Tag(outputName).Add(outputPtr.release(), cc->InputTimestamp());
+                cc->Outputs().Tag(outputName).Add(outputPtr.release(), timestamp);
             }
         }
+        if (pushLoopback) {
+            timestamp++;
+            cc->Outputs().Tag("LOOPBACK").Add(std::make_unique<bool>(true).release(), timestamp);
+        }
+    }
+
+    bool receivedNewData(CalculatorContext* cc) {
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            if (tag != "LOOPBACK") {
+                if (!cc->Inputs().Tag(tag).IsEmpty()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
 public:
@@ -63,11 +76,21 @@ public:
         LOG(INFO) << "PythonExecutorCalculator [Node: " << cc->GetNodeName() << "] GetContract start";
         RET_CHECK(!cc->Inputs().GetTags().empty());
         RET_CHECK(!cc->Outputs().GetTags().empty());
-        for (auto& input : cc->Inputs()) {
-            input.Set<PyObjectWrapper<py::object>>();
+
+        for (const std::string& tag : cc->Inputs().GetTags()) {
+            if (tag == "LOOPBACK") {
+                cc->Inputs().Tag(tag).Set<bool>();
+            } else {
+                cc->Inputs().Tag(tag).Set<PyObjectWrapper<py::object>>();
+            }
         }
-        for (auto& output : cc->Outputs()) {
-            output.Set<PyObjectWrapper<py::object>>();
+
+        for (const std::string& tag : cc->Outputs().GetTags()) {
+            if (tag == "LOOPBACK") {
+                cc->Outputs().Tag(tag).Set<bool>();
+            } else {
+                cc->Outputs().Tag(tag).Set<PyObjectWrapper<py::object>>();
+            }
         }
         cc->InputSidePackets().Tag(INPUT_SIDE_PACKET_TAG).Set<PythonNodesResources>();
         LOG(INFO) << "PythonExecutorCalculator [Node: " << cc->GetNodeName() << "] GetContract end";
@@ -88,51 +111,66 @@ public:
             RET_CHECK(false);
         }
         nodeResources = it->second;
+        outputTimestamp = mediapipe::Timestamp(mediapipe::Timestamp::Unset());
         LOG(INFO) << "PythonExecutorCalculator [Node: " << cc->NodeName() << "] Open end";
         return absl::OkStatus();
     }
 
     absl::Status Process(CalculatorContext* cc) final {
         LOG(INFO) << "PythonExecutorCalculator [Node: " << cc->NodeName() << "] Process start";
+        LOG(INFO) << "Input timestamp : " << cc->InputTimestamp();
+        for (const auto& input : cc->Inputs()) {
+            LOG(INFO) << input.Name() << " : " << !input.IsEmpty();
+        }
         py::gil_scoped_acquire acquire;
         try {
-            py::print("PYTHON: Acquired GIL");
+            LOG(INFO) << "PYTHON: Acquired GIL";
             if (pyIteratorPtr) {  // Iterator initialized
-                py::print("PyIterator initialized block");
+                if (receivedNewData(cc)) {
+                    LOG(INFO) << "[Node: " << cc->NodeName() << "] Node is already processing data. Create new stream for another request.";
+                    return absl::Status(absl::StatusCode::kResourceExhausted, "Node is already processing data. Create new stream for another request.");
+                }
+
+                LOG(INFO) << "PyIterator initialized block";
                 if (pyIteratorPtr->getObject() != py::iterator::sentinel()) {
                     py::list pyOutputs = py::cast<py::list>(*pyIteratorPtr->getObject());
-                    pushOutputs(cc, pyOutputs);
+                    pushOutputs(cc, pyOutputs, outputTimestamp, true);
                     ++(pyIteratorPtr->getObject());
                 } else {
                     LOG(INFO) << "PythonExecutorCalculator [Node: " << cc->NodeName() << "] finished generating. Reseting the iterator.";
                     pyIteratorPtr.reset();
                 }
             } else {  // Iterator not initialized, either first iteration or execute is not yielding
-                py::print("PyIterator uninitialized block");
+                LOG(INFO) << "PyIterator uninitialized block";
                 std::vector<py::object> pyInputs;
                 for (const std::string& tag : cc->Inputs().GetTags()) {
-                    const py::object& pyInput = cc->Inputs().Tag(tag).Get<PyObjectWrapper<py::object>>().getObject();
-                    nodeResources->pythonBackend->validateOvmsPyTensor(pyInput);
-                    pyInputs.push_back(pyInput);
+                    if (tag != "LOOPBACK") {
+                        const py::object& pyInput = cc->Inputs().Tag(tag).Get<PyObjectWrapper<py::object>>().getObject();
+                        nodeResources->pythonBackend->validateOvmsPyTensor(pyInput);
+                        pyInputs.push_back(pyInput);
+                    }
                 }
 
                 py::object executeResult = std::move(nodeResources->nodeResourceObject->attr("execute")(pyInputs));
-                py::print(executeResult.attr("__class__").attr("__name__"));
+
+                // If execute yields, first request sets initial timestamp to input timestamp, then each cycle increments it.
+                // If execute returns, input timestamp is also output timestamp.
+                outputTimestamp = cc->InputTimestamp();
 
                 if (py::isinstance<py::list>(executeResult)) {
-                    py::print("Regular execution (execute returned)");
-                    pushOutputs(cc, executeResult);
+                    LOG(INFO) << "Regular execution (execute returned)";
+                    pushOutputs(cc, executeResult, outputTimestamp, false);
                 } else if (py::isinstance<py::iterator>(executeResult)) {
-                    py::print("Iterator initialization (execute yielded)");
+                    LOG(INFO) << "Iterator initialization (execute yielded)";
                     pyIteratorPtr = std::make_unique<PyObjectWrapper<py::iterator>>(executeResult);
                     py::list pyOutputs = py::cast<py::list>(*pyIteratorPtr->getObject());
-                    pushOutputs(cc, pyOutputs);
+                    pushOutputs(cc, pyOutputs, outputTimestamp, true);
                     ++(pyIteratorPtr->getObject());
                 } else {
                     throw UnexpectedPythonObjectError(executeResult, "list or generator");
                 }
             }
-            py::print("PYTHON: Released GIL");
+            LOG(INFO) << "PYTHON: Released GIL";
         } catch (const UnexpectedPythonObjectError& e) {
             // TODO: maybe some more descriptive information where to seek the issue.
             LOG(INFO) << "Wrong object on node " << cc->NodeName() << " execute input or output: " << e.what();

--- a/src/test/get_mediapipe_graph_metadata_response_test.cpp
+++ b/src/test/get_mediapipe_graph_metadata_response_test.cpp
@@ -47,23 +47,6 @@
 using namespace ovms;
 using namespace rapidjson;
 
-class DummyMediapipeGraphDefinition : public MediapipeGraphDefinition {
-public:
-    std::string inputConfig;
-
-public:
-    DummyMediapipeGraphDefinition(const std::string name,
-        const MediapipeGraphConfig& config,
-        std::string inputConfig) :
-        MediapipeGraphDefinition(name, config, nullptr, nullptr) {}
-
-    // Do not read from path - use predefined config contents
-    Status validateForConfigFileExistence() override {
-        this->chosenConfig = this->inputConfig;
-        return StatusCode::OK;
-    }
-};
-
 class GetMediapipeGraphMetadataResponse : public ::testing::Test {
 protected:
     KFSModelMetadataResponse response;

--- a/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py
+++ b/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py
@@ -35,6 +35,3 @@ class OvmsPythonModel:
                 outputs.append(Tensor(output_name, output_data))
             print(outputs)
             yield outputs
-
-    def finalize(self, kwargs: dict):
-        return

--- a/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py
+++ b/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #*****************************************************************************
-import numpy as np
+import struct
 from pyovms import Tensor
 class OvmsPythonModel:
 
@@ -21,16 +21,19 @@ class OvmsPythonModel:
         self.model_outputs = kwargs 
         return
 
-    def execute(self, inputs: list, kwargs: dict = {}):
+    def execute(self, inputs: list):
         # Increment every element of every input and return them with changed tensor name.
-        outputs = []
-        inputs_npy = [np.array(input) for input in inputs]
+        inputs_data = {}
         for _ in range(3):
             outputs = []
-            for input_npy in inputs_npy:
-                input_npy = input_npy + 1
-                output_name = input.name.replace("INPUT", "OUTPUT")
-                outputs.append(Tensor(output_name, input_npy))
+            for input in inputs:
+                output_name = input.name.replace("input", "OUTPUT")
+                input_fp32 = struct.unpack('f', bytes(input))[0] if input.name not in inputs_data else inputs_data[input.name]
+                input_fp32 = input_fp32 + 1.0
+                inputs_data[input.name] = input_fp32
+                output_data = struct.pack('f', input_fp32)
+                outputs.append(Tensor(output_name, output_data))
+            print(outputs)
             yield outputs
 
     def finalize(self, kwargs: dict):

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -1541,23 +1541,6 @@ TEST(Mediapipe, MetadataDummy) {
     EXPECT_EQ(output->getPrecision(), ovms::Precision::UNDEFINED);
 }
 
-class DummyMediapipeGraphDefinition : public MediapipeGraphDefinition {
-public:
-    std::string inputConfig;
-
-public:
-    DummyMediapipeGraphDefinition(const std::string name,
-        const MediapipeGraphConfig& config,
-        std::string inputConfig) :
-        MediapipeGraphDefinition(name, config, nullptr, nullptr) {}
-
-    // Do not read from path - use predefined config contents
-    Status validateForConfigFileExistence() override {
-        this->chosenConfig = this->inputConfig;
-        return StatusCode::OK;
-    }
-};
-
 TEST(Mediapipe, MetadataDummyInputTypes) {
     ConstructorEnabledModelManager manager;
     std::string testPbtxt = R"(

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -149,7 +149,7 @@ TEST_F(PythonFlowTest, PythonNodeFileDoesNotExist) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_FILE_DOES_NOT_EXIST);
 }
@@ -186,7 +186,7 @@ TEST_F(PythonFlowTest, PythonNodeNameAlreadyExist) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_NAME_ALREADY_EXISTS);
 }
@@ -211,7 +211,7 @@ TEST_F(PythonFlowTest, PythonNodeInitFailed) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_FILE_STATE_INITIALIZATION_FAILED);
 }
@@ -236,7 +236,7 @@ TEST_F(PythonFlowTest, PythonNodeInitFailedImportOutsideTheClassError) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_FILE_STATE_INITIALIZATION_FAILED);
 }
@@ -261,7 +261,7 @@ TEST_F(PythonFlowTest, PythonNodeInitException) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_FILE_STATE_INITIALIZATION_FAILED);
 }
@@ -281,7 +281,7 @@ TEST_F(PythonFlowTest, PythonNodeOptionsMissing) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_MISSING_OPTIONS);
 }
@@ -305,7 +305,7 @@ TEST_F(PythonFlowTest, PythonNodeNameMissing) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_MISSING_NAME);
 }
@@ -330,7 +330,7 @@ TEST_F(PythonFlowTest, PythonNodeNameDoesNotExist) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
     ASSERT_EQ(mediapipeDummy.getPythonNodeResource("pythonNode4"), nullptr);
@@ -356,7 +356,7 @@ TEST_F(PythonFlowTest, PythonNodeInitMembers) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
     PythonNodeResource* nodeRes = mediapipeDummy.getPythonNodeResource("pythonNode2");
@@ -414,7 +414,7 @@ TEST_F(PythonFlowTest, PythonNodePassInitArguments) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
     PythonNodeResource* nodeRes = mediapipeDummy.getPythonNodeResource("pythonNode2");
@@ -475,7 +475,7 @@ TEST_F(PythonFlowTest, PythonNodePassArgumentsToConstructor) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
     PythonNodeResource* nodeRes = mediapipeDummy.getPythonNodeResource("pythonNode2");
@@ -636,7 +636,7 @@ static std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> prep
 }
 
 TEST_F(PythonFlowTest, PythonCalculatorTestSingleInSingleOut) {
-    ConstructorEnabledModelManager manager;
+    ConstructorEnabledModelManager manager{"", getPythonBackend()};
     std::string testPbtxt = R"(
     input_stream: "OVMS_PY_TENSOR:in"
     output_stream: "OVMS_PY_TENSOR:out"
@@ -654,7 +654,7 @@ TEST_F(PythonFlowTest, PythonCalculatorTestSingleInSingleOut) {
         }
     )";
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
 
@@ -702,7 +702,7 @@ TEST_F(PythonFlowTest, PythonCalculatorTestMultiInMultiOut) {
         }
     )";
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
 
@@ -982,7 +982,7 @@ TEST_F(PythonFlowTest, ReloadWithDifferentScriptName) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, firstTestPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, firstTestPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = firstTestPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
 
@@ -1070,7 +1070,7 @@ TEST_F(PythonFlowTest, FailingToInitializeOneNodeDestructsAllResources) {
     )";
 
     ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
-    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, firstTestPbtxt);
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, firstTestPbtxt, getPythonBackend());
     mediapipeDummy.inputConfig = firstTestPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::PYTHON_NODE_FILE_STATE_INITIALIZATION_FAILED);
     ASSERT_EQ(mediapipeDummy.getPythonNodeResource("pythonNode1"), nullptr);

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -547,21 +547,21 @@ public:
         return tensor;
     }
 
-    static std::vector<T> readVectorFromOutput(const std::string& outputName, int numElements, const mediapipe::CalculatorRunner* runner) {
-        const PyObjectWrapper<py::object>& pyOutput = runner->Outputs().Tag(outputName).packets[0].Get<PyObjectWrapper<py::object>>();
+    static std::vector<T> readVectorFromOutput(const std::string& outputName, int numElements, const mediapipe::CalculatorRunner* runner, int packetIndex = 0) {
+        const PyObjectWrapper<py::object>& pyOutput = runner->Outputs().Tag(outputName).packets[packetIndex].Get<PyObjectWrapper<py::object>>();
         T* outputData = (T*)pyOutput.getProperty<void*>("ptr");
         std::vector<T> output;
         output.assign(outputData, outputData + numElements);
         return output;
     }
 
-    std::vector<T> getIncrementedVector() {
+    std::vector<T> getIncrementedVector(int value = 1) {
         // SimpleTensor is expected to hold data in shape (1, X),
         // therefore we iterate over the second dimension as it holds the actual data
         std::vector<T> output;
         T* fpData = (T*)data;
         for (int i = 0; i < shape[1]; i++) {
-            output.push_back(fpData[i] + 1);
+            output.push_back(fpData[i] + value);
         }
         return output;
     }

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -129,32 +129,6 @@ TEST_F(PythonFlowTest, FinalizationPass) {
     ASSERT_TRUE(std::filesystem::exists(path));
 }
 
-class DummyMediapipeGraphDefinition : public MediapipeGraphDefinition {
-public:
-    std::string inputConfig;
-
-    PythonNodeResource* getPythonNodeResource(const std::string& nodeName) {
-        auto it = this->pythonNodeResources.find(nodeName);
-        if (it == std::end(pythonNodeResources)) {
-            return nullptr;
-        } else {
-            return it->second.get();
-        }
-    }
-
-public:
-    DummyMediapipeGraphDefinition(const std::string name,
-        const MediapipeGraphConfig& config,
-        std::string inputConfig) :
-        MediapipeGraphDefinition(name, config, nullptr, nullptr, getPythonBackend()) {}
-
-    // Do not read from path - use predefined config contents
-    Status validateForConfigFileExistence() override {
-        this->chosenConfig = this->inputConfig;
-        return StatusCode::OK;
-    }
-};
-
 TEST_F(PythonFlowTest, PythonNodeFileDoesNotExist) {
     ConstructorEnabledModelManager manager;
     std::string testPbtxt = R"(

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -20,7 +20,9 @@
 #include <gtest/gtest.h>
 
 #include "../kfs_frontend/kfs_grpc_inference_service.hpp"
+#include "../mediapipe_internal/mediapipegraphdefinition.hpp"
 #include "../mediapipe_internal/mediapipegraphexecutor.hpp"
+#include "../pythoninterpretermodule.hpp"
 #include "../status.hpp"
 #include "../stringutils.hpp"
 #include "test_utils.hpp"
@@ -453,176 +455,155 @@ node {
 
 #include <pybind11/embed.h>  // everything needed for embedding
 namespace py = pybind11;
-
-#include "../mediapipe_internal/pythonnoderesource.hpp"
 #include "../python/python_backend.hpp"
 
-static std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> prepareInputSidePacket(const std::string& handlerPath, PythonBackend* pythonBackend) {
-    // Create side packets
-    auto fsHandlerPath = std::filesystem::path(handlerPath);
-    fsHandlerPath.replace_extension();
-
-    std::string parentPath = fsHandlerPath.parent_path();
-    std::string filename = fsHandlerPath.filename();
-
-    py::gil_scoped_acquire acquire;
-    py::module_ sys = py::module_::import("sys");
-    sys.attr("path").attr("append")(parentPath.c_str());
-    py::module_ script = py::module_::import(filename.c_str());
-    py::object OvmsPythonModel = script.attr("OvmsPythonModel");
-    py::object pythonModel = OvmsPythonModel();
-
-    std::shared_ptr<PythonNodeResource> nodeResource = std::make_shared<PythonNodeResource>(pythonBackend);
-    nodeResource->nodeResourceObject = std::make_unique<py::object>(pythonModel);
-
-    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources{{"pythonNode", nodeResource}};
-    return nodesResources;
-}
-
 TEST_F(StreamingTest, SingleStreamSend1Receive3Python) {
-    py::scoped_interpreter guard{};  // start the interpreter and keep it alive
-    const std::string pbTxt{R"(
-input_stream: "OVMS_PY_TENSOR:input"
-output_stream: "OVMS_PY_TENSOR:output"
-node {
-    calculator: "PythonExecutorCalculator"
-    name: "pythonNode"
-    input_side_packet: "PYTHON_NODE_RESOURCES:py"
-    input_stream: "LOOPBACK:loopback"
-    input_stream: "INPUT:input"
-    input_stream_info: {
-        tag_index: 'LOOPBACK:0',
-        back_edge: true
-    }
-    input_stream_handler {
-        input_stream_handler: "SyncSetInputStreamHandler",
-        options {
-            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
-                sync_set {
-                    tag_index: "LOOPBACK:0"
+    PythonInterpreterModule pythonModule;
+    pythonModule.start(ovms::Config::instance());
+    // Running everything in the scope, so Python objects get destroyed before module shutdown.
+    {
+        PythonBackend* pythonBackend = pythonModule.getPythonBackend();
+        ConstructorEnabledModelManager manager{"", pythonBackend};
+        const std::string testPbtxt{R"(
+    input_stream: "OVMS_PY_TENSOR:input"
+    output_stream: "OVMS_PY_TENSOR:output"
+    node {
+        calculator: "PythonExecutorCalculator"
+        name: "pythonNode"
+        input_side_packet: "PYTHON_NODE_RESOURCES:py"
+        input_stream: "LOOPBACK:loopback"
+        input_stream: "INPUT:input"
+        input_stream_info: {
+            tag_index: 'LOOPBACK:0',
+            back_edge: true
+        }
+        input_stream_handler {
+            input_stream_handler: "SyncSetInputStreamHandler",
+            options {
+                [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                    sync_set {
+                        tag_index: "LOOPBACK:0"
+                    }
                 }
             }
         }
-    }
-    output_stream: "LOOPBACK:loopback"
-    output_stream: "OUTPUT:output"
-    node_options: {
-        [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
-            handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+        output_stream: "LOOPBACK:loopback"
+        output_stream: "OUTPUT:output"
+        node_options: {
+            [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+                handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+            }
         }
     }
-}
-)"};
+    )"};
 
-    ::mediapipe::CalculatorGraphConfig config;
-    ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(pbTxt, &config));
+        ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
+        DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, pythonBackend);
+        ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
 
-    PythonBackend* pythonBackend;
-    ASSERT_TRUE(PythonBackend::createPythonBackend(&pythonBackend));
-    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources = prepareInputSidePacket(
-        "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py",
-        pythonBackend);
+        std::shared_ptr<MediapipeGraphExecutor> pipeline;
+        ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
+        ASSERT_NE(pipeline, nullptr);
 
-    MediapipeGraphExecutor executor{
-        this->name, this->version, config,
-        {{"input", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
-        {{"output", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
-        {"input"}, {"output"}, nodesResources, pythonBackend};
+        pythonModule.releaseGILFromThisThread();
+        // Mock only 1 request and disconnect immediately
+        prepareRequest(this->firstRequest, {{"input", 3.5f}});
+        EXPECT_CALL(this->stream, Read(_))
+            .WillOnce(Disconnect());
 
-    py::gil_scoped_release release{};
-    // Mock only 1 request and disconnect immediately
-    prepareRequest(this->firstRequest, {{"input", 3.5f}});
-    EXPECT_CALL(this->stream, Read(_))
-        .WillOnce(Disconnect());
+        // Expect 3 responses (cycle)
+        // The PythonExecutorCalculator produces increasing timestamps
+        EXPECT_CALL(this->stream, Write(_, _))
+            .WillOnce(SendWithTimestamp({{"OUTPUT", 4.5f}}, 0))
+            .WillOnce(SendWithTimestamp({{"OUTPUT", 5.5f}}, 1))
+            .WillOnce(SendWithTimestamp({{"OUTPUT", 6.5f}}, 2));
 
-    // Expect 3 responses (cycle)
-    // The PythonExecutorCalculator produces increasing timestamps
-    EXPECT_CALL(this->stream, Write(_, _))
-        .WillOnce(SendWithTimestamp({{"OUTPUT", 4.5f}}, 0))
-        .WillOnce(SendWithTimestamp({{"OUTPUT", 5.5f}}, 1))
-        .WillOnce(SendWithTimestamp({{"OUTPUT", 6.5f}}, 2));
-
-    ASSERT_EQ(executor.inferStream(this->firstRequest, this->stream), StatusCode::OK);
+        ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
+    }
+    pythonModule.shutdown();
 }
 
 TEST_F(StreamingTest, MultipleStreamsInSingleRequestSend1Receive3Python) {
-    py::scoped_interpreter guard{};  // start the interpreter and keep it alive
-    const std::string pbTxt{R"(
-input_stream: "OVMS_PY_TENSOR1:input1"
-input_stream: "OVMS_PY_TENSOR2:input2"
-output_stream: "OVMS_PY_TENSOR1:output1"
-output_stream: "OVMS_PY_TENSOR2:output2"
-node {
-    calculator: "PythonExecutorCalculator"
-    name: "pythonNode"
-    input_side_packet: "PYTHON_NODE_RESOURCES:py"
-    input_stream: "LOOPBACK:loopback"
-    input_stream: "INPUT1:input1"
-    input_stream: "INPUT2:input2"
-    input_stream_info: {
-        tag_index: 'LOOPBACK:0',
-        back_edge: true
-    }
-    input_stream_handler {
-        input_stream_handler: "SyncSetInputStreamHandler",
-        options {
-            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
-                sync_set {
-                    tag_index: "LOOPBACK:0"
+    PythonInterpreterModule pythonModule;
+    pythonModule.start(ovms::Config::instance());
+    // Running everything in the scope, so Python objects get destroyed before module shutdown.
+    {
+        PythonBackend* pythonBackend = pythonModule.getPythonBackend();
+        ConstructorEnabledModelManager manager{"", pythonBackend};
+        const std::string testPbtxt{R"(
+    input_stream: "OVMS_PY_TENSOR1:input1"
+    input_stream: "OVMS_PY_TENSOR2:input2"
+    output_stream: "OVMS_PY_TENSOR1:output1"
+    output_stream: "OVMS_PY_TENSOR2:output2"
+    node {
+        calculator: "PythonExecutorCalculator"
+        name: "pythonNode"
+        input_side_packet: "PYTHON_NODE_RESOURCES:py"
+        input_stream: "LOOPBACK:loopback"
+        input_stream: "INPUT1:input1"
+        input_stream: "INPUT2:input2"
+        input_stream_info: {
+            tag_index: 'LOOPBACK:0',
+            back_edge: true
+        }
+        input_stream_handler {
+            input_stream_handler: "SyncSetInputStreamHandler",
+            options {
+                [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                    sync_set {
+                        tag_index: "LOOPBACK:0"
+                    }
                 }
             }
         }
-    }
-    output_stream: "LOOPBACK:loopback"
-    output_stream: "OUTPUT1:output1"
-    output_stream: "OUTPUT2:output2"
-    node_options: {
-        [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
-            handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+        output_stream: "LOOPBACK:loopback"
+        output_stream: "OUTPUT1:output1"
+        output_stream: "OUTPUT2:output2"
+        node_options: {
+            [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+                handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+            }
         }
     }
-}
-)"};
+    )"};
 
-    ::mediapipe::CalculatorGraphConfig config;
-    ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(pbTxt, &config));
+        ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
+        DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, pythonBackend);
+        ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
 
-    PythonBackend* pythonBackend;
-    ASSERT_TRUE(PythonBackend::createPythonBackend(&pythonBackend));
-    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources = prepareInputSidePacket(
-        "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py",
-        pythonBackend);
+        std::shared_ptr<MediapipeGraphExecutor> pipeline;
+        ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
+        ASSERT_NE(pipeline, nullptr);
 
-    MediapipeGraphExecutor executor{
-        this->name, this->version, config,
-        {{"input1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
-            {"input2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
-        {{"output1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
-            {"output2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
-        {"input1", "input2"}, {"output1", "output2"}, nodesResources, pythonBackend};
+        pythonModule.releaseGILFromThisThread();
+        // Mock only 1 request and disconnect immediately
+        prepareRequest(this->firstRequest, {{"input1", 3.5f}, {"input2", 13.5f}});
+        EXPECT_CALL(this->stream, Read(_))
+            .WillOnce(Disconnect());
 
-    py::gil_scoped_release release{};
-    // Mock only 1 request and disconnect immediately
-    prepareRequest(this->firstRequest, {{"input1", 3.5f}, {"input2", 13.5f}});
-    EXPECT_CALL(this->stream, Read(_))
-        .WillOnce(Disconnect());
+        // Expect 6 responses (cycle)
+        // The PythonExecutorCalculator produces increasing timestamps
+        EXPECT_CALL(this->stream, Write(_, _))
+            .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, 0))
+            .WillOnce(SendWithTimestamp({{"OUTPUT2", 14.5f}}, 0))
+            .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, 1))
+            .WillOnce(SendWithTimestamp({{"OUTPUT2", 15.5f}}, 1))
+            .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, 2))
+            .WillOnce(SendWithTimestamp({{"OUTPUT2", 16.5f}}, 2));
 
-    // Expect 6 responses (cycle)
-    // The PythonExecutorCalculator produces increasing timestamps
-    EXPECT_CALL(this->stream, Write(_, _))
-        .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, 0))
-        .WillOnce(SendWithTimestamp({{"OUTPUT2", 14.5f}}, 0))
-        .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, 1))
-        .WillOnce(SendWithTimestamp({{"OUTPUT2", 15.5f}}, 1))
-        .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, 2))
-        .WillOnce(SendWithTimestamp({{"OUTPUT2", 16.5f}}, 2));
-
-    ASSERT_EQ(executor.inferStream(this->firstRequest, this->stream), StatusCode::OK);
+        ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
+    }
+    pythonModule.shutdown();
 }
 
 TEST_F(StreamingTest, MultipleStreamsInMultipleRequestSend1Receive3Python) {
-    py::scoped_interpreter guard{};  // start the interpreter and keep it alive
-    const std::string pbTxt{R"(
+    PythonInterpreterModule pythonModule;
+    pythonModule.start(ovms::Config::instance());
+    // Running everything in the scope, so Python objects get destroyed before module shutdown.
+    {
+        PythonBackend* pythonBackend = pythonModule.getPythonBackend();
+        ConstructorEnabledModelManager manager{"", pythonBackend};
+        const std::string testPbtxt{R"(
 input_stream: "OVMS_PY_TENSOR1:input1"
 input_stream: "OVMS_PY_TENSOR2:input2"
 output_stream: "OVMS_PY_TENSOR1:output1"
@@ -659,42 +640,35 @@ node {
 }
 )"};
 
-    ::mediapipe::CalculatorGraphConfig config;
-    ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(pbTxt, &config));
+        ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
+        DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, pythonBackend);
+        ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
 
-    PythonBackend* pythonBackend;
-    ASSERT_TRUE(PythonBackend::createPythonBackend(&pythonBackend));
-    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources = prepareInputSidePacket(
-        "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py",
-        pythonBackend);
+        std::shared_ptr<MediapipeGraphExecutor> pipeline;
+        ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
+        ASSERT_NE(pipeline, nullptr);
 
-    MediapipeGraphExecutor executor{
-        this->name, this->version, config,
-        {{"input1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
-            {"input2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
-        {{"output1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
-            {"output2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
-        {"input1", "input2"}, {"output1", "output2"}, nodesResources, pythonBackend};
+        pythonModule.releaseGILFromThisThread();
 
-    py::gil_scoped_release release{};
+        std::mutex mtx;
+        const int64_t timestamp = 64;
 
-    std::mutex mtx;
-    const int64_t timestamp = 64;
+        prepareRequest(this->firstRequest, {{"input1", 3.5f}}, timestamp);
+        EXPECT_CALL(this->stream, Read(_))
+            .WillOnce(ReceiveWithTimestamp({{"input2", 7.2f}}, timestamp))
+            .WillOnce(DisconnectWhenNotified(mtx));
 
-    prepareRequest(this->firstRequest, {{"input1", 3.5f}}, timestamp);
-    EXPECT_CALL(this->stream, Read(_))
-        .WillOnce(ReceiveWithTimestamp({{"input2", 7.2f}}, timestamp))
-        .WillOnce(DisconnectWhenNotified(mtx));
+        EXPECT_CALL(this->stream, Write(_, _))
+            .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, timestamp))
+            .WillOnce(SendWithTimestamp({{"OUTPUT2", 8.2f}}, timestamp))
+            .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, timestamp + 1))
+            .WillOnce(SendWithTimestamp({{"OUTPUT2", 9.2f}}, timestamp + 1))
+            .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, timestamp + 2))
+            .WillOnce(SendWithTimestampAndNotifyEnd({{"OUTPUT2", 10.2f}}, timestamp + 2, mtx));
 
-    EXPECT_CALL(this->stream, Write(_, _))
-        .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, timestamp))
-        .WillOnce(SendWithTimestamp({{"OUTPUT2", 8.2f}}, timestamp))
-        .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, timestamp + 1))
-        .WillOnce(SendWithTimestamp({{"OUTPUT2", 9.2f}}, timestamp + 1))
-        .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, timestamp + 2))
-        .WillOnce(SendWithTimestampAndNotifyEnd({{"OUTPUT2", 10.2f}}, timestamp + 2, mtx));
-
-    ASSERT_EQ(executor.inferStream(this->firstRequest, this->stream), StatusCode::OK);
+        ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
+    }
+    pythonModule.shutdown();
 }
 
 // --- End Gen AI Python cases

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -77,8 +77,6 @@ public:
     }
 };
 
-
-
 static void setRequestTimestamp(KFSRequest& request, const std::string& value) {
     request.clear_parameters();
     auto intOpt = ovms::stoi64(value);

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -449,6 +449,256 @@ node {
     ASSERT_EQ(executor.inferStream(this->firstRequest, this->stream), StatusCode::OK);
 }
 
+// Generative AI case + automatic timestamping server-side - Python
+
+#include <pybind11/embed.h>  // everything needed for embedding
+namespace py = pybind11;
+
+#include "../mediapipe_internal/pythonnoderesource.hpp"
+#include "../python/python_backend.hpp"
+
+static std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> prepareInputSidePacket(const std::string& handlerPath, PythonBackend* pythonBackend) {
+    // Create side packets
+    auto fsHandlerPath = std::filesystem::path(handlerPath);
+    fsHandlerPath.replace_extension();
+
+    std::string parentPath = fsHandlerPath.parent_path();
+    std::string filename = fsHandlerPath.filename();
+
+    py::gil_scoped_acquire acquire;
+    py::module_ sys = py::module_::import("sys");
+    sys.attr("path").attr("append")(parentPath.c_str());
+    py::module_ script = py::module_::import(filename.c_str());
+    py::object OvmsPythonModel = script.attr("OvmsPythonModel");
+    py::object pythonModel = OvmsPythonModel();
+
+    std::shared_ptr<PythonNodeResource> nodeResource = std::make_shared<PythonNodeResource>(pythonBackend);
+    nodeResource->nodeResourceObject = std::make_unique<py::object>(pythonModel);
+
+    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources{{"pythonNode", nodeResource}};
+    return nodesResources;
+}
+
+TEST_F(StreamingTest, SingleStreamSend1Receive3Python) {
+    py::scoped_interpreter guard{};  // start the interpreter and keep it alive
+    const std::string pbTxt{R"(
+input_stream: "OVMS_PY_TENSOR:input"
+output_stream: "OVMS_PY_TENSOR:output"
+node {
+    calculator: "PythonExecutorCalculator"
+    name: "pythonNode"
+    input_side_packet: "PYTHON_NODE_RESOURCES:py"
+    input_stream: "LOOPBACK:loopback"
+    input_stream: "INPUT:input"
+    input_stream_info: {
+        tag_index: 'LOOPBACK:0',
+        back_edge: true
+    }
+    input_stream_handler {
+        input_stream_handler: "SyncSetInputStreamHandler",
+        options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                    tag_index: "LOOPBACK:0"
+                }
+            }
+        }
+    }
+    output_stream: "LOOPBACK:loopback"
+    output_stream: "OUTPUT:output"
+    node_options: {
+        [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+            handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+        }
+    }
+}
+)"};
+
+    ::mediapipe::CalculatorGraphConfig config;
+    ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(pbTxt, &config));
+
+    PythonBackend* pythonBackend;
+    ASSERT_TRUE(PythonBackend::createPythonBackend(&pythonBackend));
+    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources = prepareInputSidePacket(
+        "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py",
+        pythonBackend);
+
+    MediapipeGraphExecutor executor{
+        this->name, this->version, config,
+        {{"input", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
+        {{"output", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
+        {"input"}, {"output"}, nodesResources, pythonBackend};
+
+    py::gil_scoped_release release{};
+    // Mock only 1 request and disconnect immediately
+    prepareRequest(this->firstRequest, {{"input", 3.5f}});
+    EXPECT_CALL(this->stream, Read(_))
+        .WillOnce(Disconnect());
+
+    // Expect 3 responses (cycle)
+    // The PythonExecutorCalculator produces increasing timestamps
+    EXPECT_CALL(this->stream, Write(_, _))
+        .WillOnce(SendWithTimestamp({{"OUTPUT", 4.5f}}, 0))
+        .WillOnce(SendWithTimestamp({{"OUTPUT", 5.5f}}, 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT", 6.5f}}, 2));
+
+    ASSERT_EQ(executor.inferStream(this->firstRequest, this->stream), StatusCode::OK);
+}
+
+TEST_F(StreamingTest, MultipleStreamsInSingleRequestSend1Receive3Python) {
+    py::scoped_interpreter guard{};  // start the interpreter and keep it alive
+    const std::string pbTxt{R"(
+input_stream: "OVMS_PY_TENSOR1:input1"
+input_stream: "OVMS_PY_TENSOR2:input2"
+output_stream: "OVMS_PY_TENSOR1:output1"
+output_stream: "OVMS_PY_TENSOR2:output2"
+node {
+    calculator: "PythonExecutorCalculator"
+    name: "pythonNode"
+    input_side_packet: "PYTHON_NODE_RESOURCES:py"
+    input_stream: "LOOPBACK:loopback"
+    input_stream: "INPUT1:input1"
+    input_stream: "INPUT2:input2"
+    input_stream_info: {
+        tag_index: 'LOOPBACK:0',
+        back_edge: true
+    }
+    input_stream_handler {
+        input_stream_handler: "SyncSetInputStreamHandler",
+        options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                    tag_index: "LOOPBACK:0"
+                }
+            }
+        }
+    }
+    output_stream: "LOOPBACK:loopback"
+    output_stream: "OUTPUT1:output1"
+    output_stream: "OUTPUT2:output2"
+    node_options: {
+        [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+            handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+        }
+    }
+}
+)"};
+
+    ::mediapipe::CalculatorGraphConfig config;
+    ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(pbTxt, &config));
+
+    PythonBackend* pythonBackend;
+    ASSERT_TRUE(PythonBackend::createPythonBackend(&pythonBackend));
+    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources = prepareInputSidePacket(
+        "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py",
+        pythonBackend);
+
+    MediapipeGraphExecutor executor{
+        this->name, this->version, config,
+        {{"input1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
+            {"input2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
+        {{"output1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
+            {"output2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
+        {"input1", "input2"}, {"output1", "output2"}, nodesResources, pythonBackend};
+
+    py::gil_scoped_release release{};
+    // Mock only 1 request and disconnect immediately
+    prepareRequest(this->firstRequest, {{"input1", 3.5f}, {"input2", 13.5f}});
+    EXPECT_CALL(this->stream, Read(_))
+        .WillOnce(Disconnect());
+
+    // Expect 6 responses (cycle)
+    // The PythonExecutorCalculator produces increasing timestamps
+    EXPECT_CALL(this->stream, Write(_, _))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, 0))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 14.5f}}, 0))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 15.5f}}, 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, 2))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 16.5f}}, 2));
+
+    ASSERT_EQ(executor.inferStream(this->firstRequest, this->stream), StatusCode::OK);
+}
+
+TEST_F(StreamingTest, MultipleStreamsInMultipleRequestSend1Receive3Python) {
+    py::scoped_interpreter guard{};  // start the interpreter and keep it alive
+    const std::string pbTxt{R"(
+input_stream: "OVMS_PY_TENSOR1:input1"
+input_stream: "OVMS_PY_TENSOR2:input2"
+output_stream: "OVMS_PY_TENSOR1:output1"
+output_stream: "OVMS_PY_TENSOR2:output2"
+node {
+    calculator: "PythonExecutorCalculator"
+    name: "pythonNode"
+    input_side_packet: "PYTHON_NODE_RESOURCES:py"
+    input_stream: "LOOPBACK:loopback"
+    input_stream: "INPUT1:input1"
+    input_stream: "INPUT2:input2"
+    input_stream_info: {
+        tag_index: 'LOOPBACK:0',
+        back_edge: true
+    }
+    input_stream_handler {
+        input_stream_handler: "SyncSetInputStreamHandler",
+        options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                    tag_index: "LOOPBACK:0"
+                }
+            }
+        }
+    }
+    output_stream: "LOOPBACK:loopback"
+    output_stream: "OUTPUT1:output1"
+    output_stream: "OUTPUT2:output2"
+    node_options: {
+        [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+            handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+        }
+    }
+}
+)"};
+
+    ::mediapipe::CalculatorGraphConfig config;
+    ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(pbTxt, &config));
+
+    PythonBackend* pythonBackend;
+    ASSERT_TRUE(PythonBackend::createPythonBackend(&pythonBackend));
+    std::unordered_map<std::string, std::shared_ptr<PythonNodeResource>> nodesResources = prepareInputSidePacket(
+        "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py",
+        pythonBackend);
+
+    MediapipeGraphExecutor executor{
+        this->name, this->version, config,
+        {{"input1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
+            {"input2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
+        {{"output1", mediapipe_packet_type_enum::OVMS_PY_TENSOR},
+            {"output2", mediapipe_packet_type_enum::OVMS_PY_TENSOR}},
+        {"input1", "input2"}, {"output1", "output2"}, nodesResources, pythonBackend};
+
+    py::gil_scoped_release release{};
+
+    std::mutex mtx;
+    const int64_t timestamp = 64;
+
+    prepareRequest(this->firstRequest, {{"input1", 3.5f}}, timestamp);
+    EXPECT_CALL(this->stream, Read(_))
+        .WillOnce(ReceiveWithTimestamp({{"input2", 7.2f}}, timestamp))
+        .WillOnce(DisconnectWhenNotified(mtx));
+
+    EXPECT_CALL(this->stream, Write(_, _))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, timestamp))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 8.2f}}, timestamp))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, timestamp + 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 9.2f}}, timestamp + 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, timestamp + 2))
+        .WillOnce(SendWithTimestampAndNotifyEnd({{"OUTPUT2", 10.2f}}, timestamp + 2, mtx));
+
+    ASSERT_EQ(executor.inferStream(this->firstRequest, this->stream), StatusCode::OK);
+}
+
+// --- End Gen AI Python cases
+
 // Sending inputs separately for synchronized graph
 TEST_F(StreamingTest, MultipleStreamsDeliveredViaMultipleRequests) {
     const std::string pbTxt{R"(

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -53,6 +53,32 @@ protected:
     MockedServerReaderWriter<::inference::ModelStreamInferResponse, ::inference::ModelInferRequest> stream;
 };
 
+class PythonStreamingTest : public StreamingTest {
+protected:
+    // Defaults for executor
+    std::unique_ptr<PythonInterpreterModule> pythonModule;
+    PythonBackend* pythonBackend;
+
+    std::unique_ptr<ConstructorEnabledModelManager> manager;
+
+public:
+    void SetUp() {
+        pythonModule = std::make_unique<PythonInterpreterModule>();
+        pythonModule->start(ovms::Config::instance());
+        pythonBackend = pythonModule->getPythonBackend();
+        manager = std::make_unique<ConstructorEnabledModelManager>("", pythonBackend);
+    }
+
+    void TearDown() {
+        manager.reset();
+        pythonModule->reacquireGILForThisThread();
+        pythonModule->shutdown();
+        pythonModule.reset();
+    }
+};
+
+
+
 static void setRequestTimestamp(KFSRequest& request, const std::string& value) {
     request.clear_parameters();
     auto intOpt = ovms::stoi64(value);
@@ -457,153 +483,66 @@ node {
 namespace py = pybind11;
 #include "../python/python_backend.hpp"
 
-TEST_F(StreamingTest, SingleStreamSend1Receive3Python) {
-    PythonInterpreterModule pythonModule;
-    pythonModule.start(ovms::Config::instance());
-    // Running everything in the scope, so Python objects get destroyed before module shutdown.
-    {
-        PythonBackend* pythonBackend = pythonModule.getPythonBackend();
-        ConstructorEnabledModelManager manager{"", pythonBackend};
-        const std::string testPbtxt{R"(
-    input_stream: "OVMS_PY_TENSOR:input"
-    output_stream: "OVMS_PY_TENSOR:output"
-    node {
-        calculator: "PythonExecutorCalculator"
-        name: "pythonNode"
-        input_side_packet: "PYTHON_NODE_RESOURCES:py"
-        input_stream: "LOOPBACK:loopback"
-        input_stream: "INPUT:input"
-        input_stream_info: {
-            tag_index: 'LOOPBACK:0',
-            back_edge: true
-        }
-        input_stream_handler {
-            input_stream_handler: "SyncSetInputStreamHandler",
-            options {
-                [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
-                    sync_set {
-                        tag_index: "LOOPBACK:0"
-                    }
+TEST_F(PythonStreamingTest, SingleStreamSend1Receive3Python) {
+    const std::string testPbtxt{R"(
+input_stream: "OVMS_PY_TENSOR:input"
+output_stream: "OVMS_PY_TENSOR:output"
+node {
+    calculator: "PythonExecutorCalculator"
+    name: "pythonNode"
+    input_side_packet: "PYTHON_NODE_RESOURCES:py"
+    input_stream: "LOOPBACK:loopback"
+    input_stream: "INPUT:input"
+    input_stream_info: {
+        tag_index: 'LOOPBACK:0',
+        back_edge: true
+    }
+    input_stream_handler {
+        input_stream_handler: "SyncSetInputStreamHandler",
+        options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                    tag_index: "LOOPBACK:0"
                 }
             }
         }
-        output_stream: "LOOPBACK:loopback"
-        output_stream: "OUTPUT:output"
-        node_options: {
-            [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
-                handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
-            }
+    }
+    output_stream: "LOOPBACK:loopback"
+    output_stream: "OUTPUT:output"
+    node_options: {
+        [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+            handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
         }
     }
-    )"};
+}
+)"};
 
-        ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
-        DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, pythonBackend);
-        ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
+    ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
+    DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, this->pythonBackend);
+    ASSERT_EQ(mediapipeDummy.validate(*this->manager), StatusCode::OK);
 
-        std::shared_ptr<MediapipeGraphExecutor> pipeline;
-        ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
-        ASSERT_NE(pipeline, nullptr);
+    std::shared_ptr<MediapipeGraphExecutor> pipeline;
+    ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
+    ASSERT_NE(pipeline, nullptr);
 
-        pythonModule.releaseGILFromThisThread();
-        // Mock only 1 request and disconnect immediately
-        prepareRequest(this->firstRequest, {{"input", 3.5f}});
-        EXPECT_CALL(this->stream, Read(_))
-            .WillOnce(Disconnect());
+    this->pythonModule->releaseGILFromThisThread();
+    // Mock only 1 request and disconnect immediately
+    prepareRequest(this->firstRequest, {{"input", 3.5f}});
+    EXPECT_CALL(this->stream, Read(_))
+        .WillOnce(Disconnect());
 
-        // Expect 3 responses (cycle)
-        // The PythonExecutorCalculator produces increasing timestamps
-        EXPECT_CALL(this->stream, Write(_, _))
-            .WillOnce(SendWithTimestamp({{"OUTPUT", 4.5f}}, 0))
-            .WillOnce(SendWithTimestamp({{"OUTPUT", 5.5f}}, 1))
-            .WillOnce(SendWithTimestamp({{"OUTPUT", 6.5f}}, 2));
+    // Expect 3 responses (cycle)
+    // The PythonExecutorCalculator produces increasing timestamps
+    EXPECT_CALL(this->stream, Write(_, _))
+        .WillOnce(SendWithTimestamp({{"OUTPUT", 4.5f}}, 0))
+        .WillOnce(SendWithTimestamp({{"OUTPUT", 5.5f}}, 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT", 6.5f}}, 2));
 
-        ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
-    }
-    pythonModule.shutdown();
+    ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
 }
 
-TEST_F(StreamingTest, MultipleStreamsInSingleRequestSend1Receive3Python) {
-    PythonInterpreterModule pythonModule;
-    pythonModule.start(ovms::Config::instance());
-    // Running everything in the scope, so Python objects get destroyed before module shutdown.
-    {
-        PythonBackend* pythonBackend = pythonModule.getPythonBackend();
-        ConstructorEnabledModelManager manager{"", pythonBackend};
-        const std::string testPbtxt{R"(
-    input_stream: "OVMS_PY_TENSOR1:input1"
-    input_stream: "OVMS_PY_TENSOR2:input2"
-    output_stream: "OVMS_PY_TENSOR1:output1"
-    output_stream: "OVMS_PY_TENSOR2:output2"
-    node {
-        calculator: "PythonExecutorCalculator"
-        name: "pythonNode"
-        input_side_packet: "PYTHON_NODE_RESOURCES:py"
-        input_stream: "LOOPBACK:loopback"
-        input_stream: "INPUT1:input1"
-        input_stream: "INPUT2:input2"
-        input_stream_info: {
-            tag_index: 'LOOPBACK:0',
-            back_edge: true
-        }
-        input_stream_handler {
-            input_stream_handler: "SyncSetInputStreamHandler",
-            options {
-                [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
-                    sync_set {
-                        tag_index: "LOOPBACK:0"
-                    }
-                }
-            }
-        }
-        output_stream: "LOOPBACK:loopback"
-        output_stream: "OUTPUT1:output1"
-        output_stream: "OUTPUT2:output2"
-        node_options: {
-            [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
-                handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
-            }
-        }
-    }
-    )"};
-
-        ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
-        DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, pythonBackend);
-        ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
-
-        std::shared_ptr<MediapipeGraphExecutor> pipeline;
-        ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
-        ASSERT_NE(pipeline, nullptr);
-
-        pythonModule.releaseGILFromThisThread();
-        // Mock only 1 request and disconnect immediately
-        prepareRequest(this->firstRequest, {{"input1", 3.5f}, {"input2", 13.5f}});
-        EXPECT_CALL(this->stream, Read(_))
-            .WillOnce(Disconnect());
-
-        // Expect 6 responses (cycle)
-        // The PythonExecutorCalculator produces increasing timestamps
-        EXPECT_CALL(this->stream, Write(_, _))
-            .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, 0))
-            .WillOnce(SendWithTimestamp({{"OUTPUT2", 14.5f}}, 0))
-            .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, 1))
-            .WillOnce(SendWithTimestamp({{"OUTPUT2", 15.5f}}, 1))
-            .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, 2))
-            .WillOnce(SendWithTimestamp({{"OUTPUT2", 16.5f}}, 2));
-
-        ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
-    }
-    pythonModule.shutdown();
-}
-
-TEST_F(StreamingTest, MultipleStreamsInMultipleRequestSend1Receive3Python) {
-    PythonInterpreterModule pythonModule;
-    pythonModule.start(ovms::Config::instance());
-    // Running everything in the scope, so Python objects get destroyed before module shutdown.
-    {
-        PythonBackend* pythonBackend = pythonModule.getPythonBackend();
-        ConstructorEnabledModelManager manager{"", pythonBackend};
-        const std::string testPbtxt{R"(
+TEST_F(PythonStreamingTest, MultipleStreamsInSingleRequestSend1Receive3Python) {
+    const std::string testPbtxt{R"(
 input_stream: "OVMS_PY_TENSOR1:input1"
 input_stream: "OVMS_PY_TENSOR2:input2"
 output_stream: "OVMS_PY_TENSOR1:output1"
@@ -640,35 +579,98 @@ node {
 }
 )"};
 
-        ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
-        DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, pythonBackend);
-        ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::OK);
+    ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
+    DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, this->pythonBackend);
+    ASSERT_EQ(mediapipeDummy.validate(*this->manager), StatusCode::OK);
 
-        std::shared_ptr<MediapipeGraphExecutor> pipeline;
-        ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
-        ASSERT_NE(pipeline, nullptr);
+    std::shared_ptr<MediapipeGraphExecutor> pipeline;
+    ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
+    ASSERT_NE(pipeline, nullptr);
 
-        pythonModule.releaseGILFromThisThread();
+    this->pythonModule->releaseGILFromThisThread();
+    // Mock only 1 request and disconnect immediately
+    prepareRequest(this->firstRequest, {{"input1", 3.5f}, {"input2", 13.5f}});
+    EXPECT_CALL(this->stream, Read(_))
+        .WillOnce(Disconnect());
 
-        std::mutex mtx;
-        const int64_t timestamp = 64;
+    // Expect 6 responses (cycle)
+    // The PythonExecutorCalculator produces increasing timestamps
+    EXPECT_CALL(this->stream, Write(_, _))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, 0))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 14.5f}}, 0))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 15.5f}}, 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, 2))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 16.5f}}, 2));
 
-        prepareRequest(this->firstRequest, {{"input1", 3.5f}}, timestamp);
-        EXPECT_CALL(this->stream, Read(_))
-            .WillOnce(ReceiveWithTimestamp({{"input2", 7.2f}}, timestamp))
-            .WillOnce(DisconnectWhenNotified(mtx));
+    ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
+}
 
-        EXPECT_CALL(this->stream, Write(_, _))
-            .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, timestamp))
-            .WillOnce(SendWithTimestamp({{"OUTPUT2", 8.2f}}, timestamp))
-            .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, timestamp + 1))
-            .WillOnce(SendWithTimestamp({{"OUTPUT2", 9.2f}}, timestamp + 1))
-            .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, timestamp + 2))
-            .WillOnce(SendWithTimestampAndNotifyEnd({{"OUTPUT2", 10.2f}}, timestamp + 2, mtx));
-
-        ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
+TEST_F(PythonStreamingTest, MultipleStreamsInMultipleRequestSend1Receive3Python) {
+    const std::string testPbtxt{R"(
+input_stream: "OVMS_PY_TENSOR1:input1"
+input_stream: "OVMS_PY_TENSOR2:input2"
+output_stream: "OVMS_PY_TENSOR1:output1"
+output_stream: "OVMS_PY_TENSOR2:output2"
+node {
+calculator: "PythonExecutorCalculator"
+name: "pythonNode"
+input_side_packet: "PYTHON_NODE_RESOURCES:py"
+input_stream: "LOOPBACK:loopback"
+input_stream: "INPUT1:input1"
+input_stream: "INPUT2:input2"
+input_stream_info: {
+    tag_index: 'LOOPBACK:0',
+    back_edge: true
+}
+input_stream_handler {
+    input_stream_handler: "SyncSetInputStreamHandler",
+    options {
+        [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+            sync_set {
+                tag_index: "LOOPBACK:0"
+            }
+        }
     }
-    pythonModule.shutdown();
+}
+output_stream: "LOOPBACK:loopback"
+output_stream: "OUTPUT1:output1"
+output_stream: "OUTPUT2:output2"
+node_options: {
+    [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+        handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+    }
+}
+}
+)"};
+
+    ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
+    DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, this->pythonBackend);
+    ASSERT_EQ(mediapipeDummy.validate(*this->manager), StatusCode::OK);
+
+    std::shared_ptr<MediapipeGraphExecutor> pipeline;
+    ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
+    ASSERT_NE(pipeline, nullptr);
+
+    this->pythonModule->releaseGILFromThisThread();
+
+    std::mutex mtx;
+    const int64_t timestamp = 64;
+
+    prepareRequest(this->firstRequest, {{"input1", 3.5f}}, timestamp);
+    EXPECT_CALL(this->stream, Read(_))
+        .WillOnce(ReceiveWithTimestamp({{"input2", 7.2f}}, timestamp))
+        .WillOnce(DisconnectWhenNotified(mtx));
+
+    EXPECT_CALL(this->stream, Write(_, _))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 4.5f}}, timestamp))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 8.2f}}, timestamp))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 5.5f}}, timestamp + 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT2", 9.2f}}, timestamp + 1))
+        .WillOnce(SendWithTimestamp({{"OUTPUT1", 6.5f}}, timestamp + 2))
+        .WillOnce(SendWithTimestampAndNotifyEnd({{"OUTPUT2", 10.2f}}, timestamp + 2, mtx));
+
+    ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
 }
 
 // --- End Gen AI Python cases


### PR DESCRIPTION
Summary:
- enhanced PythonExecutorCalculator with support to generation (producing packets in the loop for single input set)
- added deadline to gRPC server - after receiving shutdown signal server will try to finish gracefully. After deadline expires it will forcefully disconnect clients and try to proceed (https://grpc.github.io/grpc/cpp/classgrpc_1_1_server_interface.html#a644772d11101318f1424e595dee73ccf)
- modified writing to gRPC stream to be thread-safe