### PR TITLE
Diminish race condition probability

### DIFF
--- a/rununittest.sh
+++ b/rununittest.sh
@@ -26,7 +26,11 @@ ${debug_bazel_flags} \
 generate_coverage_report() {
     genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
 }
+test_success_procedure() {
+    grep -a " ms \| ms)" ${TEST_LOG}
+}
 test_fail_procedure() {
+    test_success_procedure
     cat ${TEST_LOG} && rm -rf ${TEST_LOG} && exit 1
 }
 echo "Run test: ${RUN_TESTS}"
@@ -43,6 +47,6 @@ if [ "$RUN_TESTS" == "1" ] ; then
         ${SHARED_OPTIONS} "${TEST_FILTER}" \
         //src:ovms_test > ${TEST_LOG} 2>&1 || \
         test_fail_procedure; } && \
-        tail -n 100 ${TEST_LOG} && \
+        test_success_procedure && \
         rm -rf ${TEST_LOG};
 fi

--- a/rununittest.sh
+++ b/rununittest.sh
@@ -23,11 +23,12 @@ ${debug_bazel_flags} \
 --test_summary=detailed \
 --test_output=streamed \
 --test_env PYTHONPATH=${PYTHONPATH}"
-generate_coverage_report() {
-    genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
-}
 test_success_procedure() {
     grep -a " ms \| ms)" ${TEST_LOG}
+}
+generate_coverage_report() {
+    test_success_procedure
+    genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
 }
 test_fail_procedure() {
     test_success_procedure

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -2163,7 +2163,8 @@ class ModelInstanceModelLoadedNotify : public ::testing::Test {};
 TEST_F(ModelInstanceModelLoadedNotify, WhenChangedStateFromLoadingToAvailableInNotReachingTimeoutShouldSuceed) {
     // Need unit tests for modelInstance load first
     ModelManagerWithModelInstanceLoadedWaitInLoadingState manager;
-    const uint32_t modelLoadingTimeoutMs = 100;
+    // This test checks for proper status in two iterations with 100ms time step and is prone for CPU overheat
+    const uint32_t modelLoadingTimeoutMs = 200;
     manager.setWaitForModelLoadedTimeoutMs(modelLoadingTimeoutMs);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
     modelWithModelInstanceLoadedWaitInLoadingState = std::make_shared<ModelWithModelInstanceLoadedWaitInLoadingState>(
@@ -2179,7 +2180,8 @@ TEST_F(ModelInstanceModelLoadedNotify, WhenChangedStateFromLoadingToAvailableInN
 TEST_F(ModelInstanceModelLoadedNotify, WhenChangedStateFromLoadingToAvailableInReachingTimeoutShouldReturnModelNotLoadedYet) {
     // Need unit tests for modelInstance load first
     ModelManagerWithModelInstanceLoadedWaitInLoadingState manager;
-    const uint32_t modelLoadingTimeoutMs = 100;
+    // This test checks for proper status in two iterations with 100ms time step and is prone for CPU overheat
+    const uint32_t modelLoadingTimeoutMs = 200;
     manager.setWaitForModelLoadedTimeoutMs(modelLoadingTimeoutMs);
     ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
 


### PR DESCRIPTION
- lets allow model instance while condition check to run at least 2 times not 1 as before, in original ovms it runs 10 times.
- lets change fail, success on tests logging from 100 lines to all tests with time they have run in ms for better understanding if test failed because of heavy cpu load.