### PR TITLE
Validate bad configuration when using Python node as generator

### DIFF
--- a/src/python/utils.hpp
+++ b/src/python/utils.hpp
@@ -92,4 +92,18 @@ public:
     }
 };
 
+class BadPythonNodeConfigurationError : public std::exception {
+    std::string message;
+
+public:
+    BadPythonNodeConfigurationError() = delete;
+    BadPythonNodeConfigurationError(const std::string& message) {
+        this->message = "Bad python node configuration. " + message;
+    }
+
+    const char* what() const throw() override {
+        return message.c_str();
+    }
+};
+
 }  // namespace ovms

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -496,6 +496,27 @@ TEST_F(PythonFlowTest, PythonNodePassArgumentsToConstructor) {
     }
 }
 
+TEST_F(PythonFlowTest, PythonNodeLoopbackDefinedOnlyOnOutput) {
+    ConstructorEnabledModelManager manager;
+    std::string testPbtxt = R"(
+    input_stream: "in"
+    output_stream: "out"
+        node {
+            name: "pythonNode2"
+            calculator: "PythonExecutorCalculator"
+            input_side_packet: "PYTHON_NODE_RESOURCES:py"
+            input_stream: "in"
+            output_stream: "out2"
+            output_stream: "LOOPBACK:loopback"
+        }
+    )";
+
+    ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, getPythonBackend());
+    mediapipeDummy.inputConfig = testPbtxt;
+    ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR);
+}
+
 // Wrapper on the OvmsPyTensor of datatype FP32 and shape (1, num_elements)
 // where num_elements is the size of C++ float array. See createTensor static method.
 template <typename T>

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -516,7 +516,7 @@ TEST_F(PythonFlowTest, PythonNodeLoopbackDefinedOnlyOnOutput) {
     mediapipeDummy.inputConfig = testPbtxt;
     ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::MEDIAPIPE_GRAPH_INITIALIZATION_ERROR);
 }
-
+// TODO: Add test with only input LOOPBACK
 // Wrapper on the OvmsPyTensor of datatype FP32 and shape (1, num_elements)
 // where num_elements is the size of C++ float array. See createTensor static method.
 template <typename T>

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -711,7 +711,7 @@ node_options: {
     EXPECT_CALL(this->stream, Read(_));
     ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::MEDIAPIPE_EXECUTION_ERROR);
 }
-
+// TODO: Add more negative tests for wrong configurations
 // --- End Gen AI Python cases
 
 // Sending inputs separately for synchronized graph

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -671,6 +671,47 @@ node_options: {
     ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::OK);
 }
 
+// Negative - execute yields, but no loopback
+TEST_F(PythonStreamingTest, ExecuteYieldsButNoLoopback) {
+    const std::string testPbtxt{R"(
+input_stream: "OVMS_PY_TENSOR1:input1"
+input_stream: "OVMS_PY_TENSOR2:input2"
+output_stream: "OVMS_PY_TENSOR1:output1"
+output_stream: "OVMS_PY_TENSOR2:output2"
+node {
+calculator: "PythonExecutorCalculator"
+name: "pythonNode"
+input_side_packet: "PYTHON_NODE_RESOURCES:py"
+input_stream: "INPUT1:input1"
+input_stream: "INPUT2:input2"
+output_stream: "OUTPUT1:output1"
+output_stream: "OUTPUT2:output2"
+node_options: {
+    [type.googleapis.com / mediapipe.PythonExecutorCalculatorOptions]: {
+        handler_path: "/ovms/src/test/mediapipe/python/scripts/symmetric_scalar_increment_generator.py"
+    }
+}
+}
+)"};
+
+    ovms::MediapipeGraphConfig mgc{"my_graph", "", ""};
+    DummyMediapipeGraphDefinition mediapipeDummy("my_graph", mgc, testPbtxt, this->pythonBackend);
+    ASSERT_EQ(mediapipeDummy.validate(*this->manager), StatusCode::OK);
+
+    std::shared_ptr<MediapipeGraphExecutor> pipeline;
+    ASSERT_EQ(mediapipeDummy.create(pipeline, nullptr, nullptr), StatusCode::OK);
+    ASSERT_NE(pipeline, nullptr);
+
+    this->pythonModule->releaseGILFromThisThread();
+
+    std::mutex mtx;
+    const int64_t timestamp = 64;
+
+    prepareRequest(this->firstRequest, {{"input1", 3.5f}, {"input2", 3.5f}}, timestamp);
+    EXPECT_CALL(this->stream, Read(_));
+    ASSERT_EQ(pipeline->inferStream(this->firstRequest, this->stream), StatusCode::MEDIAPIPE_EXECUTION_ERROR);
+}
+
 // --- End Gen AI Python cases
 
 // Sending inputs separately for synchronized graph


### PR DESCRIPTION
Summary:
- reject graphs with python nodes that have LOOPBACK only on input or output. Must be both or neither. 
- reject first request if python node is configured for regular execution, but the execute() function yields.