### PR TITLE
Fix running python nodes on RH

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -206,8 +206,8 @@ http_archive(
 http_archive(
   name = "pybind11",
   build_file = "@pybind11_bazel//:pybind11.BUILD",
-  strip_prefix = "pybind11-2.10.4",
-  urls = ["https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"],
+  strip_prefix = "pybind11-2.11.1",
+  urls = ["https://github.com/pybind/pybind11/archive/v2.11.1.tar.gz"],
 )
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")
 python_configure(name = "local_config_python")

--- a/rununittest.sh
+++ b/rununittest.sh
@@ -15,7 +15,7 @@
 #
 
 # This script should be used inside build image to run unit tests
-TEST_FILTER="--test_filter=*:-PythonFlowTest.InitializationPass:PythonFlowTest.FinalizationPass:PythonFlowTest.PythonNodePassArgumentsToConstructor:PythonFlowTest.PythonCalculatorTestSingleInSingleOut:PythonFlowTest.PythonCalculatorTestMultiInMultiOut:PythonFlowTest.PythonCalculatorTestSingleInSingleOutMultiRunWithErrors:PythonFlowTest.ReloadWithDifferentScriptName"
+TEST_FILTER="--test_filter=*"
 SHARED_OPTIONS=" \
 --jobs=$JOBS \
 ${debug_bazel_flags} \

--- a/src/test/mediapipe/python/scripts/symmetric_increment.py
+++ b/src/test/mediapipe/python/scripts/symmetric_increment.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 #*****************************************************************************
 import numpy as np
+import sys
 from pyovms import Tensor
 class OvmsPythonModel:
 
     def initialize(self, kwargs: dict):
+        for path in sys.path:
+            print(path)
         self.model_outputs = dict() 
         return
 

--- a/src/test/mediapipe/python/scripts/symmetric_increment.py
+++ b/src/test/mediapipe/python/scripts/symmetric_increment.py
@@ -14,14 +14,11 @@
 # limitations under the License.
 #*****************************************************************************
 import numpy as np
-import sys
 from pyovms import Tensor
 class OvmsPythonModel:
 
     def initialize(self, kwargs: dict):
-        for path in sys.path:
-            print(path)
-        self.model_outputs = dict() 
+        self.model_outputs = dict()
         return
 
     def execute(self, inputs: list, kwargs: dict = {}):


### PR DESCRIPTION
Issue was in different search module paths on Ubuntu vs RedHat. In RH /usr/local/lib64/python3.9/dist-packages was missing when running on pybind. It looks like newer pybind package does fix this which solves issue with importing numpy.

JIRA:CVS-126943