### PR TITLE
Fixed capi benchmark app

### DIFF
--- a/src/main_benchmark.cpp
+++ b/src/main_benchmark.cpp
@@ -83,7 +83,7 @@ void BenchmarkCLIParser::parse(int argc, char** argv) {
                 cxxopts::value<uint32_t>()->default_value("1"),
                 "NIREQ")
             ("threads_per_ireq",
-                "workload threads per ireq",
+                "maximum workload threads per ireq",
                 cxxopts::value<uint32_t>()->default_value("2"),
                 "THREADS_PER_IREQ")
             // inference data

--- a/src/main_benchmark.cpp
+++ b/src/main_benchmark.cpp
@@ -443,7 +443,7 @@ int main(int argc, char** argv) {
     size_t nireq = cliparser.result->operator[]("nireq").as<uint32_t>();
     size_t niter = cliparser.result->operator[]("niter").as<uint32_t>();
     size_t threadsPerIreq = cliparser.result->operator[]("threads_per_ireq").as<uint32_t>();
-    size_t threadCount = nireq * threadsPerIreq;
+    size_t threadCount = std::min(nireq * threadsPerIreq, niter);
     size_t niterPerThread = niter / threadCount;
 
     auto elementsCount = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<signed_shape_t::value_type>());


### PR DESCRIPTION
When the amount of spawned threads (nireq * threadsPerIreq) is greater than the number of inferences to conduct (niter) then due to integer rounding number of iterations per thread will result in 0 and thus no inference will be performed.

This fix caps the amount of created threads so it will not exceed the number of inferences to conduct (niter) and niterPerThread will always be greater or equal to 1.