### PR TITLE
Fix boost build cause by unavailable source code in JForg 

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -58,7 +58,7 @@ RUN git clone -b v1.13 https://github.com/zeux/pugixml && \
 ####### Azure SDK needs new boost:
 WORKDIR /boost
 # hadolint ignore=DL3003
-RUN wget -nv https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.gz && \
+RUN wget -nv https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.tar.gz && \
 	tar xvf boost_1_68_0.tar.gz && cd boost_1_68_0 && ./bootstrap.sh && \
 	./b2 -j ${JOBS} cxxstd=17 link=static cxxflags='-fPIC' cflags='-fPIC' \
 		--with-chrono --with-date_time --with-filesystem --with-program_options --with-system \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 ####### Azure SDK needs new boost:
 WORKDIR /boost
 # hadolint ignore=DL3003
-RUN wget -nv https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz && \
+RUN wget -nv https://sourceforge.net/projects/boost/files/boost/1.69.0/boost_1_69_0.tar.gz && \
 tar xf boost_1_69_0.tar.gz && cd boost_1_69_0 && ./bootstrap.sh && \
 sed -i -e 's|#if PTHREAD_STACK_MIN > 0|#ifdef PTHREAD_STACK_MIN|g' boost/thread/pthread/thread_data.hpp && \
 # fix for compiler >=9.5 https://github.com/boostorg/thread/pull/297/files


### PR DESCRIPTION
This PR aim to fix boost build error cause by unavailable access to JForg with not-register user, use sourceforge link instead.

Issue: both https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.gz and https://sourceforge.net/projects/boost/files/boost/1.69.0/boost_1_69_0.tar.gz will be redirect to following site without source downloading

![boost_jfrog_pacakge_unavailable](https://github.com/openvinotoolkit/model_server/assets/22404054/89870cdf-db85-4f77-b49a-a825e0b4179c)
