### PR TITLE
Remove non used oneTBB OVMS dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,7 +76,6 @@ cc_library(
         "@linux_openvino//:openvino",
         "@linux_opencv//:opencv",
         "@com_github_jupp0r_prometheus_cpp//core",
-        "@oneTBB//:tbb",
         ] + select({
             "//:not_disable_mediapipe": [
                 "@mediapipe//mediapipe/framework:calculator_framework",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -421,14 +421,6 @@ new_git_repository(
     commit = "03a6cee5d486ee9eabb625e4388e69fe9c50ef20"
 )
 
-git_repository(
-    name = "oneTBB",
-    branch = "v2021.10.0", # need newer version to be compatible with bazel 6.0
-    remote = "https://github.com/oneapi-src/oneTBB/",
-    patch_args = ["-p1"],
-    patches = ["mwaitpkg.patch",]
-)
-
 new_local_repository(
     name = "mediapipe_calculators",
     build_file = "@//third_party/mediapipe_calculators:BUILD",

--- a/src/BUILD
+++ b/src/BUILD
@@ -126,7 +126,6 @@ cc_shared_library(
         "@com_github_grpc_grpc//:__subpackages__",
         "@upb//:__subpackages__",
         "@zlib//:__subpackages__",
-        "@oneTBB//:__subpackages__",
         "@com_github_glog_glog//:__subpackages__",
         "@com_github_gflags_gflags//:__subpackages__",
         "@XNNPACK//:__subpackages__",

--- a/src/systeminfo.cpp
+++ b/src/systeminfo.cpp
@@ -20,14 +20,11 @@
 #include <string>
 #include <thread>
 
-#include <openvino/core/parallel.hpp>
-
 #include "logging.hpp"
 #include "status.hpp"
 
 namespace ovms {
 uint16_t getCoreCount() {
-    // return parallel_get_num_threads();
     return std::thread::hardware_concurrency();
 }
 }  // namespace ovms


### PR DESCRIPTION
Previously planned to be used to calculate REST threads 