### PR TITLE
Improve validation of duplicated keys

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -59,6 +59,9 @@ build --define=PYTHON_DISABLE=0
 coverage --define=PYTHON_DISABLE=0
 test --define=PYTHON_DISABLE=0
 
+# sometimes failed logs exceed this threshold
+test --experimental_ui_max_stdouterr_bytes=104857600
+
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos
 

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -23,8 +23,9 @@
 
 namespace ovms {
 extern const std::string MODELS_CONFIG_SCHEMA;
+extern const std::string MODEL_CONFIG_DEFINITION2;
 extern const char* MODELS_MAPPING_SCHEMA;
 extern const std::string MEDIAPIPE_SUBCONFIG_SCHEMA;
 
-StatusCode validateJsonAgainstSchema(rapidjson::Document& json, const char* schema);
+Status validateJsonAgainstSchema(rapidjson::Document& json, const char* schema, bool detailedError = false);
 }  // namespace ovms

--- a/src/test/mediapipe/relative_paths/config_relative_dummy.json
+++ b/src/test/mediapipe/relative_paths/config_relative_dummy.json
@@ -4,13 +4,15 @@
                 "name": "dummy1",
                 "base_path": "graph1/dummy1",
                 "shape": "(1, 10)"
-		},
+            }
+        },
+        {
          "config": {
                 "name": "dummy2",
                 "base_path": "graph2/dummy2",
                 "shape": "(1, 10)"
-		}
-	}
+            }
+        }
     ],
     "mediapipe_config_list": [
         {

--- a/src/test/mediapipe/relative_paths/config_relative_dummy_negative.json
+++ b/src/test/mediapipe/relative_paths/config_relative_dummy_negative.json
@@ -4,13 +4,15 @@
                 "name": "dummy1",
                 "base_path": "dummy1",
                 "shape": "(1, 10)"
-		},
+            }
+        },
+        {
          "config": {
                 "name": "dummy2",
                 "base_path": "dummy2",
                 "shape": "(1, 10)"
-		}
-	}
+            }
+        }
     ],
     "mediapipe_config_list": [
         {


### PR DESCRIPTION
Further improvements are limited by rapidjson, as using maxProperties only makes sense when all properties are required.

Since rapidjson development seams to be ceased - no release till 2016, it would make sense to switch to nlohmann/json but that would require slightly more time.

Related issues:
https://github.com/Tencent/rapidjson/issues/1630

JIRA:CVS-128124