### PR TITLE
Quieten boost

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -59,7 +59,7 @@ RUN git clone -b v1.13 https://github.com/zeux/pugixml && \
 WORKDIR /boost
 # hadolint ignore=DL3003
 RUN wget -nv https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.tar.gz && \
-	tar xvf boost_1_68_0.tar.gz && cd boost_1_68_0 && ./bootstrap.sh && \
+	tar xf boost_1_68_0.tar.gz && cd boost_1_68_0 && ./bootstrap.sh && \
 	./b2 -j ${JOBS} cxxstd=17 link=static cxxflags='-fPIC' cflags='-fPIC' \
 		--with-chrono --with-date_time --with-filesystem --with-program_options --with-system \
 		--with-random --with-thread --with-atomic --with-regex \


### PR DESCRIPTION
By having a verbose flag, it creates ~67,000 lines of messages in the build logs just for unpacking the boost tar file. This makes it challenging to audit the build process.