### PR TITLE
Fix cpprestsdk linker flag injection bug

### DIFF
--- a/third_party/azure/azure_sdk.patch
+++ b/third_party/azure/azure_sdk.patch
@@ -7,7 +7,7 @@ index ac9e65d..fd2aca4 100644
    set(WARNINGS "${WARNINGS} ${LINUX_SUPPRESSIONS}")
  
 -  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
-+  set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs,--exclude-libs,ALL")
++  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs,--exclude-libs,ALL")
  
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
  


### PR DESCRIPTION
cpprestsdk has a bug where it tries to override LD_FLAGS. With cmake, this is not the right thing to do. You have to use a targeted CMAKE_XXX_LINKER_FLAGS variable where XXX is what you want to affect. Fortunately this repo patches the same line and we can correct this design mistake. The patch changes LD_FLAGS to CMAKE_SHARED_LINKER_FLAGS since we are building a shared object. You can now see that the flag originally trying to be patched in is visible in the linking of this part of the build.