### PR TITLE
Allow flag injection to pugixml

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -51,6 +51,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 # hadolint ignore=DL3003
 RUN git clone -b v1.13 https://github.com/zeux/pugixml && \
     cd pugixml && \
+    patch -p1 < /ovms/third_party/pugixml/pugixml_v1.13_flags.patch && \
     cmake -DBUILD_SHARED_LIBS=ON && \
     make all && \
     cp -P libpugixml.so* /usr/lib64/

--- a/third_party/pugixml/pugixml_v1.13_flags.patch
+++ b/third_party/pugixml/pugixml_v1.13_flags.patch
@@ -1,0 +1,13 @@
+diff -urp pugixml.orig/CMakeLists.txt pugixml/CMakeLists.txt
+--- pugixml.orig/CMakeLists.txt	2024-03-28 11:42:34.762099584 -0400
++++ pugixml/CMakeLists.txt	2024-03-28 11:28:37.990715094 -0400
+@@ -91,6 +91,9 @@ if (CMAKE_VERSION VERSION_LESS 3.15)
+   set(msvc-rt-mt-static $<${msvc-rt-mt-static}:-MT>)
+ endif()
+ 
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
++
+ set(versioned-dir $<$<BOOL:${PUGIXML_USE_VERSIONED_LIBDIR}>:/pugixml-${PROJECT_VERSION}>)
+ 
+ set(libs)


### PR DESCRIPTION
This commit contains a patch that adds the variables for the CXX and linker flags to the CMakeLists.txt file. It then uses the patch during build so that later we can inject build flags on the cmake command.