### PR TITLE
print_summary option to benchmark_client to parse benchmark results.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ FUZZER_BUILD ?= 0
 #         - adjust binary version path - version variable is not passed to WORKSPACE file!
 OV_SOURCE_BRANCH ?= f8d071002b6fe0bca2617558221850e01fe202ad  # 2024.1
 OV_CONTRIB_BRANCH ?= b36781b43e0fbcbbb386619b853d842c67728f3f  # 2024.0
-OV_TOKENIZERS_BRANCH ?= 2024.0.0.0
+OV_TOKENIZERS_BRANCH ?= f07f92522ee6bc8ceb3e920807453a5236e76093  # 02.04.2024 master
 
 OV_SOURCE_ORG ?= openvinotoolkit
 OV_CONTRIB_ORG ?= openvinotoolkit

--- a/demos/benchmark/python/README.md
+++ b/demos/benchmark/python/README.md
@@ -328,12 +328,12 @@ NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a 
 
 ## Summarize benchmarking results
 
-Summary of the benchmark results can be viewed with command option ```-ps```
+Summary of the benchmark results can be viewed with command option ```-ps```.
 ```
 docker run --network host benchmark_client -a localhost -r 8000 -m face-detection-retail-0005 -p 9000 -s 2 3 300 300 -t 20 -u 2 -w 10 -ps
 ```
 
-Sample ouptut log with results summary
+Sample output log with results summary:
 
 ```
 Client 2.7

--- a/demos/benchmark/python/README.md
+++ b/demos/benchmark/python/README.md
@@ -344,7 +344,7 @@ NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a 
  Model: face-detection-retail-0005
  Input shape: ['2', '3', '300', '300']
  Request concurrency: 1
- Test Duration (s): Total (t) : 20.00 | Warmup (u): 2.00 | Window (w): 10.00
+ Test Duration (s): Total (t): 20.00 | Warmup (u): 2.00 | Window (w): 10.00
 
 ### Benchmark Summary ###
  ## General Metrics ##
@@ -355,7 +355,7 @@ NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a 
  Mean: 11.20 | stdev: 0.74 | p50: 12.78 | p90: 15.26 | p95: 15.56
 
  ## Throughput Metrics (fps) ##
- Frame Rate (FPS): Brutto : 89.01 | Netto: 89.24
+ Frame Rate (FPS): Brutto: 89.01 | Netto: 89.24
  Batch Rate (batches/s): Brutto: 89.01 | Netto: 89.24
 ```
 ## MediaPipe benchmarking

--- a/demos/benchmark/python/README.md
+++ b/demos/benchmark/python/README.md
@@ -77,7 +77,7 @@ usage: main.py [-h] [-i ID] [-c CONCURRENCY] [-a SERVER_ADDRESS]
                [--max_value MAX_VALUE] [--min_value MIN_VALUE] [--xrand XRAND]
                [--dump_png] [--step_timeout STEP_TIMEOUT]
                [--metadata_timeout METADATA_TIMEOUT] [-Y DB_ENDPOINT]
-               [-y [DB_METADATA ...]] [--print_all] [--print_time]
+               [-y [DB_METADATA ...]] [--print_all] [-ps PRINT_SUMMARY] [--print_time]
                [--report_warmup] [--certs_dir CERTS_DIR] [-q STATEFUL_LENGTH]
                [--stateful_id STATEFUL_ID] [--stateful_hop STATEFUL_HOP]
                [--sync_interval SYNC_INTERVAL]
@@ -330,24 +330,33 @@ NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a 
 
 Summary of the benchmark results can be viewed with command option ```-ps```
 ```
-docker run --network host benchmark_client -a localhost -r 8000 -m face-detection-retail-0005 -p 9000 -s 2 3 300 300 -t 20 -ps
+docker run --network host benchmark_client -a localhost -r 8000 -m face-detection-retail-0005 -p 9000 -s 2 3 300 300 -t 20 -u 2 -w 10 -ps
 ```
 
 Sample ouptut log with results summary
+
 ```
 Client 2.7
-NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a localhost -r 8000 -m face-detection-retail-0005 -p 9000 -s 2 3 300 300 -t 20 -ps
+NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a localhost -r 8000 -m face-detection-retail-0005 -p 9000 -s 2 3 300 300 -t 20 -u 2 -w 10 -ps
           XI worker: start workload...
 
-### Benchmark Summary ###
+### Benchmark Parameters ###
+ Model: face-detection-retail-0005
+ Input shape: ['2', '3', '300', '300']
  Request concurrency: 1
- Throughput: 90.67 FPS 
- Latency: 
-    Mean: 11.03 ms
-    stdev: 0.81 ms
-    p50: 12.69 ms 
-    p90: 15.24 ms 
-    p95: 15.56 ms
+ Test Duration (s): Total (t) : 20.00 | Warmup (u): 2.00 | Window (w): 10.00
+
+### Benchmark Summary ###
+ ## General Metrics ##
+ Duration(s): Total: 20.01 | Window: 10.01
+ Batches: Total: 1781 | Window: 891
+
+ ## Latency Metrics (ms) ##
+ Mean: 11.20 | stdev: 0.74 | p50: 12.78 | p90: 15.26 | p95: 15.56
+
+ ## Throughput Metrics (fps) ##
+ Frame Rate (FPS): Brutto : 89.01 | Netto: 89.24
+ Batch Rate (batches/s): Brutto: 89.01 | Netto: 89.24
 ```
 ## MediaPipe benchmarking
 

--- a/demos/benchmark/python/main.py
+++ b/demos/benchmark/python/main.py
@@ -263,7 +263,7 @@ if __name__ == "__main__":
     parser.add_argument("--print_all", required=False, action="store_true",
                         help="flag to print all output")
     parser.add_argument("-ps", "--print_summary", required=False, action="store_true",
-                        help="flag to print results summary")
+                        help="flag to print output summary")
     parser.add_argument("--print_time", required=False, action="store_true",
                         help="flag to print datetime next to each output line")
     parser.add_argument("--report_warmup", required=False, action="store_true",
@@ -356,7 +356,7 @@ if __name__ == "__main__":
         sys.stdout.write(f" Request concurrency: {total_clients}\n")
         if xargs['duration']:
             total_t = float(xargs['duration'])
-            sys.stdout.write(f" Test Duration (s): Total (t) : {total_t:.2f}")
+            sys.stdout.write(f" Test Duration (s): Total (t): {total_t:.2f}")
         if xargs['warmup']:
             warm_up = float(xargs['warmup'])
             sys.stdout.write(f" | Warmup (u): {warm_up:.2f}")
@@ -405,7 +405,7 @@ if __name__ == "__main__":
             # It doesn't take into account any overhead or inefficiencies in the system
             # Netto: Effective or net frame rate, which is the frame rate adjusted for any overhead,
             # delays, or processing inefficiencies in the system
-            sys.stdout.write(f" Frame Rate (FPS): Brutto : {common_results['brutto_frame_rate']:.2f}")
+            sys.stdout.write(f" Frame Rate (FPS): Brutto: {common_results['brutto_frame_rate']:.2f}")
             sys.stdout.write(f" | Netto: {common_results['netto_frame_rate']:.2f} \n")
             sys.stdout.write(f" Batch Rate (batches/s): Brutto: {common_results['brutto_batch_rate']:.2f}")
             sys.stdout.write(f" | Netto: {common_results['netto_batch_rate']:.2f}\n")

--- a/demos/benchmark/python/main.py
+++ b/demos/benchmark/python/main.py
@@ -262,6 +262,8 @@ if __name__ == "__main__":
                         help="database metadata configuration. default: None")
     parser.add_argument("--print_all", required=False, action="store_true",
                         help="flag to print all output")
+    parser.add_argument("-ps", "--print_summary", required=False, action="store_true",
+                        help="flag to print results summary")
     parser.add_argument("--print_time", required=False, action="store_true",
                         help="flag to print datetime next to each output line")
     parser.add_argument("--report_warmup", required=False, action="store_true",
@@ -333,7 +335,43 @@ if __name__ == "__main__":
     if xargs["json"]:
         jout = json.dumps(common_results)
         print(f"{BaseClient.json_prefix}###{worker_id}###STATISTICS###{jout}")
+
     if xargs["print_all"]:
         for key, value in common_results.items():
             sys.stdout.write(f"{worker_id}: {key}: {value}\n")
+
+    if xargs["print_summary"]:
+        sys.stdout.write("\n### Benchmark Summary ###\n")
+        if 'submetrics' in common_results:
+            total_clients = common_results["submetrics"]
+        else:
+            total_clients = 1
+
+        sys.stdout.write(f" Request concurrency: {total_clients}\n")
+        if total_clients:
+            sys.stdout.write(f" Throughput: {common_results['window_netto_frame_rate']:.2f} FPS \n")
+            sys.stdout.write(" Latency: \n")
+            sys.stdout.write(f"    Mean: {common_results['window_mean_latency']*1000:.2f} ms\n")
+            sys.stdout.write(f"    stdev: {common_results['window_stdev_latency']*1000:.2f} ms\n")
+
+            base, factor = float(xargs["hist_base"]), float(xargs["hist_factor"])
+            xargs["quantile_list"] = [0.5, 0.9, 0.95]
+
+            common_results.recalculate_quantiles("window_", base, factor, xargs["quantile_list"])
+
+            for idx, v in enumerate(xargs["quantile_list"]):
+                # Convert string to float
+                try:
+                    quantile_value = float(v)
+                except ValueError:
+                    # case where the string cannot be converted to a float
+                    sys.stdout.write(f"Invalid quantile value: {v}")
+                    continue
+                # float to percentage
+                q = str(int(quantile_value * 100))
+                p = str("p") + q
+                qv = str("qos_latency_") + str(idx)
+
+                sys.stdout.write(f"    {p}: {common_results[qv]*1000:.2f} ms \n")
+
     sys.exit(return_code)

--- a/demos/benchmark/python/main.py
+++ b/demos/benchmark/python/main.py
@@ -341,18 +341,43 @@ if __name__ == "__main__":
             sys.stdout.write(f"{worker_id}: {key}: {value}\n")
 
     if xargs["print_summary"]:
-        sys.stdout.write("\n### Benchmark Summary ###\n")
+        sys.stdout.write("\n### Benchmark Parameters ###\n")
+        if xargs['model_name'] is not None:
+            model_name = xargs['model_name']
+            sys.stdout.write(f" Model: {model_name}\n")
+        if xargs['shape']:
+            inp_shape = xargs['shape']
+            sys.stdout.write(f" Input shape: {inp_shape}\n")
         if 'submetrics' in common_results:
             total_clients = common_results["submetrics"]
         else:
             total_clients = 1
 
         sys.stdout.write(f" Request concurrency: {total_clients}\n")
+        if xargs['duration']:
+            total_t = float(xargs['duration'])
+            sys.stdout.write(f" Test Duration (s): Total (t) : {total_t:.2f}")
+        if xargs['warmup']:
+            warm_up = float(xargs['warmup'])
+            sys.stdout.write(f" | Warmup (u): {warm_up:.2f}")
+        if xargs['window']:
+            window = float(xargs['window'])
+            sys.stdout.write(f" | Window (w): {window:.2f}\n")
+
+
+        sys.stdout.write("\n### Benchmark Summary ###\n")
+        sys.stdout.write(" ## General Metrics ##\n")
+
+        sys.stdout.write(f" Duration(s): Total: {common_results['total_duration']:.2f}")
+        sys.stdout.write(f" | Window: {common_results['window_total_duration']:.2f}\n")
+
+        sys.stdout.write(f" Batches: Total: {common_results['total_batches']}")
+        sys.stdout.write(f" | Window: {common_results['window_total_batches']}\n")
+
         if total_clients:
-            sys.stdout.write(f" Throughput: {common_results['window_netto_frame_rate']:.2f} FPS \n")
-            sys.stdout.write(" Latency: \n")
-            sys.stdout.write(f"    Mean: {common_results['window_mean_latency']*1000:.2f} ms\n")
-            sys.stdout.write(f"    stdev: {common_results['window_stdev_latency']*1000:.2f} ms\n")
+            sys.stdout.write("\n ## Latency Metrics (ms) ##\n")
+            sys.stdout.write(f" Mean: {common_results['window_mean_latency']*1000:.2f}")
+            sys.stdout.write(f" | stdev: {common_results['window_stdev_latency']*1000:.2f}")
 
             base, factor = float(xargs["hist_base"]), float(xargs["hist_factor"])
             xargs["quantile_list"] = [0.5, 0.9, 0.95]
@@ -372,6 +397,17 @@ if __name__ == "__main__":
                 p = str("p") + q
                 qv = str("qos_latency_") + str(idx)
 
-                sys.stdout.write(f"    {p}: {common_results[qv]*1000:.2f} ms \n")
+                sys.stdout.write(f" | {p}: {common_results[qv]*1000:.2f}")
+            sys.stdout.write("\n")
+            sys.stdout.write("\n ## Throughput Metrics (fps) ##\n")
+
+            # Brutto: Total number of frames processed or produced per second by a system or application.
+            # It doesn't take into account any overhead or inefficiencies in the system
+            # Netto: Effective or net frame rate, which is the frame rate adjusted for any overhead,
+            # delays, or processing inefficiencies in the system
+            sys.stdout.write(f" Frame Rate (FPS): Brutto : {common_results['brutto_frame_rate']:.2f}")
+            sys.stdout.write(f" | Netto: {common_results['netto_frame_rate']:.2f} \n")
+            sys.stdout.write(f" Batch Rate (batches/s): Brutto: {common_results['brutto_batch_rate']:.2f}")
+            sys.stdout.write(f" | Netto: {common_results['netto_batch_rate']:.2f}\n")
 
     sys.exit(return_code)


### PR DESCRIPTION
Added print_summary command arg to benchmark_client app to summarize benchmark results as shown below 

```
docker run --network host benchmark_client -a localhost -r 8000 -m face-detection-retail-0005 -p 9000 -s 2 3 300 300 -t 20 -u 2 -w 10  -ps
Client 2.7
NO_PROXY=localhost no_proxy=localhost python3 /ovms_benchmark_client/main.py -a localhost -r 8000 -m face-detection-retail-0005 -p 9000 -s 2 3 300 300 -t 20 -u 2 -w 10 -ps
          XI worker: start workload...

### Benchmark Parameters ###
 Model: face-detection-retail-0005
 Input shape: ['2', '3', '300', '300']
 Request concurrency: 1
 Test Duration (s): Total (t) : 20.00 | Warmup (u): 2.00 | Window (w): 10.00

### Benchmark Summary ###
 ## General Metrics ##
 Duration(s): Total: 20.01 | Window: 10.01
 Batches: Total: 1781 | Window: 891

 ## Latency Metrics (ms) ##
 Mean: 11.20 | stdev: 0.74 | p50: 12.78 | p90: 15.26 | p95: 15.56

 ## Throughput Metrics (fps) ##
 Frame Rate (FPS): Brutto : 89.01 | Netto: 89.24 
 Batch Rate (batches/s): Brutto: 89.01 | Netto: 89.24
```

Currently print_all results need manually parsing to understand the over-all performance summary. This PR helps to automate the print_all results parsing and summarize the performance benchmark results.