### PR TITLE
client tests for python3.12

### DIFF
--- a/client/python/kserve-api/samples/requirements.txt
+++ b/client/python/kserve-api/samples/requirements.txt
@@ -1,2 +1,2 @@
-tritonclient[all]==2.37.0.9383150
-requests<=2.31.0,>=2.27.1
+tritonclient[all]<=2.45.0
+requests<=2.32.2

--- a/client/python/tensorflow-serving-api/samples/requirements.txt
+++ b/client/python/tensorflow-serving-api/samples/requirements.txt
@@ -1,3 +1,3 @@
 tensorflow-serving-api<=2.13.1,>=2.10.1
 protobuf<=3.20.3
-tensorflow==2.13.1
+tensorflow>=2.13.1,>=2.10.1

--- a/demos/mediapipe/object_detection/requirements.txt
+++ b/demos/mediapipe/object_detection/requirements.txt
@@ -1,5 +1,5 @@
-protobuf==3.19.5
-tritonclient[all]==2.22.3
-requests==2.31.0
+protobuf==3.20.3
+tritonclient[all]==2.45.0
+requests==2.32.0
 grpcio
 opencv-python

--- a/tests/python/Dockerfile
+++ b/tests/python/Dockerfile
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from ubuntu:20.04
+from ubuntu:22.04
 
 env DEBIAN_FRONTEND=noninteractive
 run apt-get update && apt-get install -y git software-properties-common && add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y \
-python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 \
-python3.6-distutils python3.7-distutils python3.8-distutils python3.9-distutils python3.10-distutils python3.11-distutils \
-python3.7-dev \
-python3.6-venv python3.7-venv python3.8-venv python3.9-venv python3.10-venv python3.11-venv \
+python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 \
+python3.7-distutils python3.8-distutils python3.9-distutils python3.10-distutils python3.11-distutils python3.12-distutils  \
+python3.7-dev python3.12-dev \
+python3.7-venv python3.8-venv python3.9-venv python3.10-venv python3.11-venv python3.12-venv \
 python3-pip
 run pip install invoke
 copy client /model_server/client

--- a/tests/python/tasks.py
+++ b/tests/python/tasks.py
@@ -15,9 +15,9 @@
 #
 from invoke import task
 
-supported_clients = {"ovmsclient":["3.7", "3.8", "3.9", "3.10", "3.11"],
-                     "kserve-api":["3.7" ,"3.8", "3.9", "3.10", "3.11"],
-                     "tensorflow-serving-api":["3.7", "3.8", "3.9", "3.10", "3.11"]}
+supported_clients = {"ovmsclient":["3.7","3.8","3.9","3.10","3.11","3.12"],
+                     "kserve-api":["3.7","3.8","3.9","3.10","3.11","3.12"],
+                     "tensorflow-serving-api":["3.8","3.9","3.10","3.11","3.12"]}
 
 @task
 def deps(c, verbose=False, fastFail=False):
@@ -44,10 +44,10 @@ def test(c, rest=8000, grpc=9000, verbose=False, fastFail=False):
                     c.run(f"echo {client} $(python{v} --version)")
                     try:
                         if client == "kserve-api":
-                            c.run(f". .venv{client}{v}/bin/activate && python{v} http_infer_binary_resnet.py --http_port {rest} --images_list ../../resnet_input_images.txt --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor --model_name resnet", hide=not(verbose))
-                            c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_infer_binary_resnet.py --grpc_port {grpc} --images_list ../../resnet_input_images.txt --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor --model_name resnet", hide=not(verbose))
+                            c.run(f". .venv{client}{v}/bin/activate && python{v} http_infer_binary_resnet.py --http_port {rest} --images_list ../../resnet_input_images.txt --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor:0 --model_name resnet", hide=not(verbose))
+                            c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_infer_binary_resnet.py --grpc_port {grpc} --images_list ../../resnet_input_images.txt --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor:0 --model_name resnet", hide=not(verbose))
                         if client == "tensorflow-serving-api":
-                            c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_predict_binary_resnet.py --grpc_address localhost --model_name resnet --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor --grpc_port {grpc} --images ../../resnet_input_images.txt", hide=not(verbose))
+                            c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_predict_binary_resnet.py --grpc_address localhost --model_name resnet --input_name map/TensorArrayStack/TensorArrayGatherV3 --output_name softmax_tensor:0 --grpc_port {grpc} --images ../../resnet_input_images.txt", hide=not(verbose))
                         if client == "ovmsclient":
                             c.run(f". .venv{client}{v}/bin/activate && python{v} grpc_predict_resnet.py --images_numpy ../../imgs_nhwc.npy --model_name resnet --service_url localhost:{grpc}", hide=not(verbose))
                             c.run(f". .venv{client}{v}/bin/activate && python{v} http_predict_resnet.py --images_numpy ../../imgs_nhwc.npy --model_name resnet --service_url localhost:{rest}", hide=not(verbose))


### PR DESCRIPTION
### 🛠 Summary

JIRA/Issue CVS-141132
Enable clients dependencies for python 3.12 and update tests

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

