### PR TITLE
LLM calculator compliant with /v3/chat/completions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -391,15 +391,6 @@ http_archive(
     build_file = "@//third_party/fmtlib:BUILD"
 )
 
-# # libevent
-# http_archive(
-#     name = "com_github_libevent_libevent",
-#     url = "https://github.com/libevent/libevent/archive/release-2.1.8-stable.zip",
-#     sha256 = "70158101eab7ed44fd9cc34e7f247b3cae91a8e4490745d9d6eb7edc184e4d96",
-#     strip_prefix = "libevent-release-2.1.8-stable",
-#     build_file = "@//third_party/libevent:BUILD",
-# )
-
 # prometheus-cpp
 http_archive(
     name = "com_github_jupp0r_prometheus_cpp",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -391,14 +391,14 @@ http_archive(
     build_file = "@//third_party/fmtlib:BUILD"
 )
 
-# libevent
-http_archive(
-    name = "com_github_libevent_libevent",
-    url = "https://github.com/libevent/libevent/archive/release-2.1.8-stable.zip",
-    sha256 = "70158101eab7ed44fd9cc34e7f247b3cae91a8e4490745d9d6eb7edc184e4d96",
-    strip_prefix = "libevent-release-2.1.8-stable",
-    build_file = "@//third_party/libevent:BUILD",
-)
+# # libevent
+# http_archive(
+#     name = "com_github_libevent_libevent",
+#     url = "https://github.com/libevent/libevent/archive/release-2.1.8-stable.zip",
+#     sha256 = "70158101eab7ed44fd9cc34e7f247b3cae91a8e4490745d9d6eb7edc184e4d96",
+#     strip_prefix = "libevent-release-2.1.8-stable",
+#     build_file = "@//third_party/libevent:BUILD",
+# )
 
 # prometheus-cpp
 http_archive(

--- a/demos/continous_batching/README.md
+++ b/demos/continous_batching/README.md
@@ -8,30 +8,17 @@ PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" python3 -m pip instal
 
 Run optimum-cli to download and quantize the model:
 ```bash
-optimum-cli export openvino --model meta-llama/Llama-2-7b-chat-hf --weight-format int8 ov_model
+optimum-cli export openvino --model meta-llama/Llama-2-7b-chat-hf --weight-format int8 meta-llama/Llama-2-7b-chat-hf
 ```
-
-## Server configuration
-Prepare config.json:
-```
-{
-    "model_config_list": [],
-    "mediapipe_config_list": [
-        {
-            "name": "llama",
-            "graph_path": "graph.pbtxt"
-        }
-    ]
-}
-```
-Prepare graph.pbtxt:
-```
+Copy the graph to the model folder. The same graph can be used for a range of LLM models.
+```bash
+cat graph.pbtxt
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 
 node: {
   name: "LLMExecutor"
-  calculator: "OpenAIChatCompletionsCalculator"
+  calculator: "HttpLLMCalculator"
   input_stream: "LOOPBACK:loopback"
   input_stream: "HTTP_REQUEST_PAYLOAD:input"
   input_side_packet: "LLM_NODE_RESOURCES:llm"
@@ -43,7 +30,7 @@ node: {
   }
   node_options: {
       [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
-          workspace_path: "/model"
+          models_path: "./"
       }
   }
   input_stream_handler {
@@ -57,13 +44,65 @@ node: {
     }
   }
 }
+
+cp graph.pbtxt meta-llama/Llama-2-7b-chat-hf/
+
+tree meta-llama/
+meta-llama/
+└── Llama-2-7b-chat-hf
+    ├── config.json
+    ├── generation_config.json
+    ├── graph.pbtxt
+    ├── openvino_detokenizer.bin
+    ├── openvino_detokenizer.xml
+    ├── openvino_model.bin
+    ├── openvino_model.xml
+    ├── openvino_tokenizer.bin
+    ├── openvino_tokenizer.xml
+    ├── special_tokens_map.json
+    ├── tokenizer_config.json
+    ├── tokenizer.json
+    └── tokenizer.model
+
+```
+
+## Server configuration
+Prepare config.json:
+```bash
+cat config.json
+{
+    "model_config_list": [],
+    "mediapipe_config_list": [
+        {
+            "name": "meta-llama/Llama-2-7b-chat-hf",
+            "graph_path": "graph.pbtxt"
+        }
+    ]
+}
 ```
 
 
 ## Start-up
+```bash
+docker run -d --rm -p 8000:8000 -v $(pwd)/:/workspace:ro openvino/model_server --port 9000 --rest_port 8000 --config_path /workspace/config.json
 ```
-docker run -d --rm -p 8000:8000 -v $(pwd)/ov_model:/model:ro openvino/model_server --port 9000 --rest_port 8000 --config_path /model/config.json
-```
+Wait for the model to load. You can check the status with a simple command:
+```bash
+curl http://localhost:8000/v1/config
+{
+"meta-llama/Llama-2-7b-chat-hf" : 
+{
+ "model_version_status": [
+  {
+   "version": "1",
+   "state": "AVAILABLE",
+   "status": {
+    "error_code": "OK",
+    "error_message": "OK"
+   }
+  }
+ ]
+}
 
 ## Client code
 
@@ -74,57 +113,39 @@ Both unary and streaming calls should be available via the same servable:
 curl http://localhost:8000/v3/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "llama",
+    "model": "meta-llama/Llama-2-7b-chat-hf",
+    "max_tokens":30,
+    "stream":false,
     "messages": [
-      {
-        "role": "system",
-        "content": "You are a helpful assistant."
-      },
       {
         "role": "user",
         "content": "What is OpenVINO?"
-      },
-      {
-        "role": "assistant",
-        "content": "OpenVINO is an open-source software library for deep learning inference that is designed to optimize and run deep learning models on Intel hardware."
-      },
-      {
-        "role": "user",
-        "content": "How to install?"
       }
     ]
-  }'
-```
-
-Output:
-```json
+  }'| jq .
 {
   "choices": [
     {
       "finish_reason": "stop",
       "index": 0,
+      "logprobs": null,
       "message": {
-        "content": "Open a command prompt terminal window. You can use the keyboard shortcut: Ctrl+Alt+T\nCreate the /opt/intel folder for OpenVINO by using the following command. If the folder already exists, skip this step.",
+        "content": "\n\nOpenVINO is an open-source software library for deep learning inference that is designed to optimize and run deep learning models on a variety",
         "role": "assistant"
-      },
-      "logprobs": null
+      }
     }
   ],
-  "created": 1677664795,
-  "id": "chatcmpl-7QyqpwdfhqwajicIEznoc6Q47XAyW",
-  "model": "llama",
-  "object": "chat.completion",
-  "usage": {
-    "completion_tokens": 17,
-    "prompt_tokens": 57,
-    "total_tokens": 74
-  }
+  "created": 1716825108,
+  "model": "meta-llama/Llama-2-7b-chat-hf",
+  "object": "chat.completion"
 }
 ```
 
 ## Streaming:
 
-Partial outputs:
+The endpoint `chat/completions` is compatible with OpenAI client so it can be easily used to generated code also in streaming mode:
+
+Install the client library:
 ```bash
 pip install openai
 ```
@@ -152,4 +173,16 @@ Output:
 This is a test.
 ```
 
-Refer to [OpenAI streaming documentation](https://platform.openai.com/docs/api-reference/streaming).
+## Continuous batching
+
+OpenVINO Model Server employs efficient parallelization for text generation. It can be used to generate text also in high concurrency in the environment shared by multiple clients.
+It can be demostrated using benchmarking app from vLLM repository:
+```bash
+git clone https://github.com/vllm-project/vllm
+cd vllm/benchmarks
+pip install -r ../requirements-cpu.txt
+sed -i -e 's|v1/chat/completions|v3/chat/completions|g' backend_request_func.py  # allow calls to endpoint with v3 instead of v1 like in vLLM
+wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json  # sample dataset
+python benchmark_serving.py --host localhost --port 8000 --endpoint /v3/chat/completions --backend openai-chat --model meta-llama/Llama-2-7b-chat-hf --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json  --num-prompts 1000 --request-rate 1
+
+```

--- a/demos/continous_batching/README.md
+++ b/demos/continous_batching/README.md
@@ -1,4 +1,4 @@
-# How to serve LLM models with Continous Batching via OpenAI API
+# How to serve LLM models with Continous Batching via OpenAI API {#ovms_demos_continous_batching}
 
 ## Model preparation
 Download latest optimum-intel:
@@ -173,7 +173,7 @@ Output:
 This is a test.
 ```
 
-## Continuous batching
+## Benchmarking text generation with high concurrency
 
 OpenVINO Model Server employs efficient parallelization for text generation. It can be used to generate text also in high concurrency in the environment shared by multiple clients.
 It can be demostrated using benchmarking app from vLLM repository:

--- a/demos/continous_batching/README.md
+++ b/demos/continous_batching/README.md
@@ -1,0 +1,155 @@
+# How to serve LLM models with Continous Batching via OpenAI API
+
+## Model preparation
+Download latest optimum-intel:
+```bash
+PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" python3 -m pip install "optimum-intel[nncf,openvino]"@git+https://github.com/huggingface/optimum-intel.git openvino-tokenizers
+```
+
+Run optimum-cli to download and quantize the model:
+```bash
+optimum-cli export openvino --model meta-llama/Llama-2-7b-chat-hf --weight-format int8 ov_model
+```
+
+## Server configuration
+Prepare config.json:
+```
+{
+    "model_config_list": [],
+    "mediapipe_config_list": [
+        {
+            "name": "llama",
+            "graph_path": "graph.pbtxt"
+        }
+    ]
+}
+```
+Prepare graph.pbtxt:
+```
+input_stream: "HTTP_REQUEST_PAYLOAD:input"
+output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+
+node: {
+  name: "LLMExecutor"
+  calculator: "OpenAIChatCompletionsCalculator"
+  input_stream: "LOOPBACK:loopback"
+  input_stream: "HTTP_REQUEST_PAYLOAD:input"
+  input_side_packet: "LLM_NODE_RESOURCES:llm"
+  output_stream: "LOOPBACK:loopback"
+  output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+  input_stream_info: {
+    tag_index: 'LOOPBACK:0',
+    back_edge: true
+  }
+  node_options: {
+      [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
+          workspace_path: "/model"
+      }
+  }
+  input_stream_handler {
+    input_stream_handler: "SyncSetInputStreamHandler",
+    options {
+      [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+        sync_set {
+          tag_index: "LOOPBACK:0"
+        }
+      }
+    }
+  }
+}
+```
+
+
+## Start-up
+```
+docker run -d --rm -p 8000:8000 -v $(pwd)/ov_model:/model:ro openvino/model_server --port 9000 --rest_port 8000 --config_path /model/config.json
+```
+
+## Client code
+
+Both unary and streaming calls should be available via the same servable:
+
+### Unary:
+```bash
+curl http://localhost:8000/v3/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "What is OpenVINO?"
+      },
+      {
+        "role": "assistant",
+        "content": "OpenVINO is an open-source software library for deep learning inference that is designed to optimize and run deep learning models on Intel hardware."
+      },
+      {
+        "role": "user",
+        "content": "How to install?"
+      }
+    ]
+  }'
+```
+
+Output:
+```json
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "Open a command prompt terminal window. You can use the keyboard shortcut: Ctrl+Alt+T\nCreate the /opt/intel folder for OpenVINO by using the following command. If the folder already exists, skip this step.",
+        "role": "assistant"
+      },
+      "logprobs": null
+    }
+  ],
+  "created": 1677664795,
+  "id": "chatcmpl-7QyqpwdfhqwajicIEznoc6Q47XAyW",
+  "model": "llama",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 17,
+    "prompt_tokens": 57,
+    "total_tokens": 74
+  }
+}
+```
+
+## Streaming:
+
+Partial outputs:
+```bash
+pip install openai
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+  base_url="http://localhost:8000/v3",
+  api_key="unused"
+)
+
+stream = client.chat.completions.create(
+    model="llama",
+    messages=[{"role": "user", "content": "Say this is a test"}],
+    stream=True,
+)
+for chunk in stream:
+    if chunk.choices[0].delta.content is not None:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+Output:
+```
+This is a test.
+```
+
+Refer to [OpenAI streaming documentation](https://platform.openai.com/docs/api-reference/streaming).

--- a/demos/continous_batching/config.json
+++ b/demos/continous_batching/config.json
@@ -1,0 +1,9 @@
+{
+    "model_config_list": [],
+    "mediapipe_config_list": [
+        {
+            "name": "meta-llama/Llama-2-7b-chat-hf",
+            "graph_path": "graph.pbtxt"
+        }
+    ]
+}

--- a/demos/continous_batching/graph.pbtxt
+++ b/demos/continous_batching/graph.pbtxt
@@ -1,0 +1,32 @@
+input_stream: "HTTP_REQUEST_PAYLOAD:input"
+output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+
+node: {
+  name: "LLMExecutor"
+  calculator: "HttpLLMCalculator"
+  input_stream: "LOOPBACK:loopback"
+  input_stream: "HTTP_REQUEST_PAYLOAD:input"
+  input_side_packet: "LLM_NODE_RESOURCES:llm"
+  output_stream: "LOOPBACK:loopback"
+  output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+  input_stream_info: {
+    tag_index: 'LOOPBACK:0',
+    back_edge: true
+  }
+  node_options: {
+      [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
+          models_path: "/model/ov_model"
+      }
+  }
+  input_stream_handler {
+    input_stream_handler: "SyncSetInputStreamHandler",
+    options {
+      [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+        sync_set {
+          tag_index: "LOOPBACK:0"
+        }
+      }
+    }
+  }
+}
+

--- a/external/partial.patch
+++ b/external/partial.patch
@@ -1,8 +1,17 @@
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-index c8d0501b..e5bb9700 100644
+index c8d0501b..7f1c2a88 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-@@ -339,11 +339,19 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
+@@ -25,6 +25,8 @@ limitations under the License.
+ #include <cstring>
+ #include <string>
+ #include <vector>
++#include <iostream>
++
+ 
+ #include "absl/strings/match.h"
+ #include "absl/strings/string_view.h"
+@@ -339,16 +341,24 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
  }
  
  void EvHTTPRequest::PartialReplyWithStatus(HTTPStatusCode status) {
@@ -24,7 +33,13 @@ index c8d0501b..e5bb9700 100644
  }
  
  ServerRequestInterface::CallbackStatus
-@@ -371,6 +379,24 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
+ EvHTTPRequest::PartialReplyWithFlushCallback(std::function<void()> callback) {
+-  NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
++  NET_LOG(FATAL, "PartialReplyWithFlushCallback not implemented.");
+   return CallbackStatus::NOT_SCHEDULED;
+ }
+ 
+@@ -371,6 +381,25 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
    delete this;
  }
  
@@ -34,6 +49,7 @@ index c8d0501b..e5bb9700 100644
 +    this->is_reply_started_ = true;
 +  }
 +  evhttp_send_reply_chunk(parsed_request_->request, output_buf);
++  evbuffer_drain(output_buf, -1);
 +}
 +
 +void EvHTTPRequest::EvPartialReplyEnd() {
@@ -49,7 +65,7 @@ index c8d0501b..e5bb9700 100644
  void EvHTTPRequest::Reply() { ReplyWithStatus(HTTPStatusCode::OK); }
  
  // Treats this as 500 for now and let libevent decide what to do
-@@ -381,6 +407,18 @@ void EvHTTPRequest::Abort() {
+@@ -381,6 +410,18 @@ void EvHTTPRequest::Abort() {
    delete this;
  }
  

--- a/external/partial.patch
+++ b/external/partial.patch
@@ -1,5 +1,5 @@
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-index c8d0501b..7f1c2a88 100644
+index c8d0501b..f25a1e6b 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
 @@ -25,6 +25,8 @@ limitations under the License.
@@ -11,20 +11,22 @@ index c8d0501b..7f1c2a88 100644
  
  #include "absl/strings/match.h"
  #include "absl/strings/string_view.h"
-@@ -339,16 +341,24 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
+@@ -339,16 +341,26 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
  }
  
  void EvHTTPRequest::PartialReplyWithStatus(HTTPStatusCode status) {
 -  NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
-+  bool result =
-+      server_->EventLoopSchedule([this, status]() { EvPartialSendReply(status); });
++  EvPartialSendReply(status);
++  return;
++  // bool result =
++  //     server_->EventLoopSchedule([this, status]() { EvPartialSendReply(status); });
 +
-+  if (!result) {
-+    NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReplyWithStatus()");
-+    Abort();
-+    // TODO(wenboz): should have a forced abort that doesn't write back anything
-+    // to the event-loop
-+  }
++  // if (!result) {
++  //   NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReplyWithStatus()");
++  //   Abort();
++  //   // TODO(wenboz): should have a forced abort that doesn't write back anything
++  //   // to the event-loop
++  // }
  }
  
  void EvHTTPRequest::PartialReply() {
@@ -39,7 +41,7 @@ index c8d0501b..7f1c2a88 100644
    return CallbackStatus::NOT_SCHEDULED;
  }
  
-@@ -371,6 +381,25 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
+@@ -371,6 +383,25 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
    delete this;
  }
  
@@ -65,7 +67,7 @@ index c8d0501b..7f1c2a88 100644
  void EvHTTPRequest::Reply() { ReplyWithStatus(HTTPStatusCode::OK); }
  
  // Treats this as 500 for now and let libevent decide what to do
-@@ -381,6 +410,18 @@ void EvHTTPRequest::Abort() {
+@@ -381,6 +412,18 @@ void EvHTTPRequest::Abort() {
    delete this;
  }
  

--- a/external/partial.patch
+++ b/external/partial.patch
@@ -1,58 +1,20 @@
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-index c8d0501b..00741a47 100644
+index c8d0501b..f24a21d5 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-@@ -25,6 +25,9 @@ limitations under the License.
- #include <cstring>
- #include <string>
- #include <vector>
-+#include <chrono>
-+#include <iostream>
-+#include <thread>
- 
- #include "absl/strings/match.h"
- #include "absl/strings/string_view.h"
-@@ -339,11 +342,45 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
+@@ -342,8 +342,17 @@ void EvHTTPRequest::PartialReplyWithStatus(HTTPStatusCode status) {
+   NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
  }
  
- void EvHTTPRequest::PartialReplyWithStatus(HTTPStatusCode status) {
+-void EvHTTPRequest::PartialReply() {
 -  NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
-+  bool result =
-+      server_->EventLoopSchedule([this, status]() { EvPartialSendReply(status); });
-+  
-+  // server_->EventLoopSchedule([this]() {
-+  //   std::cout << "Sleep Start" << std::endl;
-+  //   using namespace std::chrono_literals;
-+  //   std::this_thread::sleep_for(1000ms);
-+  //   std::cout << "Sleep End" << std::endl;
-+  // });
-+
-+  if (!result) {
-+    NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReplyWithStatus()");
-+    Abort();
-+    // TODO(wenboz): should have a forced abort that doesn't write back anything
-+    // to the event-loop
-+  }
- }
- 
- void EvHTTPRequest::PartialReply() {
--  NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
-+  PartialReplyWithStatus(HTTPStatusCode::OK);
-+}
-+
-+void EvHTTPRequest::PartialReplyEx(std::string data) {
++void EvHTTPRequest::PartialReply(std::string data) {
++  // TODO: Possibly avoid copy of data
 +  bool result =
 +      server_->EventLoopSchedule([this, data]() { EvPartialSendReply(data); });
 +  
-+  // server_->EventLoopSchedule([this]() {
-+  //   std::cout << "Sleep Start" << std::endl;
-+  //   using namespace std::chrono_literals;
-+  //   std::this_thread::sleep_for(1000ms);
-+  //   std::cout << "Sleep End" << std::endl;
-+  // });
-+
 +  if (!result) {
-+    NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReplyWithStatus()");
++    NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReply()");
 +    Abort();
 +    // TODO(wenboz): should have a forced abort that doesn't write back anything
 +    // to the event-loop
@@ -60,18 +22,10 @@ index c8d0501b..00741a47 100644
  }
  
  ServerRequestInterface::CallbackStatus
-@@ -371,6 +408,33 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
+@@ -371,6 +380,25 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
    delete this;
  }
  
-+void EvHTTPRequest::EvPartialSendReply(HTTPStatusCode status) {
-+  if (!this->is_reply_started_) {
-+    evhttp_send_reply_start(parsed_request_->request, static_cast<int>(status), "reply start");
-+    this->is_reply_started_ = true;
-+  }
-+  evhttp_send_reply_chunk(parsed_request_->request, output_buf);
-+}
-+
 +void EvHTTPRequest::EvPartialSendReply(std::string data) {
 +  if (!this->is_reply_started_) {
 +    evhttp_send_reply_start(parsed_request_->request, HTTP_OK, "reply start");
@@ -94,7 +48,7 @@ index c8d0501b..00741a47 100644
  void EvHTTPRequest::Reply() { ReplyWithStatus(HTTPStatusCode::OK); }
  
  // Treats this as 500 for now and let libevent decide what to do
-@@ -381,6 +445,18 @@ void EvHTTPRequest::Abort() {
+@@ -381,6 +409,18 @@ void EvHTTPRequest::Abort() {
    delete this;
  }
  
@@ -114,18 +68,19 @@ index c8d0501b..00741a47 100644
  }  // namespace serving
  }  // namespace tensorflow
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_request.h b/tensorflow_serving/util/net_http/server/internal/evhttp_request.h
-index 2f8e601d..5fb76a12 100644
+index 2f8e601d..ff51c570 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.h
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.h
-@@ -95,6 +95,7 @@ class EvHTTPRequest final : public ServerRequestInterface {
+@@ -94,7 +94,7 @@ class EvHTTPRequest final : public ServerRequestInterface {
+                             absl::string_view value) override;
  
    void PartialReplyWithStatus(HTTPStatusCode status) override;
-   void PartialReply() override;
-+  void PartialReplyEx(std::string data) override;
+-  void PartialReply() override;
++  void PartialReply(std::string data) override;
  
    CallbackStatus PartialReplyWithFlushCallback(
        std::function<void()> callback) override;
-@@ -104,6 +105,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
+@@ -104,6 +104,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
  
    void Abort() override;
  
@@ -134,17 +89,16 @@ index 2f8e601d..5fb76a12 100644
    // Initializes the resource and returns false if any error.
    bool Initialize();
  
-@@ -114,6 +117,9 @@ class EvHTTPRequest final : public ServerRequestInterface {
+@@ -114,6 +116,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
  
   private:
    void EvSendReply(HTTPStatusCode status);
-+  void EvPartialSendReply(HTTPStatusCode status);
 +  void EvPartialSendReply(std::string data);
 +  void EvPartialReplyEnd();
  
    // Returns true if the data needs be uncompressed
    bool NeedUncompressGzipContent();
-@@ -133,6 +139,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
+@@ -133,6 +137,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
    std::unique_ptr<ParsedEvRequest> parsed_request_;
  
    evbuffer* output_buf;  // owned by this
@@ -154,18 +108,19 @@ index 2f8e601d..5fb76a12 100644
  
  }  // namespace net_http
 diff --git a/tensorflow_serving/util/net_http/server/public/server_request_interface.h b/tensorflow_serving/util/net_http/server/public/server_request_interface.h
-index e5f4b05f..ca8ec914 100644
+index e5f4b05f..7077a6c1 100644
 --- a/tensorflow_serving/util/net_http/server/public/server_request_interface.h
 +++ b/tensorflow_serving/util/net_http/server/public/server_request_interface.h
-@@ -145,6 +145,7 @@ class ServerRequestInterface {
+@@ -144,7 +144,7 @@ class ServerRequestInterface {
+   // PartialReply() is called is considered a programming error and
    // the underlying behavior is undefined.
    virtual void PartialReplyWithStatus(HTTPStatusCode status) = 0;
-   virtual void PartialReply() = 0;
-+  virtual void PartialReplyEx(std::string) = 0;
+-  virtual void PartialReply() = 0;
++  virtual void PartialReply(std::string data) = 0;
  
    // Similar to PartialReply() but with an on_flush callback which will be
    // invoked when the response data has been completely flushed by the
-@@ -182,6 +183,8 @@ class ServerRequestInterface {
+@@ -182,6 +182,8 @@ class ServerRequestInterface {
    // by the server runtime.
    virtual void Abort() = 0;
  

--- a/external/partial.patch
+++ b/external/partial.patch
@@ -1,47 +1,66 @@
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-index c8d0501b..f25a1e6b 100644
+index c8d0501b..00741a47 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-@@ -25,6 +25,8 @@ limitations under the License.
+@@ -25,6 +25,9 @@ limitations under the License.
  #include <cstring>
  #include <string>
  #include <vector>
++#include <chrono>
 +#include <iostream>
-+
++#include <thread>
  
  #include "absl/strings/match.h"
  #include "absl/strings/string_view.h"
-@@ -339,16 +341,26 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
+@@ -339,11 +342,45 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
  }
  
  void EvHTTPRequest::PartialReplyWithStatus(HTTPStatusCode status) {
 -  NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
-+  EvPartialSendReply(status);
-+  return;
-+  // bool result =
-+  //     server_->EventLoopSchedule([this, status]() { EvPartialSendReply(status); });
++  bool result =
++      server_->EventLoopSchedule([this, status]() { EvPartialSendReply(status); });
++  
++  // server_->EventLoopSchedule([this]() {
++  //   std::cout << "Sleep Start" << std::endl;
++  //   using namespace std::chrono_literals;
++  //   std::this_thread::sleep_for(1000ms);
++  //   std::cout << "Sleep End" << std::endl;
++  // });
 +
-+  // if (!result) {
-+  //   NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReplyWithStatus()");
-+  //   Abort();
-+  //   // TODO(wenboz): should have a forced abort that doesn't write back anything
-+  //   // to the event-loop
-+  // }
++  if (!result) {
++    NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReplyWithStatus()");
++    Abort();
++    // TODO(wenboz): should have a forced abort that doesn't write back anything
++    // to the event-loop
++  }
  }
  
  void EvHTTPRequest::PartialReply() {
 -  NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
 +  PartialReplyWithStatus(HTTPStatusCode::OK);
++}
++
++void EvHTTPRequest::PartialReplyEx(std::string data) {
++  bool result =
++      server_->EventLoopSchedule([this, data]() { EvPartialSendReply(data); });
++  
++  // server_->EventLoopSchedule([this]() {
++  //   std::cout << "Sleep Start" << std::endl;
++  //   using namespace std::chrono_literals;
++  //   std::this_thread::sleep_for(1000ms);
++  //   std::cout << "Sleep End" << std::endl;
++  // });
++
++  if (!result) {
++    NET_LOG(ERROR, "Failed to EventLoopSchedule PartialReplyWithStatus()");
++    Abort();
++    // TODO(wenboz): should have a forced abort that doesn't write back anything
++    // to the event-loop
++  }
  }
  
  ServerRequestInterface::CallbackStatus
- EvHTTPRequest::PartialReplyWithFlushCallback(std::function<void()> callback) {
--  NET_LOG(FATAL, "PartialReplyWithStatus not implemented.");
-+  NET_LOG(FATAL, "PartialReplyWithFlushCallback not implemented.");
-   return CallbackStatus::NOT_SCHEDULED;
- }
- 
-@@ -371,6 +383,25 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
+@@ -371,6 +408,33 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
    delete this;
  }
  
@@ -51,7 +70,15 @@ index c8d0501b..f25a1e6b 100644
 +    this->is_reply_started_ = true;
 +  }
 +  evhttp_send_reply_chunk(parsed_request_->request, output_buf);
-+  evbuffer_drain(output_buf, -1);
++}
++
++void EvHTTPRequest::EvPartialSendReply(std::string data) {
++  if (!this->is_reply_started_) {
++    evhttp_send_reply_start(parsed_request_->request, HTTP_OK, "reply start");
++    this->is_reply_started_ = true;
++  }
++  evbuffer_add(output_buf, data.data(), static_cast<int64_t>(data.size()));
++  evhttp_send_reply_chunk(parsed_request_->request, output_buf);
 +}
 +
 +void EvHTTPRequest::EvPartialReplyEnd() {
@@ -67,7 +94,7 @@ index c8d0501b..f25a1e6b 100644
  void EvHTTPRequest::Reply() { ReplyWithStatus(HTTPStatusCode::OK); }
  
  // Treats this as 500 for now and let libevent decide what to do
-@@ -381,6 +412,18 @@ void EvHTTPRequest::Abort() {
+@@ -381,6 +445,18 @@ void EvHTTPRequest::Abort() {
    delete this;
  }
  
@@ -87,10 +114,18 @@ index c8d0501b..f25a1e6b 100644
  }  // namespace serving
  }  // namespace tensorflow
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_request.h b/tensorflow_serving/util/net_http/server/internal/evhttp_request.h
-index 2f8e601d..71736175 100644
+index 2f8e601d..5fb76a12 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.h
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.h
-@@ -104,6 +104,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
+@@ -95,6 +95,7 @@ class EvHTTPRequest final : public ServerRequestInterface {
+ 
+   void PartialReplyWithStatus(HTTPStatusCode status) override;
+   void PartialReply() override;
++  void PartialReplyEx(std::string data) override;
+ 
+   CallbackStatus PartialReplyWithFlushCallback(
+       std::function<void()> callback) override;
+@@ -104,6 +105,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
  
    void Abort() override;
  
@@ -99,16 +134,17 @@ index 2f8e601d..71736175 100644
    // Initializes the resource and returns false if any error.
    bool Initialize();
  
-@@ -114,6 +116,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
+@@ -114,6 +117,9 @@ class EvHTTPRequest final : public ServerRequestInterface {
  
   private:
    void EvSendReply(HTTPStatusCode status);
 +  void EvPartialSendReply(HTTPStatusCode status);
++  void EvPartialSendReply(std::string data);
 +  void EvPartialReplyEnd();
  
    // Returns true if the data needs be uncompressed
    bool NeedUncompressGzipContent();
-@@ -133,6 +137,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
+@@ -133,6 +139,8 @@ class EvHTTPRequest final : public ServerRequestInterface {
    std::unique_ptr<ParsedEvRequest> parsed_request_;
  
    evbuffer* output_buf;  // owned by this
@@ -118,10 +154,18 @@ index 2f8e601d..71736175 100644
  
  }  // namespace net_http
 diff --git a/tensorflow_serving/util/net_http/server/public/server_request_interface.h b/tensorflow_serving/util/net_http/server/public/server_request_interface.h
-index e5f4b05f..fa462f8a 100644
+index e5f4b05f..ca8ec914 100644
 --- a/tensorflow_serving/util/net_http/server/public/server_request_interface.h
 +++ b/tensorflow_serving/util/net_http/server/public/server_request_interface.h
-@@ -182,6 +182,8 @@ class ServerRequestInterface {
+@@ -145,6 +145,7 @@ class ServerRequestInterface {
+   // the underlying behavior is undefined.
+   virtual void PartialReplyWithStatus(HTTPStatusCode status) = 0;
+   virtual void PartialReply() = 0;
++  virtual void PartialReplyEx(std::string) = 0;
+ 
+   // Similar to PartialReply() but with an on_flush callback which will be
+   // invoked when the response data has been completely flushed by the
+@@ -182,6 +183,8 @@ class ServerRequestInterface {
    // by the server runtime.
    virtual void Abort() = 0;
  

--- a/src/BUILD
+++ b/src/BUILD
@@ -1125,6 +1125,7 @@ cc_test(
         "test/c_api/config_standard_scalar.json",
         "test/configs/config_dummy_dynamic_shape.json",
         "test/configs/emptyConfigWithMetrics.json",
+        "test/llm/graphkfspass.pbtxt",
         "test/dummy/1/dummy.xml",
         "test/dummy/1/dummy.bin",
         "test/dummy_fp64/1/saved_model.xml",

--- a/src/http_frontend/http_graph_executor_impl.cpp
+++ b/src/http_frontend/http_graph_executor_impl.cpp
@@ -83,6 +83,7 @@ Status onPacketReadySerializeImpl(
     const ::mediapipe::Packet& packet,
     std::string& response) {
     response = packet.Get<std::string>();
+    //SPDLOG_DEBUG("HTTP onPacketReadySerializeImpl: {}", response);
     return StatusCode::OK;
 }
 

--- a/src/http_frontend/http_graph_executor_impl.cpp
+++ b/src/http_frontend/http_graph_executor_impl.cpp
@@ -69,15 +69,7 @@ Status onPacketReadySerializeAndSendImpl(
             packetType,
             packet,
             out));
-
-    // sync
-    //serverReaderWriter.WriteResponseString(out);
-    // evbuffer_add
-
-    // async
-    serverReaderWriter.PartialReplyEx(out);
-    // evhttp_send_reply_chunk
-    //
+    serverReaderWriter.PartialReply(out);  // TODO: Possibly avoid copy
     return StatusCode::OK;
 }
 
@@ -90,7 +82,6 @@ Status onPacketReadySerializeImpl(
     const ::mediapipe::Packet& packet,
     std::string& response) {
     response = packet.Get<std::string>();
-    //SPDLOG_DEBUG("HTTP onPacketReadySerializeImpl: {}", response);
     return StatusCode::OK;
 }
 
@@ -121,8 +112,7 @@ Status validateSubsequentRequestImpl(
 Status sendErrorImpl(
     const std::string& message,
     HttpReaderWriter& serverReaderWriter) {
-    serverReaderWriter.WriteResponseString("{\"error\": \"" + message + "\"}");
-    serverReaderWriter.PartialReply();
+    serverReaderWriter.PartialReply("{\"error\": \"" + message + "\"}");
     return StatusCode::OK;
 }
 

--- a/src/http_frontend/http_graph_executor_impl.cpp
+++ b/src/http_frontend/http_graph_executor_impl.cpp
@@ -69,8 +69,15 @@ Status onPacketReadySerializeAndSendImpl(
             packetType,
             packet,
             out));
-    serverReaderWriter.WriteResponseString(out);
-    serverReaderWriter.PartialReply();
+
+    // sync
+    //serverReaderWriter.WriteResponseString(out);
+    // evbuffer_add
+
+    // async
+    serverReaderWriter.PartialReplyEx(out);
+    // evhttp_send_reply_chunk
+    //
     return StatusCode::OK;
 }
 

--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -502,6 +502,7 @@ Status HttpRestApiHandler::processOAIChatCompletionsRequest(const HttpRequestCom
         ExecutionContext ec{ExecutionContext::Interface::REST, ExecutionContext::Method::ModelInfer};  // Unused
         return executor->infer(&request, &response, ec, smr);
     } else {
+        //serverReaderWriter->OverwriteResponseHeader("Content-Type", "text/event-stream");
         status = executor->inferStream(request, *serverReaderWriter);
         if (!status.ok()) {
             sendErrorImpl(status.string(), *serverReaderWriter);

--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -502,7 +502,9 @@ Status HttpRestApiHandler::processOAIChatCompletionsRequest(const HttpRequestCom
         ExecutionContext ec{ExecutionContext::Interface::REST, ExecutionContext::Method::ModelInfer};  // Unused
         return executor->infer(&request, &response, ec, smr);
     } else {
-        //serverReaderWriter->OverwriteResponseHeader("Content-Type", "text/event-stream");
+        serverReaderWriter->OverwriteResponseHeader("Content-Type", "text/event-stream");
+        serverReaderWriter->OverwriteResponseHeader("Cache-Control", "no-cache");
+        serverReaderWriter->OverwriteResponseHeader("Connection", "keep-alive");
         status = executor->inferStream(request, *serverReaderWriter);
         if (!status.ok()) {
             sendErrorImpl(status.string(), *serverReaderWriter);

--- a/src/llm/BUILD
+++ b/src/llm/BUILD
@@ -47,13 +47,15 @@ cc_library(
 
 cc_library(
     name = "llmcalculator",
-    srcs = ["llm_calculator.cc",],
+    srcs = ["llm_calculator.cc", "http_llm_calculator.cc"],
     deps = [
         "@linux_openvino//:openvino",
         "@mediapipe//mediapipe/framework:calculator_framework",
+        "@com_github_tencent_rapidjson//:rapidjson",
         "//src/kfserving_api:kfserving_api_cpp",
         ":llm_engine",
         ":llmnoderesources",
+        ":httppayload",
     ],
     visibility = ["//visibility:public"],
     copts = COPTS_ADJUSTED,

--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -218,7 +218,7 @@ static std::string packIntoServerSideEventMessage(const std::string& message);
 
 class HttpLLMCalculator : public CalculatorBase {
     std::shared_ptr<ovms::LLMNodeResources> nodeResources;
-    std::shared_ptr<GenerationHandle> generationHandle;
+    GenerationHandle generationHandle;
     std::shared_ptr<OpenAIChatCompletionsRequest> request;
 
     ////////////////
@@ -306,11 +306,10 @@ public:
             GenerationConfig config = GenerationConfig::greedy();
             config.max_new_tokens = this->request->getMaxTokens().value_or(30);
             config.ignore_eos = false;
-            this->generationHandle = std::make_shared<GenerationHandle>(
-                nodeResources->cbPipe->add_request(
+            this->generationHandle = nodeResources->cbPipe->add_request(
                     0/*to be removed from API?*/,
                     prompt/* to be replaced with chat*/,
-                    config));
+                    config);
             nodeResources->notifyExecutorThread();
             this->streamer = std::make_shared<TextStreamer>(
                 nodeResources->cbPipe->get_tokenizer());

--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -1,0 +1,531 @@
+//*****************************************************************************
+// Copyright 2024 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <algorithm>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <ctime>
+#include <unordered_map>
+#include <optional>
+#include <sstream>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/port/canonical_errors.h"
+#pragma GCC diagnostic pop
+
+#include <openvino/openvino.hpp>
+#include <continuous_batching_pipeline.hpp>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include "llmnoderesources.hpp"
+#include "http_payload.hpp"
+
+using namespace rapidjson;
+
+namespace mediapipe {
+
+using chat_entry_t = std::unordered_map<std::string, std::string>;
+using chat_t = std::vector<chat_entry_t>;
+
+class OpenAIChatCompletionsRequest {
+    Document& doc;
+
+    chat_t messages;
+    bool stream{false};
+    std::string model;
+    float frequencyPenalty{0.0f};
+    std::optional<int64_t> maxTokens{std::nullopt};
+    float presencePenalty{0.0f};
+    float temperature{1.0f};
+    float topP{1.0f};
+public:
+    OpenAIChatCompletionsRequest(Document& doc) : doc(doc) {}
+
+    chat_t                          getMessages()           const { return this->messages;          }
+    bool                            isStream()              const { return this->stream;            }
+    std::string                     getModel()              const { return this->model;             }
+    float                           getFrequencyPenalty()   const { return this->frequencyPenalty;  }
+    const std::optional<int64_t>&   getMaxTokens()          const { return this->maxTokens;         }
+    float                           getPresencePenalty()    const { return this->presencePenalty;   }
+    float                           getTemperature()        const { return this->temperature;       }
+    float                           getTopP()               const { return this->topP;              }
+// getTopK ?
+// 
+
+    // TODO: Use exceptions to sneak error mesages into response
+    bool parse() {
+        // stream: bool; optional
+        if (!this->doc.IsObject())
+            return false;
+        auto it = this->doc.FindMember("stream");
+        if (it != this->doc.MemberEnd()) {
+            if (!it->value.IsBool())
+                return false;
+            this->stream = it->value.GetBool();
+        }
+
+        // messages: [{role: content}, {role: content}, ...]; required
+        it = doc.FindMember("messages");
+        if (it == doc.MemberEnd())
+            return false;
+        if (!it->value.IsArray())
+            return false;
+        this->messages.clear();
+        this->messages.reserve(it->value.GetArray().Size());
+        for (int i = 0; i < it->value.GetArray().Size(); i++) {
+            const auto& obj = it->value.GetArray()[i];
+            if (!obj.IsObject())
+                return false;
+            auto& chat = this->messages.emplace_back(chat_entry_t{});
+            for (auto member = obj.MemberBegin(); member != obj.MemberEnd(); member++) {
+                if (!member->name.IsString())
+                    return false;
+                if (!member->value.IsString())
+                    return false;
+                chat[member->name.GetString()] = member->value.GetString();
+            }
+        }
+
+        // model: string; required
+        it = this->doc.FindMember("model");
+        if (it != this->doc.MemberEnd()) {
+            if (!it->value.IsString())
+                return false;
+            this->model = it->value.GetString();
+        } else {
+            return false;
+        }
+
+        // frequency_penalty: float; optional - defaults to 0
+        it = this->doc.FindMember("frequency_penalty");
+        if (it != this->doc.MemberEnd()) {
+            if (!it->value.IsDouble())
+                return false;
+            this->frequencyPenalty = it->value.GetDouble();
+            if (this->frequencyPenalty < -2.0f || this->frequencyPenalty > 2.0f)
+                return false;
+        }
+
+        // max_tokens: int; optional
+        it = this->doc.FindMember("max_tokens");
+        if (it != this->doc.MemberEnd()) {
+            if (!it->value.IsInt())
+                return false;
+            this->maxTokens = it->value.GetInt();
+            if (this->maxTokens.value() <= 0)
+                return false;
+        }
+
+        // presence_penalty: float; optional - defaults to 0
+        it = this->doc.FindMember("presence_penalty");
+        if (it != this->doc.MemberEnd()) {
+            if (!it->value.IsDouble())
+                return false;
+            this->presencePenalty = it->value.GetDouble();
+            if (this->presencePenalty < -2.0f || this->presencePenalty > 2.0f)
+                return false;
+        }
+
+        // temperature: float; optional - defaults to 1
+        it = this->doc.FindMember("temperature");
+        if (it != this->doc.MemberEnd()) {
+            if (!it->value.IsDouble())
+                return false;
+            this->temperature = it->value.GetDouble();
+            if (this->temperature < 0.0f || this->temperature > 2.0f)
+                return false;
+        }
+
+        // top_p: float; optional - defaults to 1
+        it = this->doc.FindMember("top_p");
+        if (it != this->doc.MemberEnd()) {
+            if (!it->value.IsDouble())
+                return false;
+            this->topP = it->value.GetDouble();
+            if (this->topP < 0.0f || this->topP > 1.0f)
+                return false;
+        }
+
+        // logit_bias TODO
+        // logprops TODO
+        // top_logprobs TODO
+        // n TODO
+        // response_format TODO
+        // seed TODO
+        // stop TODO
+        // stream_options TODO
+        // tools TODO
+        // tool_choice TODO
+        // user TODO
+        // function_call TODO (deprecated)
+        // functions TODO (deprecated)
+        return true;
+    }
+};
+
+// TODO: To be moved to CB library.
+class TextStreamer {
+    std::shared_ptr<Tokenizer> tokenizer;
+    std::vector<int64_t> tokenCache;
+    size_t printLen{0};
+public:
+    TextStreamer(std::shared_ptr<Tokenizer> tokenizer) : tokenizer(tokenizer) {}
+
+    std::optional<std::string> put(int64_t token) {
+        tokenCache.push_back(token);
+        std::string text = tokenizer->decode(tokenCache);
+
+        if (!text.empty() && '\n' == text.back()) {
+            std::string chunk = std::string{text.data() + printLen, text.size() - printLen};
+            tokenCache.clear();
+            printLen = 0;
+            return chunk;
+        }
+        else if (text.size() >= 3 && text.compare(text.size() - 3, 3, "�") == 0) {
+            return std::nullopt;
+        } else {
+            std::string chunk = std::string{text.data() + printLen, text.size() - printLen};
+            printLen = text.size();
+            return chunk;
+        }
+        return std::nullopt;
+    }
+};
+
+using InputDataType = ovms::HttpPayload;
+using OutputDataType = std::string;
+
+const std::string LLM_SESSION_SIDE_PACKET_TAG = "LLM_NODE_RESOURCES";
+
+static std::string packIntoServerSideEventMessage(const std::string& message);
+
+class HttpLLMCalculator : public CalculatorBase {
+    std::shared_ptr<ovms::LLMNodeResources> nodeResources;
+    std::shared_ptr<GenerationHandle> generationHandle;
+    std::shared_ptr<OpenAIChatCompletionsRequest> request;
+
+    ////////////////
+    // TODO: To be  moved to CB library
+    // Streaming related
+    std::stringstream res;
+    std::vector<int64_t> tokenCache;
+    int64_t printLen = 0;
+    std::shared_ptr<TextStreamer> streamer;
+    ////////////////
+
+    static const std::string INPUT_TAG_NAME;
+    static const std::string OUTPUT_TAG_NAME;
+    static const std::string LOOPBACK_TAG_NAME;
+
+    mediapipe::Timestamp timestamp{0};
+    std::chrono::time_point<std::chrono::system_clock> created;
+
+    std::string serializeUnaryResponse(const std::string& completeResponse);
+    std::string serializeStreamingChunk(const std::string& chunkResponse, bool stop);
+
+public:
+    static absl::Status GetContract(CalculatorContract* cc) {
+        RET_CHECK(!cc->Inputs().GetTags().empty());
+        RET_CHECK(!cc->Outputs().GetTags().empty());
+        cc->Inputs().Tag(INPUT_TAG_NAME).Set<InputDataType>();
+        cc->Inputs().Tag(LOOPBACK_TAG_NAME).Set<bool>();
+        cc->InputSidePackets().Tag(LLM_SESSION_SIDE_PACKET_TAG).Set<ovms::LLMNodeResourcesMap>();
+        cc->Outputs().Tag(OUTPUT_TAG_NAME).Set<OutputDataType>();
+        cc->Outputs().Tag(LOOPBACK_TAG_NAME).Set<bool>();
+        return absl::OkStatus();
+    }
+
+    absl::Status Close(CalculatorContext* cc) final {
+        LOG(INFO) << "LLMCalculator [Node: " << cc->NodeName() << "] Close";
+        return absl::OkStatus();
+    }
+
+    absl::Status Open(CalculatorContext* cc) final {
+        LOG(INFO) << "LLMCalculator [Node: " << cc->NodeName() << "] Open start";
+        ovms::LLMNodeResourcesMap nodeResourcesMap = cc->InputSidePackets().Tag(LLM_SESSION_SIDE_PACKET_TAG).Get<ovms::LLMNodeResourcesMap>();
+        auto it = nodeResourcesMap.find(cc->NodeName());
+        RET_CHECK(it != nodeResourcesMap.end()) << "Could not find initialized LLM node named: " << cc->NodeName();
+
+        nodeResources = it->second;
+        LOG(INFO) << "LLMCalculator [Node: " << cc->NodeName() << "] Open end";
+        return absl::OkStatus();
+    }
+
+    // greedy (no params)
+    // beam-search (num groups, num beams, penalties)
+    // random sampling - in-progress (top-p top-k)
+    absl::Status Process(CalculatorContext* cc) final {
+        RET_CHECK(this->nodeResources != nullptr);
+
+        // For cases where MediaPipe decides to trigger Process() when there are no inputs
+        if (cc->Inputs().Tag(INPUT_TAG_NAME).IsEmpty() && cc->Inputs().Tag(LOOPBACK_TAG_NAME).IsEmpty()) {
+            return absl::OkStatus();
+        }
+
+        // First iteration of Process()
+        if (!cc->Inputs().Tag(INPUT_TAG_NAME).IsEmpty()) {
+            // Check if we did not receive the payload twice
+            RET_CHECK(this->request == nullptr);
+            RET_CHECK(this->generationHandle == nullptr);
+            RET_CHECK(this->streamer == nullptr);
+
+            // Register resource creation time
+            this->created = std::chrono::system_clock::now();
+
+            InputDataType payload = cc->Inputs().Tag(INPUT_TAG_NAME).Get<InputDataType>();
+            LOG(INFO) << "HTTP Request: \n" << payload.body << "\n";
+    
+            this->request = std::make_shared<OpenAIChatCompletionsRequest>(*payload.parsedJson);
+
+            // TODO: Support chat scenario once atobisze adds that to CB library
+            RET_CHECK(this->request->parse());  // TODO: try catch and expose error message
+            RET_CHECK(this->request->getMessages().size() >= 1);
+            RET_CHECK(this->request->getMessages()[0].count("content") >= 1);
+    
+            std::string prompt = this->request->getMessages()[0]["content"];
+
+            // TODO: Support other samplings
+            // TODO: Pass more params from request
+            GenerationConfig config = GenerationConfig::greedy();
+            config.max_new_tokens = this->request->getMaxTokens().value_or(30);
+            config.ignore_eos = false;
+            this->generationHandle = std::make_shared<GenerationHandle>(
+                nodeResources->cbPipe->add_request(
+                    0/*to be removed from API?*/,
+                    prompt/* to be replaced with chat*/,
+                    config));
+            nodeResources->notifyExecutorThread();
+            this->streamer = std::make_shared<TextStreamer>(
+                nodeResources->cbPipe->get_tokenizer());
+        }
+
+        RET_CHECK(this->generationHandle != nullptr);
+        RET_CHECK(this->request != nullptr);
+        RET_CHECK(this->streamer != nullptr);
+
+        // Unary scenario
+        if (!this->request->isStream()) {
+            std::vector<GenerationOutput> generationOutput = this->generationHandle->read_all();
+            RET_CHECK(generationOutput.size() == 1);
+
+            std::vector<int64_t> tokens = generationOutput[0].generated_token_ids;
+            std::shared_ptr<Tokenizer> tokenizer = nodeResources->cbPipe->get_tokenizer();
+            std::string completion = tokenizer->decode(tokens);
+
+            std::string response = serializeUnaryResponse(tokenizer->decode(tokens));
+            //LOG(INFO) << response;
+
+            cc->Outputs().Tag(OUTPUT_TAG_NAME).Add(new OutputDataType{response}, timestamp);
+        } else {
+            // Streaming scenario
+            // Each iteration is single execution of Process() method
+
+            // Last iteration
+            if (this->generationHandle->generation_finished()) {
+                std::string response = packIntoServerSideEventMessage(serializeStreamingChunk("", true));
+                response += packIntoServerSideEventMessage("[DONE]");
+                //LOG(INFO) << response;
+                // Produce last message, but do not producce loopback packets anymore so this is last Process() call
+                cc->Outputs().Tag(OUTPUT_TAG_NAME).Add(new OutputDataType{response}, timestamp);
+            } else {
+                // Subsequent iteration
+                GenerationOutputs generationOutputs = this->generationHandle->read();
+                RET_CHECK(generationOutputs.size() == 1);  // TODO: Support multiple generations
+                RET_CHECK(generationOutputs.begin()->second.generated_token_ids.size() == 1);
+
+                // TODO(dkalinow): Move this logic to CB library
+                int64_t token = generationOutputs.begin()->second.generated_token_ids[0];
+                auto chunk = this->streamer->put(token);
+                if (chunk.has_value()) {
+                    std::string response = packIntoServerSideEventMessage(
+                        serializeStreamingChunk(chunk.value(), false));
+                    //LOG(INFO) << response;
+                    cc->Outputs().Tag(OUTPUT_TAG_NAME).Add(new OutputDataType{response}, timestamp);
+                }
+                // Continue the loop
+                cc->Outputs().Tag(LOOPBACK_TAG_NAME).Add(new bool{true}, timestamp);
+            }
+        }
+
+        timestamp = timestamp.NextAllowedInStream();
+
+        return absl::OkStatus();
+    }
+};
+
+// TODO: Different samplings may produce multiple generations.
+// Consider switching from string to vector<string>?
+std::string HttpLLMCalculator::serializeUnaryResponse(const std::string& completeResponse) {
+    StringBuffer buffer;
+    Writer<StringBuffer> writer(buffer);
+
+    writer.StartObject();  // {
+
+    // choices: array of size N, where N is related to n request parameter
+    writer.String("choices");
+    writer.StartArray();  // [
+    writer.StartObject();  // {
+    // finish_reason: string; "stop"/"length"/"content_filter"/"tool_calls"/"function_call"(deprecated)
+    // "stop" => natural stop point due to stopping criteria <---------------- the only used so far, remaining are TODO
+    // "length" => due to reaching max_tokens parameter TODO
+    // "content_filter" => when produced restricted output
+    // "tool_calls" => generation stopped and waiting for tool output
+    // "function_call" => deprecated
+    writer.String("finish_reason");
+    writer.String("stop");
+    // index: integer; Choice index, only n=1 supported anyway
+    writer.String("index");
+    writer.Int(0);
+    // logprobs: object/null; Log probability information for the choice. TODO
+    writer.String("logprobs");
+    writer.Null();
+    // message: object
+    writer.String("message");
+    writer.StartObject();  // {
+    // content: string; Actual content of the text produced
+    writer.String("content");
+    writer.String(completeResponse.c_str());
+    // role: string; Role of the text producer
+    // Will make sense once we have chat templates? TODO(atobisze)
+    writer.String("role");
+    writer.String("assistant");  // TODO - hardcoded
+    // TODO: tools_call
+    // TODO: function_call (deprecated)
+    writer.EndObject();  // }
+                
+    writer.EndObject();  // }
+    writer.EndArray();  // ]
+
+    // created: integer; Unix timestamp (in seconds) when the MP graph was created.
+    writer.String("created");
+    writer.Int(std::chrono::duration_cast<std::chrono::seconds>(this->created.time_since_epoch()).count());
+
+    // model: string; copied from the request
+    writer.String("model");
+    writer.String(this->request->getModel().c_str());
+
+    // object: string; defined that the type is unary rather than streamed chunk
+    writer.String("object");
+    writer.String("chat.completion");
+
+    // TODO
+    // id: string; A unique identifier for the chat completion.
+
+    // TODO
+    // system_fingerprint: string; This fingerprint represents the backend configuration that the model runs with.
+    // Can be used in conjunction with the seed request parameter to understand when backend changes have been made that might impact determinism.
+ 
+    // TODO
+    // usage: object; Usage statistics for the completion request.
+    // Might be crucial - possibly required for benchmarking purposes?
+
+    writer.EndObject();  // }
+    return buffer.GetString();
+}
+
+std::string HttpLLMCalculator::serializeStreamingChunk(const std::string& chunkResponse, bool stop) {
+    StringBuffer buffer;
+    Writer<StringBuffer> writer(buffer);
+
+    writer.StartObject();  // {
+
+    // choices: array of size N, where N is related to n request parameter
+    // Can also be empty for the last chunk if you set stream_options: {"include_usage": true} TODO
+    writer.String("choices");
+    writer.StartArray();  // [
+    writer.StartObject();  // {
+    // finish_reason: string or null; "stop"/"length"/"content_filter"/"tool_calls"/"function_call"(deprecated)/null
+    // "stop" => natural stop point due to stopping criteria <---------------- the only used so far, remaining are TODO
+    // "length" => due to reaching max_tokens parameter TODO
+    // "content_filter" => when produced restricted output
+    // "tool_calls" => generation stopped and waiting for tool output
+    // "function_call" => deprecated
+    // null - natural scenario when the generation has not completed yet
+    writer.String("finish_reason");
+    if (stop)
+        writer.String("stop");
+    else
+        writer.Null();
+    // index: integer; Choice index, only n=1 supported anyway
+    writer.String("index");
+    writer.Int(0);
+    // logprobs: object/null; Log probability information for the choice. TODO
+    writer.String("logprobs");
+    writer.Null();
+    // delta: object
+    writer.String("delta");
+    writer.StartObject();  // {
+    // content: string; Actual content of the text produced
+    if (!stop) {
+        writer.String("content");
+        writer.String(chunkResponse.c_str());
+    }
+    // role: string; Role of the text producer
+    // Will make sense once we have chat templates? TODO(atobisze)
+    // writer.String("role");
+    // writer.String("assistant");
+    // TODO: tools_call
+    // TODO: function_call (deprecated)
+    writer.EndObject();  // }
+                
+    writer.EndObject();  // }
+    writer.EndArray();  // ]
+
+    // created: integer; Unix timestamp (in seconds) when the MP graph was created.
+    writer.String("created");
+    writer.Int(std::chrono::duration_cast<std::chrono::seconds>(this->created.time_since_epoch()).count());
+
+    // model: string; copied from the request
+    writer.String("model");
+    writer.String(this->request->getModel().c_str());
+
+    // object: string; defined that the type streamed chunk rather than complete response
+    writer.String("object");
+    writer.String("chat.completion.chunk");
+
+    // TODO
+    // id: string; A unique identifier for the chat completion. Each chunk has the same ID.
+
+    // TODO
+    // system_fingerprint: string; This fingerprint represents the backend configuration that the model runs with.
+    // Can be used in conjunction with the seed request parameter to understand when backend changes have been made that might impact determinism.
+            
+    // TODO
+    // usage: object; An optional field that will only be present when you set stream_options: {"include_usage": true} in your request.
+    // When present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.
+    // Might be crucial - possibly required for benchmarking purposes?
+
+    writer.EndObject();  // }
+    return buffer.GetString();
+}
+
+std::string packIntoServerSideEventMessage(const std::string& message) {
+    std::stringstream ss;
+    ss << "data: " << message << "\n\n";
+    return ss.str();
+}
+
+// TODO: Names to be decided
+const std::string HttpLLMCalculator::INPUT_TAG_NAME{"HTTP_REQUEST_PAYLOAD"};
+const std::string HttpLLMCalculator::OUTPUT_TAG_NAME{"HTTP_RESPONSE_PAYLOAD"};
+const std::string HttpLLMCalculator::LOOPBACK_TAG_NAME{"LOOPBACK"};
+
+REGISTER_CALCULATOR(HttpLLMCalculator);
+}  // namespace mediapipe

--- a/src/llm/llm_calculator.cc
+++ b/src/llm/llm_calculator.cc
@@ -85,7 +85,7 @@ public:
 
             GenerationHandle generation = nodeResources->cbPipe->add_request(0, prompt, GenerationConfig::greedy());
             nodeResources->notifyExecutorThread();
-            std::vector<GenerationOutput> outputs = generation.read_all();
+            std::vector<GenerationOutput> outputs = generation->read_all();
             // For greedy this sampling params, there's only one output
             // TODO: work with multiple outputs
             std::string result = nodeResources->cbPipe->get_tokenizer()->decode(outputs[0].generated_token_ids);

--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -65,11 +65,11 @@ Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources
         return StatusCode::LLM_NODE_DIRECTORY_DOES_NOT_EXIST;
     }
 
-    size_t NUM_BLOCKS = 3640;
+    size_t NUM_BLOCKS = 364;//0;
     // Currently harrdcoded, will parametrize in future
     SchedulerConfig default_config{
         .max_num_batched_tokens = 256,
-        .num_kv_blocks = NUM_BLOCKS * 1,
+        .num_kv_blocks = NUM_BLOCKS * 10,
         .block_size = 32,
         .dynamic_split_fuse = true,//false,
         .max_num_seqs = 256,

--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -65,14 +65,15 @@ Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources
         return StatusCode::LLM_NODE_DIRECTORY_DOES_NOT_EXIST;
     }
 
-    size_t NUM_BLOCKS = 364;
+    size_t NUM_BLOCKS = 3640;
     // Currently harrdcoded, will parametrize in future
     SchedulerConfig default_config{
         .max_num_batched_tokens = 256,
-        .num_kv_blocks = NUM_BLOCKS,
+        .num_kv_blocks = NUM_BLOCKS * 1,
         .block_size = 32,
-        .dynamic_split_fuse = false,
+        .dynamic_split_fuse = true,//false,
         .max_num_seqs = 256,
+        //.max_paddings = 256,
     };
 
     try {

--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -65,15 +65,15 @@ Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources
         return StatusCode::LLM_NODE_DIRECTORY_DOES_NOT_EXIST;
     }
 
-    size_t NUM_BLOCKS = 364;//0;
+    size_t NUM_BLOCKS = 3640;
     // Currently harrdcoded, will parametrize in future
     SchedulerConfig default_config{
         .max_num_batched_tokens = 256,
-        .num_kv_blocks = NUM_BLOCKS * 10,
+        .num_kv_blocks = NUM_BLOCKS * 1,
         .block_size = 32,
-        .dynamic_split_fuse = true,//false,
+        .dynamic_split_fuse = true,
         .max_num_seqs = 256,
-        //.max_paddings = 256,
+        // .max_paddings = 256,
     };
 
     try {

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -441,7 +441,7 @@ Status MediapipeGraphDefinition::initializeNodes() {
         }
 #endif
         // Passed to both calculators that require LLM Engine (gRPC KServe & HTTP OpenAI)
-        if (config.node(i).calculator().size() >= LLM_NODE_CALCULATOR_NAME.size() && config.node(i).calculator().compare(config.node(i).calculator().size()-LLM_NODE_CALCULATOR_NAME.size(), LLM_NODE_CALCULATOR_NAME.size(), LLM_NODE_CALCULATOR_NAME) == 0) {
+        if (endsWith(config.node(i).calculator(), LLM_NODE_CALCULATOR_NAME)) {
             if (!config.node(i).node_options().size()) {
                 SPDLOG_LOGGER_ERROR(modelmanager_logger, "LLM node missing options in graph: {}. ", this->name);
                 return StatusCode::LLM_NODE_MISSING_OPTIONS;

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -440,7 +440,8 @@ Status MediapipeGraphDefinition::initializeNodes() {
             pythonResourcesCleaningGuard.disableCleaning();
         }
 #endif
-        if (config.node(i).calculator() == LLM_NODE_CALCULATOR_NAME) {
+        // Passed to both calculators that require LLM Engine (gRPC KServe & HTTP OpenAI)
+        if (config.node(i).calculator().size() >= LLM_NODE_CALCULATOR_NAME.size() && config.node(i).calculator().compare(config.node(i).calculator().size()-LLM_NODE_CALCULATOR_NAME.size(), LLM_NODE_CALCULATOR_NAME.size(), LLM_NODE_CALCULATOR_NAME) == 0) {
             if (!config.node(i).node_options().size()) {
                 SPDLOG_LOGGER_ERROR(modelmanager_logger, "LLM node missing options in graph: {}. ", this->name);
                 return StatusCode::LLM_NODE_MISSING_OPTIONS;

--- a/src/test/http_openai_handler_test.cpp
+++ b/src/test/http_openai_handler_test.cpp
@@ -45,7 +45,7 @@ public:
     MOCK_METHOD(void, OverwriteResponseHeader, (absl::string_view, absl::string_view), (override));
     MOCK_METHOD(void, AppendResponseHeader, (absl::string_view, absl::string_view), (override));
     MOCK_METHOD(void, PartialReplyWithStatus, (tensorflow::serving::net_http::HTTPStatusCode), (override));
-    MOCK_METHOD(void, PartialReply, (), (override));
+    MOCK_METHOD(void, PartialReply, (std::string), (override));
     MOCK_METHOD(tensorflow::serving::net_http::ServerRequestInterface::CallbackStatus, PartialReplyWithFlushCallback, ((std::function<void()>)), (override));
     MOCK_METHOD(tensorflow::serving::net_http::ServerRequestInterface::BodyStatus, response_body_status, (), (override));
     MOCK_METHOD(tensorflow::serving::net_http::ServerRequestInterface::BodyStatus, request_body_status, (), (override));
@@ -119,8 +119,8 @@ TEST_F(HttpOpenAIHandlerTest, Stream) {
     )";
 
     EXPECT_CALL(writer, PartialReplyEnd()).Times(1);
-    EXPECT_CALL(writer, PartialReply()).Times(9);
-    EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(9);
+    EXPECT_CALL(writer, PartialReply(::testing::_)).Times(9);
+    EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(0);
 
     ASSERT_EQ(
         handler->dispatchToProcessor(requestBody, &response, comp, responseComponents, &writer),
@@ -133,7 +133,7 @@ TEST_F(HttpOpenAIHandlerTest, BodyNotAJson) {
     std::string requestBody = "not a json";
 
     EXPECT_CALL(writer, PartialReplyEnd()).Times(0);
-    EXPECT_CALL(writer, PartialReply()).Times(0);
+    EXPECT_CALL(writer, PartialReply(::testing::_)).Times(0);
     EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(0);
 
     auto status = handler->dispatchToProcessor(requestBody, &response, comp, responseComponents, &writer);
@@ -145,7 +145,7 @@ TEST_F(HttpOpenAIHandlerTest, JsonBodyValidButNotAnObject) {
     std::string requestBody = "[1, 2, 3]";
 
     EXPECT_CALL(writer, PartialReplyEnd()).Times(0);
-    EXPECT_CALL(writer, PartialReply()).Times(0);
+    EXPECT_CALL(writer, PartialReply(::testing::_)).Times(0);
     EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(0);
 
     auto status = handler->dispatchToProcessor(requestBody, &response, comp, responseComponents, &writer);
@@ -162,7 +162,7 @@ TEST_F(HttpOpenAIHandlerTest, ModelFieldMissing) {
     )";
 
     EXPECT_CALL(writer, PartialReplyEnd()).Times(0);
-    EXPECT_CALL(writer, PartialReply()).Times(0);
+    EXPECT_CALL(writer, PartialReply(::testing::_)).Times(0);
     EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(0);
 
     auto status = handler->dispatchToProcessor(requestBody, &response, comp, responseComponents, &writer);
@@ -180,7 +180,7 @@ TEST_F(HttpOpenAIHandlerTest, ModelFieldNotAString) {
     )";
 
     EXPECT_CALL(writer, PartialReplyEnd()).Times(0);
-    EXPECT_CALL(writer, PartialReply()).Times(0);
+    EXPECT_CALL(writer, PartialReply(::testing::_)).Times(0);
     EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(0);
 
     auto status = handler->dispatchToProcessor(requestBody, &response, comp, responseComponents, &writer);
@@ -198,7 +198,7 @@ TEST_F(HttpOpenAIHandlerTest, StreamFieldNotABoolean) {
     )";
 
     EXPECT_CALL(writer, PartialReplyEnd()).Times(0);
-    EXPECT_CALL(writer, PartialReply()).Times(0);
+    EXPECT_CALL(writer, PartialReply(::testing::_)).Times(0);
     EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(0);
 
     auto status = handler->dispatchToProcessor(requestBody, &response, comp, responseComponents, &writer);
@@ -216,7 +216,7 @@ TEST_F(HttpOpenAIHandlerTest, GraphWithANameDoesNotExist) {
     )";
 
     EXPECT_CALL(writer, PartialReplyEnd()).Times(0);
-    EXPECT_CALL(writer, PartialReply()).Times(0);
+    EXPECT_CALL(writer, PartialReply(::testing::_)).Times(0);
     EXPECT_CALL(writer, WriteResponseString(::testing::_)).Times(0);
 
     auto status = handler->dispatchToProcessor(requestBody, &response, comp, responseComponents, &writer);

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -3334,6 +3334,7 @@ TEST(WhitelistRegistered, MediapipeCalculatorsList) {
         "PyTensorOvTensorConverterCalculator",   // integral OVMS calculator
         "PythonExecutorCalculator",  // integral OVMS calculator
 #endif
+        "HttpLLMCalculator",  // integral OVMS calculator
         "LLMCalculator",  // integral OVMS calculator
         "OpenAIChatCompletionsMockCalculator",  // OVMS test calculator
         "AddHeaderCalculator",

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -20,7 +20,7 @@ def llm_engine():
     new_git_repository(
         name = "llm_engine",
         remote = "https://github.com/mzegla/openvino.genai",
-        commit = "db6cc2508760f9385c7f6b11266c61513513a33f", # request_rate branch
+        commit = "b8b24d57f8889af14b5621ca6ecb2dea0cef8f76", # request_rate branch
         build_file = "@_llm_engine//:BUILD",
         init_submodules = True,
         recursive_init_submodules = True,

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -20,7 +20,7 @@ def llm_engine():
     new_git_repository(
         name = "llm_engine",
         remote = "https://github.com/mzegla/openvino.genai",
-        commit = "9e79ed7b80202e253841d3031b96648542b358b8", # request_rate branch
+        commit = "db6cc2508760f9385c7f6b11266c61513513a33f", # request_rate branch
         build_file = "@_llm_engine//:BUILD",
         init_submodules = True,
         recursive_init_submodules = True,


### PR DESCRIPTION
### 🛠 Summary

CVS-139231/CVS-139233

This introduces LLM calculator that accepts HTTP OpenAI /v3/chat/completion requests and produces compliant responses.
Working in both - unary and streaming modes.
Bunch of parameters are still marked as TODO, but should be enough to perform benchmarks.

Minimal demo description how to run.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [x] Change follows security best practices.


