### PR TITLE
Tokenizers path fix

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -202,14 +202,6 @@ RUN yum install -y http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os
 RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel/openvino/samples/cpp/build_samples.sh ; fi
 #################### END OF OPENVINO BINARY INSTALL
 
-# OpenVINO Tokenizers extension
-ENV OpenVINO_DIR=/opt/intel/openvino/runtime/cmake
-ARG ov_tokenizers_branch=master
-# hadolint ignore=DL3003
-RUN if [[ "$tokenizers" == "1" ]] ; then true ; else exit 0 ; fi ; git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-WORKDIR /openvino_tokenizers/build
-RUN if [ "$tokenizers" == "1" ] ; then true ; else exit 0 ; fi ; cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --build . --parallel $JOBS
-
 # NVIDIA
 ENV OPENVINO_BUILD_PATH=/cuda_plugin_build
 ENV OPENVINO_HOME=/openvino

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -193,6 +193,9 @@ RUN if [ "$ov_use_binary" = "1" ] && [ "$DLDT_PACKAGE_URL" = "" ] ; then true ; 
 RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel/openvino/samples/cpp/build_samples.sh ; fi
 #################### END OF OPENVINO BINARY INSTALL
 
+# OpenVINO Tokenizers extension
+ENV OpenVINO_DIR=/opt/intel/openvino/runtime/cmake
+
 # NVIDIA
 ENV OPENVINO_BUILD_PATH=/cuda_plugin_build
 ENV OPENVINO_HOME=/openvino

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -193,15 +193,6 @@ RUN if [ "$ov_use_binary" = "1" ] && [ "$DLDT_PACKAGE_URL" = "" ] ; then true ; 
 RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel/openvino/samples/cpp/build_samples.sh ; fi
 #################### END OF OPENVINO BINARY INSTALL
 
-# OpenVINO Tokenizers extension
-ENV OpenVINO_DIR=/opt/intel/openvino/runtime/cmake
-
-ARG ov_tokenizers_branch=master
-# hadolint ignore=DL3003
-RUN if [[ "$tokenizers" == "1" ]] ; then true ; else exit 0 ; fi ; git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-WORKDIR /openvino_tokenizers/build
-RUN if [ "$tokenizers" == "1" ] ; then true ; else exit 0 ; fi ; cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --build . --parallel $JOBS
-
 # NVIDIA
 ENV OPENVINO_BUILD_PATH=/cuda_plugin_build
 ENV OPENVINO_HOME=/openvino

--- a/create_package.sh
+++ b/create_package.sh
@@ -22,8 +22,9 @@ mkdir -vp /ovms_release/lib
 mkdir -vp /ovms_release/lib/hddl/config
 mkdir -vp /ovms_release/lib/custom_nodes
 
-if [ -f /openvino_tokenizers/build/src/libopenvino_tokenizers.so ]; then cp -v /openvino_tokenizers/build/src/libopenvino_tokenizers.so /ovms_release/lib/ ; fi
-if [ -f /openvino_tokenizers/build/src/libcore_tokenizers.so ]; then cp -v /openvino_tokenizers/build/src/libcore_tokenizers.so /ovms_release/lib/ ; fi
+tokenizers_path=/ovms/bazel-out/k8-opt/bin/external/llm_engine/llm_engine_cmake_ubuntu/lib/
+if [ -f ${tokenizers_path}libopenvino_tokenizers.so ]; then cp -v ${tokenizers_path}libopenvino_tokenizers.so /ovms_release/lib/ ; fi
+if [ -f ${tokenizers_path}libcore_tokenizers.so ]; then cp -v ${tokenizers_path}libcore_tokenizers.so /ovms_release/lib/ ; fi
 
 find /ovms/bazel-out/k8-*/bin -iname '*.so*' ! -type d ! -name "*params" ! -name "lib_node_*" ! -path "*test_python_binding*" ! -name "*libpython*" -exec cp -v {} /ovms_release/lib/ \;
 mv /ovms_release/lib/libcustom_node* /ovms_release/lib/custom_nodes/

--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -76,8 +76,9 @@ Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources
         //.max_paddings = 256,
     };
 
+    const std::string OVMS_TOKENIZER_SEARCH_PATH = "../lib";
     try {
-        nodeResources->cbPipe = std::make_unique<ContinuousBatchingPipeline>(basePath, default_config);
+        nodeResources->cbPipe = std::make_unique<ContinuousBatchingPipeline>(basePath, default_config, OVMS_TOKENIZER_SEARCH_PATH);
     } catch (const std::exception& e) {
         SPDLOG_ERROR("Error during llm node initialization for models_path: {} exception: {}", basePath, e.what());
         return StatusCode::LLM_NODE_RESOURCE_STATE_INITIALIZATION_FAILED;

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -20,7 +20,7 @@ def llm_engine():
     new_git_repository(
         name = "llm_engine",
         remote = "https://github.com/mzegla/openvino.genai",
-        commit = "b8b24d57f8889af14b5621ca6ecb2dea0cef8f76", # request_rate branch
+        commit = "1a9672a994407937183eaa4aefb6129671ee5aa5", # tokenizers path load
         build_file = "@_llm_engine//:BUILD",
         init_submodules = True,
         recursive_init_submodules = True,


### PR DESCRIPTION
### 🛠 Summary

JIRA CVS-142381
Adding option to pass tokenizer path at runtime and preserving compile time path setup.

Searching for libopenvino_tokenizers.so based on input paths
directory path or full file path can be provided
Search order:
backup_tokenizer_lib_path - passed during runtime - default ""
input_path - passed during compile time
LD_PRELOAD
LD_LIBRARY_PATH

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

