### PR TITLE
Text streamer fix

### DIFF
--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -335,7 +335,7 @@ public:
             return chunk;
         } else if (text.size() >= 3 && text.compare(text.size() - 3, 3, "�") == 0) {  // NOLINT
             return std::nullopt;
-        } else {
+        } else if (text.size() > printLen) {
             std::string chunk = std::string{text.data() + printLen, text.size() - printLen};
             printLen = text.size();
             return chunk;


### PR DESCRIPTION
### 🛠 Summary

There is an issue (or feature?) that adding generated token to the token cache produces shorter message than previous without newly generated one.

TextStreamer did not expect such behavior.

The fix ignores such event and makes the generation wait for the next tokens.

### 🧪 Checklist

- [ ] Unit tests added. - we have no unit tests for the calculator
- [x] The documentation updated. - not needed
- [x] Change follows security best practices.

