### PR TITLE
Fix C-API demos

### DIFF
--- a/demos/c_api_minimal_app/Makefile
+++ b/demos/c_api_minimal_app/Makefile
@@ -20,11 +20,11 @@ HTTPS_PROXY := "$(https_proxy)"
 NO_PROXY := "$(no_proxy)"
 BASE_OS_TAG_UBUNTU ?= 22.04
 BASE_OS_TAG_REDHAT ?= 8.8
-REDHAT_PACKAGE_URL ?="https://github.com/openvinotoolkit/model_server/releases/download/v2024.0/ovms_redhat.tar.gz"
-UBUNTU_PACKAGE_URL ?="https://github.com/openvinotoolkit/model_server/releases/download/v2024.0/ovms_ubuntu22.tar.gz"
+REDHAT_PACKAGE_URL ?="https://github.com/openvinotoolkit/model_server/releases/download/v2024.1/ovms_redhat.tar.gz"
+UBUNTU_PACKAGE_URL ?="https://github.com/openvinotoolkit/model_server/releases/download/v2024.1/ovms_ubuntu22.tar.gz"
 
 OVMS_CPP_DOCKER_IMAGE ?= openvino/model_server
-OVMS_CPP_IMAGE_TAG ?= 2024.0
+OVMS_CPP_IMAGE_TAG ?= 2024.1
 BASE_OS ?= ubuntu
 DIST_OS ?= $(BASE_OS)
 

--- a/demos/c_api_minimal_app/Makefile
+++ b/demos/c_api_minimal_app/Makefile
@@ -21,7 +21,7 @@ NO_PROXY := "$(no_proxy)"
 
 OVMS_CPP_DOCKER_IMAGE ?= openvino/model_server
 OVMS_CPP_IMAGE_TAG ?= 2024.1
-BASE_OS ?= ubuntu
+BASE_OS ?= ubuntu22
 
 ifeq ($(BASE_OS),ubuntu22)
   BASE_OS_TAG_UBUNTU ?= 22.04
@@ -43,7 +43,7 @@ clean:
 from_docker:
 	mkdir -p capi/$(DIST_OS)
 	docker run $(OVMS_CPP_DOCKER_IMAGE)-pkg:$(OVMS_CPP_IMAGE_TAG) bash -c \
-			"tar -c -C /ovms_pkg/$(DIST_OS) ovms.tar.gz ; sleep 2" | tar -x -C capi/$(DIST_OS)/ && cd ../../
+			"tar -c -C /ovms_pkg/$(BASE_OS) ovms.tar.gz ; sleep 2" | tar -x -C capi/$(DIST_OS)/ && cd ../../
 	-docker rm -v $$(docker ps -a -q -f status=exited -f ancestor=$(OVMS_CPP_DOCKER_IMAGE)-pkg:$(OVMS_CPP_IMAGE_TAG))
 
 from_web:

--- a/demos/c_api_minimal_app/Makefile
+++ b/demos/c_api_minimal_app/Makefile
@@ -18,22 +18,20 @@
 HTTP_PROXY := "$(http_proxy)"
 HTTPS_PROXY := "$(https_proxy)"
 NO_PROXY := "$(no_proxy)"
-BASE_OS_TAG_UBUNTU ?= 22.04
-BASE_OS_TAG_REDHAT ?= 8.8
-REDHAT_PACKAGE_URL ?="https://github.com/openvinotoolkit/model_server/releases/download/v2024.1/ovms_redhat.tar.gz"
-UBUNTU_PACKAGE_URL ?="https://github.com/openvinotoolkit/model_server/releases/download/v2024.1/ovms_ubuntu22.tar.gz"
 
 OVMS_CPP_DOCKER_IMAGE ?= openvino/model_server
 OVMS_CPP_IMAGE_TAG ?= 2024.1
 BASE_OS ?= ubuntu
-DIST_OS ?= $(BASE_OS)
 
-ifeq ($(BASE_OS),ubuntu)
-  PACKAGE_URL = ${UBUNTU_PACKAGE_URL}
+ifeq ($(BASE_OS),ubuntu22)
+  BASE_OS_TAG_UBUNTU ?= 22.04
+  PACKAGE_URL ?="https://github.com/openvinotoolkit/model_server/releases/download/v2024.1/ovms_ubuntu22.tar.gz"
   BASE_IMAGE ?= ubuntu:$(BASE_OS_TAG_UBUNTU)
+  DIST_OS=ubuntu
 endif
 ifeq ($(BASE_OS),redhat)
-  PACKAGE_URL = ${REDHAT_PACKAGE_URL}
+  BASE_OS_TAG_REDHAT ?= 8.8
+  PACKAGE_URL ="https://github.com/openvinotoolkit/model_server/releases/download/v2024.1/ovms_redhat.tar.gz"
   BASE_IMAGE ?= registry.access.redhat.com/ubi8/ubi:$(BASE_OS_TAG_REDHAT)
   DIST_OS=redhat
 endif
@@ -59,7 +57,7 @@ build_image:
 	cp -r ../../src/main_benchmark.cpp capi/$(DIST_OS)/demos
 	sed -i s+/ovms/src/test/c_api/config.json+/ovms/demos/config.json+ capi/$(DIST_OS)/demos/main_capi.c
 	sed -i s+/ovms/src/test/c_api/config_standard_dummy.json+/ovms/demos/config_standard_dummy.json+ capi/$(DIST_OS)/demos/main_capi.cpp
-	cd capi/$(DIST_OS)/ && docker build $(NO_CACHE_OPTION) -f Dockerfile.$(BASE_OS) . \
+	cd capi/$(DIST_OS)/ && docker build $(NO_CACHE_OPTION) -f Dockerfile.$(DIST_OS) . \
 		--build-arg http_proxy=$(HTTP_PROXY) --build-arg https_proxy="$(HTTPS_PROXY)" \
 		--build-arg no_proxy=$(NO_PROXY) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \

--- a/demos/c_api_minimal_app/README.md
+++ b/demos/c_api_minimal_app/README.md
@@ -31,8 +31,9 @@ make -f MakefileCapi cpp
 ```
 
 It will link the main_capi.cpp binary with the `libovms_shared.so` library from /ovms/lib and use the headers from /ovms/include directory:
-```
-g++ main_capi.cpp -I/ovms/include -L/ovms/lib -lovms_shared
+```bash
+g++ main_capi.cpp -I/ovms/include -L/ovms/lib -lovms_shared -o main_capi
+./main_capi
 ```
 
 The example output is:

--- a/demos/c_api_minimal_app/capi_files/Dockerfile.redhat
+++ b/demos/c_api_minimal_app/capi_files/Dockerfile.redhat
@@ -50,6 +50,7 @@ ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/ovms/lib"
 RUN make -f MakefileCapi cpp
 RUN make -f MakefileCapi c
 RUN make -f MakefileCapi benchmark
+RUN chown ovms:ovms /ovms/demos
 
 USER ovms
 ENTRYPOINT ["/bin/bash"]

--- a/demos/c_api_minimal_app/capi_files/Dockerfile.ubuntu
+++ b/demos/c_api_minimal_app/capi_files/Dockerfile.ubuntu
@@ -51,6 +51,7 @@ ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/ovms/lib"
 RUN make -f MakefileCapi cpp
 RUN make -f MakefileCapi c
 RUN make -f MakefileCapi benchmark
+RUN chown ovms:ovms /ovms/demos
 
 USER ovms
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Command with g++ didn't work due to improper permissions.

Additionally:
* update used OVMS packages to 2024.1
* make running g++ testable through test framework
* unify BASE_OS usage in Makefile for C-API with main OVMS Makefile

ID:CVS-143259

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.
``

