### PR TITLE
Update RH base image to UBI9.4

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -14,26 +14,23 @@
 # limitations under the License.
 #
 
-ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi:8.10
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.4
 ARG BUILD_IMAGE=build
 ARG PKG_IMAGE=pkg
-ARG RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi8/ubi:8.10
+ARG RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.4
 
 FROM $BASE_IMAGE as base_build
-ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi:8.10
-
-LABEL version="1.0.0"
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.4
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 ARG JOBS=8
 ARG VERBOSE_LOGS=OFF
 
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all && yum update -d6 -y && yum install -d6 -y \
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && dnf clean all && yum update -d6 -y && yum install -d6 -y \
             libuuid-devel \
             bc \
             cmake \
-            curl \
             gcc-c++ \
             git \
             libcurl-devel \
@@ -45,7 +42,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
             pkg-config \
             wget \
             yum-utils \
-            https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm && \
+            https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/tbb-2020.3-8.el9.x86_64.rpm \
+            https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/tbb-devel-2020.3-8.el9.x86_64.rpm && \
             yum clean all
 
 ####### Azure SDK needs new boost:
@@ -55,7 +53,8 @@ RUN wget -nv https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_6
 	if [ "$VERBOSE_LOGS" == "ON" ] ; then export BVERBOSE="-d+2" ; else export BVERBOSE="" ; fi && \
 	tar xf boost_1_68_0.tar.gz && cd boost_1_68_0 && ./bootstrap.sh && \
 	./b2 -j ${JOBS} cxxstd=17 link=static cxxflags='-fPIC' cflags='-fPIC' \
-		--with-chrono --with-date_time --with-filesystem --with-program_options --with-system \
+		--with-chrono --with-date_time --with-filesystem \
+		--with-program_options --with-system \
 		--with-random --with-thread --with-atomic --with-regex \
 		--with-log --with-locale "$BVERBOSE" \
 		install
@@ -93,13 +92,13 @@ RUN if [ "$VERBOSE_LOGS" == "ON" ] ; then export VERBOSE=1 ; fi && ./install_ope
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 FROM base_build as build
 ARG BASE_IMAGE
-LABEL version="1.0.0"
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 ARG JOBS=40
 
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && dnf clean all && yum update -d6 -y && yum install -d6 -y \
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && dnf clean all && yum update -d6 -y && yum install -d6 -y \
+            ccache \
             gdb \
             java-11-openjdk-devel \
             tzdata-java \
@@ -112,21 +111,23 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
             unzip \
             vim \
             xz \
-            python39-devel \
-            https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm && \
+            python3-devel \
+            https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/tbb-2020.3-8.el9.x86_64.rpm \
+            https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/tbb-devel-2020.3-8.el9.x86_64.rpm \
+            https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/libusb-devel-0.1.7-5.el9.x86_64.rpm \
+            https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libusb-0.1.7-5.el9.x86_64.rpm \
+            https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/libusbx-devel-1.0.26-1.el9.x86_64.rpm && \
             yum clean all
 
-RUN python3 --version && python3 -m pip install "numpy<2.0.0" --no-cache-dir && \
-    python3 --version && python3 -m pip install "Jinja2==3.1.4" --no-cache-dir
+RUN python3 --version && python3 -m pip install numpy==1.21.0 --no-cache-dir
 
 ARG NVIDIA=0
 # Add Nvidia dev tool if needed
 # hadolint ignore=DL3003
 RUN if [ "$NVIDIA" == "1" ] ; then true ; else exit 0 ; fi ; \
-    yum config-manager --save --set-enabled codeready-builder-for-rhel-8-x86_64-rpms ; \
-    yum -y module disable python36 && \
+    yum config-manager --save --set-enabled codeready-builder-for-rhel-9-x86_64-rpms ; \
     yum -y install libzstd-devel ; \
-    yum install -y  \
+    yum install -y \
         cuda-nvcc-11-8 libcublas-11-8 libcublas-devel-11-8 \
         libcudnn8-8.6.0.163-1.cuda11.8 \
         libcudnn8-devel-8.6.0.163-1.cuda11.8 \
@@ -139,12 +140,7 @@ RUN if [ "$NVIDIA" == "1" ] ; then true ; else exit 0 ; fi ; \
     curl -L https://github.com/Kitware/ninja/releases/download/v1.10.0.gfb670.kitware.jobserver-1/ninja-1.10.0.gfb670.kitware.jobserver-1_x86_64-linux-gnu.tar.gz | tar xzv --strip-components=1 -C /usr/local/bin && \
     curl https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz -L | tar xvzC /usr/local/bin --strip-components=1 --wildcards '*/sccache' && \
     chmod a+x /usr/local/bin/sccache && \
-    curl https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-x86_64.tar.gz -L | tar xzvC /usr/local --exclude={doc,man} --strip-components=1 && \
-    curl -L https://github.com/ccache/ccache/releases/download/v4.3/ccache-4.3.tar.xz | tar xJv && \
-    mkdir -p ccache-4.3/build && cd ccache-4.3/build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DZSTD_FROM_INTERNET=ON -G Ninja .. && \
-    ninja -v install && \
-    rm -rf /var/cache/yum
+    yum clean all
 
 ENV TF_SYSTEM_LIBS="curl"
 ENV TEST_LOG="/root/.cache/bazel/_bazel_root/bc57d4817a53cab8c785464da57d1983/execroot/ovms/bazel-out/test.log"
@@ -168,7 +164,7 @@ RUN if [[ "$NVIDIA" == "1" ]] ; then true ; else exit 0 ; fi ; git clone https:/
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; git clone https://github.com/$ov_source_org/openvino.git /openvino && cd /openvino && git checkout $ov_source_branch && git submodule update --init --recursive
 RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; pip3 install --no-cache-dir -r /openvino/src/bindings/python/wheel/requirements-dev.txt
 WORKDIR /openvino/build
-RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; dnf install -y http://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm && dnf clean all
+RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; dnf install -y https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/opencl-headers-3.0-6.20201007gitd65bcc5.el9.noarch.rpm && dnf clean all
 RUN if [ "$ov_use_binary" == "0" ] && [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_PYTHON=ON -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses "  ..
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_SAMPLES=0 -DNGRAPH_USE_CXX_ABI=1 -DCMAKE_CXX_FLAGS=" -D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=parentheses " ..
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; make --jobs=$JOBS
@@ -195,10 +191,8 @@ RUN if [ "$ov_use_binary" = "1" ] && [ "$DLDT_PACKAGE_URL" != "" ]; then true ; 
     ln -s /opt/intel/l_openvino_toolkit* /opt/intel/openvino_2024
 
 # install sample apps including benchmark_app
-RUN yum install -y http://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/gflags-devel-2.2.2-1.el8.x86_64.rpm \
-    http://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/gflags-2.2.2-1.el8.x86_64.rpm \
-    https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/j/json-devel-3.6.1-2.el8.x86_64.rpm && \
-    rm -rf /var/cache/yum
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && yum install -y gflags-devel gflags json-devel && \
+    yum clean all
 RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel/openvino/samples/cpp/build_samples.sh ; fi
 #################### END OF OPENVINO BINARY INSTALL
 
@@ -392,14 +386,14 @@ LABEL supported-devices="CPU=1 GPU=${GPU} NVIDIA=${NVIDIA}"
 ARG RELEASE_BASE_IMAGE
 LABEL base-image=${RELEASE_BASE_IMAGE}
 
-ENV PYTHONPATH=/ovms/lib/python:/ovms/python_deps
+ENV PYTHONPATH=/ovms/lib/python
 
 WORKDIR /
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 # hadolint ignore=DL3003,DL3041,SC2164
 RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=microdnf ; fi ; \
         $DNF_TOOL upgrade --setopt=install_weak_deps=0 -y ; \
-        $DNF_TOOL install -y pkg-config && rpm -ivh https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/tbb-2018.2-9.el8.x86_64.rpm && \
+        $DNF_TOOL install -y pkg-config python3 && rpm -ivh https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/tbb-2020.3-8.el9.x86_64.rpm && \
         if [ "$GPU" == "1" ] ; then \
                 case $INSTALL_DRIVER_VERSION in \
                 "21.38.21026") \
@@ -420,6 +414,7 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=mic
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.5/intel-igc-opencl-1.0.10409-i699.3.el8.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.5/intel-ocloc-22.10.22597-i699.3.el8.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.5/intel-opencl-22.10.22597-i699.3.el8.x86_64.rpm ; \
+                        $DNF_TOOL clean all ; \
                 ;; \
                 "22.28.23726") \
                         $DNF_TOOL install -y libedit ; \
@@ -429,6 +424,7 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=mic
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.5/intel-opencl-22.28.23726.1-i419.el8.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.5-devel/intel-level-zero-gpu-1.3.23453-i392.el8.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.5-devel/level-zero-1.8.1-i392.el8.x86_64.rpm ; \
+                        $DNF_TOOL clean all ; \
                 ;; \
                 "22.43.24595") \
                         $DNF_TOOL install -y libedit ; \
@@ -438,6 +434,7 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=mic
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.6/intel-opencl-22.43.24595.35-i538.el8.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.6/intel-level-zero-gpu-1.3.24595.35-i538.el8.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/graphics/rhel/8.6/level-zero-1.8.8-i524.el8.x86_64.rpm ; \
+                        $DNF_TOOL clean all ; \
                 ;; \
                 "23.22.26516") \
                         $DNF_TOOL install -y libedit ; \
@@ -447,6 +444,7 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=mic
                         rpm -ivh https://repositories.intel.com/gpu/rhel/8.6/pool/i/intel-opencl-23.22.26516.25-682.el8_6.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/gpu/rhel/8.6/pool/i/intel-level-zero-gpu-1.3.26516.25-682.el8_6.x86_64.rpm ; \
                         rpm -ivh https://repositories.intel.com/gpu/rhel/8.6/pool/l/level-zero-1.11.0-674.el8_6.x86_64.rpm ; \
+                        $DNF_TOOL clean all ; \
                 ;; \
 
                         *) \
@@ -457,7 +455,9 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=mic
                 echo `rpm -qa | grep intel-opencl` ; \
         fi ; \
         if [ "$INSTALL_RPMS_FROM_URL" == "" ] ; then \
-                rpm -ivh http://vault.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/ocl-icd-2.2.12-1.el8.x86_64.rpm; \
+                rpm -ivh https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/numactl-libs-2.0.16-3.el9.x86_64.rpm \
+                https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/numactl-2.0.16-3.el9.x86_64.rpm \
+                https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/ocl-icd-2.2.13-4.el9.x86_64.rpm; \
         else  \
                 $DNF_TOOL install -y tar gzip; \
                 mkdir /tmp_ovms ; \
@@ -472,7 +472,6 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; else export DNF_TOOL=mic
         fi ; \
         # For image with Python enabled install Python library
         if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then \
-            $DNF_TOOL install -y python39-libs --setopt=install_weak_deps=0; \
             mkdir -p /ovms/lib/openvino-2024.2.dist-info && \
             echo $'Metadata-Version: 1.0\nName: openvino\nVersion: 2024.2' > /ovms/lib/openvino-2024.2.dist-info/METADATA ; \
         fi ; \
@@ -491,11 +490,6 @@ RUN if [ "$NVIDIA" == "1" ]; then true ; else exit 0 ; fi ; echo "installing cud
 ENV LD_LIBRARY_PATH=/ovms/lib
 
 COPY --from=pkg /ovms_release /ovms
-COPY --from=build /usr/local/lib/python3.*/site-packages/jinja2 /ovms/python_deps/jinja2
-COPY --from=build /usr/local/lib/python3.*/site-packages/jinja2-3.1.4.dist-info /ovms/python_deps/jinja2-3.1.4.dist-info
-COPY --from=build /usr/local/lib64/python3.*/site-packages/MarkupSafe-2.1.5.dist-info /ovms/python_deps/MarkupSafe-2.1.5.dist-info
-COPY --from=build /usr/local/lib64/python3.*/site-packages/markupsafe /ovms/python_deps/markupsafe
-
 COPY --from=pkg /licenses /licenses
 USER ovms
 ENTRYPOINT ["/ovms/bin/ovms"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -19,7 +19,6 @@ ARG BUILD_IMAGE=build
 ARG PKG_IMAGE=pkg
 
 FROM $BASE_IMAGE as base_build
-LABEL version="1.0.0"
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ BASE_OS ?= ubuntu22
 BASE_OS_TAG ?= latest
 
 BASE_OS_TAG_UBUNTU ?= 22.04
-BASE_OS_TAG_REDHAT ?= 8.10
+BASE_OS_TAG_REDHAT ?= 9.4
 
 INSTALL_RPMS_FROM_URL ?=
 
@@ -165,11 +165,11 @@ ifeq ($(BASE_OS),redhat)
   BASE_OS_TAG=$(BASE_OS_TAG_REDHAT)
   OS=redhat
   ifeq ($(NVIDIA),1)
-    BASE_IMAGE=docker.io/nvidia/cuda:11.8.0-runtime-ubi8
+    BASE_IMAGE=docker.io/nvidia/cuda:11.8.0-runtime-ubi9
 	BASE_IMAGE_RELEASE=$(BASE_IMAGE)
   else
-    BASE_IMAGE ?= registry.access.redhat.com/ubi8/ubi:$(BASE_OS_TAG_REDHAT)
-	BASE_IMAGE_RELEASE=registry.access.redhat.com/ubi8/ubi-minimal:$(BASE_OS_TAG_REDHAT)
+    BASE_IMAGE ?= registry.access.redhat.com/ubi9/ubi:$(BASE_OS_TAG_REDHAT)
+	BASE_IMAGE_RELEASE=registry.access.redhat.com/ubi9/ubi-minimal:$(BASE_OS_TAG_REDHAT)
   endif	
   DIST_OS=redhat
   INSTALL_DRIVER_VERSION ?= "23.22.26516"
@@ -354,9 +354,9 @@ ifeq ($(NO_DOCKER_CACHE),true)
 	@echo "Docker image will be rebuilt from scratch"
 	@docker pull $(BASE_IMAGE)
   ifeq ($(BASE_OS),redhat)
-	@docker pull registry.access.redhat.com/ubi8/ubi-minimal:$(BASE_OS_TAG_REDHAT)
+	@docker pull registry.access.redhat.com/ubi9/ubi-minimal:$(BASE_OS_TAG_REDHAT)
     ifeq ($(NVIDIA),1)
-	@docker pull docker.io/nvidia/cuda:11.8.0-runtime-ubi8
+	@docker pull docker.io/nvidia/cuda:11.8.0-runtime-ubi9
     endif
   endif
 endif
@@ -425,7 +425,7 @@ ifeq ($(findstring ubuntu,$(BASE_OS)),ubuntu)
 endif
 ifeq ($(BASE_OS),redhat)
 	touch base_packages.txt
-	docker run registry.access.redhat.com/ubi8-minimal:8.10 rpm -qa  --qf "%{NAME}\n" | sort > base_packages.txt
+	docker run registry.access.redhat.com/ubi9-minimal:9.4 rpm -qa  --qf "%{NAME}\n" | sort > base_packages.txt
 	docker run --entrypoint rpm $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)$(IMAGE_TAG_SUFFIX) -qa  --qf "%{NAME}\n" | sort > all_packages.txt
 	rm -rf ovms_rhel_$(OVMS_CPP_IMAGE_TAG)
 	mkdir ovms_rhel_$(OVMS_CPP_IMAGE_TAG)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -254,6 +254,22 @@ cc_library(
 """,
 )
 
+# We need to override upb due to false positive stringop-truncation warning
+# second patch is needed & copied from TF
+http_archive(
+    name = "upb",
+    sha256 = "61d0417abd60e65ed589c9deee7c124fe76a4106831f6ad39464e1525cef1454",
+    strip_prefix = "upb-9effcbcb27f0a665f9f345030188c0b291e32482",
+    patches = [
+            "upb_platform_fix.patch",
+            "upb_warning_turn_off.patch"
+    ],
+    patch_args = [
+        "-p1",
+    ],
+    urls = ["https://github.com/protocolbuffers/upb/archive/9effcbcb27f0a665f9f345030188c0b291e32482.tar.gz"],
+)
+
 # TensorFlow repo should always go after the other external dependencies.
 # TF on 2023-06-13.
 _TENSORFLOW_GIT_COMMIT = "491681a5620e41bf079a582ac39c585cc86878b9"

--- a/ci/lib_search.py
+++ b/ci/lib_search.py
@@ -115,6 +115,8 @@ def check_dir(start_dir):
         'tf.patch',
         'tf_graph_info_multilinecomment.patch',
         'tftext.patch',
+        'upb_platform_fix.patch',
+        'upb_warning_turn_off.patch',
         'vehicle_images.txt',
         'bazel_rules_apple.patch',
         "pom.xml",

--- a/external/upb_platform_fix.patch
+++ b/external/upb_platform_fix.patch
@@ -1,0 +1,13 @@
+diff --git a/BUILD b/BUILD
+index ad85b202..2311b2e4 100644
+--- a/BUILD
++++ b/BUILD
+@@ -44,7 +44,7 @@ config_setting(
+
+ config_setting(
+     name = "windows",
+-    constraint_values = ["@bazel_tools//platforms:windows"],
++    constraint_values = ["@platforms//os:windows"],
+ )
+
+ config_setting(

--- a/external/upb_warning_turn_off.patch
+++ b/external/upb_warning_turn_off.patch
@@ -1,0 +1,15 @@
+diff --git a/upb/upb.c b/upb/upb.c
+index 266ea7d7..808d1f64 100644
+--- a/upb/upb.c
++++ b/upb/upb.c
+@@ -37,7 +37,10 @@ const char *upb_status_errmsg(const upb_status *status) { return status->msg; }
+ void upb_status_seterrmsg(upb_status *status, const char *msg) {
+   if (!status) return;
+   status->ok = false;
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wstringop-truncation"
+   strncpy(status->msg, msg, sizeof(status->msg));
++#pragma GCC diagnostic pop
+   nullz(status);
+ }
+ 

--- a/src/model_metric_reporter.hpp
+++ b/src/model_metric_reporter.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/src/model_service.hpp
+++ b/src/model_service.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <string>
 
 #include <grpcpp/server_context.h>

--- a/src/shape.hpp
+++ b/src/shape.hpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #pragma once
 
+#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_map>

--- a/src/test/capi_predict_validation_test.cpp
+++ b/src/test/capi_predict_validation_test.cpp
@@ -89,7 +89,7 @@ TEST_F(CAPIPredictValidation, AllowScalar) {
     requestData = std::vector<float>{2.5f};
     preparePredictRequest(request,
         {{"Input_FP32_Scalar",
-            std::tuple<ovms::signed_shape_t, ovms::Precision>{{}, ovms::Precision::FP32}}},
+            std::tuple<ovms::signed_shape_t, ovms::Precision>{std::vector<int64_t>{}, ovms::Precision::FP32}}},
         requestData);
     auto status = instance->mockValidate(&request);
     EXPECT_TRUE(status.ok()) << status.string();

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -102,7 +102,7 @@ TEST_F(TfsPredictValidation, RequestWithScalar) {
         std::make_shared<ovms::TensorInfo>("Input_FP32_Scalar", ovms::Precision::FP32, ovms::shape_t{}, ovms::Layout{"..."})}});
     preparePredictRequest(request,
         {{"Input_FP32_Scalar",
-            std::tuple<ovms::signed_shape_t, ovms::Precision>{{}, ovms::Precision::FP32}}});
+            std::tuple<ovms::signed_shape_t, ovms::Precision>{std::vector<int64_t>{}, ovms::Precision::FP32}}});
     auto status = instance->mockValidate(&request);
     EXPECT_TRUE(status.ok());
 }
@@ -333,7 +333,7 @@ TEST_F(TfsPredictValidation, RequestWithScalarBatchSizeAuto) {
 
     // First is incorrect, second is correct, but endpoint is abnormal anyway (scalar with batch size auto)
     preparePredictRequest(request, {{"im_data", {{3, 3, 800, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     servableInputs.clear();
     servableInputs = ovms::tensor_map_t{
@@ -346,7 +346,7 @@ TEST_F(TfsPredictValidation, RequestWithScalarBatchSizeAuto) {
 
     // First and second is correct, but endpoint is abnormal (scalar with batch size auto)
     preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INTERNAL_ERROR);
@@ -437,7 +437,7 @@ TEST_F(TfsPredictValidation, RequestWithScalarShapeAuto) {
 
     // First is incorrect, second is correct, expect reshape request due to shape=auto
     preparePredictRequest(request, {{"im_data", {{1, 3, 801, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     servableInputs.clear();
     servableInputs = ovms::tensor_map_t{
@@ -450,7 +450,7 @@ TEST_F(TfsPredictValidation, RequestWithScalarShapeAuto) {
 
     // First and second is correct, expect no further reshaping due to shape=auto
     preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
@@ -600,7 +600,7 @@ TEST_F(TfsPredictValidation, RequestIncorrectContentSizeForScalarEndpoint) {
         std::make_shared<ovms::TensorInfo>("Input_FP32_Scalar", ovms::Precision::FP32, ovms::shape_t{}, ovms::Layout{"..."})}});
     preparePredictRequest(request,
         {{"Input_FP32_Scalar",
-            std::tuple<ovms::signed_shape_t, ovms::Precision>{{}, ovms::Precision::FP32}}});
+            std::tuple<ovms::signed_shape_t, ovms::Precision>{std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     auto& input = (*request.mutable_inputs())["Input_FP32_Scalar"];
     *input.mutable_tensor_content() = std::string(sizeof(float) + 1, '1');
@@ -905,7 +905,7 @@ TEST_F(KFSPredictValidation, RequestWithScalar) {
         std::make_shared<ovms::TensorInfo>("Input_FP32_Scalar", ovms::Precision::FP32, ovms::shape_t{}, ovms::Layout{"..."})}});
     preparePredictRequest(request,
         {{"Input_FP32_Scalar",
-            std::tuple<ovms::signed_shape_t, ovms::Precision>{{}, ovms::Precision::FP32}}});
+            std::tuple<ovms::signed_shape_t, ovms::Precision>{std::vector<int64_t>{}, ovms::Precision::FP32}}});
     auto status = instance->mockValidate(&request);
     EXPECT_TRUE(status.ok());
 }
@@ -1118,7 +1118,7 @@ TEST_F(KFSPredictValidation, RequestWithScalarBatchSizeAuto) {
 
     // First is incorrect, second is correct, but endpoint is abnormal anyway (scalar with batch size auto)
     preparePredictRequest(request, {{"im_data", {{3, 3, 800, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     servableInputs.clear();
     servableInputs = ovms::tensor_map_t{
@@ -1131,7 +1131,7 @@ TEST_F(KFSPredictValidation, RequestWithScalarBatchSizeAuto) {
 
     // First and second is correct, but endpoint is abnormal (scalar with batch size auto)
     preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::INTERNAL_ERROR);
@@ -1221,7 +1221,7 @@ TEST_F(KFSPredictValidation, RequestWithScalarShapeAuto) {
 
     // First is incorrect, second is correct, expect reshape request due to shape=auto
     preparePredictRequest(request, {{"im_data", {{1, 3, 801, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     servableInputs.clear();
     servableInputs = ovms::tensor_map_t{
@@ -1234,7 +1234,7 @@ TEST_F(KFSPredictValidation, RequestWithScalarShapeAuto) {
 
     // First and second is correct, expect no further reshaping due to shape=auto
     preparePredictRequest(request, {{"im_data", {{1, 3, 800, 1344}, ovms::Precision::FP32}},
-                                       {"im_info", {{}, ovms::Precision::FP32}}});
+                                       {"im_info", {std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     status = instance->mockValidate(&request);
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
@@ -1328,7 +1328,7 @@ TEST_F(KFSPredictValidation, RequestIncorrectContentSizeForScalarEndpoint) {
         std::make_shared<ovms::TensorInfo>("Input_FP32_Scalar", ovms::Precision::FP32, ovms::shape_t{}, ovms::Layout{"..."})}});
     preparePredictRequest(request,
         {{"Input_FP32_Scalar",
-            std::tuple<ovms::signed_shape_t, ovms::Precision>{{}, ovms::Precision::FP32}}});
+            std::tuple<ovms::signed_shape_t, ovms::Precision>{std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     findKFSInferInputTensorContentInRawInputs(request, "Input_FP32_Scalar")->assign('c', sizeof(float) + 1);
 

--- a/src/test/prediction_service_test.cpp
+++ b/src/test/prediction_service_test.cpp
@@ -915,7 +915,7 @@ TYPED_TEST(TestPredict, SuccesfullInferenceOnModelWithScalar) {
     typename TypeParam::first_type request;
     preparer.preparePredictRequest(request,
         {{SCALAR_MODEL_INPUT_NAME,
-            std::tuple<ovms::signed_shape_t, ovms::Precision>{{}, ovms::Precision::FP32}}});
+            std::tuple<ovms::signed_shape_t, ovms::Precision>{std::vector<int64_t>{}, ovms::Precision::FP32}}});
 
     typename TypeParam::second_type response;
 

--- a/src/test/tensor_conversion_test.cpp
+++ b/src/test/tensor_conversion_test.cpp
@@ -188,7 +188,7 @@ TYPED_TEST(NativeFileInputConversionTest, positive_batch_size_2) {
     size_t batchsize = 2;
     this->prepareBinaryTensor(batchSize2RequestTensor, image_bytes, filesize, batchsize);
 
-    for (const auto layout : std::vector<Layout>{Layout("NHWC"), Layout::getDefaultLayout(4)}) {
+    for (const auto& layout : std::vector<Layout>{Layout("NHWC"), Layout::getDefaultLayout(4)}) {
         auto tensorInfo = std::make_shared<const TensorInfo>("", ovms::Precision::U8, ovms::Shape{2, 1, 1, 3}, layout);
 
         ASSERT_EQ(convertNativeFileFormatRequestTensorToOVTensor(batchSize2RequestTensor, tensor, tensorInfo, nullptr), ovms::StatusCode::OK);

--- a/third_party/opencv/install_opencv.sh
+++ b/third_party/opencv/install_opencv.sh
@@ -30,9 +30,11 @@ if [ "$os" == "auto" ] ; then
     os=$( . /etc/os-release ; echo "${ID}${VERSION_ID}" )
     if [[ "$os" =~ "rhel8".* ]] ; then
       os="rhel8"
+    elif [[ "$os" =~ "rhel9".* ]] ; then
+      os="rhel9"
     fi
     case $os in
-        rhel8|ubuntu18.04|ubuntu20.04|ubuntu21.10|ubuntu22.04) [ -z "$print" ] && echo "Detected OS: ${os}" ;;
+        rhel8|rhel9|ubuntu18.04|ubuntu20.04|ubuntu21.10|ubuntu22.04) [ -z "$print" ] && echo "Detected OS: ${os}" ;;
         *) echo "Unsupported OS: ${os:-detection failed}" >&2 ; exit 1 ;;
     esac
 fi
@@ -45,6 +47,8 @@ if [ "$os" == "ubuntu20.04" ] || [ "$os" == "ubuntu22.04" ] ; then
     apt update && apt install -y build-essential git cmake \
         && rm -rf /var/lib/apt/lists/*
 elif [ "$os" == "rhel8" ] ; then
+    yum install -d6 -y git cmake gcc-c++
+elif [ "$os" == "rhel9" ] ; then
     yum install -d6 -y git cmake gcc-c++
 else
     echo "Internal script error: unsupported OS" >&2


### PR DESCRIPTION
### 🛠 Summary

* Upb patch + compilation fixes on ubi9
* Fix hadolint
* Remove dockerfile label version
It is not used at all

TODO:
* CUDA build - there is no ubi9 based cuda img. We need CUDA plugin support for CUDA12 or we don't have dockerfile for UBI9 with CUDA plugin

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

