### PR TITLE
Detect OS for cmake

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,16 +41,8 @@ cc_library(
         "@com_github_tencent_rapidjson//:rapidjson",
         "@com_github_gabime_spdlog//:spdlog",
         "@com_github_jarro2783_cxxopts//:cxxopts",
-        ] + select({
-            "//:ubuntu_build": [
-                "@aws-sdk-cpp//:aws-sdk-cpp_ubuntu",
-                "@aws-sdk-cpp//:aws-sdk-cpp_cmake_ubuntu",
-            ],
-            "//:redhat_build": [
-                "@aws-sdk-cpp//:aws-sdk-cpp_redhat",
-                "@aws-sdk-cpp//:aws-sdk-cpp_cmake_redhat",
-            ],
-        }) + [
+        "@aws-sdk-cpp//:aws-sdk-cpp",
+        "@aws-sdk-cpp//:aws-sdk-cpp_cmake",
         "@azure//:storage",
         "@cpprest//:sdk",
         "@boost//:lib",

--- a/src/BUILD
+++ b/src/BUILD
@@ -871,14 +871,8 @@ cc_library( # make ovms_lib dependent, use share doptions
     srcs = [
             "s3filesystem.cpp",
     ],
-    deps = select({
-            "//:ubuntu_build": [
-                "@aws-sdk-cpp//:aws-sdk-cpp_ubuntu",
-            ],
-            "//:redhat_build": [
-                "@aws-sdk-cpp//:aws-sdk-cpp_redhat",
-            ],
-        }) + [
+    deps = [
+        "@aws-sdk-cpp//:aws-sdk-cpp",
         "libovmsfilesystem",
         "libovmslogging",
         "libovmsstring_utils",

--- a/src/llm/BUILD
+++ b/src/llm/BUILD
@@ -31,14 +31,7 @@ LINKOPTS_ADJUSTED = COMMON_STATIC_LIBS_LINKOPTS + select({
 cc_library(
     name = "llm_engine",
     srcs = [],
-    deps = select({
-            "//:ubuntu_build": [
-                "@llm_engine//:llm_engine_ubuntu",
-            ],
-            "//:redhat_build": [
-                "@llm_engine//:llm_engine_redhat",
-            ],
-        }),
+    deps =  ["@llm_engine//:llm_engine"],
     visibility = ["//visibility:public"],
     copts = COPTS_ADJUSTED,
     linkopts = LINKOPTS_ADJUSTED,

--- a/third_party/aws-sdk-cpp/aws-sdk-cpp.bzl
+++ b/third_party/aws-sdk-cpp/aws-sdk-cpp.bzl
@@ -32,6 +32,16 @@ def aws_sdk_cpp():
 def _impl(repository_ctx):
     http_proxy = repository_ctx.os.environ.get("http_proxy", "")
     https_proxy = repository_ctx.os.environ.get("https_proxy", "")
+
+    result = repository_ctx.execute(["cat","/etc/os-release"],quiet=False)
+    ubuntu20_count = result.stdout.count("PRETTY_NAME=\"Ubuntu 20")
+    ubuntu22_count = result.stdout.count("PRETTY_NAME=\"Ubuntu 22")
+
+    if ubuntu20_count == 1 or ubuntu22_count == 1:
+        lib_path = "lib"
+    else: # for redhat
+        lib_path = "lib64"
+
     # Note we need to escape '{/}' by doubling them due to call to format
     build_file_content = """
 load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
@@ -56,7 +66,7 @@ filegroup(
 )
 
 cmake(
-    name = "aws-sdk-cpp_cmake_ubuntu",
+    name = "aws-sdk-cpp_cmake",
     build_args = [
         "--verbose",
         "--",  # <- Pass remaining options to the native tool.
@@ -82,7 +92,7 @@ cmake(
         "HTTPS_PROXY": "{https_proxy}",
     }},
     lib_source = ":all_srcs",
-    out_lib_dir = "lib",
+    out_lib_dir = "{lib_path}",
     # linking order
     out_static_libs = select({{
            "//conditions:default": [
@@ -114,78 +124,14 @@ cmake(
 )
 
 cc_library(
-    name = "aws-sdk-cpp_ubuntu",
+    name = "aws-sdk-cpp",
     deps = [
-        ":aws-sdk-cpp_cmake_ubuntu",
+        ":aws-sdk-cpp_cmake",
     ],
     visibility = ["//visibility:public"],
     alwayslink = False,
 )
-cmake(
-    name = "aws-sdk-cpp_cmake_redhat",
-    build_args = [
-        "--verbose",
-        "--",  # <- Pass remaining options to the native tool.
-        # https://github.com/bazelbuild/rules_foreign_cc/issues/329
-        # there is no elegant paralell compilation support
-        "VERBOSE=1",
-        "-j 4",
-    ],
-    cache_entries = {{
-        "CMAKE_BUILD_TYPE": "Release",
-        "BUILD_ONLY": "s3", # core builds always
-        "ENABLE_TESTING": "OFF",
-        "AUTORUN_UNIT_TESTS": "OFF",
-        "BUILD_SHARED_LIBS": "OFF",
-        "MINIMIZE_SIZE": "ON",
-        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
-        "FORCE_SHARED_CRT": "OFF",
-        "SIMPLE_INSTALL": "OFF",
-        "CMAKE_CXX_FLAGS": "-D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=deprecated-declarations -Wuninitialized\",
-    }},
-    env = {{
-        "HTTP_PROXY": "{http_proxy}",
-        "HTTPS_PROXY": "{https_proxy}",
-    }},
-    lib_source = ":all_srcs",
-    out_lib_dir = "lib64",
-    # linking order
-    out_static_libs = select({{
-            "//conditions:default": [
-               "linux/intel64/Release/libaws-cpp-sdk-s3.a",
-                "linux/intel64/Release/libaws-cpp-sdk-core.a",
-            ],
-            ":dbg": [
-                "linux/intel64/Debug/libaws-cpp-sdk-s3.a",
-                "linux/intel64/Debug/libaws-cpp-sdk-core.a",
-            ],
-        }}) + [
-            "libaws-crt-cpp.a",
-            "libaws-c-s3.a",
-            "libaws-c-auth.a",
-            "libaws-c-cal.a",
-            "libaws-c-http.a",
-            "libaws-c-io.a",
-            "libs2n.a",
-            "libaws-c-compression.a",
-            "libaws-c-sdkutils.a",
-            "libaws-c-mqtt.a",
-            "libaws-c-event-stream.a",
-            "libaws-checksums.a",
-            "libaws-c-common.a",
-        ],
-    tags = ["requires-network"],
-    alwayslink = False,
-    visibility = ["//visibility:public"],
-)
-cc_library(
-    name = "aws-sdk-cpp_redhat",
-    deps = [
-        ":aws-sdk-cpp_cmake_redhat",
-    ],
-    visibility = ["//visibility:public"],
-    alwayslink = False,
-)
+
 """
     repository_ctx.file("BUILD", build_file_content.format(http_proxy=http_proxy, https_proxy=https_proxy))
 

--- a/third_party/aws-sdk-cpp/aws-sdk-cpp.bzl
+++ b/third_party/aws-sdk-cpp/aws-sdk-cpp.bzl
@@ -133,7 +133,7 @@ cc_library(
 )
 
 """
-    repository_ctx.file("BUILD", build_file_content.format(http_proxy=http_proxy, https_proxy=https_proxy))
+    repository_ctx.file("BUILD", build_file_content.format(http_proxy=http_proxy, https_proxy=https_proxy, lib_path=lib_path))
 
 aws_sdk_cpp_repository = repository_rule(
     implementation = _impl,

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -110,7 +110,7 @@ cc_library(
     alwayslink = False,
 )
 """
-    repository_ctx.file("BUILD", build_file_content.format(OpenVINO_DIR=OpenVINO_DIR, http_proxy=http_proxy, https_proxy=https_proxy))
+    repository_ctx.file("BUILD", build_file_content.format(OpenVINO_DIR=OpenVINO_DIR, http_proxy=http_proxy, https_proxy=https_proxy, lib_path=lib_path))
 
 llm_engine_repository = repository_rule(
     implementation = _impl,

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -36,6 +36,15 @@ def _impl(repository_ctx):
     http_proxy = repository_ctx.os.environ.get("http_proxy", "")
     https_proxy = repository_ctx.os.environ.get("https_proxy", "")
     OpenVINO_DIR = repository_ctx.os.environ.get("OpenVINO_DIR", "")
+    result = repository_ctx.execute(["cat","/etc/os-release"],quiet=False)
+    ubuntu20_count = result.stdout.count("PRETTY_NAME=\"Ubuntu 20")
+    ubuntu22_count = result.stdout.count("PRETTY_NAME=\"Ubuntu 22")
+
+    if ubuntu20_count == 1 or ubuntu22_count == 1:
+        lib_path = "lib"
+    else: # for redhat
+        lib_path = "lib64"
+
     # Note we need to escape '{/}' by doubling them due to call to format
     build_file_content = """
 load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
@@ -59,7 +68,7 @@ filegroup(
 )
 
 cmake(
-    name = "llm_engine_cmake_ubuntu",
+    name = "llm_engine_cmake",
     build_args = [
         "--verbose",
         "--",  # <- Pass remaining options to the native tool.
@@ -81,7 +90,7 @@ cmake(
         "HTTPS_PROXY": "{https_proxy}",
     }},
     lib_source = ":all_srcs",
-    out_lib_dir = "lib",
+    out_lib_dir = "{lib_path}",
    
     # linking order
     out_static_libs = [
@@ -93,52 +102,9 @@ cmake(
 )
 
 cc_library(
-    name = "llm_engine_ubuntu",
+    name = "llm_engine",
     deps = [
-        ":llm_engine_cmake_ubuntu",
-    ],
-    visibility = ["//visibility:public"],
-    alwayslink = False,
-)
-
-cmake(
-    name = "llm_engine_cmake_redhat",
-    build_args = [
-        "--verbose",
-        "--",  # <- Pass remaining options to the native tool.
-        # https://github.com/bazelbuild/rules_foreign_cc/issues/329
-        # there is no elegant paralell compilation support
-        "VERBOSE=1",
-        "-j 4",
-    ],
-    cache_entries = {{
-        "CMAKE_BUILD_TYPE": "Release",
-        "BUILD_SHARED_LIBS": "OFF",
-        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
-        "CMAKE_CXX_FLAGS": "-D_GLIBCXX_USE_CXX11_ABI=1 -Wno-error=deprecated-declarations -Wuninitialized\",
-        "CMAKE_ARCHIVE_OUTPUT_DIRECTORY": "lib"
-    }},
-    env = {{
-        "OpenVINO_DIR": "{OpenVINO_DIR}",
-        "HTTP_PROXY": "{http_proxy}",
-        "HTTPS_PROXY": "{https_proxy}",
-    }},
-    lib_source = ":all_srcs",
-    out_lib_dir = "lib64",
-   
-    # linking order
-    out_static_libs = [
-            "libopenvino_continuous_batching.a",
-        ],
-    tags = ["requires-network"],
-    alwayslink = False,
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
-    name = "llm_engine_redhat",
-    deps = [
-        ":llm_engine_cmake_redhat",
+        ":llm_engine_cmake",
     ],
     visibility = ["//visibility:public"],
     alwayslink = False,


### PR DESCRIPTION
### 🛠 Summary

JIRA CVS-140004
Detect os in _impl of cmake dependencies instead of defining two cmake implementations - redhat,ubuntu.

### 🧪 Checklist

- [x] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.
``

