### PR TITLE
validate if the end of decoded string is a valid uft8 content

### DIFF
--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -374,7 +374,7 @@ public:
             tokenCache.clear();
             printLen = 0;
             return chunk;
-        } else if (isValidUtf8(text) != true) {
+        } else if (!isValidUtf8(text)) {
             return std::nullopt;
         } else if (text.size() > printLen) {
             // The chunk is ready if the new text in the cache contains space.

--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -32,6 +32,7 @@
 #include <rapidjson/writer.h>
 
 #include "../profiler.hpp"
+#include "../stringutils.hpp"
 #include "http_payload.hpp"
 #include "llmnoderesources.hpp"
 
@@ -358,37 +359,6 @@ class TextStreamer {
     std::vector<int64_t> tokenCache;
     size_t printLen{0};
 
-private:
-    bool isValidUtf8(const std::string& text) {
-        // inspect the chars from the end of the string to test if the utf8 sequence is complete
-        int byte_counter = 0;
-        for (int i = text.size() - 1; i >= 0 && byte_counter <= 3; i--) {
-            int x = static_cast<int>(static_cast<unsigned char>(text[i]));
-            if ((x >> 7) == 0b0)
-                return true;         // last char is a single byte char
-            if ((x >> 6) == 0b10) {  // octet belong to multibyte sequence
-                byte_counter++;
-            } else if ((x >> 5) == 0b110) {  // first byte of 2 byte sequence
-                if (byte_counter + 1 == 2)
-                    return true;
-                else
-                    return false;
-            } else if ((x >> 4) == 0b1110) {  // first byte of 3 byte sequence
-                if (byte_counter + 1 == 3)
-                    return true;
-                else
-                    return false;
-            } else if ((x >> 3) == 0b11110) {  // first byte of 3 byte sequence
-                if (byte_counter + 1 == 4)
-                    return true;
-                else
-                    return false;
-            } else
-                return false;
-        }
-        return true;
-    }
-
 public:
     TextStreamer(std::shared_ptr<Tokenizer> tokenizer) :
         tokenizer(tokenizer) {}
@@ -420,7 +390,7 @@ public:
         }
         return std::nullopt;
     }
-}
+};
 
 static bool
 applyChatTemplate(TextProcessor& textProcessor, std::string modelsPath, std::string& requestBody, std::string& output) {

--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -360,22 +360,31 @@ class TextStreamer {
 
 private:
     bool isValidUtf8(const std::string& text) {
-        //checking only last 4 characters
-        std::string subtext = text.substr(text.size()-std::min(text.size(),(std::size_t) 4));
+        //inspect the chars from the end of the string to test if the utf8 sequence is complete
         int byte_counter = 0;
-        for (int i = subtext.size()-1; i >= 0; i--) {
-            std::cout<< "i:" << i << std::endl;
-            int x = static_cast<int>(static_cast<unsigned char>(subtext[i]));
-            if ((x >> 7) == 0b0) return true;  // last char is a single byte char
-            if ((x >> 6) == 0b10){ // octet belong to multibyte sequence
+        for (int i = text.size() - 1; i >= 0 && byte_counter <= 3; i--) {
+            int x = static_cast<int>(static_cast<unsigned char>(text[i]));
+            if ((x >> 7) == 0b0)
+                return true;         // last char is a single byte char
+            if ((x >> 6) == 0b10) {  // octet belong to multibyte sequence
                 byte_counter++;
-            }else if ((x >> 5) == 0b110){  // first byte of 2 byte sequence
-                if (byte_counter + 1 == 2) return true; else return false;
-            }else if ((x >> 4) == 0b1110){  // first byte of 3 byte sequence
-                if (byte_counter + 1 == 3) return true; else return false;
-            }else if ((x >> 3) == 0b11110){  // first byte of 3 byte sequence
-                if (byte_counter + 1 == 4) return true; else return false;
-            }else return false;
+            } else if ((x >> 5) == 0b110) {  // first byte of 2 byte sequence
+                if (byte_counter + 1 == 2)
+                    return true;
+                else
+                    return false;
+            } else if ((x >> 4) == 0b1110) {  // first byte of 3 byte sequence
+                if (byte_counter + 1 == 3)
+                    return true;
+                else
+                    return false;
+            } else if ((x >> 3) == 0b11110) {  // first byte of 3 byte sequence
+                if (byte_counter + 1 == 4)
+                    return true;
+                else
+                    return false;
+            } else
+                return false;
         }
         return true;
     }
@@ -386,7 +395,6 @@ public:
 
     std::optional<std::string> put(int64_t token) {
         tokenCache.push_back(token);
-        LOG(INFO) << "Adding token" << token;
         std::string text = tokenizer->decode(tokenCache);
 
         if (!text.empty() && '\n' == text.back() && text.size() > printLen) {
@@ -412,7 +420,8 @@ public:
         }
         return std::nullopt;
     }
-};;
+};
+;
 
 static bool applyChatTemplate(TextProcessor& textProcessor, std::string modelsPath, std::string& requestBody, std::string& output) {
     if (textProcessor.chatTemplate == nullptr) {

--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -387,7 +387,7 @@ private:
                 return false;
         }
         return true;
-    }
+    };
 
 public:
     TextStreamer(std::shared_ptr<Tokenizer> tokenizer) :
@@ -420,10 +420,10 @@ public:
         }
         return std::nullopt;
     }
-};
-;
+}
 
-static bool applyChatTemplate(TextProcessor& textProcessor, std::string modelsPath, std::string& requestBody, std::string& output) {
+static bool
+applyChatTemplate(TextProcessor& textProcessor, std::string modelsPath, std::string& requestBody, std::string& output) {
     if (textProcessor.chatTemplate == nullptr) {
         output = "Error: Chat template not loaded correctly, so it cannot be applied";
         return false;

--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -360,7 +360,7 @@ class TextStreamer {
 
 private:
     bool isValidUtf8(const std::string& text) {
-        //inspect the chars from the end of the string to test if the utf8 sequence is complete
+        // inspect the chars from the end of the string to test if the utf8 sequence is complete
         int byte_counter = 0;
         for (int i = text.size() - 1; i >= 0 && byte_counter <= 3; i--) {
             int x = static_cast<int>(static_cast<unsigned char>(text[i]));
@@ -387,7 +387,7 @@ private:
                 return false;
         }
         return true;
-    };
+    }
 
 public:
     TextStreamer(std::shared_ptr<Tokenizer> tokenizer) :

--- a/src/stringutils.cpp
+++ b/src/stringutils.cpp
@@ -177,8 +177,9 @@ bool isValidUtf8(const std::string& text) {
                 return true;
             else
                 return false;
-        } else
+        } else {
             return false;
+        }
     }
     return true;
 }

--- a/src/stringutils.cpp
+++ b/src/stringutils.cpp
@@ -152,4 +152,35 @@ std::optional<int64_t> stoi64(const std::string& str) {
         return std::nullopt;
     }
 }
+
+bool isValidUtf8(const std::string& text) {
+    // inspect the chars from the end of the string to test if the utf8 sequence is complete
+    int byte_counter = 0;
+    for (int i = text.size() - 1; i >= 0 && byte_counter <= 3; i--) {
+        int x = static_cast<int>(static_cast<unsigned char>(text[i]));
+        if ((x >> 7) == 0b0)
+            return true;         // last char is a single byte char
+        if ((x >> 6) == 0b10) {  // octet belong to multibyte sequence
+            byte_counter++;
+        } else if ((x >> 5) == 0b110) {  // first byte of 2 byte sequence
+            if (byte_counter + 1 == 2)
+                return true;
+            else
+                return false;
+        } else if ((x >> 4) == 0b1110) {  // first byte of 3 byte sequence
+            if (byte_counter + 1 == 3)
+                return true;
+            else
+                return false;
+        } else if ((x >> 3) == 0b11110) {  // first byte of 3 byte sequence
+            if (byte_counter + 1 == 4)
+                return true;
+            else
+                return false;
+        } else
+            return false;
+    }
+    return true;
+}
+
 }  // namespace ovms

--- a/src/stringutils.cpp
+++ b/src/stringutils.cpp
@@ -158,30 +158,20 @@ bool isValidUtf8(const std::string& text) {
     int byte_counter = 0;
     for (int i = text.size() - 1; i >= 0 && byte_counter <= 3; i--) {
         int x = static_cast<int>(static_cast<unsigned char>(text[i]));
-        if ((x >> 7) == 0b0)
-            return true;         // last char is a single byte char
-        if ((x >> 6) == 0b10) {  // octet belong to multibyte sequence
-            byte_counter++;
-        } else if ((x >> 5) == 0b110) {  // first byte of 2 byte sequence
-            if (byte_counter + 1 == 2)
-                return true;
-            else
-                return false;
-        } else if ((x >> 4) == 0b1110) {  // first byte of 3 byte sequence
-            if (byte_counter + 1 == 3)
-                return true;
-            else
-                return false;
-        } else if ((x >> 3) == 0b11110) {  // first byte of 3 byte sequence
-            if (byte_counter + 1 == 4)
-                return true;
-            else
-                return false;
-        } else {
-            return false;
-        }
+        if (((x >> 7) == 0b0) && (byte_counter == 0))
+            return true;  // last char is a single byte char
+        if ((x >> 6) == 0b10)
+            byte_counter++;  // octet belong to multibyte sequence
+        else if (((x >> 5) == 0b110) && (byte_counter + 1 == 2))
+            return true;  // first byte of 2 byte sequence
+        else if (((x >> 4) == 0b1110) && (byte_counter + 1 == 3))
+            return true;  // first byte of 3 byte sequence
+        else if (((x >> 3) == 0b11110) && (byte_counter + 1 == 4))
+            return true;  // first byte of 3 byte sequence
+        else
+            return false;  // invalid utf8 sequence
     }
-    return true;
+    return false;
 }
 
 }  // namespace ovms

--- a/src/stringutils.hpp
+++ b/src/stringutils.hpp
@@ -98,4 +98,7 @@ std::optional<uint32_t> stou32(const std::string& input);
 std::optional<int32_t> stoi32(const std::string& str);
 
 std::optional<int64_t> stoi64(const std::string& str);
+
+bool isValidUtf8(const std::string& text);
+
 }  // namespace ovms

--- a/src/test/stringutils_test.cpp
+++ b/src/test/stringutils_test.cpp
@@ -254,4 +254,10 @@ TEST(StringUtils, isValidUtf8) {
 
     result = ovms::isValidUtf8("\x1a\xca");  // ASCII char followed by incomplete UTF-8 char
     EXPECT_FALSE(result);
+
+    result = ovms::isValidUtf8("");  // Empty content considered invalid because there is nothing to return as partial response
+    EXPECT_FALSE(result);
+
+    result = ovms::isValidUtf8("\x7a\xaa\xaa");  // incorrect sequence without length information
+    EXPECT_FALSE(result);
 }

--- a/src/test/stringutils_test.cpp
+++ b/src/test/stringutils_test.cpp
@@ -223,3 +223,35 @@ TEST(StringUtils, stoi64) {
     result = ovms::stoi64("");
     EXPECT_FALSE(result);
 }
+
+TEST(StringUtils, isValidUtf8) {
+    auto result = ovms::isValidUtf8("\x7a");  // one ASCII char
+    EXPECT_TRUE(result);
+
+    result = ovms::isValidUtf8("\x1a\x2b\x3c");  // three ASCII chars
+    EXPECT_TRUE(result);
+
+    result = ovms::isValidUtf8("\x2b\x3c\x1a\x2b\x3c");  //six ASCII chars
+    EXPECT_TRUE(result);
+
+    result = ovms::isValidUtf8("\x1a\xca\xaa");  // one ASCII char and one UTF-8 char
+    EXPECT_TRUE(result);
+
+    result = ovms::isValidUtf8("\xea\xaa\xaa");  // one 3byte long UTF-8 char
+    EXPECT_TRUE(result);
+
+    result = ovms::isValidUtf8("\xf5\xab\xab\xac");  // one 4byte long UTF-8 char
+    EXPECT_TRUE(result);
+
+    result = ovms::isValidUtf8("\xf5\xab\xab");  // incomplete 4byte long UTF-8 char
+    EXPECT_FALSE(result);
+
+    result = ovms::isValidUtf8("\xea\xaa");  // incomplete 3byte long UTF-8 char
+    EXPECT_FALSE(result);
+
+    result = ovms::isValidUtf8("\xf5\xc0");  // incorrect char
+    EXPECT_FALSE(result);
+
+    result = ovms::isValidUtf8("\x1a\xca");  // ASCII char followed by incomplete UTF-8 char
+    EXPECT_FALSE(result);
+}

--- a/src/test/stringutils_test.cpp
+++ b/src/test/stringutils_test.cpp
@@ -231,7 +231,7 @@ TEST(StringUtils, isValidUtf8) {
     result = ovms::isValidUtf8("\x1a\x2b\x3c");  // three ASCII chars
     EXPECT_TRUE(result);
 
-    result = ovms::isValidUtf8("\x2b\x3c\x1a\x2b\x3c");  //six ASCII chars
+    result = ovms::isValidUtf8("\x2b\x3c\x1a\x2b\x3c");  // six ASCII chars
     EXPECT_TRUE(result);
 
     result = ovms::isValidUtf8("\x1a\xca\xaa");  // one ASCII char and one UTF-8 char


### PR DESCRIPTION
### 🛠 Summary

CVS-145315
LLM stream was handling incorrectly incomplete Unicode bytes. With this change the streamer is validating if the end of detokenized string consists of a valid utf8 encoding. When invalid content is detected, streamer will wait for more content to send the chunk.

### 🧪 Checklist

- [x] Unit tests added.
- [ ] The documentation updated.
- [x] Change follows security best practices.
``

