### PR TITLE
Updating CB library commit and removing cache_size workaround

### DIFF
--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -136,16 +136,9 @@ Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources
         return StatusCode::LLM_NODE_DIRECTORY_DOES_NOT_EXIST;
     }
 
-    // temporary fix for wrong cache size calculation on in GenAI
-    size_t cache_size;
-    if (nodeOptions.cache_size() % 2)
-        cache_size = nodeOptions.cache_size() / 2 + 1;
-    else
-        cache_size = nodeOptions.cache_size() / 2;
-
     nodeResources->schedulerConfig = {
         .max_num_batched_tokens = nodeOptions.max_num_batched_tokens(),
-        .cache_size = cache_size,
+        .cache_size = nodeOptions.cache_size(),
         .block_size = nodeOptions.block_size(),
         .dynamic_split_fuse = nodeOptions.dynamic_split_fuse(),
         .max_num_seqs = nodeOptions.max_num_seqs(),

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -488,7 +488,7 @@ TEST_F(LLMOptionsHttpTest, LLMNodeOptionsCheckDefault) {
     ASSERT_EQ(LLMNodeResources::createLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::OK);
     std::cout << "------------------------B--------------------\n";
     ASSERT_EQ(nodeResources->schedulerConfig.max_num_batched_tokens, 256);
-    ASSERT_EQ(nodeResources->schedulerConfig.cache_size, 4);
+    ASSERT_EQ(nodeResources->schedulerConfig.cache_size, 8);
     ASSERT_EQ(nodeResources->schedulerConfig.block_size, 32);
     ASSERT_EQ(nodeResources->schedulerConfig.dynamic_split_fuse, true);
     ASSERT_EQ(nodeResources->schedulerConfig.max_num_seqs, 256);

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -20,8 +20,8 @@ def llm_engine():
     new_git_repository(
         name = "llm_engine",
         remote = "https://github.com/mzegla/openvino.genai",
-        branch = "simple_metrics",
-        #commit = "a239f418eef034da0c067c695e5f60aee18319d3", # merge CB lib
+        #branch = "simple_metrics",
+        commit = "27a5c69cc97db7fca6ec6163b471db9cb0f876d1", # sampler optimization
         build_file = "@_llm_engine//:BUILD",
         init_submodules = True,
         recursive_init_submodules = True,

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -21,7 +21,7 @@ def llm_engine():
         name = "llm_engine",
         remote = "https://github.com/mzegla/openvino.genai",
         #branch = "simple_metrics",
-        commit = "27a5c69cc97db7fca6ec6163b471db9cb0f876d1", # sampler optimization
+        commit = "511431ab428409ae061639724b5008bdb9a40b52", # sampler optimization
         build_file = "@_llm_engine//:BUILD",
         init_submodules = True,
         recursive_init_submodules = True,


### PR DESCRIPTION
### 🛠 Summary

Changes summary:

- changed CB library version to fork with sampling optimizations - new commit contains significantly reduced sampling overhead providing better overall performance of OV continuous batching and therefore OVMS LLM nodes capacity
- removed `cache_size` workaround - this version of CB library has a fix for wrong KV blocks calculation, so providing the same `cache_size` now will result in 2x more space for KV cache

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

