### PR TITLE
More frequent token cache flush when streaming

### DIFF
--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -385,8 +385,9 @@ public:
             if (lastSpacePos == std::string::npos || lastSpacePos < printLen) {
                 return std::nullopt;
             }
-            std::string chunk = std::string{text.data() + printLen, lastSpacePos - printLen + 1};
-            printLen = lastSpacePos + 1;
+            std::string chunk = std::string{text.data() + printLen, text.size() - printLen + 1};
+            tokenCache.clear();
+            printLen = 0;
             return chunk;
         }
         return std::nullopt;

--- a/src/test/llmtemplate_test.cpp
+++ b/src/test/llmtemplate_test.cpp
@@ -657,7 +657,7 @@ TEST_F(LLMJinjaChatTemplateHttpTest, inferChatCompletionsStream) {
 
     ASSERT_EQ(response, "");
 
-    ASSERT_EQ(fullResponse, "\n\nThe first thing ");
+    ASSERT_EQ(fullResponse, "\n\nThe first thing that");
 }
 
 TEST_F(LLMJinjaChatTemplateHttpTest, inferCompletionsStream) {
@@ -696,5 +696,5 @@ TEST_F(LLMJinjaChatTemplateHttpTest, inferCompletionsStream) {
 
     ASSERT_EQ(response, "");
 
-    ASSERT_EQ(fullResponse, "\n\nThe first thing ");
+    ASSERT_EQ(fullResponse, "\n\nThe first thing that");
 }


### PR DESCRIPTION
### 🛠 Summary

Changing text streamer to flush token cache more frequently

### 🧪 Checklist

 Unit tests added. - not needed
 The documentation updated. - not needed
 Change follows security best practices.

