### PR TITLE
Drop ccache to resolve conflict with genai lib building in bazel

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -140,10 +140,6 @@ RUN if [ "$NVIDIA" == "1" ] ; then true ; else exit 0 ; fi ; \
     curl https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz -L | tar xvzC /usr/local/bin --strip-components=1 --wildcards '*/sccache' && \
     chmod a+x /usr/local/bin/sccache && \
     curl https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0-linux-x86_64.tar.gz -L | tar xzvC /usr/local --exclude={doc,man} --strip-components=1 && \
-    curl -L https://github.com/ccache/ccache/releases/download/v4.3/ccache-4.3.tar.xz | tar xJv && \
-    mkdir -p ccache-4.3/build && cd ccache-4.3/build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DZSTD_FROM_INTERNET=ON -G Ninja .. && \
-    ninja -v install && \
     rm -rf /var/cache/yum
 
 ENV TF_SYSTEM_LIBS="curl"
@@ -334,6 +330,7 @@ RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:release_custom_nodes
 
 # OVMS
 # hadolint ignore=DL3059
+
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} ${minitrace_flags} //src:ovms
 
 # hadolint ignore=DL3059

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -330,7 +330,6 @@ RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:release_custom_nodes
 
 # OVMS
 # hadolint ignore=DL3059
-
 RUN bazel build --jobs=$JOBS ${debug_bazel_flags} ${minitrace_flags} //src:ovms
 
 # hadolint ignore=DL3059

--- a/create_package.sh
+++ b/create_package.sh
@@ -70,6 +70,8 @@ find /ovms_release/lib/ -iname '*.so*' -exec patchelf --debug --set-rpath '$ORIG
 find /opt/intel/openvino/runtime/lib/intel64/ -iname '*.so*' -exec cp -vP {} /ovms_release/lib/ \;
 patchelf --debug --set-rpath '$ORIGIN' /ovms_release/lib/libopenvino.so
 patchelf --debug --set-rpath '$ORIGIN' /ovms_release/lib/lib*plugin.so
+if [ -f  /ovms_release/lib/libopenvino_nvidia_gpu_plugin.so ]; then patchelf  --replace-needed libcutensor.so.1 /usr/lib/x86_64-linux-gnu/libcutensor/11/libcutensor.so.1 /ovms_release/lib/libopenvino_nvidia_gpu_plugin.so ; fi
+
 cd /ovms
 cp -v /ovms/release_files/LICENSE /ovms_release/
 cp -v /ovms/release_files/metadata.json /ovms_release/

--- a/create_package.sh
+++ b/create_package.sh
@@ -70,7 +70,7 @@ find /ovms_release/lib/ -iname '*.so*' -exec patchelf --debug --set-rpath '$ORIG
 find /opt/intel/openvino/runtime/lib/intel64/ -iname '*.so*' -exec cp -vP {} /ovms_release/lib/ \;
 patchelf --debug --set-rpath '$ORIGIN' /ovms_release/lib/libopenvino.so
 patchelf --debug --set-rpath '$ORIGIN' /ovms_release/lib/lib*plugin.so
-if [ -f  /ovms_release/lib/libopenvino_nvidia_gpu_plugin.so ]; then patchelf  --replace-needed libcutensor.so.1 /usr/lib/x86_64-linux-gnu/libcutensor/11/libcutensor.so.1 /ovms_release/lib/libopenvino_nvidia_gpu_plugin.so ; fi
+if [ -f  /ovms_release/lib/libopenvino_nvidia_gpu_plugin.so ] && [ "$BASE_OS" != "redhat" ]; then patchelf  --replace-needed libcutensor.so.1 /usr/lib/x86_64-linux-gnu/libcutensor/11/libcutensor.so.1 /ovms_release/lib/libopenvino_nvidia_gpu_plugin.so ; fi
 
 cd /ovms
 cp -v /ovms/release_files/LICENSE /ovms_release/


### PR DESCRIPTION
### 🛠 Summary

ccache using during nvidia plugin build is not needed in the docker image and is breaking compiler detection in genai lib build.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [x] Change follows security best practices.
``

