### PR TITLE
Fix loading Qwen chat template

### DIFF
--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -87,7 +87,9 @@ void LLMNodeResources::loadTextProcessor(std::shared_ptr<LLMNodeResources>& node
                 f = open(templates_directory + "/tokenizer_config.json")
                 data = json.load(f)
                 bos_token = data.get("bos_token", "")
+                bos_token = bos_token if isinstance(bos_token, str) else ""  # tokenizer_config.json allows for different types than string
                 eos_token = data.get("eos_token", "")
+                eos_token = eos_token if isinstance(eos_token, str) else ""  # tokenizer_config.json allows for different types than string
                 chat_template = data.get("chat_template", default_chat_template)
 
             if template is None:
@@ -102,6 +104,12 @@ void LLMNodeResources::loadTextProcessor(std::shared_ptr<LLMNodeResources>& node
         nodeResources->textProcessor.eosToken = locals["eos_token"].cast<std::string>();
         nodeResources->textProcessor.chatTemplate = std::make_unique<PyObjectWrapper<py::object>>(locals["template"]);
     } catch (const pybind11::error_already_set& e) {
+        SPDLOG_INFO(CHAT_TEMPLATE_WARNING_MESSAGE);
+        SPDLOG_DEBUG("Chat template loading failed with error: {}", e.what());
+    } catch (const pybind11::cast_error& e) {
+        SPDLOG_INFO(CHAT_TEMPLATE_WARNING_MESSAGE);
+        SPDLOG_DEBUG("Chat template loading failed with error: {}", e.what());
+    } catch (const pybind11::key_error& e) {
         SPDLOG_INFO(CHAT_TEMPLATE_WARNING_MESSAGE);
         SPDLOG_DEBUG("Chat template loading failed with error: {}", e.what());
     } catch (...) {

--- a/src/test/llmtemplate_test.cpp
+++ b/src/test/llmtemplate_test.cpp
@@ -254,6 +254,54 @@ TEST_F(LLMChatTemplateTest, ChatTemplateTokenizerDefault) {
     ASSERT_EQ(finalPrompt, expectedOutput);
 }
 
+TEST_F(LLMChatTemplateTest, ChatTemplateTokenizerBosNull) {
+    std::string tokenizerJson = R"({
+    "bos_token": null,
+    "eos_token": "</s>"
+    })";
+    ASSERT_EQ(CreateTokenizerConfig(tokenizerJson), true);
+    std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<LLMNodeResources>();
+    nodeResources->modelsPath = directoryPath;
+    LLMNodeResources::loadTextProcessor(nodeResources, nodeResources->modelsPath);
+
+    std::string finalPrompt = "";
+    std::string payloadBody = R"(
+        {
+            "model": "gpt",
+            "stream": false,
+            "messages": [{"role": "user", "content": "hello"}]
+        }
+    )";
+    std::string expectedOutput = "hello";
+    // Expect no issues with chat template since non string bos token is ignored
+    ASSERT_EQ(TextProcessor::applyChatTemplate(nodeResources->textProcessor, nodeResources->modelsPath, payloadBody, finalPrompt), true);
+    ASSERT_EQ(finalPrompt, expectedOutput);
+}
+
+TEST_F(LLMChatTemplateTest, ChatTemplateTokenizerEosNull) {
+    std::string tokenizerJson = R"({
+    "bos_token": "</s>",
+    "eos_token": null
+    })";
+    ASSERT_EQ(CreateTokenizerConfig(tokenizerJson), true);
+    std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<LLMNodeResources>();
+    nodeResources->modelsPath = directoryPath;
+    LLMNodeResources::loadTextProcessor(nodeResources, nodeResources->modelsPath);
+
+    std::string finalPrompt = "";
+    std::string payloadBody = R"(
+        {
+            "model": "gpt",
+            "stream": false,
+            "messages": [{"role": "user", "content": "hello"}]
+        }
+    )";
+    std::string expectedOutput = "hello";
+    // Expect no issues with chat template since non string eos token is ignored
+    ASSERT_EQ(TextProcessor::applyChatTemplate(nodeResources->textProcessor, nodeResources->modelsPath, payloadBody, finalPrompt), true);
+    ASSERT_EQ(finalPrompt, expectedOutput);
+}
+
 TEST_F(LLMChatTemplateTest, ChatTemplateTokenizerException) {
     std::string tokenizerJson = R"({
     "bos_token": "</s>",


### PR DESCRIPTION
### 🛠 Summary

There was an issue when loading bos_token and eos_token from tokenizer_config.json.
OVMS assumed that if it exists, it can only be string, however, Qwen has null value.
It causes chat template loading to abort.

The fix to this issue is to override bos/eos tokens when it is not a string in config file.

CVS-147900

### 🧪 Checklist

- [x] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.

