### PR TITLE
Fix docs for building without Mediapipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ GPU ?= 0
 BUILD_NGINX ?= 0
 MEDIAPIPE_DISABLE ?= 0
 PYTHON_DISABLE ?= 0
+ifeq ($(MEDIAPIPE_DISABLE),1)
+ifeq ($(PYTHON_DISABLE),0)
+$(error PYTHON_DISABLE cannot be 0 when MEDIAPIPE_DISABLE is 1)
+endif
+endif
 FUZZER_BUILD ?= 0
 
 # NOTE: when changing any value below, you'll need to adjust WORKSPACE file by hand:

--- a/docs/build_from_source.md
+++ b/docs/build_from_source.md
@@ -119,22 +119,22 @@ make release_image JOBS=2
 ```
 <hr />
 
+### `PYTHON_DISABLE`
+
+When set to `0`, OpenVINO&trade Model Server will be built with [Python Nodes](python_support/quickstart.md) support. Default value: `0`.
+
+Example:
+```bash
+make release_image PYTHON_DISABLE=1
+```
+
 ### `MEDIAPIPE_DISABLE`
 
 When set to `0`, OpenVINO&trade Model Server will be built with [MediaPipe](mediapipe.md) support. Default value: `0`.
 
 Example:
 ```bash
-make release_image MEDIAPIPE_DISABLE=1
-```
-
-### `PYTHON_DISABLE`
-
-When set to `0`, OpenVINO&trade Model Server will be built with [Python Nodes](python_support/quickstart.md) support. Default value: `0`. 
-
-Example:
-```bash
-make release_image PYTHON_DISABLE=1
+make release_image MEDIAPIPE_DISABLE=1 PYTHON_DISABLE=1
 ```
 
  > **Note**: In order to build the image with python nodes support (PYTHON_DISABLE=0) mediapipe have to be enabled (MEDIAPIPE_DISABLE=0)


### PR DESCRIPTION
### 🛠 Summary
Docs mentioned illegal build configuration. Check was added so that it will trigger make error and documentation was improved.

Ticket:CVS-148240

### 🧪 Checklist

- [ ] Unit tests added.
- [x] The documentation updated.
- [ ] Change follows security best practices.
``

