### PR TITLE
Block model from loading when inputs or outputs are empty

### DIFF
--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -279,14 +279,19 @@ private:
          * @param config
          */
     Status loadInputTensors(const ModelConfig& config, const DynamicModelParameter& parameter = DynamicModelParameter());
-
-    Status gatherReshapeInfo(bool isBatchingModeAuto, const DynamicModelParameter& parameter, bool& isReshapeRequired, std::map<std::string, ov::PartialShape>& modelShapes);
     /**
          * @brief Internal method for loading outputs
          *
          * @param config
          */
     Status loadOutputTensors(const ModelConfig& config);
+
+protected:
+    virtual Status loadOutputTensorsImpl(const ModelConfig& config);
+    virtual Status loadInputTensorsImpl(const ModelConfig& config, const DynamicModelParameter& parameter = DynamicModelParameter());
+
+private:
+    Status gatherReshapeInfo(bool isBatchingModeAuto, const DynamicModelParameter& parameter, bool& isReshapeRequired, std::map<std::string, ov::PartialShape>& modelShapes);
 
     /**
       * @brief Flag determining if cache is disabled

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -74,6 +74,8 @@ const std::unordered_map<const StatusCode, const std::string> Status::statusMess
     {StatusCode::INVALID_BATCH_DIMENSION, "Invalid batch dimension in shape"},
     {StatusCode::LAYOUT_INCOMPATIBLE_WITH_SHAPE, "Layout incompatible with given shape"},
     {StatusCode::MODEL_WITH_SCALAR_AUTO_UNSUPPORTED, "Batching set to AUTO but model contains scalar tensor"},
+    {StatusCode::OV_NO_INPUTS, "Cannot load model with no inputs"},
+    {StatusCode::OV_NO_OUTPUTS, "Cannnot load model with no outputs"},
     {StatusCode::ALLOW_CACHE_WITH_CUSTOM_LOADER, "allow_cache is set to true with custom loader usage"},
     {StatusCode::UNKNOWN_ERROR, "Unknown error"},
 

--- a/src/status.hpp
+++ b/src/status.hpp
@@ -60,6 +60,8 @@ enum class StatusCode {
     ALLOW_CACHE_WITH_CUSTOM_LOADER,
     LAYOUT_INCOMPATIBLE_WITH_SHAPE,
     MODEL_WITH_SCALAR_AUTO_UNSUPPORTED,
+    OV_NO_INPUTS,
+    OV_NO_OUTPUTS,
 
     // Model management
     MODEL_MISSING,                                     /*!< Model with such name and/or version does not exist */

--- a/src/test/modelinstance_test.cpp
+++ b/src/test/modelinstance_test.cpp
@@ -188,6 +188,41 @@ protected:
     }
 };
 
+using ovms::Status;
+using ovms::StatusCode;
+using testing::_;
+namespace {
+class MockModelInstanceEmptyInputs : public ovms::ModelInstance {
+public:
+    MockModelInstanceEmptyInputs(ov::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
+    MOCK_METHOD(ovms::Status, loadInputTensorsImpl, (const ovms::ModelConfig&, const ovms::DynamicModelParameter&), (override));
+};
+class MockModelInstanceEmptyOutputs : public ovms::ModelInstance {
+public:
+    MockModelInstanceEmptyOutputs(ov::Core& ieCore) :
+        ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore) {}
+    MOCK_METHOD(ovms::Status, loadOutputTensorsImpl, (const ovms::ModelConfig&), (override));
+};
+}  // namespace
+
+TEST_F(TestLoadModel, ShouldFailWithEmptyInputs) {
+    MockModelInstanceEmptyInputs mockModelInstance(*ieCore);
+    EXPECT_CALL(mockModelInstance, loadInputTensorsImpl(_, _))
+        .WillOnce(Return(Status(StatusCode::OK)));
+    auto status = mockModelInstance.loadModel(DUMMY_MODEL_CONFIG);
+    EXPECT_EQ(status, StatusCode::OV_NO_INPUTS) << status.string();
+    EXPECT_EQ(ovms::ModelVersionState::LOADING, mockModelInstance.getStatus().getState());
+}
+TEST_F(TestLoadModel, ShouldFailWithEmptyOutputs) {
+    MockModelInstanceEmptyOutputs mockModelInstance(*ieCore);
+    EXPECT_CALL(mockModelInstance, loadOutputTensorsImpl(_))
+        .WillOnce(Return(Status(StatusCode::OK)));
+    auto status = mockModelInstance.loadModel(DUMMY_MODEL_CONFIG);
+    EXPECT_EQ(status, StatusCode::OV_NO_OUTPUTS) << status.string();
+    EXPECT_EQ(ovms::ModelVersionState::LOADING, mockModelInstance.getStatus().getState());
+}
+
 class MockModelInstanceWithRTMap : public ovms::ModelInstance {
 private:
     ov::RTMap inputRtMap;


### PR DESCRIPTION

Ticket: CVS-146399

- [x] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.


