### PR TITLE
Fix KFS model metadata during model reloading

### DIFF
--- a/src/kfs_frontend/kfs_grpc_inference_service.cpp
+++ b/src/kfs_frontend/kfs_grpc_inference_service.cpp
@@ -385,10 +385,16 @@ Status KFSInferenceServiceImpl::buildResponse(
 #endif
 
 static void addReadyVersions(Model& model,
+    model_version_t versionAvailableDuringInitialCheck,
     KFSModelMetadataResponse* response) {
     auto modelVersions = model.getModelVersionsMapCopy();
     for (auto& [modelVersion, modelInstance] : modelVersions) {
-        if (modelInstance.getStatus().getState() == ModelVersionState::AVAILABLE)
+        // even if we have modelUnloadGuard model can have already state set to LOADING/UNLOADING
+        // here we make choice to report it as AVAILABLE even if it is already in different state
+        // since we achieved to gain guard. Model could change state after sending response anyway.
+        // Otherwise we could respond with metadata of one version but in response send information
+        // that different version is ready
+        if ((modelVersion == versionAvailableDuringInitialCheck) || (modelInstance.getStatus().getState() == ModelVersionState::AVAILABLE))
             response->add_versions(std::to_string(modelVersion));
     }
 }
@@ -408,7 +414,7 @@ Status KFSInferenceServiceImpl::buildResponse(
 
     response->Clear();
     response->set_name(instance.getName());
-    addReadyVersions(model, response);
+    addReadyVersions(model, instance.getVersion(), response);
     response->set_platform(PLATFORM);
 
     for (const auto& input : instance.getInputsInfo()) {

--- a/src/kfs_frontend/kfs_grpc_inference_service.cpp
+++ b/src/kfs_frontend/kfs_grpc_inference_service.cpp
@@ -391,7 +391,7 @@ static void addReadyVersions(Model& model,
     for (auto& [modelVersion, modelInstance] : modelVersions) {
         // even if we have modelUnloadGuard model can have already state set to LOADING/UNLOADING
         // here we make choice to report it as AVAILABLE even if it is already in different state
-        // since we achieved to gain guard. Model could change state after sending response anyway.
+        // since we managed to obtain guard. Model could change state after sending response anyway.
         // Otherwise we could respond with metadata of one version but in response send information
         // that different version is ready
         if ((modelVersion == versionAvailableDuringInitialCheck) || (modelInstance.getStatus().getState() == ModelVersionState::AVAILABLE))


### PR DESCRIPTION
If we respond with metadata of one version we include that version as a ready in response regardless if it just changed its state to LOADING/UNLOADING.

Ticket:CVS-145765

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

