### PR TITLE
allow sampling params as int

### DIFF
--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -274,7 +274,7 @@ public:
         // Extension, unsupported by OpenAI API however supported by vLLM and CB lib
         it = this->doc.FindMember("length_penalty");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble() $$ !it->value.IsInt())
+            if (!it->value.IsDouble() && !it->value.IsInt())
                 return absl::InvalidArgumentError("length_penalty is not a valid number");
             this->lengthPenalty = it->value.GetDouble();
         }

--- a/src/llm/http_llm_calculator.cc
+++ b/src/llm/http_llm_calculator.cc
@@ -235,8 +235,8 @@ public:
         // frequence_penalty: float; optional - defaults to 0
         it = this->doc.FindMember("frequence_penalty");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble())
-                return absl::InvalidArgumentError("frequence_penalty is not a floating point number");
+            if (!it->value.IsDouble() && !it->value.IsInt())
+                return absl::InvalidArgumentError("frequence_penalty is not a valid number");
             this->frequencePenalty = it->value.GetDouble();
             if (this->frequencePenalty < -2.0f || this->frequencePenalty > 2.0f)
                 return absl::InvalidArgumentError("frequence_penalty out of range(-2.0, 2.0)");
@@ -245,8 +245,8 @@ public:
         // presence_penalty: float; optional - defaults to 0
         it = this->doc.FindMember("presence_penalty");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble())
-                return absl::InvalidArgumentError("presence_penalty is not a floating point number");
+            if (!it->value.IsDouble() && !it->value.IsInt())
+                return absl::InvalidArgumentError("presence_penalty is not a valid number");
             this->presencePenalty = it->value.GetDouble();
             if (this->presencePenalty < -2.0f || this->presencePenalty > 2.0f)
                 return absl::InvalidArgumentError("presence_penalty out of range(-2.0, 2.0)");
@@ -256,8 +256,8 @@ public:
         // Extension, unsupported by OpenAI API, however supported by vLLM and CB lib
         it = this->doc.FindMember("repetition_penalty");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble())
-                return absl::InvalidArgumentError("repetition_penalty is not a floating point number");
+            if (!it->value.IsDouble() && !it->value.IsInt())
+                return absl::InvalidArgumentError("repetition_penalty is not a valid number");
             this->repetitionPenalty = it->value.GetDouble();
         }
 
@@ -265,8 +265,8 @@ public:
         // Extension, unsupported by OpenAI API and vLLM, however available in CB lib
         it = this->doc.FindMember("diversity_penalty");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble())
-                return absl::InvalidArgumentError("diversity_penalty is not a floating point number");
+            if (!it->value.IsDouble() && !it->value.IsInt())
+                return absl::InvalidArgumentError("diversity_penalty is not a valid number");
             this->diversityPenalty = it->value.GetDouble();
         }
 
@@ -274,16 +274,16 @@ public:
         // Extension, unsupported by OpenAI API however supported by vLLM and CB lib
         it = this->doc.FindMember("length_penalty");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble())
-                return absl::InvalidArgumentError("length_penalty is not a floating point number");
+            if (!it->value.IsDouble() $$ !it->value.IsInt())
+                return absl::InvalidArgumentError("length_penalty is not a valid number");
             this->lengthPenalty = it->value.GetDouble();
         }
 
         // temperature: float; optional - defaults to 0.0 (different than OpenAI which is 1.0)
         it = this->doc.FindMember("temperature");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble())
-                return absl::InvalidArgumentError("temperature is not a floating point number");
+            if (!it->value.IsDouble() && !it->value.IsInt())
+                return absl::InvalidArgumentError("temperature is not a valid number");
             this->temperature = it->value.GetDouble();
             if (this->temperature < 0.0f || this->temperature > 2.0f)
                 return absl::InvalidArgumentError("temperature out of range(0.0, 2.0)");
@@ -292,8 +292,8 @@ public:
         // top_p: float; optional - defaults to 1
         it = this->doc.FindMember("top_p");
         if (it != this->doc.MemberEnd()) {
-            if (!it->value.IsDouble())
-                return absl::InvalidArgumentError("top_p is not a floating point number");
+            if (!it->value.IsDouble() && !it->value.IsInt())
+                return absl::InvalidArgumentError("top_p is not a valid number");
             this->topP = it->value.GetDouble();
             if (this->topP < 0.0f || this->topP > 1.0f)
                 return absl::InvalidArgumentError("top_p out of range(0.0, 1.0)");

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -752,7 +752,7 @@ TEST_F(LLMHttpParametersValidationTest, presencePenaltyValid) {
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
 
-    reinterpret_cast = validRequestBodyWithParameter("presence_penalty", "1");
+    requestBody = validRequestBodyWithParameter("presence_penalty", "1");
 
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -663,6 +663,12 @@ TEST_F(LLMHttpParametersValidationTest, lengthPenaltyValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
+    
+    requestBody = validRequestBodyWithParameter("length_penalty", "2");
+
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
+        ovms::StatusCode::OK);
 }
 
 TEST_F(LLMHttpParametersValidationTest, lengthPenaltyInvalid) {
@@ -675,6 +681,18 @@ TEST_F(LLMHttpParametersValidationTest, lengthPenaltyInvalid) {
 
 TEST_F(LLMHttpParametersValidationTest, temperatureValid) {
     std::string requestBody = validRequestBodyWithParameter("temperature", "1.5");
+
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
+        ovms::StatusCode::OK);
+    
+    requestBody = validRequestBodyWithParameter("temperature", "0");
+
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
+        ovms::StatusCode::OK);
+
+    requestBody = validRequestBodyWithParameter("temperature", "2");
 
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
@@ -703,6 +721,12 @@ TEST_F(LLMHttpParametersValidationTest, frequencePenaltyValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
+
+    requestBody = validRequestBodyWithParameter("frequence_penalty", "1");
+
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
+        ovms::StatusCode::OK);
 }
 
 TEST_F(LLMHttpParametersValidationTest, frequencePenaltyInvalid) {
@@ -727,6 +751,12 @@ TEST_F(LLMHttpParametersValidationTest, presencePenaltyValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
+    
+    std::string requestBody = validRequestBodyWithParameter("presence_penalty", "1");
+
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
+        ovms::StatusCode::OK);
 }
 
 TEST_F(LLMHttpParametersValidationTest, presencePenaltyInvalid) {
@@ -747,6 +777,12 @@ TEST_F(LLMHttpParametersValidationTest, presencePenaltyOutOfRange) {
 
 TEST_F(LLMHttpParametersValidationTest, topPValid) {
     std::string requestBody = validRequestBodyWithParameter("top_p", "0.5");
+
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
+        ovms::StatusCode::OK);
+    
+    requestBody = validRequestBodyWithParameter("top_p", "1");
 
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -752,7 +752,7 @@ TEST_F(LLMHttpParametersValidationTest, presencePenaltyValid) {
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
 
-    std::string requestBody = validRequestBodyWithParameter("presence_penalty", "1");
+    reinterpret_cast = validRequestBodyWithParameter("presence_penalty", "1");
 
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -631,6 +631,12 @@ TEST_F(LLMHttpParametersValidationTest, repetitionPenaltyValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
+
+    requestBody = validRequestBodyWithParameter("repetition_penalty", "1");
+
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
+        ovms::StatusCode::OK);
 }
 
 TEST_F(LLMHttpParametersValidationTest, repetitionPenaltyInvalid) {

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -663,7 +663,7 @@ TEST_F(LLMHttpParametersValidationTest, lengthPenaltyValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
-    
+
     requestBody = validRequestBodyWithParameter("length_penalty", "2");
 
     ASSERT_EQ(
@@ -685,7 +685,7 @@ TEST_F(LLMHttpParametersValidationTest, temperatureValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
-    
+
     requestBody = validRequestBodyWithParameter("temperature", "0");
 
     ASSERT_EQ(
@@ -751,7 +751,7 @@ TEST_F(LLMHttpParametersValidationTest, presencePenaltyValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
-    
+
     std::string requestBody = validRequestBodyWithParameter("presence_penalty", "1");
 
     ASSERT_EQ(
@@ -781,7 +781,7 @@ TEST_F(LLMHttpParametersValidationTest, topPValid) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, &writer),
         ovms::StatusCode::OK);
-    
+
     requestBody = validRequestBodyWithParameter("top_p", "1");
 
     ASSERT_EQ(


### PR DESCRIPTION
### 🛠 Summary

JIRA CVS-149051
frontend was incorrectly blocking sampling parameters sent as integers allowing only floats

### 🧪 Checklist

- [x] Unit tests added.
- [ ] The documentation updated.
- [x] Change follows security best practices.
``

