### PR TITLE
Reducing unit test time

### DIFF
--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -36,7 +36,7 @@ echo "Number of warnings in tests about not direct includes:" ${NO_WARNINGS_TEST
 echo "Number of warnings in tests about not used: " ${NO_WARNINGS_TEST_NOTUSED}
 
 errors=""
-if [ ${NO_WARNINGS_FORWARD} -gt 9 ]; then
+if [ ${NO_WARNINGS_FORWARD} -gt 10 ]; then
     errors+="Failed due to not using forward declarations where possible: ${NO_WARNINGS_FORWARD}"$'\n'
 fi
 if [ ${NO_WARNINGS_DIRECT} -gt 15 ]; then
@@ -54,7 +54,7 @@ fi
 if [ ${NO_WARNINGS_TEST_NOTUSED} -gt 0 ]; then
     errors+="Failed probably due to unnecessary forward includes: ${NO_WARNINGS_TEST_NOTUSED}"$'\n'
 fi
-if [ ${NO_WARNINGS} -gt  163 ]; then
+if [ ${NO_WARNINGS} -gt  164 ]; then
     errors+="Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"$'\n'
 fi
 if [ ${NO_WARNINGS_TEST} -gt  52 ]; then

--- a/ci/cppclean.sh
+++ b/ci/cppclean.sh
@@ -36,7 +36,7 @@ echo "Number of warnings in tests about not direct includes:" ${NO_WARNINGS_TEST
 echo "Number of warnings in tests about not used: " ${NO_WARNINGS_TEST_NOTUSED}
 
 errors=""
-if [ ${NO_WARNINGS_FORWARD} -gt 10 ]; then
+if [ ${NO_WARNINGS_FORWARD} -gt 9 ]; then
     errors+="Failed due to not using forward declarations where possible: ${NO_WARNINGS_FORWARD}"$'\n'
 fi
 if [ ${NO_WARNINGS_DIRECT} -gt 15 ]; then
@@ -54,7 +54,7 @@ fi
 if [ ${NO_WARNINGS_TEST_NOTUSED} -gt 0 ]; then
     errors+="Failed probably due to unnecessary forward includes: ${NO_WARNINGS_TEST_NOTUSED}"$'\n'
 fi
-if [ ${NO_WARNINGS} -gt  164 ]; then
+if [ ${NO_WARNINGS} -gt  163 ]; then
     errors+="Failed due to higher than allowed number of issues in code: ${NO_WARNINGS}"$'\n'
 fi
 if [ ${NO_WARNINGS_TEST} -gt  52 ]; then

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -384,7 +384,7 @@ DLL_PUBLIC OVMS_Status* OVMS_ServerSettingsSetFileSystemPollWaitSeconds(OVMS_Ser
         return reinterpret_cast<OVMS_Status*>(new Status(StatusCode::NONEXISTENT_PTR, "server settings"));
     }
     ovms::ServerSettingsImpl* serverSettings = reinterpret_cast<ovms::ServerSettingsImpl*>(settings);
-    serverSettings->filesystemPollWaitSeconds = seconds;
+    serverSettings->filesystemPollWaitMilliseconds = seconds * 1000;
     return nullptr;
 }
 

--- a/src/capi_frontend/server_settings.hpp
+++ b/src/capi_frontend/server_settings.hpp
@@ -38,7 +38,7 @@ struct ServerSettingsImpl {
 #endif
     std::optional<size_t> grpcMemoryQuota;
     std::string grpcChannelArguments;
-    uint32_t filesystemPollWaitSeconds = 1;
+    uint32_t filesystemPollWaitMilliseconds = 1000;
     uint32_t sequenceCleanerPollWaitMinutes = 5;
     uint32_t resourcesCleanerPollWaitSeconds = 1;
     std::string cacheDir;

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -285,7 +285,7 @@ void CLIParser::prepare(ServerSettingsImpl* serverSettings, ModelsSettingsImpl* 
     if (result->count("grpc_channel_arguments"))
         serverSettings->grpcChannelArguments = result->operator[]("grpc_channel_arguments").as<std::string>();
 
-    serverSettings->filesystemPollWaitSeconds = result->operator[]("file_system_poll_wait_seconds").as<uint32_t>();
+    serverSettings->filesystemPollWaitMilliseconds = result->operator[]("file_system_poll_wait_seconds").as<uint32_t>() * 1000;
     serverSettings->sequenceCleanerPollWaitMinutes = result->operator[]("sequence_cleaner_poll_wait_minutes").as<uint32_t>();
     serverSettings->resourcesCleanerPollWaitSeconds = result->operator[]("custom_node_resources_cleaner_interval_seconds").as<uint32_t>();
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -207,7 +207,7 @@ const std::string& Config::logPath() const { return this->serverSettings.logPath
 const std::string& Config::tracePath() const { return this->serverSettings.tracePath; }
 #endif
 const std::string& Config::grpcChannelArguments() const { return this->serverSettings.grpcChannelArguments; }
-uint32_t Config::filesystemPollWaitSeconds() const { return this->serverSettings.filesystemPollWaitSeconds; }
+uint32_t Config::filesystemPollWaitMilliseconds() const { return this->serverSettings.filesystemPollWaitMilliseconds; }
 uint32_t Config::sequenceCleanerPollWaitMinutes() const { return this->serverSettings.sequenceCleanerPollWaitMinutes; }
 uint32_t Config::resourcesCleanerPollWaitSeconds() const { return this->serverSettings.resourcesCleanerPollWaitSeconds; }
 const std::string Config::cacheDir() const { return this->serverSettings.cacheDir; }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -289,11 +289,11 @@ public:
     const std::string& grpcChannelArguments() const;
 
     /**
-     * @brief Get the filesystem poll wait time in seconds
+     * @brief Get the filesystem poll wait time in milliseconds
      * 
      * @return uint 
      */
-    uint32_t filesystemPollWaitSeconds() const;
+    uint32_t filesystemPollWaitMilliseconds() const;
 
     /**
      * @brief Get the sequence cleanup poll wait time in minutes

--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -118,7 +118,7 @@ void LLMNodeResources::loadTextProcessor(std::shared_ptr<LLMNodeResources>& node
     }
 }
 
-Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources>& nodeResources, const ::mediapipe::CalculatorGraphConfig::Node& graphNodeConfig, std::string graphPath) {
+Status LLMNodeResources::initializeLLMNodeResources(std::shared_ptr<LLMNodeResources>& nodeResources, const ::mediapipe::CalculatorGraphConfig::Node& graphNodeConfig, std::string graphPath) {
     mediapipe::LLMCalculatorOptions nodeOptions;
     graphNodeConfig.node_options(0).UnpackTo(&nodeOptions);
     auto fsModelsPath = std::filesystem::path(nodeOptions.models_path());

--- a/src/llm/llmnoderesources.cpp
+++ b/src/llm/llmnoderesources.cpp
@@ -162,11 +162,7 @@ Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources
 
     try {
         plugin_config_t tokenizerPluginConfig = {{"PERFORMANCE_HINT", "THROUGHPUT"}};
-        auto status = nodeResources->initializeContinuousBatchingPipeline(basePath, nodeResources->schedulerConfig, nodeResources->device, nodeResources->pluginConfig, tokenizerPluginConfig);
-        if (!status.ok()) {
-            SPDLOG_ERROR("Error during llm node initialization for models_path: {}", basePath);
-            return StatusCode::LLM_NODE_RESOURCE_STATE_INITIALIZATION_FAILED;
-        }
+        nodeResources->initializeContinuousBatchingPipeline(basePath, nodeResources->schedulerConfig, nodeResources->device, nodeResources->pluginConfig, tokenizerPluginConfig);
     } catch (const std::exception& e) {
         SPDLOG_ERROR("Error during llm node initialization for models_path: {} exception: {}", basePath, e.what());
         return StatusCode::LLM_NODE_RESOURCE_STATE_INITIALIZATION_FAILED;
@@ -185,14 +181,13 @@ Status LLMNodeResources::createLLMNodeResources(std::shared_ptr<LLMNodeResources
     return StatusCode::OK;
 }
 
-Status LLMNodeResources::initializeContinuousBatchingPipeline(
+void LLMNodeResources::initializeContinuousBatchingPipeline(
     const std::string& basePath,
     const ov::genai::SchedulerConfig& schedulerConfig,
     const std::string& device,
     const plugin_config_t& pluginConfig,
     const plugin_config_t& tokenizerPluginConfig) {
     this->cbPipe = std::make_unique<ov::genai::ContinuousBatchingPipeline>(basePath, schedulerConfig, device, pluginConfig, tokenizerPluginConfig);
-    return StatusCode::OK;
 }
 
 void LLMNodeResources::initiateGeneration() {

--- a/src/llm/llmnoderesources.hpp
+++ b/src/llm/llmnoderesources.hpp
@@ -37,11 +37,12 @@
 
 #include "../logging.hpp"
 #include "../stringutils.hpp"
-#include "llm_executor.hpp"
 #include "src/python/utils.hpp"
 #include "text_processor.hpp"
 
 namespace ovms {
+
+class LLMExecutorWrapper;
 
 // TODO: To be moved to CB library.
 class TextStreamer {
@@ -128,7 +129,7 @@ private:
     static std::unordered_map<std::string, std::string> prepareLLMNodeInitializeArguments(const ::mediapipe::CalculatorGraphConfig::Node& graphNodeConfig, std::string basePath);
 
 public:
-    virtual Status initializeContinuousBatchingPipeline(
+    virtual void initializeContinuousBatchingPipeline(
         const std::string& basePath,
         const ov::genai::SchedulerConfig& schedulerConfig,
         const std::string& device,

--- a/src/llm/llmnoderesources.hpp
+++ b/src/llm/llmnoderesources.hpp
@@ -37,6 +37,7 @@
 
 #include "../logging.hpp"
 #include "../stringutils.hpp"
+#include "llm_executor.hpp"
 #include "src/python/utils.hpp"
 #include "text_processor.hpp"
 
@@ -94,7 +95,6 @@ public:
 };
 
 class Status;
-class LLMExecutorWrapper;
 
 using plugin_config_t = std::map<std::string, ov::Any>;
 
@@ -117,6 +117,7 @@ public:
     LLMNodeResources(const LLMNodeResources&) = delete;
     LLMNodeResources& operator=(LLMNodeResources&) = delete;
     LLMNodeResources() = default;
+    virtual ~LLMNodeResources() = default;
 
     void initiateGeneration();
 
@@ -125,6 +126,14 @@ public:
 private:
     std::unique_ptr<LLMExecutorWrapper> llmExecutorWrapper;
     static std::unordered_map<std::string, std::string> prepareLLMNodeInitializeArguments(const ::mediapipe::CalculatorGraphConfig::Node& graphNodeConfig, std::string basePath);
+
+public:
+    virtual Status initializeContinuousBatchingPipeline(
+        const std::string& basePath,
+        const ov::genai::SchedulerConfig& schedulerConfig,
+        const std::string& device,
+        const plugin_config_t& pluginConfig,
+        const plugin_config_t& tokenizerPluginConfig);
 };
 #pragma GCC visibility pop
 using LLMNodeResourcesMap = std::unordered_map<std::string, std::shared_ptr<LLMNodeResources>>;

--- a/src/llm/llmnoderesources.hpp
+++ b/src/llm/llmnoderesources.hpp
@@ -112,7 +112,7 @@ public:
     int maxTokensLimit;
     int bestOfLimit;
 
-    static Status createLLMNodeResources(std::shared_ptr<LLMNodeResources>& nodeResources, const ::mediapipe::CalculatorGraphConfig::Node& graphNode, std::string graphPath);
+    static Status initializeLLMNodeResources(std::shared_ptr<LLMNodeResources>& nodeResources, const ::mediapipe::CalculatorGraphConfig::Node& graphNode, std::string graphPath);
     static void loadTextProcessor(std::shared_ptr<LLMNodeResources>& nodeResources, const std::string& chatTemplateDirectory);
 
     LLMNodeResources(const LLMNodeResources&) = delete;

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -461,7 +461,7 @@ Status MediapipeGraphDefinition::initializeNodes() {
                 return StatusCode::LLM_NODE_NAME_ALREADY_EXISTS;
             }
 
-            std::shared_ptr<LLMNodeResources> nodeResources = nullptr;
+            std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<LLMNodeResources>();
             Status status = LLMNodeResources::createLLMNodeResources(nodeResources, config.node(i), mgconfig.getBasePath());
             if (nodeResources == nullptr || !status.ok()) {
                 SPDLOG_ERROR("Failed to process LLM node graph {}", this->name);

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -463,7 +463,7 @@ Status MediapipeGraphDefinition::initializeNodes() {
             }
 
             std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<LLMNodeResources>();
-            Status status = LLMNodeResources::createLLMNodeResources(nodeResources, config.node(i), mgconfig.getBasePath());
+            Status status = LLMNodeResources::initializeLLMNodeResources(nodeResources, config.node(i), mgconfig.getBasePath());
             if (nodeResources == nullptr || !status.ok()) {
                 SPDLOG_ERROR("Failed to process LLM node graph {}", this->name);
                 return status;

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -33,6 +33,7 @@
 #include "../modelmanager.hpp"
 #include "../ov_utils.hpp"
 #if (PYTHON_DISABLE == 0)
+#include "../llm/llm_executor.hpp"
 #include "../llm/llmnoderesources.hpp"
 #include "../python/pythonnoderesources.hpp"
 #endif

--- a/src/modelmanager.hpp
+++ b/src/modelmanager.hpp
@@ -126,7 +126,7 @@ private:
     /**
      * @brief Cleaner thread for sequence and resources cleanup
      */
-    void cleanerRoutine(uint32_t resourcesCleanupIntervalSec, uint32_t sequenceCleanerIntervalMinutes, std::future<void> cleanerExitSignal);
+    void cleanerRoutine(uint32_t resourcesCleanupIntervalMillisec, uint32_t sequenceCleanerIntervalMinutes, std::future<void> cleanerExitSignal);
 
     /**
      * @brief Mutex for blocking concurrent add & remove of resources
@@ -199,11 +199,13 @@ private:
      */
     uint32_t sequenceCleaupIntervalMinutes = 5;
 
+protected:
     /**
-     * Time interval between two consecutive resources cleanup scans (in seconds)
+     * Time interval between two consecutive resources cleanup scans (in milliseconds)
      */
-    uint32_t resourcesCleanupIntervalSec = 1;
+    uint32_t resourcesCleanupIntervalMillisec = 1000;
 
+private:
     /**
       * @brief last md5sum of configfile
       */
@@ -263,8 +265,8 @@ public:
     /**
      *  @brief Gets the cleaner resources interval timestep in seconds
      */
-    uint32_t getResourcesCleanupIntervalSec() {
-        return resourcesCleanupIntervalSec;
+    uint32_t getResourcesCleanupIntervalMillisec() {
+        return resourcesCleanupIntervalMillisec;
     }
 
     /**

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -102,7 +102,7 @@ static void logConfig(const Config& config) {
     SPDLOG_DEBUG("gRPC channel arguments: {}", config.grpcChannelArguments());
     SPDLOG_DEBUG("log level: {}", config.logLevel());
     SPDLOG_DEBUG("log path: {}", config.logPath());
-    SPDLOG_DEBUG("file system poll wait seconds: {}", config.filesystemPollWaitSeconds());
+    SPDLOG_DEBUG("file system poll wait milliseconds: {}", config.filesystemPollWaitMilliseconds());
     SPDLOG_DEBUG("sequence cleaner poll wait minutes: {}", config.sequenceCleanerPollWaitMinutes());
 }
 

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -5638,6 +5638,7 @@ TEST_F(EnsembleFlowCustomNodePipelineExecutionTest, MultipleDeinitializeCallsOnR
     //  O--------->O--------->O--------->O---------->O
     //          add-sub    add-sub    add-sub
     ResourcesAccessModelManager manager;
+    manager.setResourcesCleanupIntervalMillisec(20);  // Mock cleaner to work in 20ms intervals instead of >1s
     manager.startCleaner();
     ASSERT_EQ(manager.getResourcesSize(), 0);
     PipelineFactory factory;
@@ -5699,6 +5700,7 @@ TEST_F(EnsembleFlowCustomNodePipelineExecutionTest, ReloadPipelineWithoutNodeDei
     //  O--------->O--------->O--------->O---------->O
     //          add-sub    add-sub    add-sub
     ResourcesAccessModelManager manager;
+    manager.setResourcesCleanupIntervalMillisec(20);  // Mock cleaner to work in 20ms intervals instead of >1s
     manager.startCleaner();
     ASSERT_EQ(manager.getResourcesSize(), 0);
     PipelineFactory factory;
@@ -5742,7 +5744,7 @@ TEST_F(EnsembleFlowCustomNodePipelineExecutionTest, ReloadPipelineWithoutNodeDei
         {"custom_node_3", {{customNodeOutputName, pipelineOutputName}}}};
 
     ASSERT_EQ(factory.createDefinition("my_new_pipeline", info, connections, manager), StatusCode::OK);
-    waitForOVMSResourcesCleanup(manager);
+    waitForOVMSResourcesCleanup(manager);  // 20ms * 1.8 wait time
     ASSERT_EQ(manager.getResourcesSize(), 3);
 
     // Nodes
@@ -5754,7 +5756,7 @@ TEST_F(EnsembleFlowCustomNodePipelineExecutionTest, ReloadPipelineWithoutNodeDei
     connections[EXIT_NODE_NAME] = {
         {"custom_node_2", {{customNodeOutputName, pipelineOutputName}}}};
     ASSERT_EQ(factory.reloadDefinition("my_new_pipeline", std::move(info), std::move(connections), manager), StatusCode::OK);
-    waitForOVMSResourcesCleanup(manager);
+    waitForOVMSResourcesCleanup(manager);  // 20ms * 1.8 wait time
     ASSERT_EQ(manager.getResourcesSize(), 2);
     manager.join();
     // Each custom node has effectively 1 internalManager initialized, because they use same library instance

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -1813,14 +1813,13 @@ TEST_F(LLMConfigHttpTest, LLMNodeResourceInitFailed) {
 
 struct MockedLLMNodeResources : public LLMNodeResources {
 public:
-    Status initializeContinuousBatchingPipeline(
+    void initializeContinuousBatchingPipeline(
         const std::string& basePath,
         const ov::genai::SchedulerConfig& schedulerConfig,
         const std::string& device,
         const plugin_config_t& pluginConfig,
         const plugin_config_t& tokenizerPluginConfig) override {
         // Do not initialize, it is not needed in a test
-        return StatusCode::OK;
     }
 };
 

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -1867,7 +1867,7 @@ TEST_F(LLMOptionsHttpTest, LLMNodeOptionsCheckDefault) {
     ::mediapipe::CalculatorGraphConfig config;
     ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(testPbtxt, &config));
     std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<MockedLLMNodeResources>();
-    ASSERT_EQ(LLMNodeResources::createLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::OK);
+    ASSERT_EQ(LLMNodeResources::initializeLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::OK);
     std::cout << "------------------------B--------------------\n";
     ASSERT_EQ(nodeResources->schedulerConfig.max_num_batched_tokens, 256);
     ASSERT_EQ(nodeResources->schedulerConfig.cache_size, 8);
@@ -1919,7 +1919,7 @@ TEST_F(LLMOptionsHttpTest, LLMNodeOptionsCheckHalfDefault) {
     ::mediapipe::CalculatorGraphConfig config;
     ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(testPbtxt, &config));
     std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<MockedLLMNodeResources>();
-    ASSERT_EQ(LLMNodeResources::createLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::OK);
+    ASSERT_EQ(LLMNodeResources::initializeLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::OK);
 
     ASSERT_EQ(nodeResources->schedulerConfig.max_num_batched_tokens, 98);
     ASSERT_EQ(nodeResources->schedulerConfig.cache_size, 1);
@@ -1969,7 +1969,7 @@ TEST_F(LLMOptionsHttpTest, LLMNodeOptionsWrongPluginFormat) {
     ::mediapipe::CalculatorGraphConfig config;
     ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(testPbtxt, &config));
     std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<MockedLLMNodeResources>();
-    ASSERT_EQ(LLMNodeResources::createLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::PLUGIN_CONFIG_WRONG_FORMAT);
+    ASSERT_EQ(LLMNodeResources::initializeLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::PLUGIN_CONFIG_WRONG_FORMAT);
 }
 
 TEST_F(LLMOptionsHttpTest, LLMNodeOptionsCheckNonDefault) {
@@ -2015,7 +2015,7 @@ TEST_F(LLMOptionsHttpTest, LLMNodeOptionsCheckNonDefault) {
     ::mediapipe::CalculatorGraphConfig config;
     ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(testPbtxt, &config));
     std::shared_ptr<LLMNodeResources> nodeResources = std::make_shared<MockedLLMNodeResources>();
-    ASSERT_EQ(LLMNodeResources::createLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::OK);
+    ASSERT_EQ(LLMNodeResources::initializeLLMNodeResources(nodeResources, config.node(0), ""), StatusCode::OK);
 
     ASSERT_EQ(nodeResources->schedulerConfig.max_num_batched_tokens, 1024);
     ASSERT_EQ(nodeResources->schedulerConfig.cache_size, 1);

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -357,7 +357,7 @@ TEST(OvmsConfigTest, positiveMulti) {
     EXPECT_EQ(config.restWorkers(), 46);
     EXPECT_EQ(config.restBindAddress(), "2.2.2.2");
     EXPECT_EQ(config.grpcChannelArguments(), "grpc_channel_args");
-    EXPECT_EQ(config.filesystemPollWaitSeconds(), 2);
+    EXPECT_EQ(config.filesystemPollWaitMilliseconds(), 2000);
     EXPECT_EQ(config.sequenceCleanerPollWaitMinutes(), 7);
     EXPECT_EQ(config.resourcesCleanerPollWaitSeconds(), 8);
     EXPECT_EQ(config.cpuExtensionLibraryPath(), "/ovms");
@@ -439,7 +439,7 @@ TEST(OvmsConfigTest, positiveSingle) {
     EXPECT_EQ(config.restWorkers(), 46);
     EXPECT_EQ(config.restBindAddress(), "2.2.2.2");
     EXPECT_EQ(config.grpcChannelArguments(), "grpc_channel_args");
-    EXPECT_EQ(config.filesystemPollWaitSeconds(), 2);
+    EXPECT_EQ(config.filesystemPollWaitMilliseconds(), 2000);
     EXPECT_EQ(config.sequenceCleanerPollWaitMinutes(), 7);
     EXPECT_EQ(config.resourcesCleanerPollWaitSeconds(), 8);
     EXPECT_EQ(config.cpuExtensionLibraryPath(), "/ovms");

--- a/src/test/predict_validation_test.cpp
+++ b/src/test/predict_validation_test.cpp
@@ -1924,6 +1924,7 @@ TYPED_TEST(PredictValidationString2DTest, negative_no_string) {
     EXPECT_EQ(status, ovms::StatusCode::INVALID_BATCH_SIZE);
 }
 
+// To be removed once this test is moved to functional test suite
 TYPED_TEST(PredictValidationString2DTest, negative_over_1gb_after_expansion) {
     std::string longString(1024 * 1024 * 512 * 1, 'a');            // 512mb
     std::vector<std::string> inputStrings = {longString, "", ""};  // sum=1.5gb
@@ -2021,6 +2022,7 @@ TYPED_TEST(PredictValidationString1DTest, negative_wrong_request_shape) {
     EXPECT_EQ(status, ovms::StatusCode::NOT_IMPLEMENTED);
 }
 
+// To be removed once this test is moved to functional test suite
 TYPED_TEST(PredictValidationString1DTest, positive_over_1gb) {
     std::string longString(1024 * 1024 * 512 * 1, 'a');            // 512mb
     std::vector<std::string> inputStrings = {longString, "", ""};  // sum=1.5gb
@@ -2083,6 +2085,7 @@ TYPED_TEST(PredictValidationStringNativeTest, negative_wrong_request_shape) {
     EXPECT_EQ(status, ovms::StatusCode::INVALID_NO_OF_SHAPE_DIMENSIONS);
 }
 
+// To be removed once this test is moved to functional test suite
 TYPED_TEST(PredictValidationStringNativeTest, positive_over_1gb) {
     std::string longString(1024 * 1024 * 512 * 1, 'a');                            // 512mb
     std::vector<std::string> inputStrings = {longString, longString, longString};  // sum=1.5gb

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -31,6 +31,7 @@
 #include "../http_rest_api_handler.hpp"
 #include "../kfs_frontend/kfs_graph_executor_impl.hpp"
 #include "../kfs_frontend/kfs_grpc_inference_service.hpp"
+#include "../llm/llm_executor.hpp"
 #include "../llm/llmnoderesources.hpp"
 #include "../mediapipe_internal/mediapipefactory.hpp"
 #include "../mediapipe_internal/mediapipegraphdefinition.hpp"

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -122,21 +122,23 @@ void waitForOVMSResourcesCleanup(ovms::ModelManager& manager) {
     // This is effectively multiplying by 1.8 to have 1 config reload in between
     // two test steps
     const float WAIT_MULTIPLIER_FACTOR = 1.8;
-    const uint waitTime = WAIT_MULTIPLIER_FACTOR * manager.getResourcesCleanupIntervalSec() * 1000;
+    const uint waitTime = WAIT_MULTIPLIER_FACTOR * manager.getResourcesCleanupIntervalMillisec();
+    SPDLOG_DEBUG("waitForOVMSResourcesCleanup {} ms", waitTime);
     std::this_thread::sleep_for(std::chrono::milliseconds(waitTime));
 }
 
-std::string createConfigFileWithContent(const std::string& content, std::string filename) {
+bool createConfigFileWithContent(const std::string& content, std::string filename) {
     std::ofstream configFile{filename};
     SPDLOG_INFO("Creating config file: {}\n with content:\n{}", filename, content);
     configFile << content << std::endl;
     configFile.close();
     if (configFile.fail()) {
         SPDLOG_INFO("Closing configFile failed");
+        return false;
     } else {
         SPDLOG_INFO("Closing configFile succeed");
     }
-    return filename;
+    return true;
 }
 
 ovms::tensor_map_t prepareTensors(

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -667,7 +667,7 @@ static std::vector<google::protobuf::int32> asVector(google::protobuf::RepeatedF
 }
 
 // returns path to a file.
-std::string createConfigFileWithContent(const std::string& content, std::string filename = "/tmp/ovms_config_file.json");
+bool createConfigFileWithContent(const std::string& content, std::string filename = "/tmp/ovms_config_file.json");
 #pragma GCC diagnostic pop
 
 template <typename T>
@@ -730,6 +730,10 @@ class ResourcesAccessModelManager : public ConstructorEnabledModelManager {
 public:
     int getResourcesSize() {
         return resources.size();
+    }
+
+    void setResourcesCleanupIntervalMillisec(uint32_t value) {
+        this->resourcesCleanupIntervalMillisec = value;
     }
 };
 
@@ -1035,6 +1039,12 @@ public:
             return it->second.get();
         }
     }
+
+    ovms::Status validateForConfigLoadablenessPublic() {
+        return this->validateForConfigLoadableness();
+    }
+
+    ovms::LLMNodeResourcesMap& getLLMNodeResourcesMap() { return this->llmNodeResourcesMap; }
 
     DummyMediapipeGraphDefinition(const std::string name,
         const ovms::MediapipeGraphConfig& config,

--- a/src/test/text_streamer_test.cpp
+++ b/src/test/text_streamer_test.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #include <string>
 
+#include "../llm/llm_executor.hpp"
 #include "../llm/llmnoderesources.hpp"
 #include "gtest/gtest.h"
 #include "test_utils.hpp"

--- a/src/test/text_streamer_test.cpp
+++ b/src/test/text_streamer_test.cpp
@@ -41,7 +41,7 @@ public:
     static void SetUpTestSuite() {
         py::initialize_interpreter();
         ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(testPbtxt, &config));
-        ASSERT_EQ(ovms::LLMNodeResources::createLLMNodeResources(nodeResources, config.node(0), ""), ovms::StatusCode::OK);
+        ASSERT_EQ(ovms::LLMNodeResources::initializeLLMNodeResources(nodeResources, config.node(0), ""), ovms::StatusCode::OK);
         tokenizer = std::make_shared<ov::genai::Tokenizer>("/ovms/llm_testing/facebook/opt-125m");
         streamer = std::make_shared<ovms::TextStreamer>(tokenizer);
     }

--- a/src/test/text_streamer_test.cpp
+++ b/src/test/text_streamer_test.cpp
@@ -21,11 +21,11 @@
 
 class TextStreamerTest : public ::testing::Test {
 public:
-    ::mediapipe::CalculatorGraphConfig config;
-    std::shared_ptr<ovms::LLMNodeResources> nodeResources = nullptr;
-    std::shared_ptr<ov::genai::Tokenizer> tokenizer;
-    std::shared_ptr<ovms::TextStreamer> streamer;
-    std::string testPbtxt = R"(
+    static inline ::mediapipe::CalculatorGraphConfig config;
+    static inline std::shared_ptr<ovms::LLMNodeResources> nodeResources = std::make_shared<ovms::LLMNodeResources>();
+    static inline std::shared_ptr<ov::genai::Tokenizer> tokenizer;
+    static inline std::shared_ptr<ovms::TextStreamer> streamer;
+    static inline const std::string testPbtxt = R"(
     node: {
     name: "llmNode"
     calculator: "HttpLLMCalculator"
@@ -37,14 +37,14 @@ public:
     }
 )";
 
-    void SetUp() override {
+    static void SetUpTestSuite() {
         py::initialize_interpreter();
         ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(testPbtxt, &config));
         ASSERT_EQ(ovms::LLMNodeResources::createLLMNodeResources(nodeResources, config.node(0), ""), ovms::StatusCode::OK);
         tokenizer = std::make_shared<ov::genai::Tokenizer>("/ovms/llm_testing/facebook/opt-125m");
         streamer = std::make_shared<ovms::TextStreamer>(tokenizer);
     }
-    void TearDown() {
+    static void TearDownTestSuite() {
         nodeResources.reset();
         py::finalize_interpreter();
     }

--- a/src/test/threadsafequeue_test.cpp
+++ b/src/test/threadsafequeue_test.cpp
@@ -68,7 +68,7 @@ TEST(TestThreadSafeQueue, SeveralElementsInFIFOOrder) {
 TEST(TestThreadSafeQueue, NoElementsPushed) {
     const std::vector<int> elements = {};
     ThreadSafeQueue<int> queue;
-    EXPECT_EQ(std::nullopt, queue.tryPull(WAIT_FOR_ELEMENT_TIMEOUT_MICROSECONDS));
+    EXPECT_EQ(std::nullopt, queue.tryPull(200));  // 200ms
 }
 
 const uint ELEMENTS_TO_INSERT = 500;


### PR DESCRIPTION
### 🛠 Summary
Addressing JIRA tickets:
CVS-150532
CVS-150533

- Shortened waiting time to wait for free infer request from the queue in unit test
- Reduced multi-thread infer requests queue unit test workload to last 0.5s instead of 4 seconds
- Re-use already loaded LLM model wherever possible. Grouped all LLM unit tests with the same server configuration into single test suite.
- Setting max tokens=1 in all unit tests to avoid unlimited llm text generation
- Changed underlying file system poll wait seconds variable from seconds to milliseconds to be able to reduce waiting times (public APIs remain **unchanged** - seconds)
- Changed underlying resource cleaner interval seconds variable from seconds to milliseconds to be able to reduce waiting times (public APIs remain **unchanged** - seconds)
- Tests which wait for config.json to be reloaded or for resources to be cleaned have shortened interval from 1 second to 20s using the changes above
- Moved creation of ContinuousBatchingPipeline out of createLLMNodeResources to separate virtual method (LLMNodeResources::initializeContinuousBatchingPipeline) to be able to mock it and do not load model in tests where it is unnecessary
- Cleanup unused/duplicated code in unit tests (CreateConfig instead of using existing util createConfigFileWithContent)

There are multiple unit tests with over 1.5gb string preparation that take 4s+, those will be removed from unit tests once similar tests appear in functional test suite. It is planned by validation team @pgladkows CVS-151232

Unit tests sorted by execution time before change:
```
LLMJinjaChatTemplateHttpTest.inferChatCompletionsUnary: 5865 ms
TextStreamerTest.noValueReturnedStringWithoutNewLineOrSpace: 4985 ms
LLMJinjaChatTemplateHttpTest.inferCompletionsStream: 4964 ms
LLMJinjaChatTemplateHttpTest.inferCompletionsUnary: 4925 ms
LLMDefaultChatTemplateHttpTest.inferDefaultChatCompletionsUnary: 4914 ms
TextStreamerTest.putReturnsValue: 4880 ms
TextStreamerTest.putDoesNotReturnValueUntilNewLineDetected: 4870 ms
TextStreamerTest.putReturnsValueTextWithSpaces: 4868 ms
TextStreamerTest.valueReturnedCacheCleared: 4859 ms
TextStreamerTest.putReturnsValueAfterEndCalled: 4857 ms
TextStreamerTest.putReturnsValueTextWithNewLineInTheMiddle: 4847 ms
LLMJinjaChatTemplateHttpTest.inferChatCompletionsStream: 4813 ms
LLMOptionsHttpTest.LLMNodeOptionsCheckDefault: 4679 ms
PredictValidationStringNativeTest/0.positive_over_1gb: 4540 ms
PredictValidationStringNativeTest/1.positive_over_1gb: 4352 ms 
EnsembleFlowCustomNodePipelineExecutionTest.MultipleDeinitializeCallsOnRetire: 3604 ms
EnsembleFlowCustomNodePipelineExecutionTest.ReloadPipelineWithoutNodeDeinitializeAllCustomNodes: 3604 ms
ModelManagerCleaner.ConfigReloadShouldCleanupResources: 3603 ms
OVInferRequestQueue.MultiThread: 3040 ms
CAPIStateIntegration.Config: 2172 ms
PredictValidationString1DTest/1.positive_over_1gb: 1695 ms
PredictValidationString1DTest/0.positive_over_1gb: 1657 ms
PredictValidationString2DTest/1.negative_over_1gb_after_expansion: 1636 ms
PredictValidationString2DTest/0.negative_over_1gb_after_expansion: 1634 ms
LLMFlowHttpTest.streamChatCompletionsFinishReasonStop: 1617 ms
LLMHttpParametersValidationTest.MessagesWithOnlyContent: 1172 ms
LLMOptionsHttpTest.LLMNodeOptionsCheckHalfDefault: 1050 ms
LLMConfigHttpTest.LLMNodeNameExists: 1039 ms
LLMOptionsHttpTest.LLMNodeOptionsCheckNonDefault: 1019 ms
ModelManager.ConfigReloadingShouldRetireModelInstancesOfModelRemovedFromJsonRelative: 1017 ms
ModelManager.ConfigReloadingShouldRetireModelInstancesOfModelRemovedFromJson: 1016 ms
OVInferRequestQueue.FullQueue: 1013 ms
TestThreadSafeQueue.NoElementsPushed: 1000 ms
LLMFlowHttpTest.unaryCompletionsJson: 822 ms
...
```

Unit tests sorted by execution time after change:
```
PredictValidationStringNativeTest/0.positive_over_1gb: 4489 ms // will be moved to functional CVS-151232
PredictValidationStringNativeTest/1.positive_over_1gb: 4447 ms // will be moved to functional CVS-151232
PredictValidationString1DTest/0.positive_over_1gb: 1710 ms // will be moved to functional CVS-151232
PredictValidationString1DTest/1.positive_over_1gb: 1676 ms // will be moved to functional CVS-151232
PredictValidationString2DTest/1.negative_over_1gb_after_expansion: 1660 ms // will be moved to functional CVS-151232
PredictValidationString2DTest/0.negative_over_1gb_after_expansion: 1653 ms // will be moved to functional CVS-151232
LLMFlowHttpTest.unaryCompletionsJson: 985 ms
...
```

### 🧪 Checklist

- [x] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.


