### PR TITLE
Fix issue with Inference-Header-Content-Length

### DIFF
--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -331,6 +331,10 @@ Status HttpRestApiHandler::prepareGrpcRequest(const std::string modelName, const
     KFSRestParser requestParser;
 
     size_t endOfJson = inferenceHeaderContentLength.value_or(request_body.length());
+    if (endOfJson > request_body.length()) {
+        SPDLOG_DEBUG("Inference header content length exceeded JSON size");
+        return StatusCode::REST_INFERENCE_HEADER_CONTENT_LENGTH_EXCEEDED;
+    }
     auto status = requestParser.parse(request_body.substr(0, endOfJson).c_str());
     if (!status.ok()) {
         SPDLOG_DEBUG("Parsing http request failed");

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -151,6 +151,7 @@ const std::unordered_map<const StatusCode, const std::string> Status::statusMess
     {StatusCode::REST_UNSUPPORTED_PRECISION, "Could not parse input content. Unsupported data precision detected"},
     {StatusCode::REST_SERIALIZE_TENSOR_CONTENT_INVALID_SIZE, "Size of data in tensor_content does not match declared tensor shape"},
     {StatusCode::REST_SERIALIZE_VAL_FIELD_INVALID_SIZE, "Number of elements in xxx_val field does not match declared tensor shape"},
+    {StatusCode::REST_INFERENCE_HEADER_CONTENT_LENGTH_EXCEEDED, "Inference-Header-Content-Length header exceeds actual payload length"},
     {StatusCode::REST_BINARY_DATA_SIZE_PARAMETER_INVALID, "binary_data_size parameter is invalid and cannot be parsed"},
     {StatusCode::REST_BINARY_BUFFER_EXCEEDED, "Received buffer size is smaller than binary_data_size parameter indicates"},
     {StatusCode::REST_INFERENCE_HEADER_CONTENT_LENGTH_INVALID, "Inference-Header-Content-Length header is invalid and couldn't be parsed"},

--- a/src/status.hpp
+++ b/src/status.hpp
@@ -174,30 +174,30 @@ enum class StatusCode {
     UNKNOWN_REQUEST_COMPONENTS_TYPE, /*!< Components type not recognized */
 
     // REST Parse
-    REST_BODY_IS_NOT_AN_OBJECT,                   /*!< REST body should be JSON object */
-    REST_PREDICT_UNKNOWN_ORDER,                   /*!< Could not detect order (row/column) */
-    REST_INSTANCES_NOT_AN_ARRAY,                  /*!< When parsing row order, instances must be an array */
-    REST_NAMED_INSTANCE_NOT_AN_OBJECT,            /*!< When parsing named instance it needs to be an object */
-    REST_INPUT_NOT_PREALLOCATED,                  /*!< When parsing no named instance, exactly one input need to be preallocated */
-    REST_NO_INSTANCES_FOUND,                      /*!< Missing instances in row order */
-    REST_INSTANCES_NOT_NAMED_OR_NONAMED,          /*!< Unknown instance format, neither named or nonamed */
-    REST_COULD_NOT_PARSE_INSTANCE,                /*!< Error while parsing instance content, not valid ndarray */
-    REST_INSTANCES_BATCH_SIZE_DIFFER,             /*!< In row order 0-th dimension (batch size) must be equal for all inputs */
-    REST_INPUTS_NOT_AN_OBJECT,                    /*!< When parsing column order, inputs must be an object */
-    REST_NO_INPUTS_FOUND,                         /*!< Missing inputs in column order */
-    REST_COULD_NOT_PARSE_INPUT,                   /*!< Error while parsing input content, not valid ndarray */
-    REST_COULD_NOT_PARSE_OUTPUT,                  /*!< Error while parsing output content */
-    REST_COULD_NOT_PARSE_PARAMETERS,              /*!< Error while parsing request parameters */
-    REST_PROTO_TO_STRING_ERROR,                   /*!< Error while parsing ResponseProto to JSON string */
-    REST_BASE64_DECODE_ERROR,                     /*!< Error while decoding base64 REST binary input */
-    REST_UNSUPPORTED_PRECISION,                   /*!< Unsupported conversion from tensor_content to _val container */
-    REST_SERIALIZE_TENSOR_CONTENT_INVALID_SIZE,   /*!< Size of data in tensor_content does not match declared tensor shape */
-    REST_SERIALIZE_VAL_FIELD_INVALID_SIZE,        /*!< Number of elements in xxx_val field does not match declared tensor shape */
-    REST_INFERENCE_HEADER_CONTENT_LENGTH_EXCEEDED,/*!< Inference-Header-Content-Length header exceeds actual payload length */
-    REST_BINARY_DATA_SIZE_PARAMETER_INVALID,      /*!< binary_data_size parameter is invalid and cannot be parsed*/
-    REST_INFERENCE_HEADER_CONTENT_LENGTH_INVALID, /*!< inferenceHeaderContentLength parameter is invalid and cannot be parsed*/
-    REST_BINARY_BUFFER_EXCEEDED,                  /*!< Received buffer size is smaller than binary_data_size parameter indicates*/
-    REST_CONTENTS_FIELD_NOT_EMPTY,                /*!< Request contains values both in binary data and in content value*/
+    REST_BODY_IS_NOT_AN_OBJECT,                    /*!< REST body should be JSON object */
+    REST_PREDICT_UNKNOWN_ORDER,                    /*!< Could not detect order (row/column) */
+    REST_INSTANCES_NOT_AN_ARRAY,                   /*!< When parsing row order, instances must be an array */
+    REST_NAMED_INSTANCE_NOT_AN_OBJECT,             /*!< When parsing named instance it needs to be an object */
+    REST_INPUT_NOT_PREALLOCATED,                   /*!< When parsing no named instance, exactly one input need to be preallocated */
+    REST_NO_INSTANCES_FOUND,                       /*!< Missing instances in row order */
+    REST_INSTANCES_NOT_NAMED_OR_NONAMED,           /*!< Unknown instance format, neither named or nonamed */
+    REST_COULD_NOT_PARSE_INSTANCE,                 /*!< Error while parsing instance content, not valid ndarray */
+    REST_INSTANCES_BATCH_SIZE_DIFFER,              /*!< In row order 0-th dimension (batch size) must be equal for all inputs */
+    REST_INPUTS_NOT_AN_OBJECT,                     /*!< When parsing column order, inputs must be an object */
+    REST_NO_INPUTS_FOUND,                          /*!< Missing inputs in column order */
+    REST_COULD_NOT_PARSE_INPUT,                    /*!< Error while parsing input content, not valid ndarray */
+    REST_COULD_NOT_PARSE_OUTPUT,                   /*!< Error while parsing output content */
+    REST_COULD_NOT_PARSE_PARAMETERS,               /*!< Error while parsing request parameters */
+    REST_PROTO_TO_STRING_ERROR,                    /*!< Error while parsing ResponseProto to JSON string */
+    REST_BASE64_DECODE_ERROR,                      /*!< Error while decoding base64 REST binary input */
+    REST_UNSUPPORTED_PRECISION,                    /*!< Unsupported conversion from tensor_content to _val container */
+    REST_SERIALIZE_TENSOR_CONTENT_INVALID_SIZE,    /*!< Size of data in tensor_content does not match declared tensor shape */
+    REST_SERIALIZE_VAL_FIELD_INVALID_SIZE,         /*!< Number of elements in xxx_val field does not match declared tensor shape */
+    REST_INFERENCE_HEADER_CONTENT_LENGTH_EXCEEDED, /*!< Inference-Header-Content-Length header exceeds actual payload length */
+    REST_BINARY_DATA_SIZE_PARAMETER_INVALID,       /*!< binary_data_size parameter is invalid and cannot be parsed*/
+    REST_INFERENCE_HEADER_CONTENT_LENGTH_INVALID,  /*!< inferenceHeaderContentLength parameter is invalid and cannot be parsed*/
+    REST_BINARY_BUFFER_EXCEEDED,                   /*!< Received buffer size is smaller than binary_data_size parameter indicates*/
+    REST_CONTENTS_FIELD_NOT_EMPTY,                 /*!< Request contains values both in binary data and in content value*/
 
     // Pipeline validation errors
     PIPELINE_DEFINITION_ALREADY_EXIST,

--- a/src/status.hpp
+++ b/src/status.hpp
@@ -193,6 +193,7 @@ enum class StatusCode {
     REST_UNSUPPORTED_PRECISION,                   /*!< Unsupported conversion from tensor_content to _val container */
     REST_SERIALIZE_TENSOR_CONTENT_INVALID_SIZE,   /*!< Size of data in tensor_content does not match declared tensor shape */
     REST_SERIALIZE_VAL_FIELD_INVALID_SIZE,        /*!< Number of elements in xxx_val field does not match declared tensor shape */
+    REST_INFERENCE_HEADER_CONTENT_LENGTH_EXCEEDED,/*!< Inference-Header-Content-Length header exceeds actual payload length */
     REST_BINARY_DATA_SIZE_PARAMETER_INVALID,      /*!< binary_data_size parameter is invalid and cannot be parsed*/
     REST_INFERENCE_HEADER_CONTENT_LENGTH_INVALID, /*!< inferenceHeaderContentLength parameter is invalid and cannot be parsed*/
     REST_BINARY_BUFFER_EXCEEDED,                  /*!< Received buffer size is smaller than binary_data_size parameter indicates*/

--- a/src/test/kfs_rest_test.cpp
+++ b/src/test/kfs_rest_test.cpp
@@ -1232,6 +1232,22 @@ TEST_F(HttpRestApiHandlerTest, binaryInputsBufferSmallerThanExpected_noBinaryDat
     ASSERT_EQ(HttpRestApiHandler::prepareGrpcRequest(modelName, modelVersion, request_body, grpc_request, inferenceHeaderContentLength), ovms::StatusCode::REST_BINARY_BUFFER_EXCEEDED);
 }
 
+TEST_F(HttpRestApiHandlerTest, binaryInputsInferenceHeaderContentLengthSmallerThanJsonBody) {
+    std::string request_body = "{\"inputs\":[{\"name\":\"b\",\"shape\":[1,4],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":true}}]}";
+    int inferenceHeaderContentLength = request_body.size() - 1;
+
+    ::KFSRequest grpc_request;
+    ASSERT_EQ(HttpRestApiHandler::prepareGrpcRequest(modelName, modelVersion, request_body, grpc_request, inferenceHeaderContentLength), ovms::StatusCode::JSON_INVALID);
+}
+
+TEST_F(HttpRestApiHandlerTest, binaryInputsInferenceHeaderContentLengthLargerThanJsonBody) {
+    std::string request_body = "{\"inputs\":[{\"name\":\"b\",\"shape\":[1,4],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":true}}]}";
+    int inferenceHeaderContentLength = request_body.size() + 1;
+
+    ::KFSRequest grpc_request;
+    ASSERT_EQ(HttpRestApiHandler::prepareGrpcRequest(modelName, modelVersion, request_body, grpc_request, inferenceHeaderContentLength), ovms::StatusCode::REST_INFERENCE_HEADER_CONTENT_LENGTH_EXCEEDED);
+}
+
 TEST_F(HttpRestApiHandlerTest, binaryInputsInvalidBinaryDataSizeParameter) {
     std::string binaryData{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00};
     std::string request_body = "{\"inputs\":[{\"name\":\"b\",\"shape\":[1,4],\"datatype\":\"INT32\",\"parameters\":{\"binary_data_size\":true}}]}";


### PR DESCRIPTION
### 🛠 Summary

There was issue when Inference-Header-Content-Length header value exceeded actual request body length.
Adding unit tests.

CVS-151199

### 🧪 Checklist

- [x] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.


