### PR TITLE
cvs-151579 update benchmark_serving.py output: Total Token throughput

### DIFF
--- a/demos/continuous_batching/README.md
+++ b/demos/continuous_batching/README.md
@@ -293,7 +293,7 @@ It looks like you're testing me!
 OpenVINO Model Server employs efficient parallelization for text generation. It can be used to generate text also in high concurrency in the environment shared by multiple clients.
 It can be demonstrated using benchmarking app from vLLM repository:
 ```bash
-git clone https://github.com/vllm-project/vllm
+git clone --branch v0.6.0 --depth 1 https://github.com/vllm-project/vllm
 cd vllm
 pip3 install -r requirements-cpu.txt
 cd benchmarks

--- a/demos/continuous_batching/README.md
+++ b/demos/continuous_batching/README.md
@@ -309,8 +309,8 @@ Benchmark duration (s):                  447.62
 Total input tokens:                      215201
 Total generated tokens:                  198588
 Request throughput (req/s):              2.23
-Input token throughput (tok/s):          480.76
 Output token throughput (tok/s):         443.65
+Total Token throughput (tok/s):          924.41
 ---------------Time to First Token----------------
 Mean TTFT (ms):                          171999.94
 Median TTFT (ms):                        170699.21

--- a/demos/continuous_batching/scaling/README.md
+++ b/demos/continuous_batching/scaling/README.md
@@ -60,8 +60,8 @@ Benchmark duration (s):                  488.53
 Total input tokens:                      443650
 Total generated tokens:                  367462
 Request throughput (req/s):              4.09
-Input token throughput (tok/s):          908.14
 Output token throughput (tok/s):         752.18
+Total Token throughput (tok/s):          1660.32
 ---------------Time to First Token----------------
 Mean TTFT (ms):                          188339.52
 Median TTFT (ms):                        186645.04


### PR DESCRIPTION
### 🛠 Summary

JIRA/Issue if applicable: https://jira.devtools.intel.com/browse/CVS-151579
Total Token throughput recently replaced Input Token throughput in benchmark_serving.py
This change updates continuous batching demos outputs only.
Sample passing test run: http://validationreports.sclab.intel.com:8001/reports/test_result/66d9abdffa59b5cdb3183cac

### 🧪 Checklist

- [-] Unit tests added.
- [+] The documentation updated.
- [+] Change follows security best practices.
``

