### PR TITLE
warn about python version require to prepare test models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,11 @@ ifeq ($(FUZZER_BUILD),1)
 	@echo "Cannot run fuzzer with redhat"; exit 1 ;
   endif
 endif
+ifeq ($(BASE_OS_TAG),20.04)
+  ifeq ($(RUN_TESTS),1)
+	@echo "On ubuntu20 run tests via make run_unit_tests"; exit 1 ;
+  endif
+endif
 ifeq ($(NVIDIA),1)
   ifeq ($(OV_USE_BINARY),1)
 	@echo "Building NVIDIA plugin requires OV built from source. To build NVIDIA plugin and OV from source make command should look like this 'NVIDIA=1 OV_USE_BINARY=0 make docker_build'"; exit 1 ;

--- a/prepare_llm_models.sh
+++ b/prepare_llm_models.sh
@@ -19,6 +19,7 @@ if [ -d "$1/facebook/opt-125m" ]; then
   echo "Models directory $1 exists. Skipping downloading models."
   exit 0
 fi
+if [ "$(python3 -c 'import sys; print(sys.version_info[1])')" -le "8" ]; then echo "Prepare models with python > 3.8."; exit 1 ; fi
 
 echo "Downloading LLM testing models to directory $1"
 export PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"


### PR DESCRIPTION
### 🛠 Summary

CVS151629
warn about python version requirement in the script downloading test model
warn about unsupported unit tests execution during the docker image build on ubuntu20

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

