### PR TITLE
Warn about unsupported NPU on ubuntu20 during build

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -457,7 +457,6 @@ RUN     apt-get update -y ; \
                         curl -L -O https://github.com/intel/compute-runtime/releases/download/24.26.30049.6/libigdgmm12_22.3.20_amd64.deb ; \
                         curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17193.4/intel-igc-core_1.0.17193.4_amd64.deb ; \
                         curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17193.4/intel-igc-opencl_1.0.17193.4_amd64.deb ; \
-
                         dpkg -i *.deb && rm -Rf /tmp/gpu_deps ; \
                 ;; \                
                 *) \

--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,6 @@ BUILD_ARGS = --build-arg http_proxy=$(HTTP_PROXY)\
 	--build-arg ov_tokenizers_branch=$(OV_TOKENIZERS_BRANCH)\
 	--build-arg INSTALL_RPMS_FROM_URL=$(INSTALL_RPMS_FROM_URL)\
 	--build-arg INSTALL_DRIVER_VERSION=$(INSTALL_DRIVER_VERSION)\
-	--build-arg GPU=$(GPU)\
-	--build-arg NPU=$(NPU)\
 	--build-arg RELEASE_BASE_IMAGE=$(BASE_IMAGE_RELEASE)\
 	--build-arg JOBS=$(JOBS)\
 	--build-arg CAPI_FLAGS=$(CAPI_FLAGS)\
@@ -418,7 +416,7 @@ endif
 	docker $(BUILDX) build $(NO_CACHE_OPTION) -f Dockerfile.$(DIST_OS) . \
 		$(BUILD_ARGS) \
 		--build-arg GPU=1 \
-		--build-arg NPU=1 \
+		--build-arg NPU=$$(if [ "$(BASE_OS_TAG)"="22.04" ]; then echo 1; else echo 0 ; fi) \
 		-t $(OVMS_CPP_DOCKER_IMAGE)-gpu:$(OVMS_CPP_IMAGE_TAG)$(IMAGE_TAG_SUFFIX) \
 		--target=release && \
 	docker tag $(OVMS_CPP_DOCKER_IMAGE)-gpu:$(OVMS_CPP_IMAGE_TAG)$(IMAGE_TAG_SUFFIX) $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-gpu$(IMAGE_TAG_SUFFIX)
@@ -459,7 +457,9 @@ ifeq ($(USE_BUILDX),true)
 endif
 	docker $(BUILDX) build $(NO_CACHE_OPTION) -f Dockerfile.$(DIST_OS) . \
 		$(BUILD_ARGS) \
-		-t $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)
+		--build-arg GPU=$(GPU) \
+		--build-arg NPU=$(NPU) \
+		-t $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG) \
 		--target=release
 ifeq ($(BUILD_NGINX), 1)
 	cd extras/nginx-mtls-auth && \

--- a/Makefile
+++ b/Makefile
@@ -355,10 +355,6 @@ ifeq ($(NVIDIA),1)
 	@echo "Building NVIDIA plugin requires OV built from source. To build NVIDIA plugin and OV from source make command should look like this 'NVIDIA=1 OV_USE_BINARY=0 make docker_build'"; exit 1 ;
   endif
 endif
-ifeq ($(BASE_OS),redhat)
-	@mkdir -p entitlement
-	@mkdir -p rhsm-ca
-endif
 ifeq ($(NO_DOCKER_CACHE),true)
 	$(eval NO_CACHE_OPTION:=--no-cache)
 	@echo "Docker image will be rebuilt from scratch"
@@ -451,6 +447,11 @@ ifeq ($(BASE_OS),redhat)
 endif
 
 release_image:
+ifeq ($(BASE_OS_TAG),20.04)
+  ifeq ($(NPU),1)
+	@echo "NPU is not supported on Ubuntu 20.04" ; exit 1
+  endif
+endif
 ifeq ($(USE_BUILDX),true)
 	$(eval BUILDX:=buildx)
 	$(eval NO_CACHE_OPTION:=--no-cache-filter release)

--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ endif
 	docker $(BUILDX) build $(NO_CACHE_OPTION) -f Dockerfile.$(DIST_OS) . \
 		$(BUILD_ARGS) \
 		--build-arg GPU=1 \
-		--build-arg NPU=$$(if [ "$(BASE_OS_TAG)"="22.04" ]; then echo 1; else echo 0 ; fi) \
+		--build-arg NPU=$$(if [ "$(BASE_OS_TAG)" = "22.04" ]; then echo 1; else echo 0 ; fi) \
 		-t $(OVMS_CPP_DOCKER_IMAGE)-gpu:$(OVMS_CPP_IMAGE_TAG)$(IMAGE_TAG_SUFFIX) \
 		--target=release && \
 	docker tag $(OVMS_CPP_DOCKER_IMAGE)-gpu:$(OVMS_CPP_IMAGE_TAG)$(IMAGE_TAG_SUFFIX) $(OVMS_CPP_DOCKER_IMAGE):$(OVMS_CPP_IMAGE_TAG)-gpu$(IMAGE_TAG_SUFFIX)


### PR DESCRIPTION
### 🛠 Summary

CVS 150445
Warn about unsupported NPU on ubuntu20 during image build

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

