### PR TITLE
Remove old TODOs in LLM tests

### DIFF
--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -150,13 +150,6 @@ std::unique_ptr<std::thread> LLMFlowHttpTest::t;
 
 // --------------------------------------- OVMS LLM nodes tests
 
-// TODO: Test bad sampling configuration that would cause errors in step() phase. Need to replace hardcoded generation config
-// with user defined one to do that.
-// TODO: Test bad message or sampling configuration that would cause errors in add_request() phase. Need to replace hardcoded generation config
-// with user defined one to do that.
-// TODO: Consider stress testing - existing model server under heavy load to check notifications work us expected.
-//
-
 TEST_F(LLMFlowHttpTest, writeLogprobs) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(buffer);


### PR DESCRIPTION
### 🛠 Summary

TODOs removed as:
- invalid sampling parameters is being checked in UT and internal tests
- step() should not throw errors - if it does, there's a bug that needs to be fixed and positive tests would be failing
- stress testing is done via performance checks and in internal tests

