### PR TITLE
Change python deps installation in continuous batching demo

### DIFF
--- a/demos/continuous_batching/README.md
+++ b/demos/continuous_batching/README.md
@@ -30,8 +30,8 @@ LLM engine parameters will be defined inside the `graph.pbtxt` file.
 
 Install python dependencies for the conversion script:
 ```bash
-export PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu https://storage.openvinotoolkit.org/simple/wheels/pre-release"
-pip3 install --pre "optimum-intel[nncf,openvino]"@git+https://github.com/huggingface/optimum-intel.git  openvino_tokenizers==2024.4.* openvino==2024.4.*
+export PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
+pip3 install optimum-intel@git+https://github.com/huggingface/optimum-intel.git  openvino-tokenizers[transformers]==2024.4.* openvino==2024.4.* nncf>=2.11.0
 ```
 
 Run optimum-cli to download and quantize the model:


### PR DESCRIPTION
### 🛠 Summary

Due to changes in optimum intel pinning OV version in extras requirements we need to change installation to go with basic optimum installation bypassing problematic extras path. 

It should solve: https://github.com/openvinotoolkit/model_server/issues/2707