### PR TITLE
Update partial.patch

### DIFF
--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -21,7 +21,7 @@ pipeline {
               } else {  // branches without PR - check changes in last commit
                 git_diff = sh (script: "git diff --name-only HEAD^..HEAD", returnStdout: true).trim()
               }
-              def matched = (git_diff =~ /src|third_party|(\n|^)Dockerfile|(\n|^)Makefile|\.c|\.h|\.bazel|\.bzl|BUILD|WORKSPACE|(\n|^)run_unit_tests\.sh/)
+              def matched = (git_diff =~ /src|third_party|external|(\n|^)Dockerfile|(\n|^)Makefile|\.c|\.h|\.bazel|\.bzl|BUILD|WORKSPACE|(\n|^)run_unit_tests\.sh/)
                 if (matched){
                   image_build_needed = "true"
               }

--- a/docs/llm/reference.md
+++ b/docs/llm/reference.md
@@ -117,7 +117,7 @@ for chunk in stream:
         break
 ```
 
-> NOTE: To leverage LLM graph cancelation upon client disconnection, use `stream=True` parameter.
+> NOTE: To leverage LLM graph cancellation upon client disconnection, use `stream=True` parameter.
 
 ## Models Directory
 

--- a/docs/llm/reference.md
+++ b/docs/llm/reference.md
@@ -117,6 +117,8 @@ for chunk in stream:
         break
 ```
 
+> NOTE: To leverage LLM graph cancelation upon client disconnection, use `stream=True` parameter.
+
 ## Models Directory
 
 In node configuration we set `models_path` indicating location of the directory with files loaded by LLM engine. It loads following files:

--- a/external/partial.patch
+++ b/external/partial.patch
@@ -1,5 +1,5 @@
 diff --git a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
-index c8d0501b..ecddbac3 100644
+index c8d0501b..0484bf97 100644
 --- a/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
 +++ b/tensorflow_serving/util/net_http/server/internal/evhttp_request.cc
 @@ -17,6 +17,8 @@ limitations under the License.
@@ -20,7 +20,7 @@ index c8d0501b..ecddbac3 100644
  #include "absl/strings/match.h"
  #include "absl/strings/string_view.h"
  #include "absl/types/span.h"
-@@ -118,18 +122,47 @@ bool ParsedEvRequest::decode() {
+@@ -118,18 +122,43 @@ bool ParsedEvRequest::decode() {
    return true;
  }
  
@@ -35,12 +35,8 @@ index c8d0501b..ecddbac3 100644
        parsed_request_(std::move(request)),
 -      output_buf(nullptr) {}
 +      output_buf(nullptr) {
-+
 +  struct evhttp_connection *conn = evhttp_request_get_connection(parsed_request_->request);
 +  evhttp_connection_set_closecb(conn, connection_close_callback, (void*)this);
-+
-+  struct bufferevent *bev = evhttp_connection_get_bufferevent(conn);
-+  bufferevent_enable(bev, EV_READ);
 +}
  
  EvHTTPRequest::~EvHTTPRequest() {
@@ -69,7 +65,7 @@ index c8d0501b..ecddbac3 100644
  absl::string_view EvHTTPRequest::uri_path() const {
    return parsed_request_->path_and_query;
  }
-@@ -338,12 +371,18 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
+@@ -338,12 +367,18 @@ void EvHTTPRequest::AppendResponseHeader(absl::string_view header,
    }
  }
  
@@ -92,7 +88,7 @@ index c8d0501b..ecddbac3 100644
  }
  
  ServerRequestInterface::CallbackStatus
-@@ -371,6 +410,33 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
+@@ -371,6 +406,33 @@ void EvHTTPRequest::EvSendReply(HTTPStatusCode status) {
    delete this;
  }
  
@@ -126,7 +122,7 @@ index c8d0501b..ecddbac3 100644
  void EvHTTPRequest::Reply() { ReplyWithStatus(HTTPStatusCode::OK); }
  
  // Treats this as 500 for now and let libevent decide what to do
-@@ -381,6 +447,16 @@ void EvHTTPRequest::Abort() {
+@@ -381,6 +443,16 @@ void EvHTTPRequest::Abort() {
    delete this;
  }
  


### PR DESCRIPTION
### 🛠 Summary

Modifying net_http patch.
In order to workaround libevent issue, we need to apply this patch.
This patch changes disconnect behavior so that we only get client disconnection information when server sends data to it. It will cancel LLM streaming workloads, but will no longer stop LLM unary calls.

CVS-148009

### 🧪 Checklist

- [x] Change follows security best practices.

