### PR TITLE
Fix failing builds due to MarkupSafe

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -128,7 +128,7 @@ RUN wget -q https://rpmfind.net/linux/centos-stream/10-stream/AppStream/x86_64/o
     groupadd --gid 5000 ovms && groupadd --gid 44 video1 && \
     useradd --home-dir /home/ovms --create-home --uid 5000 --gid 5000 --groups 39,44 --shell /bin/bash --skel /dev/null ovms
 RUN python3 --version && python3 -m pip install "numpy<2.0.0" --no-cache-dir && \
-    python3 --version && python3 -m pip install "Jinja2==3.1.4" --no-cache-dir
+    python3 --version && python3 -m pip install "Jinja2==3.1.4" "MarkupSafe==3.0.1" --no-cache-dir
 
 # Set up Bazel
 ENV BAZEL_VERSION 6.1.1
@@ -445,7 +445,7 @@ ENV LD_LIBRARY_PATH=/ovms/lib
 COPY --from=pkg /ovms_release /ovms
 COPY --from=build /usr/local/lib/python3.*/site-packages/jinja2 /ovms/python_deps/jinja2
 COPY --from=build /usr/local/lib/python3.*/site-packages/jinja2-3.1.4.dist-info /ovms/python_deps/jinja2-3.1.4.dist-info
-COPY --from=build /usr/local/lib64/python3.*/site-packages/MarkupSafe-2.1.5.dist-info /ovms/python_deps/MarkupSafe-2.1.5.dist-info
+COPY --from=build /usr/local/lib64/python3.*/site-packages/MarkupSafe-3.0.1.dist-info /ovms/python_deps/MarkupSafe-3.0.1.dist-info
 COPY --from=build /usr/local/lib64/python3.*/site-packages/markupsafe /ovms/python_deps/markupsafe
 
 COPY --from=pkg /licenses /licenses

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -121,7 +121,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
             apt-get clean && \
             rm -rf /var/lib/apt/lists/* && \
     python3 -m pip install "numpy<2.0.0" --no-cache-dir  && \
-    python3 -m pip install "Jinja2==3.1.4" --no-cache-dir
+    python3 -m pip install "Jinja2==3.1.4" "MarkupSafe==3.0.1" --no-cache-dir
 
 RUN apt-get update; apt-get install -y --no-install-recommends libxml2 && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
 
@@ -452,7 +452,7 @@ RUN if [ "$NVIDIA" == "1" ]; then true ; else exit 0 ; fi ; echo "installing cud
     apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
 
 COPY --from=pkg /ovms_release /ovms
-COPY --from=build /usr/local/lib/python3.*/dist-packages/MarkupSafe-2.1.5.dist-info /ovms/python_deps/MarkupSafe-2.1.5.dist-info
+COPY --from=build /usr/local/lib/python3.*/dist-packages/MarkupSafe-3.0.1.dist-info /ovms/python_deps/MarkupSafe-3.0.1.dist-info
 COPY --from=build /usr/local/lib/python3.*/dist-packages/jinja2 /ovms/python_deps/jinja2
 COPY --from=build /usr/local/lib/python3.*/dist-packages/jinja2-3.1.4.dist-info /ovms/python_deps/jinja2-3.1.4.dist-info
 COPY --from=build /usr/local/lib/python3.*/dist-packages/markupsafe /ovms/python_deps/markupsafe


### PR DESCRIPTION
### 🛠 Summary

MarkupSafe jinja's dependency was latest but copy static