### PR TITLE
Update URLs in RAG demo

### DIFF
--- a/demos/continuous_batching/rag/rag_demo.ipynb
+++ b/demos/continuous_batching/rag/rag_demo.ipynb
@@ -35,7 +35,7 @@
     }
    ],
    "source": [
-    "!pip install -q -r requirements.txt"
+    "%pip install -q -r requirements.txt"
    ]
   },
   {
@@ -140,10 +140,10 @@
     }
    ],
    "source": [
-    "!curl https://docs.openvino.ai/2024/ovms_what_is_openvino_model_server.html --create-dirs -o ./docs/ovms_what_is_openvino_model_server.html\n",
-    "!curl https://docs.openvino.ai/2024/ovms_docs_metrics.html -o ./docs/ovms_docs_metrics.html\n",
-    "!curl https://docs.openvino.ai/2024/ovms_docs_streaming_endpoints.html -o ./docs/ovms_docs_streaming_endpoints.html\n",
-    "!curl https://docs.openvino.ai/2024/ovms_docs_target_devices.html -o ./docs/ovms_docs_target_devices.html\n"
+    "!curl https://docs.openvino.ai/2024/openvino-workflow/model-server/ovms_what_is_openvino_model_server.html --create-dirs -o ./docs/ovms_what_is_openvino_model_server.html\n",
+    "!curl https://docs.openvino.ai/2024/openvino-workflow/model-server/ovms_docs_metrics.html -o ./docs/ovms_docs_metrics.html\n",
+    "!curl https://docs.openvino.ai/2024/openvino-workflow/model-server/ovms_docs_streaming_endpoints.html -o ./docs/ovms_docs_streaming_endpoints.html\n",
+    "!curl https://docs.openvino.ai/2024/openvino-workflow/model-server/ovms_docs_target_devices.html -o ./docs/ovms_docs_target_devices.html"
    ]
   },
   {

--- a/demos/continuous_batching/rag/requirements.txt
+++ b/demos/continuous_batching/rag/requirements.txt
@@ -7,3 +7,4 @@ unstructured
 langchain-openai
 langchain
 langchainhub
+ipywidgets


### PR DESCRIPTION
The existing URLs now resulted in empty documents and a cryptic error. With the URLs from this PR the notebook works as expected.

Also added ipywidgets to requirements.txt (to prevent a message about it) and changed `!pip` to `%pip` because it should be safer with virtualenvs.

FWIW: I also had to build OVMS from source to run this demo, it didn't work with the image pulled from Docker hub
