### PR TITLE
rollback tokenizers and update genai

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ FUZZER_BUILD ?= 0
 #         - adjust binary version path - version variable is not passed to WORKSPACE file!
 OV_SOURCE_BRANCH ?= 03c9ae38292a90ecb5cbfe2c8d5472eed0ec1aa9  # master 2024-10-18
 OV_CONTRIB_BRANCH ?= 4272f47cb3ffbaf5c0fb5db569deb16856c578a1  # master 2024-10-11
-OV_TOKENIZERS_BRANCH ?= 57b236f113d78767657676cdefee6695e5e914ff  # master 2024-10-18
+OV_TOKENIZERS_BRANCH ?=  81c067c557d48011e6879a42d4a25147060eaeff # master 2024-10-18
 
 OV_SOURCE_ORG ?= openvinotoolkit
 OV_CONTRIB_ORG ?= openvinotoolkit

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ FUZZER_BUILD ?= 0
 #         - adjust binary version path - version variable is not passed to WORKSPACE file!
 OV_SOURCE_BRANCH ?= 03c9ae38292a90ecb5cbfe2c8d5472eed0ec1aa9  # master 2024-10-18
 OV_CONTRIB_BRANCH ?= 4272f47cb3ffbaf5c0fb5db569deb16856c578a1  # master 2024-10-11
-OV_TOKENIZERS_BRANCH ?=  81c067c557d48011e6879a42d4a25147060eaeff # master 2024-10-18
+OV_TOKENIZERS_BRANCH ?=  81c067c557d48011e6879a42d4a25147060eaeff # master 2024-09-19
 
 OV_SOURCE_ORG ?= openvinotoolkit
 OV_CONTRIB_ORG ?= openvinotoolkit

--- a/external/cb.patch
+++ b/external/cb.patch
@@ -1,15 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7059324..29f964a 100644
+index b08debb..4171092 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -59,8 +59,8 @@ endif()
- 
+@@ -62,9 +62,9 @@ endif()
+
  add_subdirectory(thirdparty)
  add_subdirectory(src)
 -add_subdirectory(samples)
+-add_subdirectory(tools/continuous_batching)
 -add_subdirectory(tests/cpp)
 +#add_subdirectory(samples)
++#add_subdirectory(tools/continuous_batching)
 +#add_subdirectory(tests/cpp)
- 
+
  install(FILES LICENSE DESTINATION docs/licensing COMPONENT licensing_genai RENAME LICENSE-GENAI)
  install(FILES third-party-programs.txt DESTINATION docs/licensing COMPONENT licensing_genai RENAME third-party-programs-genai.txt)
+

--- a/third_party/llm_engine/llm_engine.bzl
+++ b/third_party/llm_engine/llm_engine.bzl
@@ -20,7 +20,7 @@ def llm_engine():
     new_git_repository(
         name = "llm_engine",
         remote = "https://github.com/openvinotoolkit/openvino.genai",
-        commit = "ee5aa1ef95f1d0075b3b9d056ff86d360e7c736e", # master / 26 Sep 2024
+        commit = "72be4adef4ebeaec8ca7c63ce051cba5419a8fc3", # master / 22 oct 2024
         build_file = "@_llm_engine//:BUILD",
         init_submodules = True,
         recursive_init_submodules = True,


### PR DESCRIPTION
### 🛠 Summary

CVS-155625
rollback tokenizer version which reported execution error in embedding models

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

