### PR TITLE
Fix config path location in Makefile

### DIFF
--- a/demos/c_api_minimal_app/Makefile
+++ b/demos/c_api_minimal_app/Makefile
@@ -55,8 +55,8 @@ build_image:
 	cp -r ../../src/test/dummy capi/$(DIST_OS)/demos
 	cp -r ../../src/main_capi.c* capi/$(DIST_OS)/demos
 	cp -r ../../src/main_benchmark.cpp capi/$(DIST_OS)/demos
-	sed -i s+/ovms/src/test/c_api/config.json+/ovms/demos/config.json+ capi/$(DIST_OS)/demos/main_capi.c
-	sed -i s+/ovms/src/test/c_api/config_standard_dummy.json+/ovms/demos/config_standard_dummy.json+ capi/$(DIST_OS)/demos/main_capi.cpp
+	sed -i s+/ovms/src/test/configs/config.json+/ovms/demos/config.json+ capi/$(DIST_OS)/demos/main_capi.c
+	sed -i s+/ovms/src/test/configs/config_standard_dummy.json+/ovms/demos/config_standard_dummy.json+ capi/$(DIST_OS)/demos/main_capi.cpp
 	cd capi/$(DIST_OS)/ && docker build $(NO_CACHE_OPTION) -f Dockerfile.$(DIST_OS) . \
 		--build-arg http_proxy=$(HTTP_PROXY) --build-arg https_proxy="$(HTTPS_PROXY)" \
 		--build-arg no_proxy=$(NO_PROXY) \


### PR DESCRIPTION
Fix after moving test configs from 0cef8c9702b49b8ba42bdef1ab63d6c4f141f1c4 (#2683).

Ticket:CVS-155917

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [x] Change follows security best practices.


