### PR TITLE
Move sample cpu extension

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -302,7 +302,7 @@ COPY demos/benchmark/cpp/synthetic_client_async_benchmark.cpp demos/image_classi
 
 # Sample CPU Extension
 WORKDIR /ovms/src/example/SampleCpuExtension/
-RUN make && mv libcustom_relu_cpu_extension.so /opt
+RUN make && cp libcustom_relu_cpu_extension.so /opt
 
 RUN if ! [[ $debug_bazel_flags == *"py_off"* ]]; then true ; else exit 0 ; fi ; \
     mkdir -p /opt/intel/openvino/python/openvino-2024.5.dist-info && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -302,7 +302,7 @@ COPY demos/benchmark/cpp/synthetic_client_async_benchmark.cpp demos/image_classi
 
 # Sample CPU Extension
 WORKDIR /ovms/src/example/SampleCpuExtension/
-RUN make
+RUN make && mv libcustom_relu_cpu_extension.so /opt
 
 RUN if ! [[ $debug_bazel_flags == *"py_off"* ]]; then true ; else exit 0 ; fi ; \
     mkdir -p /opt/intel/openvino/python/openvino-2024.5.dist-info && \

--- a/src/test/embeddingsnode_test.cpp
+++ b/src/test/embeddingsnode_test.cpp
@@ -301,7 +301,7 @@ public:
         std::string port = "9173";
         ovms::Server& server = ovms::Server::instance();
         const char* configPath = "/ovms/src/test/embeddings/config_embeddings.json";
-        const char* extensionPath = "/ovms/src/example/SampleCpuExtension/libcustom_relu_cpu_extension.so";
+        const char* extensionPath = std::filesystem::exists("/opt/libcustom_relu_cpu_extension.so") ? "/opt/libcustom_relu_cpu_extension.so" : "/ovms/src/example/SampleCpuExtension/libcustom_relu_cpu_extension.so";
         server.setShutdownRequest(0);
         randomizePort(port);
         char* argv[] = {(char*)"ovms",


### PR DESCRIPTION
### 🛠 Summary

Currently	mounting /ovms will override cpu extension needed for unit tests.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

