### PR TITLE
CAPI callback error signaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ else
 endif
 
 ifeq ($(OV_TRACING_ENABLE),1)
-  OV_TRACING_PARAMS = " --cxxopt=-DOV_TRACING=1"
+  OV_TRACING_PARAMS = " --define OV_TRACE=1"
 else
   OV_TRACING_PARAMS = ""
 endif

--- a/common_settings.bzl
+++ b/common_settings.bzl
@@ -58,6 +58,17 @@ def create_config_settings():
         negate = ":disable_python",
     )
     native.config_setting(
+        name = "disable_ov_trace",
+        define_values = {
+            "OV_TRACE": "0",
+        },
+        visibility = ["//visibility:public"],
+    )
+    more_selects.config_setting_negation(
+        name = "not_disable_ov_trace",
+        negate = ":disable_ov_trace",
+    )
+    native.config_setting(
         name = "fuzzer_build",
         define_values = {
             "FUZZER_BUILD": "1",

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -63,26 +63,27 @@ In-case of problems, see [Debugging](#debugging).
 
 4. In the docker container context compile the source code via :
 	```bash
-	bazel build --config=linux --define PYTHON_DISABLE=0 --cxxopt=-DPYTHON_DISABLE=0 //src:ovms
+	bazel build --config=mp_on_py_on //src:ovms
+> **NOTE**: There are several options that would disable specific parts of OVMS. For details check ovms bazel build files.
 	```
 
 5. From the container, run a single unit test :
 	```bash
-	bazel test --config=linux --test_env PYTHONPATH=${PYTHONPATH} --define PYTHON_DISABLE=0 --cxxopt=-DPYTHON_DISABLE=0 --test_summary=detailed --test_output=all --test_filter='ModelVersionStatus.*' //src:ovms_test
+	bazel test --config=mp_on_py_on --test_summary=detailed --test_output=all --test_filter='ModelVersionStatus.*' //src:ovms_test
 	```
 
 | Argument      | Description |
 | :---        |    :----   |
 | `test`       | builds and runs the specified test target       |
 | `--test_summary=detailed`   |   the output includes failure information       |
-| `--test_output=all` | log all tests |
+| `--test_output=all` | log all tests stdout at the end |
 | `--test_filter='ModelVersionStatus.*'` | limits the tests run to the indicated test  |
 | `//src:ovms_test` | the test source |
 > **NOTE**: For more information, see the [bazel command-line reference](https://docs.bazel.build/versions/master/command-line-reference.html)
 > **NOTE**: If container has access to Intel GPU device and test models, add `--test_env RUN_GPU_TESTS=1` to run GPU unit tests.
 
 
-5. Select one of these options to change the target image name or network port to be used in tests. It might be helpful on a shared development host:
+6. Select one of these options to change the target image name or network port to be used in tests. It might be helpful on a shared development host:
 
 	* With a Docker cache :
 
@@ -340,7 +341,7 @@ Debugging options are available. Click on the required option :
 	mkdir -p /models/1 && wget -P /models/1 https://storage.openvinotoolkit.org/repositories/open_model_zoo/2022.1/models_bin/2/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin && wget -P /models/1 https://storage.openvinotoolkit.org/repositories/open_model_zoo/2022.1/models_bin/2/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
 	```
 	```bash
-	bazel build --config=linux //src:ovms -c dbg
+	bazel build --config=mp_on_py_on //src:ovms -c dbg
 	```
 	```bash
 	gdb --args ./bazel-bin/src/ovms --model_name resnet --model_path /models
@@ -357,6 +358,7 @@ Debugging options are available. Click on the required option :
 	```
 	# (in gdb cli) set follow-fork-mode child
 	```
+- For tracing what OpenVINO calls are used underneath you can use `--define OV_TRACE=1` option when building ovms with bazel or its tests.
 </details>
 
 <details><summary>Use minitrace to display flame graph</summary>

--- a/src/BUILD
+++ b/src/BUILD
@@ -19,6 +19,10 @@ load("//:common_settings.bzl",
      "COMMON_STATIC_TEST_COPTS", "COMMON_STATIC_LIBS_COPTS_VISIBLE", "COMMON_STATIC_LIBS_COPTS", "COMMON_STATIC_LIBS_LINKOPTS", "COMMON_FUZZER_COPTS", "COMMON_FUZZER_LINKOPTS", "COMMON_LOCAL_DEFINES",
      "create_config_settings")
 
+COPTS_OV_TRACE = select({
+    "//conditions:default": ["-DOV_TRACE=0"],
+    "//:not_disable_ov_trace" : ["-DOV_TRACE=1"],
+})
 COPTS_ADJUSTED = COMMON_STATIC_LIBS_COPTS + select({
         "//conditions:default": [],
         "//:fuzzer_build" : COMMON_FUZZER_COPTS,
@@ -41,16 +45,7 @@ COPTS_CLOUD = select({
     "//:not_disable_cloud" : ["-DCLOUD_DISABLE=0"],
 })
 
-COPTS_TESTS = COMMON_STATIC_TEST_COPTS + select({
-        "//conditions:default": ["-DPYTHON_DISABLE=1"],
-        "//:not_disable_python" : ["-DPYTHON_DISABLE=0"],
-}) + select({
-        "//conditions:default": ["-DMEDIAPIPE_DISABLE=1"],
-        "//:not_disable_mediapipe" : ["-DMEDIAPIPE_DISABLE=0"],
-}) + select({
-        "//conditions:default": ["-DCLOUD_DISABLE=1"],
-        "//:not_disable_cloud" : ["-DCLOUD_DISABLE=0"],
-})
+COPTS_TESTS = COMMON_STATIC_TEST_COPTS + COPTS_PYTHON + COPTS_MEDIAPIPE + COPTS_CLOUD
 
 config_setting(
     name = "windows",
@@ -59,14 +54,14 @@ config_setting(
 )
 
 cc_library(
-    name = "custom_nodes_common_lib",
+    name = "custom_nodes_common_buffersqueue",
     linkstatic = 1,
     hdrs = ["custom_nodes/common/buffersqueue.hpp"],
     srcs = [
-        "queue.hpp",
         "custom_nodes/common/buffersqueue.hpp",
         "custom_nodes/common/buffersqueue.cpp",
     ],
+    deps = ["libovms_queue"],
     copts = COMMON_STATIC_LIBS_COPTS_VISIBLE,
 )
 
@@ -164,6 +159,26 @@ mediapipe_proto_library(
 )
 
 cc_library(
+    name = "libovms_queue",
+    hdrs = ["queue.hpp"],
+    copts = [],
+    visibility = ["//visibility:public",],
+    linkopts = [],
+)
+cc_library(
+    name = "libovms_ovinferrequestsqueue",
+    hdrs = ["ovinferrequestsqueue.hpp"],
+    srcs = ["ovinferrequestsqueue.cpp"],
+    deps = [
+        "libovms_queue",
+        "libovmslogging",
+        "//third_party:openvino",
+    ],
+    copts = [],
+    visibility = ["//visibility:public",],
+    linkopts = [],
+)
+cc_library(
     name = "ovms_header",
     hdrs = ["ovms.h"],
     copts = [],
@@ -171,7 +186,152 @@ cc_library(
     linkopts = [],
     alwayslink = 1,
 )
-
+cc_library(
+    name = "libovms_server_settings",
+    hdrs = ["capi_frontend/server_settings.hpp"],
+    srcs = [],
+    deps = [],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_version",
+    hdrs = ["version.hpp"],
+    srcs = [],
+    deps = [],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_systeminfo",
+    hdrs = ["systeminfo.hpp"],
+    srcs = ["systeminfo.cpp"],
+    deps = [
+        "libovmslogging",
+        "libovmsstatus",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_config",
+    hdrs = ["config.hpp"],
+    srcs = ["config.cpp"],
+    deps = [
+        "libovms_server_settings",
+        "libovmslogging",
+        "libovmsmodelconfig",
+        "libovms_cliparser",
+        "libovms_systeminfo",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_cliparser",
+    hdrs = ["cli_parser.hpp"],
+    srcs = ["cli_parser.cpp"],
+    deps = [
+        "@com_github_jarro2783_cxxopts//:cxxopts",
+        "libovms_server_settings",
+        "libovms_version",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_capi_servable_metadata",
+    hdrs = ["capi_frontend/servablemetadata.hpp"],
+    srcs = ["capi_frontend/servablemetadata.cpp"],
+    deps = [
+        "libovms_tensorinfo",
+        "libovmsmodelversion",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_sequence",
+    hdrs = ["sequence.hpp"],
+    srcs = ["sequence.cpp"],
+    deps = [
+        "libovmsstatus",
+        "libovms_ov_utils",
+        "//third_party:openvino",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_sequence_manager",
+    hdrs = ["sequence_manager.hpp"],
+    srcs = ["sequence_manager.cpp"],
+    deps = [
+        "libovms_sequence",
+        "libovmsmodelversion",
+        "libovmsstatus",
+        "libovmslogging",
+        "libovms_sequence_processing_spec",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_sequence_processing_spec",
+    hdrs = ["sequence_processing_spec.hpp"],
+    deps = [],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_kfs_utils",
+    hdrs = ["kfs_frontend/kfs_utils.hpp"],
+    srcs = ["kfs_frontend/kfs_utils.cpp"],
+    deps = [
+        "//src/kfserving_api:kfserving_api_cpp",
+        "libovmslogging",
+        "libovmsstatus",
+        "libovmsprofiler",
+        "libovms_tensorinfo",
+        "libovmsprecision",
+        "libovmsmodelversion",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
+cc_library(
+    name = "libovms_kfs_grpc_inference_service_h",
+    hdrs = ["kfs_frontend/kfs_grpc_inference_service.hpp"],
+    deps = [
+        "//src/kfserving_api:kfserving_api_cpp",
+        "//third_party:openvino",
+        "@com_github_grpc_grpc//:grpc++",
+    ],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
 cc_library(
     name = "ovms_lib",
     hdrs = ["ovms.h",
@@ -179,15 +339,8 @@ cc_library(
     ],
     srcs = [
         "capi_frontend/capi.cpp",
-        "capi_frontend/servablemetadata.cpp",
-        "capi_frontend/servablemetadata.hpp",
-        "capi_frontend/server_settings.hpp",
         "cleaner_utils.cpp",
         "cleaner_utils.hpp",
-        "cli_parser.cpp",
-        "cli_parser.hpp",
-        "config.cpp",
-        "config.hpp",
         "custom_node_interface.h",
         "customloaderconfig.hpp",
         "customloaders.hpp",
@@ -260,9 +413,6 @@ cc_library(
         "grpcservermodule.cpp",
         "grpcservermodule.hpp",
         "kfs_frontend/kfs_grpc_inference_service.cpp",
-        "kfs_frontend/kfs_grpc_inference_service.hpp",
-        "kfs_frontend/kfs_utils.cpp",
-        "kfs_frontend/kfs_utils.hpp",
         "model.cpp",
         "model.hpp",
         "modelchangesubscription.cpp",
@@ -277,10 +427,6 @@ cc_library(
         "model_service.cpp",
         "model_metric_reporter.cpp",
         "model_metric_reporter.hpp",
-        "module.hpp",
-        "ovinferrequestsqueue.hpp",
-        "ov_utils.cpp",
-        "ov_utils.hpp",
         "ovms.h",
         "ovms_exit_codes.hpp",
         "prediction_service.cpp",
@@ -299,19 +445,8 @@ cc_library(
         "servablemanagermodule.hpp",
         "server.cpp",
         "server.hpp",
-        "sequence.cpp",
-        "sequence.hpp",
-        "sequence_manager.cpp",
-        "sequence_manager.hpp",
-        "sequence_processing_spec.hpp",
         "statefulmodelinstance.cpp",
         "statefulmodelinstance.hpp",
-        "systeminfo.cpp",
-        "systeminfo.hpp",
-        "queue.hpp",
-        "tensorinfo.cpp",
-        "tensorinfo.hpp",
-        "version.hpp",
         "tensor_conversion.hpp",
         "tensor_conversion.cpp",
          ] + select({
@@ -346,6 +481,7 @@ cc_library(
                 "//src/rerank:rerankcalculator",],
         }) + [
             "cpp_headers",
+            "libovms_capi_servable_metadata",
             "libmodelconfigjsonparser",
             "libovmsmodelconfig",
             "libovmscapibuffer",
@@ -354,6 +490,8 @@ cc_library(
             "libovmscapiinferencerequest",
             "libovmscapiinferenceresponse",
             "libovmscapiinferencetensor",
+            "libovms_cliparser",
+            "libovms_config",
             "libovmsdagspipelinedefinitionstatus",
             "libovms_dags_aliases",
             "libovms_dags_node",
@@ -366,18 +504,28 @@ cc_library(
             "libovmsfilesystem",
             "libovmsfilesystemfactory_h",
             "libovmsfilesystemfactory", # TODO FIXME missing symbols @atobisze when not in ovms_lib
+            "libovms_kfs_utils",
+            "libovms_kfs_grpc_inference_service_h",
             "libovmslocalfilesystem", # indirectly & directly through factory
             "libovmslogging",
             "libovmsmetrics",
+            "libovms_ov_utils",
             "libovmsprecision",
             "libovmsshape",
             "libovmsschema",
             "libovmslayout",
             "libovmslayout_configuration",
+            "libovms_tensorinfo",
             "libovmstimer",
             "libovmstfs_grpc",
-            "//src:libovmsprofiler",
+            "libovms_version",
+            "libovmsprofiler",
             "libovmsstatus",
+            "libovms_sequence",
+            "libovms_sequence_manager",
+            "libovms_sequence_processing_spec",
+            "libovms_queue",
+            "libovms_ovinferrequestsqueue",
             "libovmstensor_utils",
             "libovms_dags_tensormap",
             "libovmsstring_utils",
@@ -417,7 +565,7 @@ cc_library(
         }),
     visibility = ["//visibility:public",],
     local_defines = COMMON_LOCAL_DEFINES,
-    copts = COPTS_ADJUSTED + COPTS_PYTHON + COPTS_MEDIAPIPE,
+    copts = COPTS_ADJUSTED + COPTS_PYTHON + COPTS_MEDIAPIPE + COPTS_OV_TRACE,
     linkopts = LINKOPTS_ADJUSTED + select({
                 "//conditions:default": ["-lOpenCL"], # TODO make as direct dependency
                 "//src:windows" : [],}),
@@ -439,6 +587,7 @@ cc_library(
         "profilermodule.cpp",],
     deps = [
         "@minitrace//:trace",
+        "libovms_module",
         "//src:cpp_headers",
         "//src:libovmslogging",
         "//src:libovmsstatus",
@@ -462,7 +611,7 @@ cc_library(
     ],
     visibility = ["//visibility:public",],
     local_defines = COMMON_LOCAL_DEFINES,
-    copts = COPTS_ADJUSTED,
+    copts = COPTS_ADJUSTED + COPTS_OV_TRACE,
     linkopts = LINKOPTS_ADJUSTED,
     alwayslink = 1,
 )
@@ -505,6 +654,14 @@ cc_library(
     alwayslink = 1,
 )
 
+cc_library(
+    name = "libovms_module",
+    hdrs = ["module.hpp"],
+    visibility = ["//visibility:public",],
+    local_defines = COMMON_LOCAL_DEFINES,
+    copts = COPTS_ADJUSTED,
+    linkopts = LINKOPTS_ADJUSTED,
+)
 cc_library(
     name = "libovmsprecision",
     hdrs = ["precision.hpp"],
@@ -628,14 +785,15 @@ cc_binary(
     name = "libcustom_node_add_one.so",
     srcs = [
         "custom_nodes/common/utils.hpp",
-        "custom_nodes/common/buffersqueue.hpp",
-        "custom_nodes/common/buffersqueue.cpp",
         "custom_nodes/common/custom_node_library_internal_manager.hpp",
         "custom_nodes/common/custom_node_library_internal_manager.cpp",
-        "queue.hpp",
         "custom_nodes/add_one/add_one.cpp",
         "custom_node_interface.h",
         "custom_nodes/add_one/add_one_internal_manager.hpp"
+    ],
+    deps = [
+        "custom_nodes_common_buffersqueue",
+        "libovms_queue",
     ],
     linkshared = 1,
     copts = COMMON_STATIC_LIBS_COPTS_VISIBLE,
@@ -646,16 +804,15 @@ cc_binary(
     srcs = [
         "custom_nodes/common/utils.hpp",
         "custom_nodes/common/opencv_utils.hpp",
-        "custom_nodes/common/buffersqueue.hpp",
-        "custom_nodes/common/buffersqueue.cpp",
         "custom_nodes/common/custom_node_library_internal_manager.hpp",
         "custom_nodes/common/custom_node_library_internal_manager.cpp",
-        "queue.hpp",
         "custom_nodes/model_zoo_intel_object_detection/model_zoo_intel_object_detection.cpp",
         "custom_node_interface.h",
     ],
     deps = [
+        "custom_nodes_common_buffersqueue",
         "//third_party:opencv",
+        "libovms_queue",
     ],
     linkshared = 1,
     copts = COMMON_STATIC_LIBS_COPTS_VISIBLE,
@@ -754,6 +911,7 @@ cc_library( # TODO split dependencies
         "@tensorflow_serving//tensorflow_serving/util/net_http/server/public:http_server_api",
         "@tensorflow_serving//tensorflow_serving/util:threadpool_executor",
         "@tensorflow_serving//tensorflow_serving/util:json_tensor",
+        "libovms_module",
         "libovmslogging",
         "libovmsprofiler",
         "libovmsstatus",
@@ -805,6 +963,7 @@ cc_library(
         "@com_github_jupp0r_prometheus_cpp//core",
         "@com_github_tencent_rapidjson//:rapidjson",
         "cpp_headers",
+        "libovms_module",
         "libovmslogging",
         "libovmsschema",
         "libovmsstatus",
@@ -1515,7 +1674,7 @@ cc_library( # TODO split further
         "status.hpp",
         "module_names.hpp",
         "module_names.cpp",
-        "module.hpp",],
+    ],
     deps = [],
     visibility = ["//visibility:public"],
     local_defines = COMMON_LOCAL_DEFINES,
@@ -1810,7 +1969,7 @@ cc_test(
             ":libtest_gpuenvironment",
             "//src:ovms_lib",
             "//src:libovmsfilesystemfactory",
-            "//src:custom_nodes_common_lib",
+            "//src:custom_nodes_common_buffersqueue",
             "@com_google_googletest//:gtest",
             ] + select({
                 "//conditions:default": [

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -944,7 +944,7 @@ DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceReq
             if (!success) {
                 if (!userCallback)
                     return;
-                SPDLOG_DEBUG("Calling user provided callback with success: {}", success);
+                SPDLOG_DEBUG("Calling user provided callback with failure");
                 Timer<TIMER_END> timer;
                 timer.start(TIMER_CALLBACK);
                 userCallback(nullptr, 1, userCallbackData);
@@ -955,6 +955,7 @@ DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceReq
                 if (userCallback) {
                     Timer<TIMER_END> timer;
                     *userResponsePtr = reinterpret_cast<OVMS_InferenceResponse*>(response.release());
+                    SPDLOG_DEBUG("Calling user provided callback with success");
                     timer.start(TIMER_CALLBACK);
                     userCallback(*userResponsePtr, 0, userCallbackData);
                     timer.stop(TIMER_CALLBACK);

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -943,7 +943,7 @@ DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceReq
         ~CallbackGuard() {
             if (!success) {
                 if (!userCallback)
-                   return;
+                    return;
                 SPDLOG_DEBUG("Calling user provided callback with success: {}", success);
                 Timer<TIMER_END> timer;
                 timer.start(TIMER_CALLBACK);

--- a/src/capi_frontend/capi.cpp
+++ b/src/capi_frontend/capi.cpp
@@ -929,6 +929,43 @@ static Status getPipelineDefinition(Server& server, const std::string& servableN
 }  // namespace
 
 DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceRequest* request, OVMS_InferenceResponse** response) {
+    struct CallbackGuard {
+        OVMS_InferenceRequestCompletionCallback_t userCallback{nullptr};
+        void* userCallbackData{nullptr};
+        bool success{false};
+        OVMS_InferenceResponse** userResponsePtr{nullptr};
+        std::unique_ptr<ovms::InferenceResponse> response{nullptr};
+        CallbackGuard(OVMS_InferenceRequestCompletionCallback_t userCallback, void* userCallbackData, OVMS_InferenceResponse** userResponse, std::unique_ptr<ovms::InferenceResponse>&& response) :
+            userCallback(userCallback),
+            userCallbackData(userCallbackData),
+            userResponsePtr(userResponse),
+            response(std::move(response)) {}
+        ~CallbackGuard() {
+            if (!success) {
+                if (!userCallback)
+                   return;
+                SPDLOG_DEBUG("Calling user provided callback with success: {}", success);
+                Timer<TIMER_END> timer;
+                timer.start(TIMER_CALLBACK);
+                userCallback(nullptr, 1, userCallbackData);
+                timer.stop(TIMER_CALLBACK);
+                double reqCallback = timer.elapsed<microseconds>(TIMER_CALLBACK);
+                SPDLOG_DEBUG("Called response complete callback time: {} ms", reqCallback / 1000);
+            } else {
+                if (userCallback) {
+                    Timer<TIMER_END> timer;
+                    *userResponsePtr = reinterpret_cast<OVMS_InferenceResponse*>(response.release());
+                    timer.start(TIMER_CALLBACK);
+                    userCallback(*userResponsePtr, 0, userCallbackData);
+                    timer.stop(TIMER_CALLBACK);
+                    double reqCallback = timer.elapsed<microseconds>(TIMER_CALLBACK);
+                    SPDLOG_DEBUG("Called response complete callback time: {} ms", reqCallback / 1000);
+                } else {
+                    *userResponsePtr = reinterpret_cast<OVMS_InferenceResponse*>(response.release());
+                }
+            }
+        }
+    };
     OVMS_PROFILE_FUNCTION();
     using std::chrono::microseconds;
     Timer<TIMER_END> timer;
@@ -944,6 +981,12 @@ DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceReq
     }
     auto req = reinterpret_cast<ovms::InferenceRequest*>(request);
     ovms::Server& server = *reinterpret_cast<ovms::Server*>(serverPtr);
+    OVMS_InferenceRequestCompletionCallback_t callback = nullptr;
+    callback = req->getResponseCompleteCallback();
+    std::unique_ptr<ovms::InferenceResponse> responseTemp(new ovms::InferenceResponse(req->getServableName(), req->getServableVersion()));
+    std::unique_ptr<ModelInstanceUnloadGuard> modelInstanceUnloadGuard;
+    CallbackGuard callbackGuard(callback, req->getResponseCompleteCallbackData(), response, std::move(responseTemp));
+    auto& res = callbackGuard.response;
 
     SPDLOG_DEBUG("Processing C-API inference request for servable: {}; version: {}",
         req->getServableName(),
@@ -952,10 +995,8 @@ DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceReq
     std::shared_ptr<ovms::ModelInstance> modelInstance;
     std::unique_ptr<ovms::Pipeline> pipelinePtr;
 
-    std::unique_ptr<ModelInstanceUnloadGuard> modelInstanceUnloadGuard;
     auto status = getModelInstance(server, req->getServableName(), req->getServableVersion(), modelInstance, modelInstanceUnloadGuard);
 
-    std::unique_ptr<ovms::InferenceResponse> res(new ovms::InferenceResponse(req->getServableName(), req->getServableVersion()));
     if (status == StatusCode::MODEL_NAME_MISSING) {
         SPDLOG_DEBUG("Requested model: {} does not exist. Searching for pipeline with that name...", req->getServableName());
         status = getPipeline(server, req, res.get(), pipelinePtr);
@@ -981,7 +1022,6 @@ DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceReq
     }
 
     if (!status.ok()) {
-        // TODO fixme error handling with callbacks - we may need to move callback usage here
         return reinterpret_cast<OVMS_Status*>(new Status(std::move(status)));
     }
 
@@ -993,20 +1033,7 @@ DLL_PUBLIC OVMS_Status* OVMS_Inference(OVMS_Server* serverPtr, OVMS_InferenceReq
         //   OBSERVE_IF_ENABLED(modelInstance->getMetricReporter().reqTimeGrpc, reqTotal);
     }
     SPDLOG_DEBUG("Total C-API req processing time: {} ms", reqTotal / 1000);
-
-    *response = reinterpret_cast<OVMS_InferenceResponse*>(res.release());
-    OVMS_InferenceRequestCompletionCallback_t callback = nullptr;
-    callback = req->getResponseCompleteCallback();
-    // TODO cleanup all paths
-    if (callback) {
-        timer.start(TIMER_CALLBACK);
-        auto completeCallbackData = req->getResponseCompleteCallbackData();
-        SPDLOG_DEBUG("Calling response complete callback");
-        callback(*response, 0, completeCallbackData);
-        timer.stop(TIMER_CALLBACK);
-        double reqCallback = timer.elapsed<microseconds>(TIMER_CALLBACK);
-        SPDLOG_DEBUG("Called response complete callback time: {} ms", reqCallback / 1000);
-    }
+    callbackGuard.success = true;
     return nullptr;
 }
 

--- a/src/executingstreamidguard.cpp
+++ b/src/executingstreamidguard.cpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #include "executingstreamidguard.hpp"
 
+#include "logging.hpp"
 #include "model_metric_reporter.hpp"
 #include "ovinferrequestsqueue.hpp"
 
@@ -44,6 +45,7 @@ StreamIdGuard::StreamIdGuard(OVInferRequestsQueue& inferRequestsQueue) :
     inferRequestsQueue_(inferRequestsQueue),
     id_(inferRequestsQueue_.getIdleStream().get()),
     inferRequest(inferRequestsQueue.getInferRequest(id_)) {
+    SPDLOG_TRACE("Got request id:{}", getId());
 }
 
 StreamIdGuard::~StreamIdGuard() {

--- a/src/kfs_frontend/kfs_grpc_inference_service.hpp
+++ b/src/kfs_frontend/kfs_grpc_inference_service.hpp
@@ -22,26 +22,10 @@
 #include <grpcpp/server_context.h>
 #include <openvino/openvino.hpp>
 
+#include "kfs_utils.hpp"
 #include "src/kfserving_api/grpc_predict_v2.grpc.pb.h"
 #include "src/kfserving_api/grpc_predict_v2.pb.h"
-
 using inference::GRPCInferenceService;
-using KFSServerMetadataRequest = inference::ServerMetadataRequest;
-using KFSServerMetadataResponse = inference::ServerMetadataResponse;
-using KFSModelMetadataRequest = inference::ModelMetadataRequest;
-using KFSModelMetadataResponse = inference::ModelMetadataResponse;
-using KFSRequest = inference::ModelInferRequest;
-using KFSResponse = inference::ModelInferResponse;
-using KFSStreamResponse = inference::ModelStreamInferResponse;
-using KFSServerReaderWriter = ::grpc::ServerReaderWriterInterface<KFSStreamResponse, KFSRequest>;
-using KFSTensorInputProto = inference::ModelInferRequest::InferInputTensor;
-using KFSTensorOutputProto = inference::ModelInferResponse::InferOutputTensor;
-using KFSShapeType = google::protobuf::RepeatedField<int64_t>;
-using KFSGetModelStatusRequest = inference::ModelReadyRequest;
-using KFSGetModelStatusResponse = inference::ModelReadyResponse;
-using KFSDataType = std::string;
-using KFSInputTensorIteratorType = google::protobuf::internal::RepeatedPtrIterator<const ::inference::ModelInferRequest_InferInputTensor>;
-using KFSOutputTensorIteratorType = google::protobuf::internal::RepeatedPtrIterator<const ::inference::ModelInferResponse_InferOutputTensor>;
 
 struct KFSModelExtraMetadata {
     ov::AnyMap rt_info;

--- a/src/kfs_frontend/kfs_utils.cpp
+++ b/src/kfs_frontend/kfs_utils.cpp
@@ -26,7 +26,6 @@
 #include "../profiler.hpp"
 #include "../status.hpp"
 #include "../tensorinfo.hpp"
-#include "opencv2/opencv.hpp"
 
 namespace ovms {
 Precision KFSPrecisionToOvmsPrecision(const KFSDataType& datatype) {
@@ -215,5 +214,4 @@ Status validateRequestCoherencyKFS(const KFSRequest& request, const std::string 
     }
     return StatusCode::OK;
 }
-
 }  // namespace ovms

--- a/src/kfs_frontend/kfs_utils.hpp
+++ b/src/kfs_frontend/kfs_utils.hpp
@@ -18,8 +18,25 @@
 
 #include "../modelversion.hpp"
 #include "../precision.hpp"
-#include "kfs_grpc_inference_service.hpp"
+#include "src/kfserving_api/grpc_predict_v2.grpc.pb.h"
+#include "src/kfserving_api/grpc_predict_v2.pb.h"
 
+using KFSServerMetadataRequest = inference::ServerMetadataRequest;
+using KFSServerMetadataResponse = inference::ServerMetadataResponse;
+using KFSModelMetadataRequest = inference::ModelMetadataRequest;
+using KFSModelMetadataResponse = inference::ModelMetadataResponse;
+using KFSRequest = inference::ModelInferRequest;
+using KFSResponse = inference::ModelInferResponse;
+using KFSStreamResponse = inference::ModelStreamInferResponse;
+using KFSServerReaderWriter = ::grpc::ServerReaderWriterInterface<KFSStreamResponse, KFSRequest>;
+using KFSTensorInputProto = inference::ModelInferRequest::InferInputTensor;
+using KFSTensorOutputProto = inference::ModelInferResponse::InferOutputTensor;
+using KFSShapeType = google::protobuf::RepeatedField<int64_t>;
+using KFSGetModelStatusRequest = inference::ModelReadyRequest;
+using KFSGetModelStatusResponse = inference::ModelReadyResponse;
+using KFSDataType = std::string;
+using KFSInputTensorIteratorType = google::protobuf::internal::RepeatedPtrIterator<const ::inference::ModelInferRequest_InferInputTensor>;
+using KFSOutputTensorIteratorType = google::protobuf::internal::RepeatedPtrIterator<const ::inference::ModelInferResponse_InferOutputTensor>;
 namespace ovms {
 class Status;
 std::string tensorShapeToString(const KFSShapeType& tensorShape);

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<spdlog::logger> llm_calculator_logger = std::make_shared<spdlog:
 std::shared_ptr<spdlog::logger> embeddings_calculator_logger = std::make_shared<spdlog::logger>("embeddings_calculator");
 std::shared_ptr<spdlog::logger> rerank_calculator_logger = std::make_shared<spdlog::logger>("rerank_calculator");
 #endif
-#if (OV_TRACING == 1)
+#if (OV_TRACE == 1)
 std::shared_ptr<spdlog::logger> ov_logger = std::make_shared<spdlog::logger>("openvino");
 #endif
 const std::string default_pattern = "[%Y-%m-%d %T.%e][%t][%n][%l][%s:%#] %v";
@@ -76,7 +76,7 @@ static void register_loggers(const std::string& log_level, std::vector<spdlog::s
     llm_calculator_logger->set_pattern(default_pattern);
     rerank_calculator_logger->set_pattern(default_pattern);
 #endif
-#if (OV_TRACING == 1)
+#if (OV_TRACE == 1)
     ov_logger->set_pattern(default_pattern);
 #endif
     for (auto& sink : sinks) {
@@ -93,7 +93,7 @@ static void register_loggers(const std::string& log_level, std::vector<spdlog::s
         llm_calculator_logger->sinks().push_back(sink);
         rerank_calculator_logger->sinks().push_back(sink);
 #endif
-#if (OV_TRACING == 1)
+#if (OV_TRACE == 1)
         ov_logger->sinks().push_back(sink);
 #endif
     }
@@ -111,7 +111,7 @@ static void register_loggers(const std::string& log_level, std::vector<spdlog::s
     set_log_level(log_level, llm_calculator_logger);
     set_log_level(log_level, rerank_calculator_logger);
 #endif
-#if (OV_TRACING == 1)
+#if (OV_TRACE == 1)
     set_log_level(log_level, ov_logger);
 #endif
     spdlog::set_default_logger(serving_logger);

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -39,7 +39,7 @@ extern std::shared_ptr<spdlog::logger> llm_calculator_logger;
 extern std::shared_ptr<spdlog::logger> embeddings_calculator_logger;
 extern std::shared_ptr<spdlog::logger> rerank_calculator_logger;
 #endif
-#if (OV_TRACING == 1)
+#if (OV_TRACE == 1)
 extern std::shared_ptr<spdlog::logger> ov_logger;
 #define OV_LOGGER(...) SPDLOG_LOGGER_TRACE(ov_logger, __VA_ARGS__)
 #else

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -1549,22 +1549,22 @@ bool ModelInstance::doesSupportOutputReset() const {
 
 #pragma GCC diagnostic pop
 template <typename RequestType, typename ResponseType>
-Status ModelInstance::inferAsync(const RequestType* requestProto,
+Status ModelInstance::inferAsync(const RequestType* request,
     std::unique_ptr<ModelInstanceUnloadGuard>& modelUnloadGuardPtr) {
     OVMS_PROFILE_FUNCTION();
     Timer<TIMER_END> timer;
     using std::chrono::microseconds;
     // we don't have response yet
-    // auto requestProcessor = createRequestProcessor(requestProto, responseProto);  // request, response passed only to deduce type
-    // auto status = requestProcessor->extractRequestParameters(requestProto);
+    // auto requestProcessor = createRequestProcessor(request, responseProto);  // request, response passed only to deduce type
+    // auto status = requestProcessor->extractRequestParameters(request);
     // if (!status.ok())
     //    return status;
-    auto status = validate(requestProto);
+    auto status = validate(request);
     if (status.batchSizeChangeRequired() || status.reshapeRequired()) {
         // We are ensured that request shape is valid and convertible to model shape (non negative, non zero)
         // We can use it to perform reshape via shape=auto
-        auto requestBatchSize = getRequestBatchSize(requestProto, this->getBatchSizeIndex());
-        auto requestShapes = getRequestShapes(requestProto);
+        auto requestBatchSize = getRequestBatchSize(request, this->getBatchSizeIndex());
+        auto requestShapes = getRequestShapes(request);
         status = reloadModelIfRequired(status, requestBatchSize, requestShapes, modelUnloadGuardPtr);
     }
     if (!status.ok())
@@ -1601,7 +1601,7 @@ Status ModelInstance::inferAsync(const RequestType* requestProto,
     if (this->doesSupportOutputReset()) {
         outKeeper = std::make_shared<OutputKeeper>(executingStreamIdGuard.getInferRequest(), getOutputsInfo());
     }
-    status = deserializePredictRequest<ConcreteTensorProtoDeserializator, InputSink<ov::InferRequest&>>(*requestProto, getInputsInfo(), getOutputsInfo(), inputSink, isPipeline, this->tensorFactories);
+    status = deserializePredictRequest<ConcreteTensorProtoDeserializator, InputSink<ov::InferRequest&>>(*request, getInputsInfo(), getOutputsInfo(), inputSink, isPipeline, this->tensorFactories);
     timer.stop(DESERIALIZE);
     if (!status.ok()) {
         SPDLOG_DEBUG("Deserialization of outputs failed for model {}, version {}", getName(), getVersion());
@@ -1611,17 +1611,51 @@ Status ModelInstance::inferAsync(const RequestType* requestProto,
         getName(), getVersion(), executingInferId, timer.elapsed<microseconds>(DESERIALIZE) / 1000);
     // set callback
     // TODO check if there is callback in async
-    OVMS_InferenceRequestCompletionCallback_t userCallback = requestProto->getResponseCompleteCallback();
+    OVMS_InferenceRequestCompletionCallback_t userCallback = request->getResponseCompleteCallback();
     if (userCallback == nullptr) {
         SPDLOG_DEBUG("User callback not set for async inference.");
         return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
     }
 
-    void* userCallbackData = requestProto->getResponseCompleteCallbackData();
+    void* userCallbackData = request->getResponseCompleteCallbackData();
     // here pass by copy into callback
     {
-        inferRequest.set_callback([this, requestProto, &inferRequest, movedOutputKeeper = std::move(outKeeper), userCallback, userCallbackData, modelUnloadGuardPtrMoved = std::shared_ptr<ModelInstanceUnloadGuard>(std::move(modelUnloadGuardPtr))](std::exception_ptr exception) mutable {
+        inferRequest.set_callback([this, request, &inferRequest, movedOutputKeeper = std::move(outKeeper), userCallback, userCallbackData, modelUnloadGuardPtrMoved = std::shared_ptr<ModelInstanceUnloadGuard>(std::move(modelUnloadGuardPtr))](std::exception_ptr exception) mutable {
+            struct CallbackGuard {
+                OVMS_InferenceRequestCompletionCallback_t userCallback{nullptr};
+                void* userCallbackData{nullptr};
+                bool success{false};
+                ov::InferRequest& request;
+                OVMS_InferenceResponse* response{nullptr};
+                CallbackGuard(OVMS_InferenceRequestCompletionCallback_t userCallback, void* userCallbackData, ov::InferRequest& request) :
+                    userCallback(userCallback),
+                    userCallbackData(userCallbackData),
+                    request(request) {}
+                ~CallbackGuard() {
+                    SPDLOG_DEBUG("Calling user provided callback with success: {}", success);
+                    if (!success) {
+                        userCallback(nullptr, 1, userCallbackData);
+                    } else {
+                        userCallback(response, 0, userCallbackData);
+                    }
+                    SPDLOG_DEBUG("Called user provided callback");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+                    try {
+                        OV_LOGGER("ov::InferRequest: {} set_callback() with empty lambda", (void*)&request);
+                        request.set_callback([](std::exception_ptr exception_ptr) {});
+                    } catch (std::exception& e) {
+                        SPDLOG_ERROR("Caught critical exception from OpenVINO InferRequest", e.what());
+                        throw e;
+                    } catch (...) {
+                        SPDLOG_ERROR("Caught critical exception from OpenVINO InferRequest");
+                        throw;
+                    }
+#pragma GCC diagnostic pop
+                }
+            };
             SPDLOG_DEBUG("Entry of ov::InferRequest callback call");
+            CallbackGuard callbackGuard(userCallback, userCallbackData, inferRequest);
             if (exception) {
                 try {
                     SPDLOG_DEBUG("rethrow_exception");
@@ -1633,24 +1667,22 @@ Status ModelInstance::inferAsync(const RequestType* requestProto,
                     return;
                 }
             }
-            // here use OVMS response serialization
-            // here call user set callback
-            // here will go OVMS C-API serialization code
             std::unique_ptr<ResponseType> res(new ResponseType(this->getName(), this->getVersion()));
             OutputGetter<ov::InferRequest&> outputGetter(inferRequest);
             try {
                 // TODO created filter based on what is in request, then perform casual serialization for what was NOT in request, and rewrite tensors from request to response for those that were
-                auto status = serializePredictResponse(outputGetter, getName(), getVersion(), getOutputsInfo(), requestProto, res.get(), getTensorInfoName, useSharedOutputContentFn(requestProto));  // TODO FIXME handle status
+                auto status = serializePredictResponse(outputGetter, getName(), getVersion(), getOutputsInfo(), request, res.get(), getTensorInfoName, useSharedOutputContentFn(request));
+                if (!status.ok()) {
+                    SPDLOG_DEBUG("Encountered issue during response serialization:{}", status.string());
+                    return;
+                }
             } catch (std::exception& e) {
                 SPDLOG_DEBUG("caught exception in ov::InferRequest callback: {}", e.what());
             } catch (...) {
                 SPDLOG_DEBUG("caught exception in ov::InferRequest callback");
             }
-            OVMS_InferenceResponse* response = reinterpret_cast<OVMS_InferenceResponse*>(res.release());
-            SPDLOG_DEBUG("Calling user provided callback");  // TODO check if this shows
-            userCallback(response, 1, userCallbackData);
-            SPDLOG_DEBUG("Called user provided callback");                       // TODO check if this shows
-            inferRequest.set_callback([](std::exception_ptr exception_ptr) {});  // reset callback on infer request // TODO this should be called on all exit paths
+            callbackGuard.response = reinterpret_cast<OVMS_InferenceResponse*>(res.release());
+            callbackGuard.success = true;
         });
     }
 

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -279,8 +279,10 @@ private:
     /**
          * @brief Holds the information about outputs and it's parameters
          */
+protected:
     tensor_map_t outputsInfo;
 
+private:
     /**
          * @brief OpenVINO inference execution stream pool
          */

--- a/src/ovinferrequestsqueue.cpp
+++ b/src/ovinferrequestsqueue.cpp
@@ -1,5 +1,5 @@
 //*****************************************************************************
-// Copyright 2020 Intel Corporation
+// Copyright 2024 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,17 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#pragma once
+#include "ovinferrequestsqueue.hpp"
 
 #include <openvino/openvino.hpp>
 
-#include "queue.hpp"
+#include "logging.hpp"
 
 namespace ovms {
-
-class OVInferRequestsQueue : public Queue<ov::InferRequest> {
-public:
-    OVInferRequestsQueue(ov::CompiledModel& compiledModel, int streamsLength);
-};
-
+OVInferRequestsQueue::OVInferRequestsQueue(ov::CompiledModel& compiledModel, int streamsLength) :
+    Queue(streamsLength) {
+    for (int i = 0; i < streamsLength; ++i) {
+        streams[i] = i;
+        OV_LOGGER("ov::CompiledModel: {} compiledModel.create_infer_request()", reinterpret_cast<void*>(&compiledModel));
+        inferRequests.push_back(compiledModel.create_infer_request());
+    }
+}
 }  // namespace ovms

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -33,7 +33,7 @@ typedef struct OVMS_ServableMetadata_ OVMS_ServableMetadata;
 typedef struct OVMS_Metadata_ OVMS_Metadata;
 
 #define OVMS_API_VERSION_MAJOR 1
-#define OVMS_API_VERSION_MINOR 1
+#define OVMS_API_VERSION_MINOR 2
 
 // Function to retrieve OVMS API version.
 //
@@ -579,12 +579,17 @@ OVMS_Status* OVMS_InferenceAsync(OVMS_Server* server, OVMS_InferenceRequest* req
 // Flag specifies if the response is final coming from inference request, and if there were errors in execution
 //
 // \param response resp
-// \param flag Flag specifying if the response is final response for request
+// \param flag Flag specifying if the call was successful - 0, or not
 // \param userStruct Data provided to callback, set in OVMS_InferenceRequestSetCompletionCallback
 typedef void (* OVMS_InferenceRequestCompletionCallback_t)(OVMS_InferenceResponse*, uint32_t flag, void* userstruct);
 
-// TODO description
-// TODO consider allocators
+// Set callback for inference request
+//
+// Setting completion callback with OVMS_InferenceRequestSetCompletionCallback is required to receive a reply.
+//
+// \param server The server object
+// \param completeCallback The callback
+// \return OVMS_Status object in case of failure to set callback
 OVMS_Status* OVMS_InferenceRequestSetCompletionCallback(OVMS_InferenceRequest*, OVMS_InferenceRequestCompletionCallback_t completeCallback, void* userStruct);
 
 // Get OVMS_ServableMetadata object

--- a/src/predict_request_validation_utils.cpp
+++ b/src/predict_request_validation_utils.cpp
@@ -74,7 +74,7 @@ Status validateCapiTensorContent(const InferenceTensor& tensor, ovms::Precision 
         std::stringstream ss;
         ss << "Servable: " << servableName
            << "; version: " << servableVersion
-           << "; is missing buffer for tensor: " << bufferId;
+           << "; is missing buffer for tensor: " << tensorName;
         const std::string details = ss.str();
         SPDLOG_DEBUG(details);
         return Status(StatusCode::NONEXISTENT_BUFFER, details);
@@ -719,7 +719,7 @@ Status RequestValidator<RequestType, InputTensorType, choice, IteratorType, Shap
 
     if (buffer->getBufferType() == OVMS_BUFFERTYPE_CPU && buffer->getDeviceId() != std::nullopt && buffer->getDeviceId() != 0) {
         std::stringstream ss;
-        ss << "Required input ";
+        ss << "Required input " << getCurrentlyValidatedTensorName();
         const std::string details = ss.str();
         SPDLOG_DEBUG("[servable name: {} version: {}] Has invalid device id for buffer, input with specific name - {}", servableName, servableVersion, details);
         return Status(StatusCode::INVALID_DEVICE_ID, details);

--- a/src/python/BUILD
+++ b/src/python/BUILD
@@ -162,6 +162,7 @@ cc_library(
     deps = PYBIND_DEPS + [
         "//src:cpp_headers", # TODO make ovmslib depend on that
         "//src:libovmslogging",
+        "//src:libovms_module",
         "//src:libovmsmediapipe_utils",
         "ovmspytensor",
         "pytensorovtensorconvertercalculator",

--- a/src/sequence.cpp
+++ b/src/sequence.cpp
@@ -64,5 +64,4 @@ bool Sequence::isTerminated() const {
 void Sequence::setTerminated() {
     this->terminated = true;
 }
-
 }  // namespace ovms

--- a/src/sequence.hpp
+++ b/src/sequence.hpp
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include <openvino/openvino.hpp>
-#include <spdlog/spdlog.h>
 
 namespace ovms {
 

--- a/src/test/c_api_test_utils.cpp
+++ b/src/test/c_api_test_utils.cpp
@@ -15,13 +15,47 @@
 //*****************************************************************************
 #include "c_api_test_utils.hpp"
 
+#include <vector>
+
 #include "../logging.hpp"
 #include "../ovms.h"  // NOLINT
 
+void callbackMarkingItWasUsedWith42AndUnblockingAndCheckingCAPICorrectness(OVMS_InferenceResponse* response, uint32_t flag, void* userStruct) {
+    using ovms::StatusCode;
+    SPDLOG_INFO("Using callback: callbackMarkingItWasUsedWith42!");
+    uint32_t* usedFlag = reinterpret_cast<uint32_t*>(userStruct);
+    *usedFlag = 42;
+    OVMS_InferenceResponseDelete(response);
+}
 void callbackMarkingItWasUsedWith42(OVMS_InferenceResponse* response, uint32_t flag, void* userStruct) {
     using ovms::StatusCode;
     SPDLOG_INFO("Using callback: callbackMarkingItWasUsedWith42!");
     uint32_t* usedFlag = reinterpret_cast<uint32_t*>(userStruct);
     *usedFlag = 42;
     OVMS_InferenceResponseDelete(response);
+}
+void checkDummyResponse(OVMS_InferenceResponse* response, double expectedValue, double tolerance) {
+    const void* voutputData{nullptr};
+    size_t bytesize = 42;
+    uint32_t outputId = 0;
+    OVMS_DataType datatype = (OVMS_DataType)199;
+    const int64_t* shape{nullptr};
+    size_t dimCount = 42;
+    OVMS_BufferType bufferType = (OVMS_BufferType)199;
+    uint32_t ovmsDeviceId = 42;
+    const char* outputName{nullptr};
+    ASSERT_CAPI_STATUS_NULL(OVMS_InferenceResponseOutput(response, outputId, &outputName, &datatype, &shape, &dimCount, &voutputData, &bytesize, &bufferType, &ovmsDeviceId));
+    ASSERT_EQ(std::string(DUMMY_MODEL_OUTPUT_NAME), outputName);
+    EXPECT_EQ(datatype, OVMS_DATATYPE_FP32);
+    EXPECT_EQ(dimCount, 2);
+    EXPECT_EQ(bufferType, OVMS_BUFFERTYPE_CPU);
+    EXPECT_EQ(ovmsDeviceId, 0);
+    std::vector<int> expectedShape{1, 10};
+    for (size_t i = 0; i < DUMMY_MODEL_SHAPE.size(); ++i) {
+        EXPECT_EQ(expectedShape[i], shape[i]) << "Different at:" << i << " place.";
+    }
+    const float* outputData = reinterpret_cast<const float*>(voutputData);
+    for (int i = 0; i < expectedShape[1]; ++i) {
+        EXPECT_NEAR(expectedValue, outputData[i], tolerance) << "Different at:" << i << " place.";
+    }
 }

--- a/src/test/c_api_test_utils.hpp
+++ b/src/test/c_api_test_utils.hpp
@@ -137,3 +137,4 @@ struct CallbackUnblockingStruct {
     void* bufferAddr = nullptr;
 };
 void callbackMarkingItWasUsedWith42(OVMS_InferenceResponse* response, uint32_t flag, void* userStruct);
+void checkDummyResponse(OVMS_InferenceResponse* response, double expectedValue, double tolerance);

--- a/src/test/c_api_tests.cpp
+++ b/src/test/c_api_tests.cpp
@@ -395,19 +395,8 @@ TEST(CAPIInferenceResponse, Basic) {
 }
 
 TEST_F(CAPIInference, Validation) {
-    std::string port = "9000";
-    randomizePort(port);
-    OVMS_ServerSettings* serverSettings = nullptr;
-    OVMS_ModelsSettings* modelsSettings = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsNew(&serverSettings));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsNew(&modelsSettings));
-    ASSERT_NE(serverSettings, nullptr);
-    ASSERT_NE(modelsSettings, nullptr);
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, std::stoi(port)));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsSetConfigPath(modelsSettings, "/ovms/src/test/configs/config_standard_dummy.json"));
-    OVMS_Server* cserver = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerStartFromConfigurationFile(cserver, serverSettings, modelsSettings));
+    ServerGuard serverGuard("/ovms/src/test/configs/config_standard_dummy.json");
+    OVMS_Server* cserver = serverGuard.server;
     ASSERT_NE(cserver, nullptr);
     OVMS_InferenceRequest* request{nullptr};
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestNew(&request, cserver, "dummy", 1));
@@ -423,7 +412,6 @@ TEST_F(CAPIInference, Validation) {
     OVMS_InferenceResponse* response = nullptr;
     ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_Inference(cserver, request, &response), StatusCode::INVALID_PRECISION);
     OVMS_InferenceRequestDelete(request);
-    OVMS_ServerDelete(cserver);
 }
 TEST_F(CAPIInference, AcceptInputRejectOutputStringPrecision) {
     ServerGuard serverGuard("/ovms/src/test/configs/config_string.json");
@@ -443,19 +431,8 @@ TEST_F(CAPIInference, AcceptInputRejectOutputStringPrecision) {
 }
 
 TEST_F(CAPIInference, TwoInputs) {
-    std::string port = "9000";
-    randomizePort(port);
-    OVMS_ServerSettings* serverSettings = nullptr;
-    OVMS_ModelsSettings* modelsSettings = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsNew(&serverSettings));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsNew(&modelsSettings));
-    ASSERT_NE(serverSettings, nullptr);
-    ASSERT_NE(modelsSettings, nullptr);
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, std::stoi(port)));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsSetConfigPath(modelsSettings, "/ovms/src/test/configs/config_double_dummy.json"));
-    OVMS_Server* cserver = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerStartFromConfigurationFile(cserver, serverSettings, modelsSettings));
+    ServerGuard serverGuard("/ovms/src/test/configs/config_double_dummy.json");
+    OVMS_Server* cserver = serverGuard.server;
     ASSERT_NE(cserver, nullptr);
     OVMS_InferenceRequest* request{nullptr};
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestNew(&request, cserver, "pipeline1Dummy", 1));
@@ -507,28 +484,13 @@ TEST_F(CAPIInference, TwoInputs) {
     }
     OVMS_InferenceResponseDelete(response);
     OVMS_InferenceRequestDelete(request);
-    OVMS_ServerDelete(cserver);
 }
 TEST_F(CAPIInference, Basic) {
     //////////////////////
     // start server
     //////////////////////
-    // remove when C-API start implemented
-    std::string port = "9000";
-    randomizePort(port);
-    // prepare options
-    OVMS_ServerSettings* serverSettings = nullptr;
-    OVMS_ModelsSettings* modelsSettings = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsNew(&serverSettings));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsNew(&modelsSettings));
-    ASSERT_NE(serverSettings, nullptr);
-    ASSERT_NE(modelsSettings, nullptr);
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, std::stoi(port)));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsSetConfigPath(modelsSettings, "/ovms/src/test/configs/config_standard_dummy.json"));
-
-    OVMS_Server* cserver = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerStartFromConfigurationFile(cserver, serverSettings, modelsSettings));
+    ServerGuard serverGuard("/ovms/src/test/configs/config_standard_dummy.json");
+    OVMS_Server* cserver = serverGuard.server;
     ASSERT_NE(cserver, nullptr);
     ///////////////////////
     // request creation
@@ -641,22 +603,10 @@ TEST_F(CAPIInference, Basic) {
     ASSERT_CAPI_STATUS_NOT_NULL_EXPECT_CODE(OVMS_InferenceRequestRemoveInput(request, nullptr), StatusCode::NONEXISTENT_PTR);
     OVMS_InferenceRequestDelete(nullptr);
     OVMS_InferenceRequestDelete(request);
-    OVMS_ServerDelete(cserver);
 }
 TEST_F(CAPIInference, ReuseInputRemoveAndAddData) {
-    std::string port = "9000";
-    randomizePort(port);
-    OVMS_ServerSettings* serverSettings = nullptr;
-    OVMS_ModelsSettings* modelsSettings = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsNew(&serverSettings));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsNew(&modelsSettings));
-    ASSERT_NE(serverSettings, nullptr);
-    ASSERT_NE(modelsSettings, nullptr);
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, std::stoi(port)));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsSetConfigPath(modelsSettings, "/ovms/src/test/configs/config_standard_dummy.json"));
-    OVMS_Server* cserver = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerStartFromConfigurationFile(cserver, serverSettings, modelsSettings));
+    ServerGuard serverGuard("/ovms/src/test/configs/config_standard_dummy.json");
+    OVMS_Server* cserver = serverGuard.server;
     ASSERT_NE(cserver, nullptr);
     ///////////////////////
     // request creation
@@ -744,23 +694,11 @@ TEST_F(CAPIInference, ReuseInputRemoveAndAddData) {
     }
     OVMS_InferenceResponseDelete(response);
     OVMS_InferenceRequestDelete(request);
-    OVMS_ServerDelete(cserver);
 }
 
 TEST_F(CAPIInference, ReuseRequestRemoveAndAddInput) {
-    std::string port = "9000";
-    randomizePort(port);
-    OVMS_ServerSettings* serverSettings = nullptr;
-    OVMS_ModelsSettings* modelsSettings = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsNew(&serverSettings));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsNew(&modelsSettings));
-    ASSERT_NE(serverSettings, nullptr);
-    ASSERT_NE(modelsSettings, nullptr);
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, std::stoi(port)));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsSetConfigPath(modelsSettings, "/ovms/src/test/configs/config_dummy_dynamic_shape.json"));
-    OVMS_Server* cserver = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerStartFromConfigurationFile(cserver, serverSettings, modelsSettings));
+    ServerGuard serverGuard("/ovms/src/test/configs/config_dummy_dynamic_shape.json");
+    OVMS_Server* cserver = serverGuard.server;
     ASSERT_NE(cserver, nullptr);
     ///////////////////////
     // request creation
@@ -850,7 +788,6 @@ TEST_F(CAPIInference, ReuseRequestRemoveAndAddInput) {
     }
     OVMS_InferenceResponseDelete(response);
     OVMS_InferenceRequestDelete(request);
-    OVMS_ServerDelete(cserver);
 }
 
 TEST_F(CAPIInference, NegativeInference) {
@@ -1025,22 +962,8 @@ TEST_F(CAPIInference, Scalar) {
     //////////////////////
     // start server
     //////////////////////
-    // remove when C-API start implemented
-    std::string port = "9000";
-    randomizePort(port);
-    // prepare options
-    OVMS_ServerSettings* serverSettings = nullptr;
-    OVMS_ModelsSettings* modelsSettings = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsNew(&serverSettings));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsNew(&modelsSettings));
-    ASSERT_NE(serverSettings, nullptr);
-    ASSERT_NE(modelsSettings, nullptr);
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetGrpcPort(serverSettings, std::stoi(port)));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ModelsSettingsSetConfigPath(modelsSettings, "/ovms/src/test/configs/config_standard_scalar.json"));
-
-    OVMS_Server* cserver = nullptr;
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerNew(&cserver));
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerStartFromConfigurationFile(cserver, serverSettings, modelsSettings));
+    ServerGuard serverGuard("/ovms/src/test/configs/config_standard_scalar.json");
+    OVMS_Server* cserver = serverGuard.server;
     ASSERT_NE(cserver, nullptr);
     ///////////////////////
     // request creation
@@ -1064,6 +987,7 @@ TEST_F(CAPIInference, Scalar) {
     ASSERT_CAPI_STATUS_NULL(OVMS_Inference(cserver, request, &response));
     // verify GetOutputCount
     uint32_t outputCount = 42;
+    ASSERT_NE(nullptr, response);
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceResponseOutputCount(response, &outputCount));
     ASSERT_EQ(outputCount, 1);
     // verify GetOutput
@@ -1090,7 +1014,6 @@ TEST_F(CAPIInference, Scalar) {
     ///////////////
     OVMS_InferenceResponseDelete(response);
     OVMS_InferenceRequestDelete(request);
-    OVMS_ServerDelete(cserver);
 }
 
 namespace {

--- a/src/test/c_api_tests.cpp
+++ b/src/test/c_api_tests.cpp
@@ -1882,7 +1882,7 @@ public:
 
 const float INITIAL_VALUE{0.13666};
 const float GARBAGE_VALUE = 42.66613;
-const float FLOAT_TOLLERANCE{0.001};
+const float FLOAT_TOLERANCE{0.001};
 TEST_F(CAPIInference, AsyncWithCallbackDummy) {
     std::vector<float> in(10, INITIAL_VALUE);
     std::vector<float> out(10, GARBAGE_VALUE);
@@ -1911,7 +1911,7 @@ TEST_F(CAPIInference, AsyncWithCallbackDummy) {
 
     const float* outputData = reinterpret_cast<const float*>(out.data());
     for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_NEAR(in[i] + 1, outputData[i], FLOAT_TOLLERANCE) << "Different at:" << i << " place.";
+        EXPECT_NEAR(in[i] + 1, outputData[i], FLOAT_TOLERANCE) << "Different at:" << i << " place.";
     }
     SPDLOG_INFO("Using callbacks!");
 }

--- a/src/test/openvino_remote_tensors_tests.cpp
+++ b/src/test/openvino_remote_tensors_tests.cpp
@@ -1213,7 +1213,7 @@ static void callbackMarkingItWasUsedWith42AndUnblockingAndCheckingCAPIOpenCLCorr
 
 const float INITIAL_VALUE{0.13666};
 const float GARBAGE_VALUE = 42.66613;
-const float FLOAT_TOLLERANCE{0.001};
+const float FLOAT_TOLERANCE{0.001};
 
 TEST_F(CAPINonCopy, SyncWithCallbackDummy) {
     std::string port = "9000";
@@ -1355,13 +1355,13 @@ TEST_F(CAPINonCopy, OpenCL_SyncWithCallbackDummyCheckResetOutputGPU) {
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestOutputRemoveData(request, DUMMY_MODEL_OUTPUT_NAME));
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestRemoveOutput(request, DUMMY_MODEL_OUTPUT_NAME));
     ASSERT_CAPI_STATUS_NULL(OVMS_Inference(cserver, request, &response));
-    checkDummyResponse(response, INITIAL_VALUE * 2 + 1, FLOAT_TOLLERANCE);
+    checkDummyResponse(response, INITIAL_VALUE * 2 + 1, FLOAT_TOLERANCE);
     OVMS_InferenceResponseDelete(response);
     std::vector<float> dataFromPreviousOutputBuffer(10, 1231521);
     // now we need to check if previous output wasn't changed
     EXPECT_EQ(0, queue.enqueueReadBuffer(openCLCppOutputBuffer, queueReadWriteBlockingTrue, 0, inputByteSize, dataFromPreviousOutputBuffer.data()));
     for (int i = 0; i < DUMMY_MODEL_INPUT_SIZE; ++i) {
-        EXPECT_NEAR(dataFromPreviousOutputBuffer[i], INITIAL_VALUE + 1, FLOAT_TOLLERANCE) << " at place i:" << i;
+        EXPECT_NEAR(dataFromPreviousOutputBuffer[i], INITIAL_VALUE + 1, FLOAT_TOLERANCE) << " at place i:" << i;
     }
 }
 TEST_F(CAPINonCopy, SyncWithoutCallbackDummyCheckResetOutputCPU) {
@@ -1382,7 +1382,7 @@ TEST_F(CAPINonCopy, SyncWithoutCallbackDummyCheckResetOutputCPU) {
     OVMS_InferenceResponse* response = nullptr;
     ASSERT_CAPI_STATUS_NULL(OVMS_Inference(cserver, request, &response));
     // check
-    checkDummyResponse(response, INITIAL_VALUE + 1, FLOAT_TOLLERANCE);
+    checkDummyResponse(response, INITIAL_VALUE + 1, FLOAT_TOLERANCE);
     OVMS_InferenceResponseDelete(response);
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestSetCompletionCallback(request, nullptr, nullptr));
     // now check with default output buffer
@@ -1392,10 +1392,10 @@ TEST_F(CAPINonCopy, SyncWithoutCallbackDummyCheckResetOutputCPU) {
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestOutputRemoveData(request, DUMMY_MODEL_OUTPUT_NAME));
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceRequestRemoveOutput(request, DUMMY_MODEL_OUTPUT_NAME));
     ASSERT_CAPI_STATUS_NULL(OVMS_Inference(cserver, request, &response));
-    checkDummyResponse(response, INITIAL_VALUE + 42 + 1, FLOAT_TOLLERANCE);
+    checkDummyResponse(response, INITIAL_VALUE + 42 + 1, FLOAT_TOLERANCE);
     // intentional check for original output buffer if they were not overridden
     for (size_t i = 0; i < out1.size(); ++i) {
-        EXPECT_NEAR(INITIAL_VALUE + 1, out1[i], FLOAT_TOLLERANCE) << "Different at:" << i << " place.";
+        EXPECT_NEAR(INITIAL_VALUE + 1, out1[i], FLOAT_TOLERANCE) << "Different at:" << i << " place.";
     }
     OVMS_InferenceResponseDelete(response);
 }
@@ -1422,7 +1422,7 @@ TEST_F(CAPINonCopy, AsyncDummyCheckResetOutputCPU) {
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceAsync(cserver, request));
     unblockSignal.get();
     // check
-    checkDummyResponse(callbackStruct.response, INITIAL_VALUE + 1, FLOAT_TOLLERANCE);
+    checkDummyResponse(callbackStruct.response, INITIAL_VALUE + 1, FLOAT_TOLERANCE);
     OVMS_InferenceResponseDelete(callbackStruct.response);
     callbackStruct.response = nullptr;
     // perform 2nd inference
@@ -1437,11 +1437,11 @@ TEST_F(CAPINonCopy, AsyncDummyCheckResetOutputCPU) {
 
     ASSERT_CAPI_STATUS_NULL(OVMS_InferenceAsync(cserver, request));
     unblockSignal.get();
-    checkDummyResponse(callbackStruct.response, INITIAL_VALUE + 42 + 1, FLOAT_TOLLERANCE);
+    checkDummyResponse(callbackStruct.response, INITIAL_VALUE + 42 + 1, FLOAT_TOLERANCE);
     OVMS_InferenceResponseDelete(callbackStruct.response);
     // intentional check for original output buffer if they were not overridden
     for (size_t i = 0; i < out1.size(); ++i) {
-        EXPECT_NEAR(INITIAL_VALUE + 1, out1[i], FLOAT_TOLLERANCE) << "Different at:" << i << " place.";
+        EXPECT_NEAR(INITIAL_VALUE + 1, out1[i], FLOAT_TOLERANCE) << "Different at:" << i << " place.";
     }
 }
 
@@ -1506,7 +1506,7 @@ TEST_F(CAPINonCopy, AsyncWithCallbackDummy) {
     EXPECT_EQ(0, queue.enqueueReadBuffer(openCLCppOutputBuffer, queueReadWriteBlockingTrue, 0, inputByteSize, outputBufferData));
     const float* outputData = reinterpret_cast<const float*>(outputBufferData);
     for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_NEAR(in[i] + 1, outputData[i], FLOAT_TOLLERANCE) << "Different at:" << i << " place.";
+        EXPECT_NEAR(in[i] + 1, outputData[i], FLOAT_TOLERANCE) << "Different at:" << i << " place.";
     }
     ASSERT_EQ(42, callbackReturnValue);
     SPDLOG_INFO("Using callbacks!");
@@ -1726,7 +1726,7 @@ TEST_F(OpenVINOGPUContextFromModel, OutputTensorHasBiggerUnderlyingOCLBufferThan
     EXPECT_EQ(0, queueFromModelContext->enqueueReadBuffer(openCLCppOutputBuffer, queueReadWriteBlockingTrue, 0, outputByteSize, bufferOut));
     const float* outputData = reinterpret_cast<const float*>(bufferOut);
     for (size_t i = 0; i < out.size(); ++i) {
-        EXPECT_NEAR(in[i] + 1, outputData[i], FLOAT_TOLLERANCE) << "Different at:" << i << " place.";
+        EXPECT_NEAR(in[i] + 1, outputData[i], FLOAT_TOLERANCE) << "Different at:" << i << " place.";
     }
     // TODO separate test for below - extracting what kind of tensor in output it isa
     ov::Tensor outOvTensor = inferRequest->get_tensor(output);
@@ -1863,7 +1863,7 @@ static void checkDummyOpenCLResponse(OVMS_InferenceResponse* response, cl::Comma
     EXPECT_EQ(0, clError);
     const float* outputData = reinterpret_cast<const float*>(bufferOut);
     for (size_t i = 0; i < out.size(); ++i) {
-        EXPECT_NEAR(expectedValue, outputData[i], FLOAT_TOLLERANCE) << "Different at:" << i << " place.";
+        EXPECT_NEAR(expectedValue, outputData[i], FLOAT_TOLERANCE) << "Different at:" << i << " place.";
     }
 }
 
@@ -1873,7 +1873,7 @@ static void callbackMarkingItWasUsedWith42AndUnblockingAndCheckingCAPIOpenCLCorr
     SPDLOG_ERROR("ER:{}", userStruct);
     SPDLOG_ERROR("ER:{}", (void*)&callbackUnblockingStruct->signal);
     callbackUnblockingStruct->signal.set_value(42);
-    checkDummyOpenCLResponse(response, *callbackUnblockingStruct->queue, INITIAL_VALUE + 1, FLOAT_TOLLERANCE);
+    checkDummyOpenCLResponse(response, *callbackUnblockingStruct->queue, INITIAL_VALUE + 1, FLOAT_TOLERANCE);
     OVMS_InferenceResponseDelete(response);
 }
 static void callbackUnblockingAndFreeingRequest(OVMS_InferenceResponse* response, uint32_t flag, void* userStruct) {


### PR DESCRIPTION
* Fix bug in async execution
Additionally there are few improvements in building:
* stop recompiling whole OVMS with dependencies when enabling OV_TRACING
* further ovms_lib separation which should enhance further using bazel cache and rebuilds
Eg. changing from python/mp disable to enable should affect lesser scope of compilation units which should improve bazel caching.

Ticket:CVS-141785

### 🧪 Checklist

- [x] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.


