### PR TITLE
filter rt_info to publish only model_info object

### DIFF
--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -620,8 +620,19 @@ Status HttpRestApiHandler::processModelMetadataKFSRequest(const HttpRequestCompo
 
     convertShapeType(doc["inputs"], doc);
     convertShapeType(doc["outputs"], doc);
-    doc.AddMember("rt_info", Value(rapidjson::kObjectType), doc.GetAllocator());
-    convertRTInfo(doc["rt_info"], doc, extraMetadata.rt_info);
+    if (extraMetadata.rt_info.count("model_info")) {
+        rapidjson::Value modelInfoScope, rtInfoScope;
+        modelInfoScope.SetObject();
+        rtInfoScope.SetObject();
+        try {
+            convertRTInfo(modelInfoScope, doc, extraMetadata.rt_info["model_info"].as<ov::AnyMap>());
+        } catch (const std::exception& e) {
+            SPDLOG_DEBUG("Error converting RT info: {}", e.what());
+            return StatusCode::INTERNAL_ERROR;
+        }
+        rtInfoScope.AddMember("model_info", modelInfoScope, doc.GetAllocator());
+        doc.AddMember("rt_info", rtInfoScope, doc.GetAllocator());
+    }
 
     rapidjson::StringBuffer buffer;
     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);

--- a/src/test/kfs_rest_test.cpp
+++ b/src/test/kfs_rest_test.cpp
@@ -612,10 +612,9 @@ TEST_F(HttpRestApiHandlerTest, modelMetadataRequest) {
     ASSERT_EQ(doc["outputs"].GetArray()[0].GetObject()["shape"].GetArray().Size(), 2);
     ASSERT_EQ(doc["outputs"].GetArray()[0].GetObject()["shape"].GetArray()[0].GetInt(), 1);
     ASSERT_EQ(doc["outputs"].GetArray()[0].GetObject()["shape"].GetArray()[1].GetInt(), 10);
-    ASSERT_EQ(std::string(doc["rt_info"].GetObject()["MO_version"].GetString()), "2020.1.0-61-gd349c3ba4a");
+    ASSERT_EQ(doc["rt_info"].GetArray().Size(), 1);
     ASSERT_EQ(std::string(doc["rt_info"].GetObject()["model_info"].GetObject()["resolution"].GetObject()["height"].GetString()), "200");
-    ASSERT_EQ(std::string(doc["rt_info"].GetObject()["conversion_parameters"].GetObject()["data_type"].GetString()), "float");
-    ASSERT_TRUE(doc["rt_info"].GetObject()["optimization"].GetObject().ObjectEmpty());
+    ASSERT_EQ(std::string(doc["rt_info"].GetObject()["model_info"].GetObject()["precision"].GetString()), "FP16");
 }
 
 TEST_F(HttpRestApiHandlerWithScalarModelTest, modelMetadataRequest) {


### PR DESCRIPTION
### 🛠 Summary

CVS-157125
Filter rt_info in the response in model_metdata to show only model_info object.

### 🧪 Checklist

- [x] Unit tests added.
- [ ] The documentation updated.
- [x] Change follows security best practices.
``

