### PR TITLE
Fix ci

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -20,14 +20,14 @@ setlocal EnableExtensions DisableDelayedExpansion
 set "BAZEL_SHORT_PATH=C:\%1"
 set "bazelStartupCmd=--output_user_root=%BAZEL_SHORT_PATH%"
 
-set "buildCommand=bazel %bazelStartupCmd% build --config=windows --jobs=%NUMBER_OF_PROCESSORS% --verbose_failures //src:ovms 2>&1 | tee build.log"
-set "buildTestCommand=bazel %bazelStartupCmd% build --config=windows --jobs=%NUMBER_OF_PROCESSORS% --verbose_failures //src:ovms_test 2>&1 | tee build_test.log"
-set "runTest=%cd%\bazel-bin\src\ovms_test.exe --gtest_filter=-OvmsConfigTest 2>&1 | tee test.log"
+set "buildCommand=bazel %bazelStartupCmd% build --config=windows --jobs=%NUMBER_OF_PROCESSORS% --verbose_failures //src:ovms 2>&1 | tee win_build.log"
+set "buildTestCommand=bazel %bazelStartupCmd% build --config=windows --jobs=%NUMBER_OF_PROCESSORS% --verbose_failures //src:ovms_test 2>&1 | tee win_build_test.log"
+set "runTest=%cd%\bazel-bin\src\ovms_test.exe --gtest_filter=-OvmsConfigTest 2>&1 | tee win_full_test.log"
 
 :: Setting PATH environment variable based on default windows node settings: Added ovms_windows specific python settings and c:/opt and removed unused Nvidia and OCL specific tools.
 :: When changing the values here you can print the node default PATH value and base your changes on it.
 set "setPath=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\bin\HostX86\x86;c:\opt;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\VC\VCPackages;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Team Tools\Performance Tools;C:\Program Files (x86)\Microsoft Visual Studio\Shared\Common\VSPerfCollectionTools\vs2019\;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\devinit;C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86;C:\Program Files (x86)\Windows Kits\10\bin\x86;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\\MSBuild\Current\Bin;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\;C:\Program Files\Common Files\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Utils\;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Ninja;C:\Program Files\CMake\bin;C:\Program Files\7-zip;C:\opt\Python39\Scripts\;C:\opt\Python39\;C:\opencl\install\;C:\opencl\;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja"
-set "envPath=environment.log"
+set "envPath=win_environment.log"
 
 :: Set proper PATH environment variable: Remove other python paths and add c:\opt with bazel to PATH
 set "PATH=%setPath%"
@@ -51,4 +51,9 @@ set > %envPath%
 
 :: Start unit test
 %runTest%
+
+:: Cut tests log to results
+set regex="\[  .* ms"
+set sed_clean="s/ (.* ms)//g"
+grep -a %regex% win_full_test.log | sed %sed_clean% | tee win_test.log
 endlocal

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -75,11 +75,13 @@ pipeline {
               }
               when { expression { win_image_build_needed == "true" } }
               steps {
-                  windows = load 'ci/loadWin.groovy'
-                  windows.clean()
-                  windows.build_and_test()
-                  windows.check_tests()
-                  windows.archive_artifacts()
+                  script {
+                      windows = load 'ci/loadWin.groovy'
+                      windows.clean()
+                      windows.build_and_test()
+                      windows.check_tests()
+                      windows.archive_artifacts()
+                  }
               }
             }
           }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -75,8 +75,8 @@ pipeline {
               }
               when { expression { win_image_build_needed == "true" } }
               steps {
-                  def windows = load 'ci/loadWin.groovy'
                   script {
+                      def windows = load 'ci/loadWin.groovy'
                       if (windows != null) {
                           windows.clean()
                           windows.build_and_test()

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -75,8 +75,8 @@ pipeline {
               }
               when { expression { win_image_build_needed == "true" } }
               steps {
+                  def windows = load 'ci/loadWin.groovy'
                   script {
-                      def windows = load 'ci/loadWin.groovy'
                       if (windows != null) {
                           windows.clean()
                           windows.build_and_test()

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -75,7 +75,11 @@ pipeline {
               }
               when { expression { win_image_build_needed == "true" } }
               steps {
-                  load 'ci/loadWin.groovy'
+                  windows = load 'ci/loadWin.groovy'
+                  windows.clean()
+                  windows.build_and_test()
+                  windows.check_tests()
+                  windows.archive_artifacts()
               }
             }
           }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -75,8 +75,8 @@ pipeline {
               }
               when { expression { win_image_build_needed == "true" } }
               steps {
-                  load 'ci/build_test_OnCommitWin.groovy'
-            }
+                  load 'ci/loadWin.groovy'
+              }
             }
           }
         }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -1,4 +1,5 @@
 def image_build_needed = "false"
+def win_image_build_needed = "false"
 def client_test_needed = "false"
 def shortCommit = ""
 
@@ -32,6 +33,10 @@ pipeline {
                 if (matched){
                   client_test_needed = "true"
               }
+              def win_matched = (git_diff =~ /src|third_party|external|ci|\.c|\.h|\.bazel|\.bzl|BUILD|WORKSPACE|\.bat|\.groovy/)
+              if (win_matched){
+                  win_image_build_needed = "true"
+              }
             }
           }
         }
@@ -64,10 +69,14 @@ pipeline {
                       sh "make ovms_builder_image RUN_TESTS=0 OV_USE_BINARY=1 BASE_OS=redhat OVMS_CPP_IMAGE_TAG=${shortCommit}"
                     }
             }
-            stage('Build windows') {
-              steps {
-                  build job: 'ovms/ovms-windows/'+ env.JOB_BASE_NAME
+            stage('Build and test windows') {
+              agent {
+                label 'win_ovms'
               }
+              when { expression { win_image_build_needed == "true" } }
+              steps {
+                  load 'ci/build_test_OnCommitWin.groovy'
+            }
             }
           }
         }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -76,11 +76,15 @@ pipeline {
               when { expression { win_image_build_needed == "true" } }
               steps {
                   script {
-                      windows = load 'ci/loadWin.groovy'
-                      windows.clean()
-                      windows.build_and_test()
-                      windows.check_tests()
-                      windows.archive_artifacts()
+                      def windows = load 'ci/loadWin.groovy'
+                      if (windows != null) {
+                          windows.clean()
+                          windows.build_and_test()
+                          windows.check_tests()
+                          windows.archive_artifacts()
+                      } else {
+                          error "Cannot load ci/loadWin.groovy file."
+                      }
                   }
               }
             }

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -8,7 +8,11 @@ pipeline {
     stages {
         stage ("Build and test windows") {
             steps {
-                  load 'ci/loadWin.groovy'
+                  windows = load 'ci/loadWin.groovy'
+                  windows.clean()
+                  windows.build_and_test()
+                  windows.check_tests()
+                  windows.archive_artifacts()
               }
         }
     }

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -6,63 +6,10 @@ pipeline {
         label 'win_ovms'
     }
     stages {
-        stage ("Clean") {
+        stage ("Build and test windows") {
             steps {
-                script{
-                    def output1 = bat(returnStdout: true, script: 'clean_windows.bat ' + env.JOB_BASE_NAME + ' ' + env.OVMS_CLEAN_EXPUNGE)
-                }
-            }
-        }
-        // Build windows
-        stage("Build windows") {
-            steps {
-                script {
-                    def status = bat(returnStatus: true, script: 'build_windows.bat ' + env.JOB_BASE_NAME)
-                    status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms.exe build.log | grep "Build completed successfully"')
-                    if (status != 0) {
-                            error "Error: Windows build failed ${status}. Check build.log for details."
-                    } else {
-                        echo "Build successful."
-                    }
-                }
-                }
-            }
-        stage("Check tests windows") {
-            steps {
-                script {
-                    def status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms_test.exe build_test.log | grep "Build completed successfully"')
-                    if (status != 0) {
-                            error "Error: Windows build test failed ${status}. Check build_test.log for details."
-                    } else {
-                        echo "Build test successful."
-                    }
-                }
-                script {
-                    def status = bat(returnStatus: true, script: 'grep "[  PASSED  ]" test.log')
-                    if (status != 0) {
-                            error "Error: Windows run test failed ${status}. Check test.log for details."
-                    }
-
-                    // TODO Windows: Currently some tests fail change to no fail when fixed.
-                    status = bat(returnStatus: true, script: 'grep "[  FAILED  ]" test.log')
-                    if (status != 0) {
-                            error "Error: Windows run test failed ${status}. Check test.log for details."
-                    } else {
-                        echo "Run test successful."
-                    }
-                }
-            }
-        }
-    }
-    //Post build steps
-    post {
-        always {
-            // Left for tests when enabled - junit allowEmptyResults: true, testResults: "logs/**/*.xml"
-            archiveArtifacts allowEmptyArchive: true, artifacts: "bazel-bin\\src\\ovms.exe"
-            archiveArtifacts allowEmptyArchive: true, artifacts: "environment.log"
-            archiveArtifacts allowEmptyArchive: true, artifacts: "build.log"
-            archiveArtifacts allowEmptyArchive: true, artifacts: "build_test.log"
-            archiveArtifacts allowEmptyArchive: true, artifacts: "test.log"
+                  load 'ci/loadWin.groovy'
+              }
         }
     }
 }

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -6,36 +6,6 @@ pipeline {
         label 'win_ovms'
     }
     stages {
-        stage('Configure') {
-            steps {
-                script
-                {
-                    println "BUILD CAUSE: ${currentBuild.getBuildCauses()}"
-                    // BRANCH INDEXING BUILD CAUSE: [[_class:jenkins.branch.BranchIndexingCause, shortDescription:Branch indexing]]
-                    def isTriggeredByIndexing = currentBuild.getBuildCauses('jenkins.branch.BranchIndexingCause').size()
-                    // ON COMMIT TRIGGER BUILD CAUSE: [[_class:org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause, 
-                    def isTriggeredByOnCommit = currentBuild.getBuildCauses('org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause').size()
-                    // Below are just examples how to find specific build trigger in case we wanted to change this in future.
-                    def isTriggeredByUser = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').size()  
-                    def isTriggeredByTimer = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause').size()
-
-                    // Indexing trigger
-                    if (isTriggeredByIndexing) {
-                        // First build for indexing is allowed so that onCommit will see this configuration once it starts.
-                        if (currentBuild.getNumber() == 1) {
-                            echo "First build on branch discovered by branch indexing"
-                            echo "Continue building"
-                        }
-                        else {
-                            echo "Branch discovered by branch indexing"
-                            currentBuild.result = 'ABORTED'
-                            error "Caught branch indexing for subsequent build. Canceling build"
-                        }
-                    }
-                }
-            }
-            
-        }
         stage ("Clean") {
             steps {
                 script{

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -8,8 +8,8 @@ pipeline {
     stages {
         stage ("Build and test windows") {
             steps {
-                def windows = load 'ci/loadWin.groovy'
                 script {
+                    def windows = load 'ci/loadWin.groovy'
                     if (windows != null) {
                         windows.clean()
                         windows.build_and_test()

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -8,8 +8,8 @@ pipeline {
     stages {
         stage ("Build and test windows") {
             steps {
+                def windows = load 'ci/loadWin.groovy'
                 script {
-                    def windows = load 'ci/loadWin.groovy'
                     if (windows != null) {
                         windows.clean()
                         windows.build_and_test()

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -33,24 +33,6 @@ pipeline {
                         }
                     }
                 }
-                script {
-                    shortCommit = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
-                    echo shortCommit
-                    echo sh(script: 'env|sort', returnStdout: true)
-                    def git_diff = ""
-                    if (env.CHANGE_ID){ // PR - check changes between target branch
-                        sh 'git fetch origin ${CHANGE_TARGET}'
-                        git_diff = sh (script: "git diff --name-only \$(git merge-base FETCH_HEAD HEAD)", returnStdout: true).trim()
-                        println("git diff:\n${git_diff}")
-                    } else {  // branches without PR - check changes in last commit
-                        git_diff = sh (script: "git diff --name-only HEAD^..HEAD", returnStdout: true).trim()
-                    }
-                    def matched = (git_diff =~ /src|third_party|external|ci|\.c|\.h|\.bazel|\.bzl|BUILD|WORKSPACE|\.bat|\.groovy/)
-                    if (!matched){
-                        currentBuild.result = 'ABORTED'
-                        error "No changes matched required files to start build."
-                    }
-                }
             }
             
         }

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -9,11 +9,15 @@ pipeline {
         stage ("Build and test windows") {
             steps {
                 script {
-                    windows = load 'ci/loadWin.groovy'
-                    windows.clean()
-                    windows.build_and_test()
-                    windows.check_tests()
-                    windows.archive_artifacts()
+                    def windows = load 'ci/loadWin.groovy'
+                    if (windows != null) {
+                        windows.clean()
+                        windows.build_and_test()
+                        windows.check_tests()
+                        windows.archive_artifacts()
+                    } else {
+                        error "Cannot load ci/loadWin.groovy file."
+                    }
                 }
             }
         }

--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -8,12 +8,14 @@ pipeline {
     stages {
         stage ("Build and test windows") {
             steps {
-                  windows = load 'ci/loadWin.groovy'
-                  windows.clean()
-                  windows.build_and_test()
-                  windows.check_tests()
-                  windows.archive_artifacts()
-              }
+                script {
+                    windows = load 'ci/loadWin.groovy'
+                    windows.clean()
+                    windows.build_and_test()
+                    windows.check_tests()
+                    windows.archive_artifacts()
+                }
+            }
         }
     }
 }

--- a/ci/loadWin.groovy
+++ b/ci/loadWin.groovy
@@ -43,3 +43,5 @@ def archive_artifacts(){
     archiveArtifacts allowEmptyArchive: true, artifacts: "build_test.log"
     archiveArtifacts allowEmptyArchive: true, artifacts: "test.log"
 }
+
+return this

--- a/ci/loadWin.groovy
+++ b/ci/loadWin.groovy
@@ -4,31 +4,31 @@ def clean() {
 
 def build_and_test(){
     def status = bat(returnStatus: true, script: 'build_windows.bat ' + env.JOB_BASE_NAME)
-    status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms.exe build.log | grep "Build completed successfully"')
+    status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms.exe win_build.log | grep "Build completed successfully"')
     if (status != 0) {
-        error "Error: Windows build failed ${status}. Check build.log for details."
+        error "Error: Windows build failed ${status}. Check win_build.log for details."
     } else {
         echo "Build successful."
     }
 }
 
 def check_tests(){
-    def status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms_test.exe build_test.log | grep "Build completed successfully"')
+    def status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms_test.exe win_build_test.log | grep "Build completed successfully"')
     if (status != 0) {
-            error "Error: Windows build test failed ${status}. Check build_test.log for details."
+            error "Error: Windows build test failed ${status}. Check win_build_test.log for details."
     } else {
         echo "Build test successful."
     }
 
-    status = bat(returnStatus: true, script: 'grep "[  PASSED  ]" test.log')
+    status = bat(returnStatus: true, script: 'grep "[  PASSED  ]" win_test.log')
     if (status != 0) {
-            error "Error: Windows run test failed ${status}. Check test.log for details."
+            error "Error: Windows run test failed ${status}. Check win_test.log for details."
     }
 
     // TODO Windows: Currently some tests fail change to no fail when fixed.
-    status = bat(returnStatus: true, script: 'grep "[  FAILED  ]" test.log')
+    status = bat(returnStatus: true, script: 'grep "[  FAILED  ]" win_test.log')
     if (status != 0) {
-            error "Error: Windows run test failed ${status}. Check test.log for details."
+            error "Error: Windows run test failed ${status}. Check win_test.log for details."
     } else {
         echo "Run test successful."
     }
@@ -38,10 +38,10 @@ def check_tests(){
 def archive_artifacts(){
     // Left for tests when enabled - junit allowEmptyResults: true, testResults: "logs/**/*.xml"
     archiveArtifacts allowEmptyArchive: true, artifacts: "bazel-bin\\src\\ovms.exe"
-    archiveArtifacts allowEmptyArchive: true, artifacts: "environment.log"
-    archiveArtifacts allowEmptyArchive: true, artifacts: "build.log"
-    archiveArtifacts allowEmptyArchive: true, artifacts: "build_test.log"
-    archiveArtifacts allowEmptyArchive: true, artifacts: "test.log"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "win_environment.log"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "win_build.log"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "win_build_test.log"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "win_test.log"
 }
 
 return this

--- a/ci/loadWin.groovy
+++ b/ci/loadWin.groovy
@@ -1,60 +1,45 @@
-stages {
-    stage ("Clean") {
-        steps {
-            script{
-                def output1 = bat(returnStdout: true, script: 'clean_windows.bat ' + env.JOB_BASE_NAME + ' ' + env.OVMS_CLEAN_EXPUNGE)
-            }
-        }
-    }
-    // Build windows
-    stage("Build windows") {
-        steps {
-            script {
-                def status = bat(returnStatus: true, script: 'build_windows.bat ' + env.JOB_BASE_NAME)
-                status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms.exe build.log | grep "Build completed successfully"')
-                if (status != 0) {
-                        error "Error: Windows build failed ${status}. Check build.log for details."
-                } else {
-                    echo "Build successful."
-                }
-            }
-            }
-        }
-    stage("Check tests windows") {
-        steps {
-            script {
-                def status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms_test.exe build_test.log | grep "Build completed successfully"')
-                if (status != 0) {
-                        error "Error: Windows build test failed ${status}. Check build_test.log for details."
-                } else {
-                    echo "Build test successful."
-                }
-            }
-            script {
-                def status = bat(returnStatus: true, script: 'grep "[  PASSED  ]" test.log')
-                if (status != 0) {
-                        error "Error: Windows run test failed ${status}. Check test.log for details."
-                }
+def clean() {
+    def output1 = bat(returnStdout: true, script: 'clean_windows.bat ' + env.JOB_BASE_NAME + ' ' + env.OVMS_CLEAN_EXPUNGE)
+}
 
-                // TODO Windows: Currently some tests fail change to no fail when fixed.
-                status = bat(returnStatus: true, script: 'grep "[  FAILED  ]" test.log')
-                if (status != 0) {
-                        error "Error: Windows run test failed ${status}. Check test.log for details."
-                } else {
-                    echo "Run test successful."
-                }
-            }
-        }
+def build_and_test(){
+    def status = bat(returnStatus: true, script: 'build_windows.bat ' + env.JOB_BASE_NAME)
+    status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms.exe build.log | grep "Build completed successfully"')
+    if (status != 0) {
+        error "Error: Windows build failed ${status}. Check build.log for details."
+    } else {
+        echo "Build successful."
     }
 }
-//Post build steps
-post {
-    always {
-        // Left for tests when enabled - junit allowEmptyResults: true, testResults: "logs/**/*.xml"
-        archiveArtifacts allowEmptyArchive: true, artifacts: "bazel-bin\\src\\ovms.exe"
-        archiveArtifacts allowEmptyArchive: true, artifacts: "environment.log"
-        archiveArtifacts allowEmptyArchive: true, artifacts: "build.log"
-        archiveArtifacts allowEmptyArchive: true, artifacts: "build_test.log"
-        archiveArtifacts allowEmptyArchive: true, artifacts: "test.log"
+
+def check_tests(){
+    def status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms_test.exe build_test.log | grep "Build completed successfully"')
+    if (status != 0) {
+            error "Error: Windows build test failed ${status}. Check build_test.log for details."
+    } else {
+        echo "Build test successful."
     }
+
+    status = bat(returnStatus: true, script: 'grep "[  PASSED  ]" test.log')
+    if (status != 0) {
+            error "Error: Windows run test failed ${status}. Check test.log for details."
+    }
+
+    // TODO Windows: Currently some tests fail change to no fail when fixed.
+    status = bat(returnStatus: true, script: 'grep "[  FAILED  ]" test.log')
+    if (status != 0) {
+            error "Error: Windows run test failed ${status}. Check test.log for details."
+    } else {
+        echo "Run test successful."
+    }
+}
+
+//Post build steps
+def archive_artifacts(){
+    // Left for tests when enabled - junit allowEmptyResults: true, testResults: "logs/**/*.xml"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "bazel-bin\\src\\ovms.exe"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "environment.log"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "build.log"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "build_test.log"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "test.log"
 }

--- a/ci/loadWin.groovy
+++ b/ci/loadWin.groovy
@@ -1,0 +1,60 @@
+stages {
+    stage ("Clean") {
+        steps {
+            script{
+                def output1 = bat(returnStdout: true, script: 'clean_windows.bat ' + env.JOB_BASE_NAME + ' ' + env.OVMS_CLEAN_EXPUNGE)
+            }
+        }
+    }
+    // Build windows
+    stage("Build windows") {
+        steps {
+            script {
+                def status = bat(returnStatus: true, script: 'build_windows.bat ' + env.JOB_BASE_NAME)
+                status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms.exe build.log | grep "Build completed successfully"')
+                if (status != 0) {
+                        error "Error: Windows build failed ${status}. Check build.log for details."
+                } else {
+                    echo "Build successful."
+                }
+            }
+            }
+        }
+    stage("Check tests windows") {
+        steps {
+            script {
+                def status = bat(returnStatus: true, script: 'grep -A 4 bazel-bin/src/ovms_test.exe build_test.log | grep "Build completed successfully"')
+                if (status != 0) {
+                        error "Error: Windows build test failed ${status}. Check build_test.log for details."
+                } else {
+                    echo "Build test successful."
+                }
+            }
+            script {
+                def status = bat(returnStatus: true, script: 'grep "[  PASSED  ]" test.log')
+                if (status != 0) {
+                        error "Error: Windows run test failed ${status}. Check test.log for details."
+                }
+
+                // TODO Windows: Currently some tests fail change to no fail when fixed.
+                status = bat(returnStatus: true, script: 'grep "[  FAILED  ]" test.log')
+                if (status != 0) {
+                        error "Error: Windows run test failed ${status}. Check test.log for details."
+                } else {
+                    echo "Run test successful."
+                }
+            }
+        }
+    }
+}
+//Post build steps
+post {
+    always {
+        // Left for tests when enabled - junit allowEmptyResults: true, testResults: "logs/**/*.xml"
+        archiveArtifacts allowEmptyArchive: true, artifacts: "bazel-bin\\src\\ovms.exe"
+        archiveArtifacts allowEmptyArchive: true, artifacts: "environment.log"
+        archiveArtifacts allowEmptyArchive: true, artifacts: "build.log"
+        archiveArtifacts allowEmptyArchive: true, artifacts: "build_test.log"
+        archiveArtifacts allowEmptyArchive: true, artifacts: "test.log"
+    }
+}

--- a/clean_windows.bat
+++ b/clean_windows.bat
@@ -29,8 +29,9 @@ set "PATH=%setPath%"
 
 :: Log all environment variables
 %cleanCmd%
-rm -rf environment.log
-rm -rf build.log
-rm -rf build_test.log
-rm -rf test.log
+rm -rf win_environment.log
+rm -rf win_build.log
+rm -rf win_build_test.log
+rm -rf win_full_test.log
+rm -rf win_test.log
 endlocal


### PR DESCRIPTION
### 🛠 Summary

Move windows groovy to separate script.
Load the script to perform builds in the same step as on commit.
We can remove the automatic build triggers then.
Cut tests logs for windows not to store hundreds of MB as logs.


### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

