### PR TITLE
Fix bazel build configs to disable remote/disk cache for coverity run

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -279,6 +279,10 @@ build:mp_off_py_off --define=PYTHON_DISABLE=1
 build:mp_off_py_off --disk_cache=/root/.cache/bazel_mp_off_py_off
 #build --remote_header=x-build-event-log=DEBUG
 
+# Coverity needs remote and disk cache disabled
+build:coverity --config=mp_on_py_on
+build:coverity --disk_cache=
+
 #Add this parameter for windows local builds, its added on jenkins via build_windows.bat. Must be short path on C:\ for mediapipe to compile
 #startup --output_user_root=C:/b_tmp
 

--- a/ci/Dockerfile.coverity
+++ b/ci/Dockerfile.coverity
@@ -25,9 +25,13 @@ RUN apt-get remove --yes cmake && apt-get update && apt-get install -y rapidjson
 #RUN bazel build @org_tensorflow//tensorflow/core:framework
 
 WORKDIR /ovms/
+
+# Disable remote cache
+RUN rm -rf /ovms/.user.bazelrc
+
 RUN /cov/bin/cov-configure --gcc --config coverity_config.xml && \
     /cov/bin/cov-configure --comptype gcc --compiler /usr/bin/gcc && \
-    /cov/bin/cov-build --dir cov-int bash -c 'bazel shutdown; bazel clean; bazel build --spawn_strategy=standalone //src:static_analysis'
+    /cov/bin/cov-build --dir cov-int bash -c 'bazel shutdown && bazel clean && bazel build --config=coverity --spawn_strategy=standalone //src:static_analysis'
 #    cd /example_cpp_client/cpp && \
 #    bazel build --spawn_strategy=standalone //src:all'
 


### PR DESCRIPTION
### 🛠 Summary

After enabling disk and remote cache, the build command did not analyze significant part of our artifacts including ovms source code. Now it does.

CVS-157226
