### PR TITLE
Move to generic ssl.md5

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -1579,13 +1579,8 @@ cc_library(
     deps = [
             "libovmslogging",
             "libovmsmodelversioning",
-            "libovmsstatus",]
-            + select({
-                "//conditions:default": [
-                    "@boringssl//:ssl",
-                ],
-                "//src:windows" : [],
-            }),
+            "libovmsstatus",
+            "@boringssl//:ssl"],
     visibility = ["//visibility:public"],
     local_defines = COMMON_LOCAL_DEFINES,
     copts = COPTS_ADJUSTED,

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -26,9 +26,7 @@
 
 #include "logging.hpp"
 #include "model_version_policy.hpp"
-#ifdef __linux__
 #include "openssl/md5.h"
-#endif
 #include "status.hpp"
 
 namespace ovms {
@@ -269,7 +267,6 @@ public:
     }
 
     static std::string getStringMD5(const std::string& str) {
-#ifdef __linux__
         unsigned char result[MD5_DIGEST_LENGTH];
 
 #pragma GCC diagnostic push
@@ -277,10 +274,6 @@ public:
         MD5((unsigned char*)str.c_str(), str.size(), result);
         std::string md5sum(reinterpret_cast<char*>(result), MD5_DIGEST_LENGTH);
 #pragma GCC diagnostic pop
-#else  // Windows TODO: Check how it works - tests ?
-        std::hash<std::string> hasher;
-        std::string md5sum = std::to_string(hasher(str));
-#endif
         return (md5sum);
     }
 


### PR DESCRIPTION
### 🛠 Summary

JIRA CVS-154704 
Boringssl enabled on windows.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

