### PR TITLE
Fix Windows ovms_test compile src\test\http_openai_handler_test.cpp missing dependencies

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -463,6 +463,7 @@ cc_library(
         }) + select({
             "//conditions:default": [],
             "//:not_disable_mediapipe" : [
+                "//src/llm:openai_completions_api_handler",
                 "//src/embeddings:embeddingscalculator",
                 "//src/rerank:rerankcalculator",],
         }) + select({


### PR DESCRIPTION
### 🛠 Summary

Windows compile ovms_test for unit test, error occured.
ERROR: C:/git/model_server/src/BUILD:1807:8: Compiling src/test/http_openai_handler_test.cpp failed: undeclared inclusion(s) in rule '//src:ovms_test':
![image](https://github.com/user-attachments/assets/d78f94d4-f534-4b3a-9058-7ff7e8e7ce3e)

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

