### PR TITLE
Add missing llm UTs

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -1893,7 +1893,9 @@ cc_test(
                 "test/mediapipe_framework_test.cpp",
                 "test/http_openai_handler_test.cpp",
             ],
-            "//:disable_mediapipe" : [],
+            "//:disable_mediapipe" : [
+                "test/mediapipe_disabled_test.cpp",
+            ],
         }) + select({
             "//:not_disable_python": [
                 # OvmsPyTensor is currently not used in OVMS core and is just a base for the binding.

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -589,6 +589,24 @@ TEST_F(LLMFlowHttpTest, unaryChatCompletionsJsonN) {
     EXPECT_STREQ(parsedResponse["object"].GetString(), "chat.completion");
 }
 
+TEST_F(LLMFlowHttpTest, KFSApiRequestToChatCompletionsGraph) {
+    std::string requestBody = R"({
+    "inputs" : [
+        {
+        "name" : "input",
+        "shape" : [ 2, 2 ],
+        "datatype" : "UINT32",
+        "data" : [ 1, 2, 3, 4 ]
+        }
+    ]
+    })";
+    std::vector<std::pair<std::string, std::string>> headers;
+    ASSERT_EQ(handler->parseRequestComponents(comp, "POST", "/v2/models/llmDummyKFS/versions/1/infer", headers), ovms::StatusCode::OK);
+    ASSERT_EQ(
+        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, writer),
+        ovms::StatusCode::MEDIAPIPE_GRAPH_ADD_PACKET_INPUT_STREAM);
+}
+
 TEST_F(LLMFlowHttpTest, unaryChatCompletionsJson) {
     std::string requestBody = R"(
         {


### PR DESCRIPTION
### 🛠 Summary

CVS-152723
- test that /v3/chat/completions endpoint is not reachable for builds without MediaPipe
- test negative path for accessing /v3/chat/completions graph via KFS API
- test negative path for accessing regular graph via /v3/chat/completions endpoint

### 🧪 Checklist

- [x] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

