### PR TITLE
Detect client disconnection immediately for http streaming

### DIFF
--- a/src/drogon_http_async_writer_impl.cpp
+++ b/src/drogon_http_async_writer_impl.cpp
@@ -64,7 +64,7 @@ void DrogonHttpAsyncWriterImpl::PartialReplyEnd() {
 }
 // Used by graph executor impl
 void DrogonHttpAsyncWriterImpl::PartialReply(std::string message) {
-    if (this->isDisconnected) {
+    if (this->IsDisconnected()) {
         return;
     }
     if (!this->stream->send(message))
@@ -72,7 +72,7 @@ void DrogonHttpAsyncWriterImpl::PartialReply(std::string message) {
 }
 // Used by calculator via HttpClientConnection
 bool DrogonHttpAsyncWriterImpl::IsDisconnected() const {
-    return this->isDisconnected;
+    return this->isDisconnected || !requestPtr->connected();
 }
 
 void DrogonHttpAsyncWriterImpl::RegisterDisconnectionCallback(std::function<void()> callback) {

--- a/src/drogon_http_async_writer_impl.hpp
+++ b/src/drogon_http_async_writer_impl.hpp
@@ -32,13 +32,16 @@ class DrogonHttpAsyncWriterImpl : public HttpAsyncWriter {
     drogon::ResponseStreamPtr stream;
     bool isDisconnected = false;
     std::unordered_map<std::string, std::string> additionalHeaders;
+    const drogon::HttpRequestPtr requestPtr{nullptr};
 
 public:
     DrogonHttpAsyncWriterImpl(
         std::function<void(const drogon::HttpResponsePtr&)>& callback,
-        mediapipe::ThreadPool& pool) :
+        mediapipe::ThreadPool& pool,
+        const drogon::HttpRequestPtr& requestPtr) :
         callback(callback),
-        pool(pool) {}
+        pool(pool),
+        requestPtr(requestPtr) {}
 
     // Used by V3 handler
     void OverwriteResponseHeader(const std::string& key, const std::string& value) override;

--- a/src/drogon_http_server.cpp
+++ b/src/drogon_http_server.cpp
@@ -37,6 +37,7 @@ DrogonHttpServer::DrogonHttpServer(size_t num_workers, int port, const std::stri
     SPDLOG_DEBUG("Starting http thread pool ({} threads)", num_workers);
     pool->StartWorkers();  // this is for actual workload which is scheduled to other threads than drogon's internal listener threads
     SPDLOG_DEBUG("Thread pool started");
+    trantor::Logger::setLogLevel(trantor::Logger::kInfo);
 }
 
 Status DrogonHttpServer::startAcceptingRequests() {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -200,7 +200,7 @@ std::unique_ptr<DrogonHttpServer> createAndStartDrogonHttpServer(const std::stri
         auto body = std::string(req->getBody());
         std::string output;
         HttpResponseComponents responseComponents;
-        std::shared_ptr<HttpAsyncWriter> writer = std::make_shared<DrogonHttpAsyncWriterImpl>(callback, pool);
+        std::shared_ptr<HttpAsyncWriter> writer = std::make_shared<DrogonHttpAsyncWriterImpl>(callback, pool, req);
 
         const auto status = handler->processRequest(
             drogon::to_string_view(req->getMethod()),

--- a/third_party/drogon/drogon.bzl
+++ b/third_party/drogon/drogon.bzl
@@ -46,7 +46,7 @@ cc_library(
     new_git_repository(
         name = "drogon",
         remote = "https://github.com/drogonframework/drogon",
-        tag = "v1.9.7",  # Sep 10 2024
+        tag = "v1.9.9",  # Jan 1 2025
         build_file = "@_drogon_cpp//:BUILD",
         init_submodules = True,
         recursive_init_submodules = True,

--- a/third_party/drogon/ovms_drogon_trantor.patch
+++ b/third_party/drogon/ovms_drogon_trantor.patch
@@ -27,6 +27,23 @@ index 623d906a..bd61837d 100644
      if (runAsDaemon_)
      {
          // go daemon!
+diff --git a/lib/src/Utilities.cc b/lib/src/Utilities.cc
+index c6601f61..60b2a358 100644
+--- a/lib/src/Utilities.cc
++++ b/lib/src/Utilities.cc
+@@ -20,11 +20,11 @@
+ #include <brotli/decode.h>
+ #include <brotli/encode.h>
+ #endif
++#include <iomanip>
+ #ifdef _WIN32
+ #include <rpc.h>
+ #include <direct.h>
+ #include <io.h>
+-#include <iomanip>
+ #else
+ #include <uuid.h>
+ #include <unistd.h>
 diff --git a/orm_lib/inc/drogon/orm/SqlBinder.h b/orm_lib/inc/drogon/orm/SqlBinder.h
 index 3335e6ff..7874f18b 100644
 --- a/orm_lib/inc/drogon/orm/SqlBinder.h


### PR DESCRIPTION
### 🛠 Summary

Unary still requires MP graph cycle to recognize disconnection making it impossible to cancel long running workloads (drogon still has no disconnection callback installation feature as of v1.9.9)

Updated drogon v1.9.0 -> v1.9.9 (with patch to drogon to build on redhat, it is broken)

Changed drogon log level from debug to info which disabled many annoying logs

### 🧪 Checklist
- [x] Change follows security best practices.


