### PR TITLE
Disable mmap for models on windows

### DIFF
--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -90,6 +90,10 @@ ModelManager::ModelManager(const std::string& modelCacheDirectory, MetricRegistr
     metricRegistry(registry),
     pythonBackend(pythonBackend) {
     OV_LOGGER("ov::Core(): {}", reinterpret_cast<void*>(this->ieCore.get()));
+#ifdef _WIN32
+    // On Windows, we do not want to use mmap in order to support model version management
+    ieCore->set_property(ov::AnyMap{{ov::enable_mmap(false)}});
+#endif
     // Take --cache_dir from CLI
     if (this->modelCacheDirectory.empty()) {
         this->modelCacheDirectory = ovms::Config::instance().cacheDir();

--- a/src/test/http_rest_api_handler_test.cpp
+++ b/src/test/http_rest_api_handler_test.cpp
@@ -345,11 +345,6 @@ TEST_F(ConfigReload, startWith1DummyThenAddVersion) {
     EXPECT_EQ(expectedJson2, response);
     EXPECT_EQ(status, ovms::StatusCode::OK_RELOADED);
 
-    // Workaround to unload before removing the model,
-    // because on windows does not close the handle (uses mmap)
-#ifdef _WIN32
-    this->UnloadConfig(t.getManager());
-#endif
     std::filesystem::remove_all(getGenericFullPathForTmp("/tmp/dummy"));
 }
 
@@ -391,11 +386,6 @@ TEST_F(ConfigReload, startWithMissingXmlThenAddAndReload) {
     EXPECT_EQ(expectedJson2, response);
     EXPECT_EQ(status, ovms::StatusCode::OK_RELOADED);
 
-    // Workaround to unload before removing the model,
-    // because on windows does not close the handle (uses mmap)
-#ifdef _WIN32
-    this->UnloadConfig(t.getManager());
-#endif
     std::filesystem::remove_all(getGenericFullPathForTmp("/tmp/dummy"));
 }
 
@@ -418,11 +408,6 @@ TEST_F(ConfigReload, startWithEmptyModelDir) {
     ASSERT_EQ(status, ovms::StatusCode::OK_NOT_RELOADED);
     EXPECT_EQ(expectedJson, response);
 
-    // Workaround to unload before removing the model,
-    // because on windows does not close the handle (uses mmap)
-#ifdef _WIN32
-    this->UnloadConfig(t.getManager());
-#endif
     std::filesystem::remove_all("/tmp/dummy");
 }
 


### PR DESCRIPTION
### 🛠 Summary

CVS-159635
CVS-160412

This fixes single model versioning feature on windows (unload/load models when removing/adding model directory)
The trade off is that models are loading slower

### 🧪 Checklist

- [x] Unit tests added.
- [x] Change follows security best practices.


