### PR TITLE
Allow ENABLE_MMAP plugin config key, use plugin config in Core::read_model

### DIFF
--- a/docs/model_version_policy.md
+++ b/docs/model_version_policy.md
@@ -28,5 +28,7 @@ Examples:
 
 - When the model version is deleted from the file system, it will become unavailable on the server and it will release RAM allocation. Updates in the deployed model version files will not be detected and they will not trigger changes in serving.
 
+> NOTE: On Windows, models in IR format which are loadeded by OpenVINO cannot be removed from disk until the model is unloaded. This is because OpenVINO by default uses `mmap` to speed up model loading time. To disable this feature, set `--plugin_config "{\"ENABLE_MMAP\":\"NO\"}"`. This parameter does not apply for other model formats than OpenVINO IR.
+
 - By default model server is detecting new and deleted versions in 1-second intervals. The frequency can be changed by setting a parameter --file_system_poll_wait_seconds. If set to zero, updates will be disabled.
 

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -795,7 +795,8 @@ uint32_t ModelInstance::getNumOfParallelInferRequests(const ModelConfig& modelCo
 
 std::shared_ptr<ov::Model> ModelInstance::loadOVModelPtr(const std::string& modelFile) {
     OV_LOGGER("ov::Core: {}, model = ieCore.read_model(\"{}\")", reinterpret_cast<const void*>(&this->ieCore), modelFile);
-    return this->ieCore.read_model(modelFile);
+    plugin_config_t pluginConfig = prepareDefaultPluginConfig(this->config);
+    return this->ieCore.read_model(modelFile, {}, pluginConfig);
 }
 
 Status ModelInstance::loadOVModel() {

--- a/src/ov_utils.cpp
+++ b/src/ov_utils.cpp
@@ -133,6 +133,8 @@ Status validatePluginConfiguration(const plugin_config_t& pluginConfig, const st
         insertSupportedKeys(pluginSupportedConfigKeys, targetDevice, ieCore);
     }
 
+    pluginSupportedConfigKeys.insert("ENABLE_MMAP");  // WA: always supported
+
     for (auto& config : pluginConfig) {
         if (std::find(pluginSupportedConfigKeys.begin(), pluginSupportedConfigKeys.end(), config.first) == pluginSupportedConfigKeys.end()) {
             SPDLOG_LOGGER_ERROR(modelmanager_logger, "Plugin config key: {} not found in supported config keys for device: {}.", config.first, targetDevice);

--- a/src/test/http_rest_api_handler_test.cpp
+++ b/src/test/http_rest_api_handler_test.cpp
@@ -465,7 +465,8 @@ TEST_F(ConfigReload, removeModelFromDiskWhenLoaded) {
 #ifdef _WIN32
     EXPECT_THROW({
         std::filesystem::remove_all(getGenericFullPathForSrcTest("/tmp/dummy"));
-    }, std::filesystem::filesystem_error);
+    },
+        std::filesystem::filesystem_error);
 #else
     // On linux, removing the model should be possible even if ENABLE_MMAP=YES
     std::filesystem::remove_all(getGenericFullPathForSrcTest("/tmp/dummy"));

--- a/src/test/ov_utils_test.cpp
+++ b/src/test/ov_utils_test.cpp
@@ -224,3 +224,16 @@ TEST(OVUtils, ValidatePluginConfigurationNegative) {
     auto status = ovms::validatePluginConfiguration(unsupportedPluginConfig, "CPU", ieCore);
     EXPECT_FALSE(status.ok());
 }
+
+// Multi stage (read_model & compile_model time) plugin config
+TEST(OVUtils, ValidatePluginConfigurationAllowEnableMmap) {
+    ov::Core ieCore;
+    ovms::ModelConfig config;
+    config.setTargetDevice("CPU");
+    config.setPluginConfig({{"ENABLE_MMAP", "NO"}, {"NUM_STREAMS", "1"}});
+    ovms::plugin_config_t pluginConfig = ovms::ModelInstance::prepareDefaultPluginConfig(config);
+    auto status = ovms::validatePluginConfiguration(pluginConfig, "CPU", ieCore);
+    EXPECT_TRUE(status.ok());
+    auto model = ieCore.read_model(std::filesystem::current_path().u8string() + "/src/test/dummy/1/dummy.xml", {}, pluginConfig);
+    auto compiledModel = ieCore.compile_model(model, "CPU", pluginConfig);
+}


### PR DESCRIPTION
### 🛠 Summary

CVS-159635
CVS-160412

### 🧪 Checklist

- [x] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.
