### PR TITLE
Streaming test for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ bazel-openvino-model-server/
 bazel-model_server/
 out
 .user.bazelrc
+*.log
+*.errors.txt

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -14,9 +14,9 @@
 // limitations under the License.
 //*****************************************************************************
 #include <chrono>
+#include <future>
 #include <mutex>  // ?
 #include <optional>
-#include <future>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -767,9 +767,9 @@ node {
 // symmetric_scalar_increment.py returns outputs symmetrically,
 // so if Process() is run with one input, there will be one output
 TEST_F(PythonStreamingTest, Positive_SingleStreamSendIncompleteInputs) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     std::string testPbtxt{R"(
 input_stream: "OVMS_PY_TENSOR1:input1"
 input_stream: "OVMS_PY_TENSOR2:input2"
@@ -883,9 +883,9 @@ node {
 }
 
 TEST_F(PythonStreamingTest, MultipleStreamsInSingleRequestSend1Receive3Python) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     std::string testPbtxt{R"(
 input_stream: "OVMS_PY_TENSOR1:input1"
 input_stream: "OVMS_PY_TENSOR2:input2"
@@ -952,9 +952,9 @@ node {
 }
 
 TEST_F(PythonStreamingTest, MultipleStreamsInMultipleRequestSend1Receive3Python) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     std::string testPbtxt{R"(
 input_stream: "OVMS_PY_TENSOR1:input1"
 input_stream: "OVMS_PY_TENSOR2:input2"
@@ -1135,9 +1135,9 @@ node {
 
 // Sending inputs separately for synchronized graph
 TEST_F(StreamingTest, MultipleStreamsDeliveredViaMultipleRequests) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in1"
 input_stream: "in2"
@@ -1190,9 +1190,9 @@ node {
 
 // Sending inputs together for synchronized graph
 TEST_F(StreamingTest, MultipleStreamsDeliveredViaSingleRequest) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in1"
 input_stream: "in2"
@@ -1242,9 +1242,9 @@ node {
 }
 
 TEST_F(StreamingTest, WrongOrderOfManualTimestamps) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in"
 output_stream: "out"
@@ -1332,9 +1332,9 @@ node {
 }
 
 TEST_F(StreamingTest, ErrorOnDisconnectionDuringWrite) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in"
 output_stream: "out"
@@ -1429,9 +1429,9 @@ node {
 }
 
 TEST_F(StreamingTest, ErrorDuringSubsequentRequestDeserializations) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in"
 output_stream: "out"
@@ -1454,14 +1454,12 @@ node {
     std::future<void> fut[3] = {
         prom[0].get_future(),
         prom[1].get_future(),
-        prom[2].get_future()
-    };
-
+        prom[2].get_future()};
 
     // Mock receiving 4 requests, the last two malicious
     prepareRequest(this->firstRequest, {{"in", 3.5f}}, 0);  // correct request
     EXPECT_CALL(this->stream, Read(_))
-        .WillOnce(ReceiveWithTimestamp({{"in", 7.2f}}, 1))                                             // correct request
+        .WillOnce(ReceiveWithTimestamp({{"in", 7.2f}}, 1))                                              // correct request
         .WillOnce(ReceiveInvalidWithTimestampWhenNotified_({"in"}, 2, fut[0]))                          // invalid request - missing data in buffer
         .WillOnce(ReceiveWithTimestampWhenNotified_({{"NONEXISTING", 13.f}, {"in", 2.3f}}, 2, fut[1]))  // invalid request - non existing input
         .WillOnce(DisconnectWhenNotified_(fut[2]));
@@ -1509,9 +1507,9 @@ node {
 }
 
 TEST_F(StreamingTest, ManualTimestampWrongType) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in"
 output_stream: "out"
@@ -1589,9 +1587,9 @@ node {
 }
 
 TEST_F(StreamingTest, ManualTimestampInRange) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in"
 output_stream: "out"
@@ -1627,9 +1625,9 @@ node {
 }
 
 TEST_F(StreamingTest, AutomaticTimestampingExceedsMax) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in"
 output_stream: "out"
@@ -1651,8 +1649,7 @@ node {
     std::promise<void> prom[2];
     std::future<void> fut[2] = {
         prom[0].get_future(),
-        prom[1].get_future()
-    };
+        prom[1].get_future()};
 
     prepareRequest(this->firstRequest, {{"in", 3.5f}}, ::mediapipe::Timestamp::Max().Value());  // valid
     EXPECT_CALL(this->stream, Read(_))
@@ -1794,9 +1791,9 @@ node {
 }
 
 TEST_F(StreamingTest, SubsequentRequestsDoNotMatchServableNameAndVersion) {
-// #ifdef _WIN32
-//     GTEST_SKIP() << "Test disabled on windows";
-// #endif
+    // #ifdef _WIN32
+    //     GTEST_SKIP() << "Test disabled on windows";
+    // #endif
     const std::string pbTxt{R"(
 input_stream: "in"
 output_stream: "out"
@@ -1821,10 +1818,10 @@ node {
     prepareRequest(this->firstRequest, {{"in", 3.5f}}, std::nullopt, this->name, this->version);  // no timestamp specified, server will assign one
     EXPECT_CALL(this->stream, Read(_))
         .WillOnce(ReceiveWithServableNameAndVersionWhenNotified_({{"in", 7.2f}}, "wrong name", this->version, fut))  // no timestamp specified, server will assign one
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 8.2f}}, this->name, "wrong version"))                   // no timestamp specified, server will assign one
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 9.2f}}, this->name, this->version))                     // correct
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 10.4f}}, this->name, "0"))                              // default - user does not care - correct
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 12.5f}}, this->name, ""))                               // empty = default - correct
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 8.2f}}, this->name, "wrong version"))                    // no timestamp specified, server will assign one
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 9.2f}}, this->name, this->version))                      // correct
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 10.4f}}, this->name, "0"))                               // default - user does not care - correct
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 12.5f}}, this->name, ""))                                // empty = default - correct
         .WillOnce(Disconnect());
 
     EXPECT_CALL(this->stream, Write(_, _))

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -205,13 +205,6 @@ static auto Disconnect() {
     };
 }
 
-// static auto DisconnectWhenNotified(std::mutex& mtx) {
-//     return [&mtx](::inference::ModelInferRequest* req) {
-//         std::lock_guard<std::mutex> lock(mtx);  // waits for lock to be released
-//         return false;
-//     };
-// }
-
 static auto DisconnectWhenNotified_(std::future<void>& fut) {
     return [&fut](::inference::ModelInferRequest* req) {
         fut.get();
@@ -233,14 +226,6 @@ static auto ReceiveWithServableNameAndVersion(std::vector<std::tuple<std::string
     };
 }
 
-// static auto ReceiveWithServableNameAndVersionWhenNotified(std::vector<std::tuple<std::string, float>> content, const std::string& servableName, const std::string& servableVersion, std::mutex& mtx) {
-//     return [content, servableName, servableVersion, &mtx](::inference::ModelInferRequest* req) {
-//         std::lock_guard<std::mutex> lock(mtx);
-//         prepareRequest(*req, content, std::nullopt, servableName, servableVersion);
-//         return true;
-//     };
-// }
-
 static auto ReceiveWithServableNameAndVersionWhenNotified_(std::vector<std::tuple<std::string, float>> content, const std::string& servableName, const std::string& servableVersion, std::future<void>& fut) {
     return [content, servableName, servableVersion, &fut](::inference::ModelInferRequest* req) {
         fut.get();
@@ -257,14 +242,6 @@ static auto ReceiveWithTimestamp(std::vector<std::tuple<std::string, float>> con
     };
 }
 
-// static auto ReceiveWhenNotified(std::vector<std::tuple<std::string, float>> content, std::mutex& mtx) {
-//     return [content, &mtx](::inference::ModelInferRequest* req) {
-//         std::lock_guard<std::mutex> lock(mtx);
-//         prepareRequest(*req, content);
-//         return true;
-//     };
-// }
-
 static auto ReceiveWhenNotified_(std::vector<std::tuple<std::string, float>> content, std::future<void>& fut) {
     return [content, &fut](::inference::ModelInferRequest* req) {
         fut.get();
@@ -272,15 +249,6 @@ static auto ReceiveWhenNotified_(std::vector<std::tuple<std::string, float>> con
         return true;
     };
 }
-
-// static auto ReceiveWithTimestampWhenNotified(std::vector<std::tuple<std::string, float>> content, int64_t timestamp, std::mutex& mtx) {
-//     return [content, timestamp, &mtx](::inference::ModelInferRequest* req) {
-//         std::lock_guard<std::mutex> lock(mtx);
-//         prepareRequest(*req, content);
-//         setRequestTimestamp(*req, std::to_string(timestamp));
-//         return true;
-//     };
-// }
 
 static auto ReceiveWithTimestampWhenNotified_(std::vector<std::tuple<std::string, float>> content, int64_t timestamp, std::future<void>& fut) {
     return [content, timestamp, &fut](::inference::ModelInferRequest* req) {
@@ -291,15 +259,6 @@ static auto ReceiveWithTimestampWhenNotified_(std::vector<std::tuple<std::string
     };
 }
 
-// static auto ReceiveInvalidWithTimestampWhenNotified(std::vector<std::string> inputs, int64_t timestamp, std::mutex& mtx) {
-//     return [inputs, timestamp, &mtx](::inference::ModelInferRequest* req) {
-//         std::lock_guard<std::mutex> lock(mtx);
-//         prepareInvalidRequest(*req, inputs);
-//         setRequestTimestamp(*req, std::to_string(timestamp));
-//         return true;
-//     };
-// }
-
 static auto ReceiveInvalidWithTimestampWhenNotified_(std::vector<std::string> inputs, int64_t timestamp, std::future<void>& fut) {
     return [inputs, timestamp, &fut](::inference::ModelInferRequest* req) {
         fut.get();
@@ -308,15 +267,6 @@ static auto ReceiveInvalidWithTimestampWhenNotified_(std::vector<std::string> in
         return true;
     };
 }
-
-
-// static auto DisconnectOnWriteAndNotifyEnd(std::mutex& mtx) {
-//     mtx.lock();
-//     return [&mtx](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {
-//         mtx.unlock();
-//         return false;
-//     };
-// }
 
 static auto DisconnectOnWriteAndNotifyEnd_(std::promise<void>& prom) {
     return [&prom](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {
@@ -339,15 +289,6 @@ static auto SendWithTimestampServableNameAndVersion(std::vector<std::tuple<std::
     };
 }
 
-// static auto SendWithTimestampServableNameAndVersionAndNotifyEnd(std::vector<std::tuple<std::string, float>> content, int64_t timestamp, const std::string& servableName, const std::string& servableVersion, std::mutex& mtx) {
-//     mtx.lock();
-//     return [content, timestamp, servableName, servableVersion, &mtx](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {
-//         assertResponse(msg, content, timestamp, servableName, servableVersion);
-//         mtx.unlock();
-//         return true;
-//     };
-// }
-
 static auto SendWithTimestampServableNameAndVersionAndNotifyEnd_(std::vector<std::tuple<std::string, float>> content, int64_t timestamp, const std::string& servableName, const std::string& servableVersion, std::promise<void>& prom) {
     return [content, timestamp, servableName, servableVersion, &prom](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {
         assertResponse(msg, content, timestamp, servableName, servableVersion);
@@ -355,15 +296,6 @@ static auto SendWithTimestampServableNameAndVersionAndNotifyEnd_(std::vector<std
         return true;
     };
 }
-
-// static auto SendWithTimestampAndNotifyEnd(std::vector<std::tuple<std::string, float>> content, int64_t timestamp, std::mutex& mtx) {
-//     mtx.lock();
-//     return [content, timestamp, &mtx](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {
-//         assertResponse(msg, content, timestamp);
-//         mtx.unlock();
-//         return true;
-//     };
-// }
 
 static auto SendWithTimestampAndNotifyEnd_(std::vector<std::tuple<std::string, float>> content, int64_t timestamp, std::promise<void>& prom) {
     return [content, timestamp, &prom](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {
@@ -379,15 +311,6 @@ static auto SendError(const std::string& expectedMessage) {
         return true;
     };
 }
-
-// static auto SendErrorAndNotifyEnd(const std::string& expectedMessage, std::mutex& mtx) {
-//     mtx.lock();
-//     return [expectedMessage, &mtx](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {
-//         assertResponseError(msg, expectedMessage);
-//         mtx.unlock();
-//         return true;
-//     };
-// }
 
 static auto SendErrorAndNotifyEnd_(const std::string& expectedMessage, std::promise<void>& prom) {
     return [expectedMessage, &prom](const ::inference::ModelStreamInferResponse& msg, ::grpc::WriteOptions options) {

--- a/src/test/streaming_test.cpp
+++ b/src/test/streaming_test.cpp
@@ -1434,7 +1434,7 @@ node {
     // Mock receiving 4 requests, the last two malicious
     prepareRequest(this->firstRequest, {{"in", 3.5f}}, 0);  // correct request
     EXPECT_CALL(this->stream, Read(_))
-        .WillOnce(ReceiveWithTimestamp({{"in", 7.2f}}, 1))                                              // correct request
+        .WillOnce(ReceiveWithTimestamp({{"in", 7.2f}}, 1))                                                      // correct request
         .WillOnce(ReceiveInvalidWithTimestampWhenNotified({"in"}, 2, signalFuture[0]))                          // invalid request - missing data in buffer
         .WillOnce(ReceiveWithTimestampWhenNotified({{"NONEXISTING", 13.f}, {"in", 2.3f}}, 2, signalFuture[1]))  // invalid request - non existing input
         .WillOnce(DisconnectWhenNotified(signalFuture[2]));
@@ -1781,10 +1781,10 @@ node {
     prepareRequest(this->firstRequest, {{"in", 3.5f}}, std::nullopt, this->name, this->version);  // no timestamp specified, server will assign one
     EXPECT_CALL(this->stream, Read(_))
         .WillOnce(ReceiveWithServableNameAndVersionWhenNotified({{"in", 7.2f}}, "wrong name", this->version, signalFuture))  // no timestamp specified, server will assign one
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 8.2f}}, this->name, "wrong version"))                    // no timestamp specified, server will assign one
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 9.2f}}, this->name, this->version))                      // correct
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 10.4f}}, this->name, "0"))                               // default - user does not care - correct
-        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 12.5f}}, this->name, ""))                                // empty = default - correct
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 8.2f}}, this->name, "wrong version"))                            // no timestamp specified, server will assign one
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 9.2f}}, this->name, this->version))                              // correct
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 10.4f}}, this->name, "0"))                                       // default - user does not care - correct
+        .WillOnce(ReceiveWithServableNameAndVersion({{"in", 12.5f}}, this->name, ""))                                        // empty = default - correct
         .WillOnce(Disconnect());
 
     EXPECT_CALL(this->stream, Write(_, _))


### PR DESCRIPTION
### 🛠 Summary

Changed wait mechanism from mutex to futures, it turns out there was double lock in the same thread in tests

CVS-157750

### 🧪 Checklist

- [x] Change follows security best practices.


