### PR TITLE
Enable starting OVMS without gRPC server

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -568,7 +568,7 @@ git_repository(
     remote = "https://github.com/nlohmann/json/",
     tag = "v3.11.3",
 )
-# for unit tests
+# for rest client in unit tests (server_test.cpp)
 git_repository(
     name = "cpp_httplib",
     remote = "https://github.com/yhirose/cpp-httplib/",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -569,3 +569,9 @@ git_repository(
     tag = "v3.11.3",
 )
 
+git_repository(
+    name = "cpp_httplib",
+    remote = "https://github.com/yhirose/cpp-httplib/",
+    tag = "v0.18.7",
+    build_file = "@//third_party/cpp-httplib:BUILD"
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -568,7 +568,7 @@ git_repository(
     remote = "https://github.com/nlohmann/json/",
     tag = "v3.11.3",
 )
-
+# for unit tests
 git_repository(
     name = "cpp_httplib",
     remote = "https://github.com/yhirose/cpp-httplib/",

--- a/src/BUILD
+++ b/src/BUILD
@@ -522,7 +522,7 @@ cc_library(
             "libovms_threadsafequeue",
             "//:ovms_dependencies", # TODO dispose or replace
             "//src/kfserving_api:kfserving_api_cpp",
-            "ovms_capimodule",
+            "capimodule",
          ] + select({
                 "//:not_disable_cloud": [
                     "libovmsazurefilesystem",
@@ -2214,7 +2214,7 @@ cc_library(
     linkopts = [],
 )
 cc_library(
-    name = "ovms_capimodule",
+    name = "capimodule",
     hdrs = ["capi_frontend/capimodule.hpp"],
     srcs = ["capi_frontend/capimodule.cpp"],
     deps = [

--- a/src/BUILD
+++ b/src/BUILD
@@ -522,6 +522,7 @@ cc_library(
             "libovms_threadsafequeue",
             "//:ovms_dependencies", # TODO dispose or replace
             "//src/kfserving_api:kfserving_api_cpp",
+            "ovms_capimodule",
          ] + select({
                 "//:not_disable_cloud": [
                     "libovmsazurefilesystem",
@@ -2029,6 +2030,7 @@ cc_test(
     ],
     linkopts = LINKOPTS_ADJUSTED,
     deps = [
+            "@cpp_httplib//:cpp_httplib",
             ":test_utils",
             "//src/rerank:rerank_api_handler",
             ":embeddings_handler_tests",
@@ -2207,6 +2209,19 @@ cc_library(
     deps = [
         "//src/embeddings:embeddings_api",
         "@com_google_googletest//:gtest",
+    ],
+    copts = COPTS_TESTS,
+    linkopts = [],
+)
+cc_library(
+    name = "ovms_capimodule",
+    hdrs = ["capi_frontend/capimodule.hpp"],
+    srcs = ["capi_frontend/capimodule.cpp"],
+    deps = [
+        "libovms_module",
+        "//src:cpp_headers",
+        "//src:libovmslogging",
+        "//src:libovmsstatus",
     ],
     copts = COPTS_TESTS,
     linkopts = [],

--- a/src/BUILD
+++ b/src/BUILD
@@ -2030,7 +2030,7 @@ cc_test(
     ],
     linkopts = LINKOPTS_ADJUSTED,
     deps = [
-            "@cpp_httplib//:cpp_httplib",
+            "@cpp_httplib//:cpp_httplib", # server_test.cpp
             ":test_utils",
             "//src/rerank:rerank_api_handler",
             ":embeddings_handler_tests",

--- a/src/capi_frontend/capimodule.cpp
+++ b/src/capi_frontend/capimodule.cpp
@@ -1,0 +1,55 @@
+//****************************************************************************
+// Copyright 2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include "capimodule.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <map>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../config.hpp"
+#include "../logging.hpp"
+#include "../server.hpp"
+#include "../status.hpp"
+
+namespace ovms {
+CAPIModule::~CAPIModule() {
+    this->shutdown();
+}
+
+CAPIModule::CAPIModule(Server& server) :
+    server(server) {}
+Status CAPIModule::start(const ovms::Config& config) {
+    state = ModuleState::STARTED_INITIALIZE;
+    SPDLOG_INFO("{} starting", CAPI_MODULE_NAME);
+    SPDLOG_INFO("{} starting", (void*)&server);
+    state = ModuleState::INITIALIZED;
+    SPDLOG_INFO("{} started", CAPI_MODULE_NAME);
+    return StatusCode::OK;
+}
+
+void CAPIModule::shutdown() {
+    if (state == ModuleState::SHUTDOWN)
+        return;
+    state = ModuleState::STARTED_SHUTDOWN;
+    SPDLOG_INFO("{} shutting down", CAPI_MODULE_NAME);
+    state = ModuleState::SHUTDOWN;
+    SPDLOG_INFO("{} shutdown", CAPI_MODULE_NAME);
+}
+}  // namespace ovms

--- a/src/capi_frontend/capimodule.cpp
+++ b/src/capi_frontend/capimodule.cpp
@@ -38,7 +38,6 @@ CAPIModule::CAPIModule(Server& server) :
 Status CAPIModule::start(const ovms::Config& config) {
     state = ModuleState::STARTED_INITIALIZE;
     SPDLOG_INFO("{} starting", CAPI_MODULE_NAME);
-    SPDLOG_INFO("{} starting", (void*)&server);
     state = ModuleState::INITIALIZED;
     SPDLOG_INFO("{} started", CAPI_MODULE_NAME);
     return StatusCode::OK;

--- a/src/capi_frontend/capimodule.hpp
+++ b/src/capi_frontend/capimodule.hpp
@@ -1,5 +1,5 @@
-//*****************************************************************************
-// Copyright 2024 Intel Corporation
+//****************************************************************************
+// Copyright 2025 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,23 @@
 // limitations under the License.
 //*****************************************************************************
 #pragma once
-#include <string>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "../module.hpp"
 
 namespace ovms {
-extern const std::string PROFILER_MODULE_NAME;
-extern const std::string GRPC_SERVER_MODULE_NAME;
-extern const std::string HTTP_SERVER_MODULE_NAME;
-extern const std::string SERVABLE_MANAGER_MODULE_NAME;
-extern const std::string METRICS_MODULE_NAME;
-extern const std::string PYTHON_INTERPRETER_MODULE_NAME;
-extern const std::string CAPI_MODULE_NAME;
+class Config;
+class Server;
+
+class CAPIModule : public Module {
+    Server& server;
+
+public:
+    CAPIModule(Server& server);
+    ~CAPIModule();
+    Status start(const ovms::Config& config) override;
+    void shutdown() override;
+};
 }  // namespace ovms

--- a/src/capi_frontend/server_settings.hpp
+++ b/src/capi_frontend/server_settings.hpp
@@ -21,7 +21,7 @@
 namespace ovms {
 
 struct ServerSettingsImpl {
-    uint32_t grpcPort = 9178;
+    uint32_t grpcPort = 0;
     uint32_t restPort = 0;
     uint32_t grpcWorkers = 1;
     std::string grpcBindAddress = "0.0.0.0";

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -42,7 +42,7 @@ void CLIParser::parse(int argc, char** argv) {
                 "Show binary version")
             ("port",
                 "gRPC server port",
-                cxxopts::value<uint32_t>()->default_value("9178"),
+                cxxopts::value<uint32_t>()->default_value("0"),
                 "PORT")
             ("grpc_bind_address",
                 "Network interface address to bind to for the gRPC API",

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -159,7 +159,7 @@ bool Config::validate() {
     }
 
     // port and rest_port cannot be the same
-    if (port() == restPort()) {
+    if ((port() == restPort()) && (port() != 0)) {
         std::cerr << "port and rest_port cannot have the same values" << std::endl;
         return false;
     }

--- a/src/drogon_http_server.cpp
+++ b/src/drogon_http_server.cpp
@@ -71,6 +71,7 @@ Status DrogonHttpServer::startAcceptingRequests() {
     // Should never happen
     if (drogon::app().isRunning()) {
         SPDLOG_ERROR("Drogon is already running");
+        throw std::runtime_error("Cannot start Drogon twice");
     }
 
     pool->Schedule(

--- a/src/drogon_http_server.cpp
+++ b/src/drogon_http_server.cpp
@@ -71,7 +71,6 @@ Status DrogonHttpServer::startAcceptingRequests() {
     // Should never happen
     if (drogon::app().isRunning()) {
         SPDLOG_ERROR("Drogon is already running");
-        throw 42;
     }
 
     pool->Schedule(

--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -86,7 +86,7 @@ struct WSAStartupCleanupGuard {
 struct SocketOpenCloseGuard {
     SOCKET socket;
     SocketOpenCloseGuard(SOCKET socket) : socket(socket) {}
-    ~SocketOpenCloseGuard(SOCKET socket) {
+    ~SocketOpenCloseGuard() {
         closesocket(socket);
     }
 bool GRPCServerModule::isPortAvailable(uint64_t port) {

--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -157,6 +157,14 @@ GRPCServerModule::GRPCServerModule(Server& server) :
 Status GRPCServerModule::start(const ovms::Config& config) {
     state = ModuleState::STARTED_INITIALIZE;
     SPDLOG_INFO("{} starting", GRPC_SERVER_MODULE_NAME);
+    if (config.port() == 0) {
+        // due to HTTP reusing gRPC we still need to have gRPC module initialized.
+        state = ModuleState::INITIALIZED;
+        SPDLOG_INFO("{} started", GRPC_SERVER_MODULE_NAME);
+        SPDLOG_INFO("Port was not set. GRPC server will not be started.");
+        return StatusCode::OK;
+    }
+
     std::map<std::string, std::string> channel_arguments;
     auto status = setDefaultGrpcChannelArgs(channel_arguments);
     if (!status.ok()) {

--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -76,7 +76,7 @@ bool GRPCServerModule::isPortAvailable(uint64_t port) {
     close(s);
     return true;
 }
-#else  //  __linux__
+#else  //  not __linux__
 
 struct WSAStartupCleanupGuard {
     ~WSAStartupCleanupGuard() {

--- a/src/grpcservermodule.cpp
+++ b/src/grpcservermodule.cpp
@@ -76,7 +76,7 @@ bool GRPCServerModule::isPortAvailable(uint64_t port) {
     close(s);
     return true;
 }
-#else //  __linux__
+#else  //  __linux__
 
 struct WSAStartupCleanupGuard {
     ~WSAStartupCleanupGuard() {
@@ -85,7 +85,8 @@ struct WSAStartupCleanupGuard {
 };
 struct SocketOpenCloseGuard {
     SOCKET socket;
-    SocketOpenCloseGuard(SOCKET socket) : socket(socket) {}
+    SocketOpenCloseGuard(SOCKET socket) :
+        socket(socket) {}
     ~SocketOpenCloseGuard() {
         closesocket(socket);
     }
@@ -117,7 +118,7 @@ bool GRPCServerModule::isPortAvailable(uint64_t port) {
     }
     return true;
 }
-#endif // not __linux__
+#endif  //  not __linux__
 
 static Status setDefaultGrpcChannelArgs(std::map<std::string, std::string>& result) {
     uint16_t cores = getCoreCount();

--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -221,7 +221,7 @@ Status HttpRestApiHandler::processServerReadyKFSRequest(const HttpRequestCompone
 }
 
 Status HttpRestApiHandler::processServerLiveKFSRequest(const HttpRequestComponents& request_components, std::string& response, const std::string& request_body) {
-    bool isLive = this->ovmsServer.isLive();
+    bool isLive = this->ovmsServer.isLive(HTTP_SERVER_MODULE_NAME);
     SPDLOG_DEBUG("Requested Server liveness state: {}", isLive);
     if (isLive) {
         return StatusCode::OK;

--- a/src/kfs_frontend/kfs_grpc_inference_service.cpp
+++ b/src/kfs_frontend/kfs_grpc_inference_service.cpp
@@ -93,7 +93,7 @@ const std::string PLATFORM = "OpenVINO";
     (void)context;
     (void)request;
     (void)response;
-    bool isLive = this->ovmsServer.isLive();
+    bool isLive = this->ovmsServer.isLive(GRPC_SERVER_MODULE_NAME);
     SPDLOG_DEBUG("Requested Server liveness state: {}", isLive);
     response->set_live(isLive);
     return grpc::Status::OK;

--- a/src/module_names.cpp
+++ b/src/module_names.cpp
@@ -22,4 +22,5 @@ const std::string HTTP_SERVER_MODULE_NAME = "HTTPServerModule";
 const std::string SERVABLE_MANAGER_MODULE_NAME = "ServableManagerModule";
 const std::string METRICS_MODULE_NAME = "MetricsModule";
 const std::string PYTHON_INTERPRETER_MODULE_NAME = "PythonInterpreterModule";
+const std::string CAPI_MODULE_NAME = "C-APIModule";
 }  // namespace ovms

--- a/src/ovms.h
+++ b/src/ovms.h
@@ -183,7 +183,7 @@ OVMS_Status* OVMS_ServerSettingsNew(OVMS_ServerSettings** settings);
 void OVMS_ServerSettingsDelete(OVMS_ServerSettings* settings);
 
 // Set the gRPC port of starting OVMS. Equivalent of using --port parameter from OVMS CLI.
-// If not set server will start with gRPC port set to 9178.
+// If not set server will not start gRPC server.
 //
 // \param settings The server settings object to be set
 // \param grpc_port The value to be set

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -197,10 +197,6 @@ bool Server::isLive(const std::string& moduleName) const {
     if (modules.size() == 0) {
         return false;
     }
-    if (moduleName.empty()) {
-        // this is for C-API. GRPC & HTTP have its own modules, there doesn't seemt to be need to create C-API module
-        return true;
-    }
     auto it = modules.find(moduleName);
     if (it == modules.end()) {
         return false;
@@ -418,7 +414,7 @@ Status Server::start(ServerSettingsImpl* serverSettings, ModelsSettingsImpl* mod
             SPDLOG_ERROR("Cannot start OVMS - server is already starting");
             return StatusCode::SERVER_ALREADY_STARTING;
         }
-        std::unique_lock lockModules(modulesMtx);  // TODO @atobisze consider general isLive? Or C-API module
+        std::unique_lock lockModules(modulesMtx);
         if (!modules.empty()) {
             SPDLOG_ERROR("Cannot start OVMS - server is already live");
             return StatusCode::SERVER_ALREADY_STARTED;

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -45,7 +45,7 @@ public:
     ModuleState getModuleState(const std::string& name) const;
     const Module* getModule(const std::string& name) const;
     bool isReady() const;
-    bool isLive() const;
+    bool isLive(const std::string& moduleName) const;
 
     void setShutdownRequest(int i);
     virtual ~Server();

--- a/src/test/c_api_tests.cpp
+++ b/src/test/c_api_tests.cpp
@@ -75,7 +75,7 @@ TEST(CAPIConfigTest, MultiModelConfiguration) {
     ModelsSettingsImpl* modelsSettings = reinterpret_cast<ModelsSettingsImpl*>(_modelsSettings);
 
     // Test default values
-    EXPECT_EQ(serverSettings->grpcPort, 9178);
+    EXPECT_EQ(serverSettings->grpcPort, 0);
     EXPECT_EQ(serverSettings->restPort, 0);
     EXPECT_EQ(serverSettings->grpcWorkers, 1);
     EXPECT_EQ(serverSettings->grpcBindAddress, "0.0.0.0");
@@ -254,7 +254,8 @@ TEST(CAPIStartTest, StartFlow) {
         StatusCode::OPTIONS_USAGE_ERROR);
 
     // Fix and expect ok
-    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetRestPort(serverSettings, 6666));  // Different port
+    ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetRestPort(serverSettings, 0));
+    // ASSERT_CAPI_STATUS_NULL(OVMS_ServerSettingsSetRestPort(serverSettings, 6666));  // Different port TODO @atobisze @dkalinow not really needed for C-API
     ASSERT_CAPI_STATUS_NULL(OVMS_ServerStartFromConfigurationFile(srv, serverSettings, modelsSettings));
 
     // Try to start again, expect failure
@@ -1393,7 +1394,7 @@ public:
         }
         void setLive() {
             Module* grpc = new MockGrpcServerModule();
-            modules.insert({GRPC_SERVER_MODULE_NAME, std::unique_ptr<Module>(grpc)});
+            modules.insert({CAPI_MODULE_NAME, std::unique_ptr<Module>(grpc)});
         }
     };
 };

--- a/src/test/kfs_rest_test.cpp
+++ b/src/test/kfs_rest_test.cpp
@@ -55,15 +55,6 @@ protected:
 
 public:
     static void SetUpTestSuite() {
-#ifdef _WIN32
-        /*WSADATA wsa_data;
-        auto r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
-        if (r != 0) {
-            SPDLOG_ERROR("WSAStartup failed with error: {}", r);
-            ASSERT_TRUE(false);
-            return;
-        }*/
-#endif  // _WIN32
         HttpRestApiHandlerTest::server = std::make_unique<MockedServer>();
         std::string port = "9000";
         randomizePort(port);

--- a/src/test/kfs_rest_test.cpp
+++ b/src/test/kfs_rest_test.cpp
@@ -56,13 +56,13 @@ protected:
 public:
     static void SetUpTestSuite() {
 #ifdef _WIN32
-        WSADATA wsa_data;
+        /*WSADATA wsa_data;
         auto r = WSAStartup(MAKEWORD(2, 2), &wsa_data);
         if (r != 0) {
             SPDLOG_ERROR("WSAStartup failed with error: {}", r);
             ASSERT_TRUE(false);
             return;
-        }
+        }*/
 #endif  // _WIN32
         HttpRestApiHandlerTest::server = std::make_unique<MockedServer>();
         std::string port = "9000";

--- a/src/test/mediapipe_framework_test.cpp
+++ b/src/test/mediapipe_framework_test.cpp
@@ -66,7 +66,7 @@ protected:
     void SetUp() override {
     }
     void TearDown() {
-        if (server.isLive()) {
+        if (server.isLive(CAPI_MODULE_NAME)) {
             server.setShutdownRequest(1);
             t->join();
             server.setShutdownRequest(0);

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <grpcpp/create_channel.h>
 #include <gtest/gtest.h>
+#include <httplib.h>
 
 #include "../cleaner_utils.hpp"
 #include "../dags/node_library.hpp"
@@ -29,6 +30,7 @@
 #include "../model.hpp"
 #include "../modelinstanceunloadguard.hpp"
 #include "../modelmanager.hpp"
+#include "../module_names.hpp"
 #include "../prediction_service_utils.hpp"
 #include "../servablemanagermodule.hpp"
 #include "../server.hpp"
@@ -142,6 +144,45 @@ static void checkServerMetadata(const char* grpcPort, grpc::StatusCode status = 
     client.verifyServerMetadata(status);
 }
 
+static void requestRestServerAlive(const char* httpPort, httplib::StatusCode status = httplib::StatusCode::OK_200, bool expectedStatus = true) {
+    std::unique_ptr<httplib::Client> cli{nullptr};
+    try {
+        cli = std::make_unique<httplib::Client>(std::string("http://localhost:") + httpPort);
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("Exception caught during rest request:{}", e.what());
+        EXPECT_TRUE(false);
+        return;
+    } catch (...) {
+        SPDLOG_ERROR("Exception caught during rest request");
+        EXPECT_TRUE(false);
+        return;
+    }
+    try {
+        auto res = cli->Get("/v2/health/live");
+        if (!res) {
+            SPDLOG_ERROR("Got error:{}", httplib::to_string(res.error()));
+            EXPECT_TRUE(!expectedStatus);
+            return;
+        } else {
+            EXPECT_TRUE(expectedStatus);
+        }
+        if (res->status != httplib::StatusCode::OK_200) {
+            SPDLOG_ERROR("Failed to get liveness status code: {}, status: {}", res->status, httplib::status_message(res->status));
+            EXPECT_TRUE(false);
+            return;
+        }
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("Exception caught during rest request:{}", e.what());
+        EXPECT_TRUE(false);
+        return;
+    } catch (...) {
+        SPDLOG_ERROR("Exception caught during rest request");
+        EXPECT_TRUE(false);
+        return;
+    }
+    return;
+}
+
 TEST(Server, ServerNotAliveBeforeStart) {
     // here we should fail to connect before starting server
     requestServerAlive("9178", grpc::StatusCode::UNAVAILABLE, false);
@@ -240,7 +281,7 @@ TEST(Server, ServerAliveBeforeLoadingModels) {
 
     SPDLOG_INFO(R"(here check that model & server still is not ready since servable manager module only started loading
     we have to wait for module to start loading)");
-    while ((server.getModuleState(SERVABLE_MANAGER_MODULE_NAME) == ovms::ModuleState::NOT_INITIALIZED) &&
+    while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) == ovms::ModuleState::NOT_INITIALIZED) &&
            (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
     }
     requestModelReady(argv[8], argv[2], grpc::StatusCode::NOT_FOUND, false);
@@ -306,7 +347,7 @@ TEST(Server, ServerMetadata) {
         ASSERT_EQ(EXIT_SUCCESS, server.start(7, argv));
     });
     auto start = std::chrono::high_resolution_clock::now();
-    while ((ovms::Server::instance().getModuleState("GRPCServerModule") != ovms::ModuleState::INITIALIZED) &&
+    while ((ovms::Server::instance().getModuleState(ovms::GRPC_SERVER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
            (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
     }
 
@@ -348,8 +389,8 @@ TEST(Server, ProperShutdownInCaseOfStartError) {
 TEST(Server, grpcArguments) {
     std::string port = "9000";
     std::string channel_arguments_str = "grpc.max_connection_age_ms=2000,grpc.max_concurrent_streams=10";
-    std::string grpc_max_threads = "";
-    std::string grpc_memory_quota = "";
+    std::string grpc_max_threads = "8";
+    std::string grpc_memory_quota = "100000";
     randomizePort(port);
     char* argv[] = {
         (char*)"OpenVINO Model Server",
@@ -369,10 +410,10 @@ TEST(Server, grpcArguments) {
 
     ovms::Server& server = ovms::Server::instance();
     std::thread t([&argv, &server]() {
-        ASSERT_EQ(EXIT_SUCCESS, server.start(7, argv));
+        ASSERT_EQ(EXIT_SUCCESS, server.start(13, argv));
     });
     auto start = std::chrono::high_resolution_clock::now();
-    while ((ovms::Server::instance().getModuleState("GRPCServerModule") != ovms::ModuleState::INITIALIZED) &&
+    while ((ovms::Server::instance().getModuleState(ovms::GRPC_SERVER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
            (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
     }
 
@@ -383,3 +424,73 @@ TEST(Server, grpcArguments) {
     t.join();
     server.setShutdownRequest(0);
 }
+const std::string portOldDefault{"9178"};
+const std::string typicalRestDefault{"9179"};
+TEST(Server, CAPIAliveGrpcNotHttpNot) {
+    char* argv[] = {
+        (char*)"OpenVINO Model Server",
+        (char*)"--model_name",
+        (char*)"dummy",
+        (char*)"--model_path",
+        (char*)getGenericFullPathForSrcTest("/ovms/src/test/dummy").c_str(),
+        nullptr};
+
+    ovms::Server& server = ovms::Server::instance();
+    bool isLive = true;
+    auto* cserver = reinterpret_cast<OVMS_Server*>(&server);
+    OVMS_ServerLive(cserver, &isLive);
+    ASSERT_TRUE(!isLive);
+    std::thread t([&argv, &server]() {
+        ASSERT_EQ(EXIT_SUCCESS, server.start(5, argv));
+    });
+    auto start = std::chrono::high_resolution_clock::now();
+    while ((ovms::Server::instance().getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
+           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
+    }
+    isLive = false;
+    OVMS_ServerLive(cserver, &isLive);
+    ASSERT_TRUE(isLive);
+    // GRPC is initialized before Servable ManagerModule
+    requestServerAlive(portOldDefault.c_str(), grpc::StatusCode::UNAVAILABLE, false);
+    requestRestServerAlive(typicalRestDefault.c_str(), httplib::StatusCode::NotFound_404, false);
+
+    server.setShutdownRequest(1);
+    t.join();
+    server.setShutdownRequest(0);
+}
+TEST(Server, CAPIAliveGrpcNotHttpYes) {
+    GTEST_SKIP() << "Until we have a way to launch all tests restarting drogon";  // TODO @dkalinow to enable drogon tests
+    std::string port = "9000";
+    randomizePort(port);
+    char* argv[] = {
+        (char*)"OpenVINO Model Server",
+        (char*)"--model_name",
+        (char*)"dummy",
+        (char*)"--rest_port",
+        (char*)port.c_str(),
+        (char*)"--model_path",
+        (char*)getGenericFullPathForSrcTest("/ovms/src/test/dummy").c_str(),
+        nullptr};
+
+    ovms::Server& server = ovms::Server::instance();
+    bool isLive = true;
+    auto* cserver = reinterpret_cast<OVMS_Server*>(&server);
+    OVMS_ServerLive(cserver, &isLive);
+    ASSERT_TRUE(!isLive);
+    std::thread t([&argv, &server]() {
+        ASSERT_EQ(EXIT_SUCCESS, server.start(7, argv));
+    });
+    auto start = std::chrono::high_resolution_clock::now();
+    while ((ovms::Server::instance().getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
+           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
+    }
+    isLive = false;
+    OVMS_ServerLive(cserver, &isLive);
+    ASSERT_TRUE(isLive);
+    // GrPC is initialized before Servable ManagerModule
+    requestServerAlive(portOldDefault.c_str(), grpc::StatusCode::UNAVAILABLE, false);
+    requestRestServerAlive(port.c_str());
+    server.setShutdownRequest(1);
+    t.join();
+    server.setShutdownRequest(0);
+}  // TODO

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -493,4 +493,4 @@ TEST(Server, CAPIAliveGrpcNotHttpYes) {
     server.setShutdownRequest(1);
     t.join();
     server.setShutdownRequest(0);
-}  // TODO
+}

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -51,9 +51,12 @@ using testing::UnorderedElementsAre;
 using grpc::Channel;
 using grpc::ClientContext;
 
+const std::string portOldDefault{"9178"};
+const std::string typicalRestDefault{"9179"};
+
 struct Configuration {
     std::string address = "localhost";
-    std::string port = "9178";
+    std::string port = portOldDefault;
 };
 
 class ServingClient {
@@ -185,7 +188,7 @@ static void requestRestServerAlive(const char* httpPort, httplib::StatusCode sta
 
 TEST(Server, ServerNotAliveBeforeStart) {
     // here we should fail to connect before starting server
-    requestServerAlive("9178", grpc::StatusCode::UNAVAILABLE, false);
+    requestServerAlive(portOldDefault.c_str(), grpc::StatusCode::UNAVAILABLE, false);
 }
 
 using ovms::Config;
@@ -424,8 +427,6 @@ TEST(Server, grpcArguments) {
     t.join();
     server.setShutdownRequest(0);
 }
-const std::string portOldDefault{"9178"};
-const std::string typicalRestDefault{"9179"};
 TEST(Server, CAPIAliveGrpcNotHttpNot) {
     char* argv[] = {
         (char*)"OpenVINO Model Server",

--- a/third_party/cpp-httplib/BUILD
+++ b/third_party/cpp-httplib/BUILD
@@ -20,42 +20,12 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 visibility = ["//visibility:public"]
 
-config_setting(
-    name = "dbg",
-    values = {"compilation_mode": "dbg"},
-)
-
-config_setting(
-    name = "opt",
-    values = {"compilation_mode": "opt"},
-)
-
 filegroup(
     name = "all_srcs",
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )
 
-build_release = {"CMAKE_BUILD_TYPE": "Release"}
-build_debug = {"CMAKE_BUILD_TYPE": "Debug"}
-cmake(
-    name = "cpp-httplib_cmake",
-    build_args = [
-        "--verbose",
-        "--",  # <- Pass remaining options to the native tool.
-        # https://github.com/bazelbuild/rules_foreign_cc/issues/329
-        # there is no elegant parallel compilation support
-        "VERBOSE=1",
-        "-j 8",
-    ],
-    cache_entries = {},
-    lib_source = ":all_srcs",
-    out_lib_dir = "{lib_path}",
-    out_static_libs = [],
-    tags = ["requires-network"],
-    alwayslink = False,
-    visibility = ["//visibility:public"],
-)
 cc_library(
     name = "cpp_httplib",
     srcs = [],

--- a/third_party/cpp-httplib/BUILD
+++ b/third_party/cpp-httplib/BUILD
@@ -51,7 +51,6 @@ cmake(
     cache_entries = {},
     lib_source = ":all_srcs",
     out_lib_dir = "{lib_path}",
-    # linking order
     out_static_libs = [],
     tags = ["requires-network"],
     alwayslink = False,
@@ -67,8 +66,6 @@ cc_library(
         "",
     ],
     copts = [],
-    #strip_prefix= "cpp_httplib",
-    #deps = ["cpp-httplib_cmake"],
     defines = [],
     visibility = ["//visibility:public"],
 )

--- a/third_party/cpp-httplib/BUILD
+++ b/third_party/cpp-httplib/BUILD
@@ -1,0 +1,74 @@
+#
+# Copyright (c) 2025 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+visibility = ["//visibility:public"]
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+visibility = ["//visibility:public"]
+
+config_setting(
+    name = "dbg",
+    values = {"compilation_mode": "dbg"},
+)
+
+config_setting(
+    name = "opt",
+    values = {"compilation_mode": "opt"},
+)
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+build_release = {"CMAKE_BUILD_TYPE": "Release"}
+build_debug = {"CMAKE_BUILD_TYPE": "Debug"}
+cmake(
+    name = "cpp-httplib_cmake",
+    build_args = [
+        "--verbose",
+        "--",  # <- Pass remaining options to the native tool.
+        # https://github.com/bazelbuild/rules_foreign_cc/issues/329
+        # there is no elegant parallel compilation support
+        "VERBOSE=1",
+        "-j 8",
+    ],
+    cache_entries = {},
+    lib_source = ":all_srcs",
+    out_lib_dir = "{lib_path}",
+    # linking order
+    out_static_libs = [],
+    tags = ["requires-network"],
+    alwayslink = False,
+    visibility = ["//visibility:public"],
+)
+cc_library(
+    name = "cpp_httplib",
+    srcs = [],
+    hdrs = glob([
+        "*.h",
+    ]),
+    includes = [
+        "",
+    ],
+    copts = [],
+    #strip_prefix= "cpp_httplib",
+    #deps = ["cpp-httplib_cmake"],
+    defines = [],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/drogon/drogon.bzl
+++ b/third_party/drogon/drogon.bzl
@@ -54,8 +54,6 @@ cc_library(
             # Contains submodule (trantor) patches generated using:
             # git --no-pager diff --no-color --submodule=diff
             "@//third_party/drogon:ovms_drogon_trantor.patch",
-            #"@//third_party/drogon:ovms_debug.patch",
-            #"@//third_party/drogon:ovms_trantor_add.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/third_party/drogon/drogon.bzl
+++ b/third_party/drogon/drogon.bzl
@@ -54,6 +54,8 @@ cc_library(
             # Contains submodule (trantor) patches generated using:
             # git --no-pager diff --no-color --submodule=diff
             "@//third_party/drogon:ovms_drogon_trantor.patch",
+            #"@//third_party/drogon:ovms_debug.patch",
+            #"@//third_party/drogon:ovms_trantor_add.patch",
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
New module was added to have clear situation when server is live with every API.

* Fix minor issue in server tests when improper argcount was used

JIRA:CVS-161974

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

