### PR TITLE
multimodal stbi image decoding

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -587,3 +587,18 @@ git_repository(
     tag = "v0.18.7",
     build_file = "@//third_party/cpp-httplib:BUILD"
 )
+
+new_git_repository(
+    name = "stb",
+    remote = "https://github.com/nothings/stb",
+    branch = "master",
+    build_file_content = """
+cc_library(
+    name = "image",
+    hdrs = ["stb_image.h"],
+    visibility = ["//visibility:public"],
+    local_defines = [
+    ],
+)
+""",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -591,7 +591,7 @@ git_repository(
 new_git_repository(
     name = "stb",
     remote = "https://github.com/nothings/stb",
-    branch = "master",
+    commit = "5c205738c191bcb0abc65c4febfa9bd25ff35234",
     build_file_content = """
 cc_library(
     name = "image",

--- a/src/llm/BUILD
+++ b/src/llm/BUILD
@@ -79,6 +79,7 @@ cc_library(
         "@mediapipe//mediapipe/framework:calculator_framework", # required for absl status
         "//src:libovmsprofiler",
         "//third_party:opencv",
+        "@stb//:image",
     ] + select({
         "//conditions:default": ["//third_party:genai"],
         "//:not_genai_bin" : [":llm_engine"],

--- a/src/llm/apis/openai_completions.cpp
+++ b/src/llm/apis/openai_completions.cpp
@@ -33,8 +33,7 @@
 #pragma warning(push)
 #pragma warning(disable : 6262)
 #include "stb_image.h"  // NOLINT
-#pragma warning(pop)
-#pragma warning(push)
+#pragma warning(default : 6262)
 #pragma warning(disable : 6001 4324 6385 6386)
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"

--- a/src/llm/apis/openai_completions.cpp
+++ b/src/llm/apis/openai_completions.cpp
@@ -95,7 +95,7 @@ ov::Tensor load_image_stbi(const std::string& imageBytes) {
     constexpr int desiredChannels = 3;
     unsigned char* image = stbi_load_from_memory(
         (const unsigned char*)imageBytes.data(), imageBytes.size(),
-        &x, &y,  channelsInFile, desiredChannels);
+        &x, &y, channelsInFile, desiredChannels);
     if (!image) {
         std::stringstream errorMessage;
         errorMessage << "Failed to load the image";
@@ -114,9 +114,9 @@ ov::Tensor load_image_stbi(const std::string& imageBytes) {
             if (channels * height * width != bytes) {
                 throw std::runtime_error{"Unexpected number of bytes was requested to deallocate."};
             }
-            if(image != nullptr){
+            if (image != nullptr) {
                 stbi_image_free(image);
-                image = nullptr;   
+                image = nullptr;
             }
         }
         bool is_equal(const SharedImageAllocator& other) const noexcept { return this == &other; }

--- a/src/llm/apis/openai_completions.cpp
+++ b/src/llm/apis/openai_completions.cpp
@@ -91,15 +91,15 @@ absl::Status OpenAIChatCompletionsHandler::parseCompletionsPart() {
 }
 
 ov::Tensor load_image_stbi(const std::string& imageBytes) {
-    int x = 0, y = 0, channels_in_file = 0;
-    constexpr int desired_channels = 3;
+    int x = 0, y = 0, channelsInFile = 0;
+    constexpr int desiredChannels = 3;
     unsigned char* image = stbi_load_from_memory(
         (const unsigned char*)imageBytes.data(), imageBytes.size(),
-        &x, &y, &channels_in_file, desired_channels);
+        &x, &y,  channelsInFile, desiredChannels);
     if (!image) {
-        std::stringstream error_message;
-        error_message << "Failed to load the image";
-        throw std::runtime_error{error_message.str()};
+        std::stringstream errorMessage;
+        errorMessage << "Failed to load the image";
+        throw std::runtime_error{errorMessage.str()};
     }
     struct SharedImageAllocator {
         unsigned char* image;
@@ -114,15 +114,17 @@ ov::Tensor load_image_stbi(const std::string& imageBytes) {
             if (channels * height * width != bytes) {
                 throw std::runtime_error{"Unexpected number of bytes was requested to deallocate."};
             }
-            stbi_image_free(image);
-            image = nullptr;
+            if(image != nullptr){
+                stbi_image_free(image);
+                image = nullptr;   
+            }
         }
         bool is_equal(const SharedImageAllocator& other) const noexcept { return this == &other; }
     };
     return ov::Tensor(
         ov::element::u8,
-        ov::Shape{1, size_t(y), size_t(x), size_t(desired_channels)},
-        SharedImageAllocator{image, desired_channels, y, x});
+        ov::Shape{1, size_t(y), size_t(x), size_t(desiredChannels)},
+        SharedImageAllocator{image, desiredChannels, y, x});
 }
 
 absl::Status OpenAIChatCompletionsHandler::parseMessages() {

--- a/src/llm/apis/openai_completions.cpp
+++ b/src/llm/apis/openai_completions.cpp
@@ -95,7 +95,7 @@ ov::Tensor load_image_stbi(const std::string& imageBytes) {
     constexpr int desiredChannels = 3;
     unsigned char* image = stbi_load_from_memory(
         (const unsigned char*)imageBytes.data(), imageBytes.size(),
-        &x, &y, channelsInFile, desiredChannels);
+        &x, &y, &channelsInFile, desiredChannels);
     if (!image) {
         std::stringstream errorMessage;
         errorMessage << "Failed to load the image";

--- a/src/test/http_openai_handler_test.cpp
+++ b/src/test/http_openai_handler_test.cpp
@@ -270,7 +270,7 @@ TEST_F(HttpOpenAIHandlerParsingTest, ParsingMessagesSucceeds) {
     ov::Tensor image = images[0];
     EXPECT_EQ(image.get_element_type(), ov::element::u8);
     EXPECT_EQ(image.get_size(), 3);
-    std::vector<uint8_t> expectedBytes = {160, 181, 110};
+    std::vector<uint8_t> expectedBytes = {110, 181, 160};
     for (size_t i = 0; i < image.get_size(); i++) {
         EXPECT_EQ(expectedBytes[i], ((uint8_t*)image.data())[i]);
     }
@@ -304,7 +304,7 @@ TEST_F(HttpOpenAIHandlerParsingTest, ParsingImageJpegWithNoTextSucceeds) {
     ov::Tensor image = images[0];
     EXPECT_EQ(image.get_element_type(), ov::element::u8);
     EXPECT_EQ(image.get_size(), 3);
-    std::vector<uint8_t> expectedBytes = {241, 245, 54};
+    std::vector<uint8_t> expectedBytes = {54, 245, 241};
     for (size_t i = 0; i < image.get_size(); i++) {
         EXPECT_EQ(expectedBytes[i], ((uint8_t*)image.data())[i]);
     }
@@ -385,7 +385,7 @@ TEST_F(HttpOpenAIHandlerParsingTest, ParsingMultipleMessagesSucceeds) {
     ASSERT_EQ(apiHandler->parseMessages(), absl::OkStatus());
     std::vector<ov::Tensor> images = apiHandler->getImages();
     ASSERT_EQ(images.size(), 2);
-    std::vector<uint8_t> expectedBytes = {160, 181, 110};
+    std::vector<uint8_t> expectedBytes = {110, 181, 160};
     for (auto image : images) {
         EXPECT_EQ(image.get_element_type(), ov::element::u8);
         EXPECT_EQ(image.get_size(), 3);


### PR DESCRIPTION
### 🛠 Summary
162330
Replacing opencv with stb in multimodal image deserialization.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

