### PR TITLE
More tests x

### DIFF
--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1819,9 +1819,9 @@ static const char* pipelineCustomNodeDifferentOperationsConfig = R"(
 class EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest : public EnsembleFlowCustomNodeLoadConfigThenExecuteTest {
 protected:
     void SetUp() override {
-#ifdef _WIN32
-        GTEST_SKIP() << "Test disabled on windows";
-#endif
+// #ifdef _WIN32
+//         GTEST_SKIP() << "Test disabled on windows";
+// #endif
         EnsembleFlowCustomNodeLoadConfigThenExecuteTest::SetUp();
         configJsonFilePath = directoryPath + "/ovms_config_file.json";
     }

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -2457,13 +2457,13 @@ struct LibraryParamControlledMetadata {
         const char* end = str;
         for (; *end != '\0'; ++end) {
             if ((end - str) > MAX) {
-                EXPECT_TRUE(false);
+                EXPECT_TRUE(false) << *end;
             }
         }
         const char* end2 = prefix;
         for (; *end2 != '\0'; ++end2) {
-            if ((end2 - str) > MAX) {
-                EXPECT_TRUE(false);
+            if ((end2 - prefix) > MAX) {
+                EXPECT_TRUE(false) << *end2;
             }
         }
         size_t strLen = std::strlen(str);
@@ -2552,9 +2552,6 @@ struct LibraryParamControlledMetadata {
 class EnsembleConfigurationValidationWithCustomNode : public ::testing::Test {
 protected:
     void SetUp() override {
-#ifdef _WIN32
-        GTEST_SKIP() << "Test disabled on windows";
-#endif
         mockedLibrary = createLibraryMock<LibraryParamControlledMetadata>();
         ASSERT_TRUE(mockedLibrary.isValid());
     }

--- a/src/test/ensemble_flow_custom_node_tests.cpp
+++ b/src/test/ensemble_flow_custom_node_tests.cpp
@@ -1495,13 +1495,7 @@ protected:
     }
 
     void loadConfiguration(const char* configContent, Status expectedStatus = StatusCode::OK) {
-        std::string ovmsConfig = std::string(configContent);
-
-        std::string newDir = getGenericFullPathForBazelOut("/ovms/bazel-bin/src");
-        std::regex regexPattern(R"(/ovms/bazel-bin/src)");
-        ovmsConfig = std::regex_replace(ovmsConfig, regexPattern, newDir);
-
-        createConfigFileWithContent(ovmsConfig, configJsonFilePath);
+        createConfigFileWithContent(adjustConfigForTargetPlatformCStr(configContent), configJsonFilePath);
         ASSERT_EQ(manager.loadConfig(configJsonFilePath), expectedStatus);
     }
 
@@ -1819,9 +1813,6 @@ static const char* pipelineCustomNodeDifferentOperationsConfig = R"(
 class EnsembleFlowCustomNodeAndDemultiplexerLoadConfigThenExecuteTest : public EnsembleFlowCustomNodeLoadConfigThenExecuteTest {
 protected:
     void SetUp() override {
-// #ifdef _WIN32
-//         GTEST_SKIP() << "Test disabled on windows";
-// #endif
         EnsembleFlowCustomNodeLoadConfigThenExecuteTest::SetUp();
         configJsonFilePath = directoryPath + "/ovms_config_file.json";
     }
@@ -4405,9 +4396,9 @@ TEST_F(EnsembleConfigurationValidationWithDemultiplexer, DemultiplexerWithoutGat
 class EnsembleFlowCustomNodeAndDynamicDemultiplexerLoadConfigThenExecuteTest : public EnsembleFlowCustomNodeLoadConfigThenExecuteTest {
 protected:
     void SetUp() override {
-#ifdef _WIN32
-        GTEST_SKIP() << "Test disabled on windows";
-#endif
+// #ifdef _WIN32
+//         GTEST_SKIP() << "Test disabled on windows";
+// #endif
         EnsembleFlowCustomNodeLoadConfigThenExecuteTest::SetUp();
         configJsonFilePath = directoryPath + "/ovms_config_file.json";
     }

--- a/src/test/gather_node_test.cpp
+++ b/src/test/gather_node_test.cpp
@@ -219,14 +219,11 @@ public:
 };
 
 TEST_F(GatherNodeTest, FullFlowGatherInNonExitNode) {
-#ifdef _WIN32
-    GTEST_SKIP() << "Test disabled on windows";
-#endif
     // This test simulates node with multiple subsessions connected to following node
     // that should gather it results but is not exit node
     ConstructorEnabledModelManager manager;
     const std::string fileToReload = directoryPath + "/ovms_config_file.json";
-    createConfigFileWithContent(configDummy1BsDummy2Bs, fileToReload);
+    createConfigFileWithContent(adjustConfigForTargetPlatformCStr(configDummy1BsDummy2Bs), fileToReload);
     auto status = manager.loadConfig(fileToReload);
     ASSERT_EQ(status, StatusCode::OK) << status.string();
     const std::string node1Name = "node1";

--- a/src/test/mediapipe/config_mediapipe_two_outputs_dag.json
+++ b/src/test/mediapipe/config_mediapipe_two_outputs_dag.json
@@ -3,7 +3,7 @@
     "custom_node_library_config_list": [
         {
             "name": "lib_perform_different_operations",
-            "base_path": "/ovms/bazel-bin/src/lib_node_perform_different_operations.so"
+            "base_path": "/ovms/bazel-bin//src/lib_node_perform_different_operations.so"
         }
     ],
     "pipeline_config_list": [

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -912,14 +912,11 @@ TEST_F(MediapipeFlowTwoOutputsTest, Infer) {
 class MediapipeFlowTwoOutputsDagTest : public MediapipeFlowTest {
 public:
     void SetUp() {
-        SetUpServer("/ovms/src/test/mediapipe/config_mediapipe_two_outputs_dag.json");
+        SetUpServer(getGenericFullPathForSrcTest("/ovms/src/test/mediapipe/config_mediapipe_two_outputs_dag.json"));
     }
 };
 
 TEST_F(MediapipeFlowTwoOutputsDagTest, Infer) {
-#ifdef _WIN32
-    GTEST_SKIP() << "Test disabled on windows - Custom Nodes for windows are unsupported";
-#endif
     std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     std::vector<float> factors{1, 3, 2, 2};
 

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -912,7 +912,7 @@ TEST_F(MediapipeFlowTwoOutputsTest, Infer) {
 class MediapipeFlowTwoOutputsDagTest : public MediapipeFlowTest {
 public:
     void SetUp() {
-        SetUpServer(getGenericFullPathForSrcTest("/ovms/src/test/mediapipe/config_mediapipe_two_outputs_dag.json"));
+        SetUpServer("/ovms/src/test/mediapipe/config_mediapipe_two_outputs_dag.json");
     }
 };
 

--- a/src/test/model_service_test.cpp
+++ b/src/test/model_service_test.cpp
@@ -163,11 +163,8 @@ static const char* pipelineOneDummyConfig = R"(
 })";
 
 TYPED_TEST(ModelServiceTest, pipeline) {
-#ifdef _WIN32
-    GTEST_SKIP() << "Test disabled on windows";
-#endif
     std::string fileToReload = getGenericFullPathForTmp("/tmp/ovms_single_version_pipeline.json");
-    createConfigFileWithContent(pipelineOneDummyConfig, fileToReload);
+    createConfigFileWithContent(adjustConfigForTargetPlatformCStr(pipelineOneDummyConfig), fileToReload);
     ASSERT_EQ(this->manager.startFromFile(fileToReload), StatusCode::OK);
 
     const std::string name = "dummyPipeline";

--- a/windows_change_test_configs.py
+++ b/windows_change_test_configs.py
@@ -36,27 +36,35 @@ def main():
         replace_back = True
         start_dir = os.path.dirname(os.path.realpath(__file__)) + "\\src\\test\\"
         windows_path = start_dir
+        windows_bazel_bin_path = os.path.dirname(os.path.realpath(__file__)) + "\\bazel-bin\\"
         print('Setting cwd\\src\\test start search dir: ' + start_dir)
     elif len(sys.argv) == 1:
         start_dir = os.path.dirname(os.path.realpath(__file__)) + "\\src\\test\\"
         windows_path = start_dir
+        windows_bazel_bin_path = os.path.dirname(os.path.realpath(__file__)) + "\\bazel-bin\\"
         print('Setting cwd\\src\\test start search dir: ' + start_dir)
     else:
         print("[ERROR] Wrong number of parameters.")
         exit()
             
     linux_path = "/ovms/src/test/"
+    linux_path_bazel_bin = "/ovms/bazel-bin/"
     
     print("Replacing back set to: " + str(replace_back))
 
     # Change c:\something\else to c:\\something\\else for json parser compatybility
     windows_path = windows_path.replace("\\","\\\\")
+    windows_bazel_bin_path = windows_bazel_bin_path.replace("\\","\\\\")
     if replace_back:
         tmp_path = windows_path
         windows_path = linux_path
         linux_path = tmp_path
+        tmp_path = windows_bazel_bin_path
+        windows_bazel_bin_path = linux_path_bazel_bin
+        linux_path_bazel_bin = tmp_path
 
-    print("Replace string: {} with: {} ".format(linux_path, windows_path))
+    print("Replace string: {} with: {} \nand\n {} with {}".format(
+        linux_path, windows_path, linux_path_bazel_bin, windows_bazel_bin_path))
 
     extension = '.json'  # replace with your desired extension
     files_with_extension = []
@@ -79,6 +87,7 @@ def main():
     for file in files_with_extension:
         try:
             replace_string_in_file(file, linux_path, windows_path)
+            replace_string_in_file(file, linux_path_bazel_bin, windows_bazel_bin_path)
         except Exception as e:
             print(f"Error parsing file {file}: {e} - changes were not applied")
 

--- a/windows_test.bat
+++ b/windows_test.bat
@@ -29,7 +29,7 @@ set "bazelStartupCmd=--output_user_root=!BAZEL_SHORT_PATH!"
 set "openvino_dir=!BAZEL_SHORT_PATH!/openvino/runtime/cmake"
 
 set "bazelBuildArgs=--config=windows --action_env OpenVINO_DIR=%openvino_dir%"
-set "buildTestCommand=bazel %bazelStartupCmd% build %bazelBuildArgs% --jobs=%NUMBER_OF_PROCESSORS% --verbose_failures //src:ovms_test 2>&1 | tee win_build_test.log"
+set "buildTestCommand=bazel %bazelStartupCmd% build %bazelBuildArgs% --jobs=%NUMBER_OF_PROCESSORS% --verbose_failures //src:ovms_test"
 set "changeConfigsCmd=python windows_change_test_configs.py"
 set "runTest=%cd%\bazel-bin\src\ovms_test.exe --gtest_filter=* 2>&1 > win_full_test.log"
 
@@ -78,8 +78,13 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Start bazel build test
-%buildTestCommand%
-if !errorlevel! neq 0 exit /b !errorlevel!
+%buildTestCommand% > win_build_test.log 2>&1
+set "bazelExitCode=!errorlevel!"
+:: Output the log to the console
+type win_build_test.log
+:: Check the exit code and exit if it's not 0
+if !bazelExitCode! neq 0 exit /b !bazelExitCode!
+
 
 :: Change tests configs to windows paths
 %changeConfigsCmd%


### PR DESCRIPTION
### 🛠 Summary

+ fix for non-failing CI builds when ovms_test building fails

After this change we have only those skips:
- custom loader (deprecated)
- sporadics which will be fixed in other tasks
- embeddings tests which require custom extension


