### PR TITLE
Add bazel build verbosity control to Dockerfile.redhat

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -98,6 +98,7 @@ ARG BASE_IMAGE
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 ARG JOBS=40
+ARG VERBOSE_LOGS=OFF
 
 # hadolint ignore=DL3041
 RUN dnf install -y https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/opencl-headers-3.0-6.20201007gitd65bcc5.el9.noarch.rpm && \


### PR DESCRIPTION
An ARG was missing in the main build section of the bazel build. The bazel build uses it. It's just missing from this part of the build. This adds it so that bazel can be made verbose.
