### PR TITLE
store-ovms-windows-artifacts

### DIFF
--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -185,7 +185,7 @@ pipeline {
             node("${agent_name_windows}") {
                 script {
                     if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
-                        bat(returnStatus:true, script: "copy C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip Z:\\ovms-windows-main-latest.zip")
+                        bat(returnStatus:true, script: "xcopy /Y C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip \\\\10.211.120.232\\data\\cv_bench_cache\\OVMS_do_not_remove\\ovms-windows-main-latest.zip")
                     } else {
                         echo "Not a main branch, skipping copying artifacts."
                     }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -183,8 +183,9 @@ pipeline {
     post {
         always {
             script {
-                if (env.BRANCH_NAME == "main" && windows_success == "True") {
-                    build job: "ovms/store_ovms_windows_artifacts"
+                if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
+                    build job: "ovms/store_ovms_windows_artifacts",
+                    parameters: [ string(name: 'NODE_NAME', value: "${agent_name_windows}") ]
                 } else {
                     echo "Not a main branch, skipping artifacts job trigger."
                 }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -103,12 +103,13 @@ pipeline {
                           windows.build()
                         } finally {
                           windows.archive_build_artifacts()
+                          windows_success = "True"
                           /*
                           if (${env.BRANCH_NAME} == "main") {
                             build job: "ovms/store_ovms_windows_artifacts"
                           }
                           */
-                          build job: "ovms/store_ovms_windows_artifacts", wait: false
+                          // build job: "ovms/store_ovms_windows_artifacts", wait: false
                         }
                       } else {
                           error "Cannot load ci/loadWin.groovy file."
@@ -137,7 +138,8 @@ pipeline {
               }
               } 
               }
-            } 
+            }
+            /*
             stage("Internal tests") {
               agent {
                 label "${agent_name_linux}"
@@ -157,6 +159,7 @@ pipeline {
                 }
               }            
             }
+
             stage('Test windows') {
               agent {
                 label "${agent_name_windows}"
@@ -181,8 +184,20 @@ pipeline {
                       }
                   }
               }
-            }           
+            }
+            */
           }
+        }
+    }
+    post {
+        always {
+            script {
+                if (windows_success == "True") {    // env.BRANCH_NAME == "main" &&
+                    build job: "ovms/store_ovms_windows_artifacts"
+                } else {
+                    echo "Not a main branch, skipping artifacts job trigger."
+                }
+            }
         }
     }
 }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -74,7 +74,7 @@ pipeline {
         }
         stage('Build') {
           parallel {
-            stage("Build linux") {
+            /* stage("Build linux") {
               agent {
                 label "${agent_name_linux}"
               }
@@ -83,7 +83,8 @@ pipeline {
                       sh "echo build --remote_cache=${env.OVMS_BAZEL_REMOTE_CACHE_URL} > .user.bazelrc"
                       sh "make ovms_builder_image RUN_TESTS=0 OPTIMIZE_BUILDING_TESTS=1 OV_USE_BINARY=1 BASE_OS=redhat OVMS_CPP_IMAGE_TAG=${shortCommit} BUILD_IMAGE=openvino/model_server-build:${shortCommit}"
                     }
-            }
+            } 
+            */
             stage('Build windows') {
               agent {
                 label 'win_ovms'
@@ -102,9 +103,12 @@ pipeline {
                           windows.build()
                         } finally {
                           windows.archive_build_artifacts()
+                          /*
                           if (${env.BRANCH_NAME} == "main") {
                             build job: "ovms/store_ovms_windows_artifacts"
                           }
+                          */
+                          build job: "ovms/store_ovms_windows_artifacts"
                         }
                       } else {
                           error "Cannot load ci/loadWin.groovy file."

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -184,7 +184,7 @@ pipeline {
         always {
             node("${agent_name_windows}") {
                 script {
-                    if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
+                    if (env.BRANCH_NAME == "main" && windows_success == "True") {
                         bat(returnStatus:true, script: "copy C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip Z:\\ovms-windows-main-latest.zip")
                     } else {
                         echo "Not a main branch, skipping copying artifacts."

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -4,6 +4,7 @@ def client_test_needed = "false"
 def shortCommit = ""
 def agent_name_windows = ""
 def agent_name_linux = ""
+def windows_success = ""
 
 pipeline {
     agent {
@@ -74,7 +75,7 @@ pipeline {
         }
         stage('Build') {
           parallel {
-            /* stage("Build linux") {
+            stage("Build linux") {
               agent {
                 label "${agent_name_linux}"
               }
@@ -84,7 +85,6 @@ pipeline {
                       sh "make ovms_builder_image RUN_TESTS=0 OPTIMIZE_BUILDING_TESTS=1 OV_USE_BINARY=1 BASE_OS=redhat OVMS_CPP_IMAGE_TAG=${shortCommit} BUILD_IMAGE=openvino/model_server-build:${shortCommit}"
                     }
             }
-            */
             stage('Build windows') {
               agent {
                 label 'win_ovms'
@@ -104,12 +104,6 @@ pipeline {
                         } finally {
                           windows.archive_build_artifacts()
                           windows_success = "True"
-                          /*
-                          if (${env.BRANCH_NAME} == "main") {
-                            build job: "ovms/store_ovms_windows_artifacts"
-                          }
-                          */
-                          // build job: "ovms/store_ovms_windows_artifacts", wait: false
                         }
                       } else {
                           error "Cannot load ci/loadWin.groovy file."
@@ -139,7 +133,6 @@ pipeline {
               } 
               }
             }
-            /*
             stage("Internal tests") {
               agent {
                 label "${agent_name_linux}"
@@ -159,7 +152,6 @@ pipeline {
                 }
               }            
             }
-
             stage('Test windows') {
               agent {
                 label "${agent_name_windows}"
@@ -185,14 +177,13 @@ pipeline {
                   }
               }
             }
-            */
           }
         }
     }
     post {
         always {
             script {
-                if (windows_success == "True") {    // env.BRANCH_NAME == "main" &&
+                if (env.BRANCH_NAME == "main" && windows_success == "True") {
                     build job: "ovms/store_ovms_windows_artifacts"
                 } else {
                     echo "Not a main branch, skipping artifacts job trigger."

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -182,13 +182,10 @@ pipeline {
     }
     post {
         always {
+            when { expression { windows_success == "True" } } // env.BRANCH_NAME == "main" &&
             node("${agent_name_windows}") {
                 script {
-                    if (env.BRANCH_NAME == "main" && windows_success == "True") {
-                        bat(returnStatus:true, script: "xcopy /Y C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip \\\\10.211.120.232\\data\\cv_bench_cache\\OVMS_do_not_remove\\ovms-windows-main-latest.zip")
-                    } else {
-                        echo "Not a main branch, skipping copying artifacts."
-                    }
+                    bat(returnStatus:true, script: "ECHO F | xcopy /Y /E C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip \\\\${env.OV_SHARE_05_IP}\\data\\cv_bench_cache\\OVMS_do_not_remove\\ovms-windows-main-latest.zip")
                 }
             }
         }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -182,11 +182,13 @@ pipeline {
     }
     post {
         always {
-            script {
-                if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
-                    bat(returnStatus:true, script: "copy C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip Z:\\ovms-windows-main-latest.zip")
-                } else {
-                    echo "Not a main branch, skipping copying artifacts."
+            node("${agent_name_windows}") {
+                script {
+                    if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
+                        bat(returnStatus:true, script: "copy C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip Z:\\ovms-windows-main-latest.zip")
+                    } else {
+                        echo "Not a main branch, skipping copying artifacts."
+                    }
                 }
             }
         }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -102,6 +102,9 @@ pipeline {
                           windows.build()
                         } finally {
                           windows.archive_build_artifacts()
+                          if (${env.BRANCH_NAME} == "main") {
+                            build job: "ovms/store_ovms_windows_artifacts"
+                          }
                         }
                       } else {
                           error "Cannot load ci/loadWin.groovy file."

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -184,10 +184,9 @@ pipeline {
         always {
             script {
                 if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
-                    build job: "ovms/store_ovms_windows_artifacts",
-                    parameters: [ string(name: 'NODE_NAME', value: "${agent_name_windows}") ]
+                    bat(returnStatus:true, script: "copy C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip Z:\\ovms-windows-main-latest.zip")
                 } else {
-                    echo "Not a main branch, skipping artifacts job trigger."
+                    echo "Not a main branch, skipping copying artifacts."
                 }
             }
         }

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -83,7 +83,7 @@ pipeline {
                       sh "echo build --remote_cache=${env.OVMS_BAZEL_REMOTE_CACHE_URL} > .user.bazelrc"
                       sh "make ovms_builder_image RUN_TESTS=0 OPTIMIZE_BUILDING_TESTS=1 OV_USE_BINARY=1 BASE_OS=redhat OVMS_CPP_IMAGE_TAG=${shortCommit} BUILD_IMAGE=openvino/model_server-build:${shortCommit}"
                     }
-            } 
+            }
             */
             stage('Build windows') {
               agent {
@@ -108,7 +108,7 @@ pipeline {
                             build job: "ovms/store_ovms_windows_artifacts"
                           }
                           */
-                          build job: "ovms/store_ovms_windows_artifacts"
+                          build job: "ovms/store_ovms_windows_artifacts", wait: false
                         }
                       } else {
                           error "Cannot load ci/loadWin.groovy file."

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -184,7 +184,7 @@ pipeline {
         always {
             node("${agent_name_windows}") {
                 script {
-                    if (env.BRANCH_NAME == "main" && windows_success == "True") {
+                    if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
                         bat(returnStatus:true, script: "copy C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip Z:\\ovms-windows-main-latest.zip")
                     } else {
                         echo "Not a main branch, skipping copying artifacts."

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -184,7 +184,7 @@ pipeline {
         always {
             node("${agent_name_windows}") {
                 script {
-                    if (windows_success == "True") { // env.BRANCH_NAME == "main" &&
+                    if (env.BRANCH_NAME == "main" && windows_success == "True") {
                         bat(returnStatus:true, script: "xcopy /Y C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip \\\\10.211.120.232\\data\\cv_bench_cache\\OVMS_do_not_remove\\ovms-windows-main-latest.zip")
                     } else {
                         echo "Not a main branch, skipping copying artifacts."

--- a/ci/build_test_OnCommit.groovy
+++ b/ci/build_test_OnCommit.groovy
@@ -182,10 +182,13 @@ pipeline {
     }
     post {
         always {
-            when { expression { windows_success == "True" } } // env.BRANCH_NAME == "main" &&
             node("${agent_name_windows}") {
                 script {
-                    bat(returnStatus:true, script: "ECHO F | xcopy /Y /E C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip \\\\${env.OV_SHARE_05_IP}\\data\\cv_bench_cache\\OVMS_do_not_remove\\ovms-windows-main-latest.zip")
+                    if (env.BRANCH_NAME == "main" && windows_success == "True") {
+                        bat(returnStatus:true, script: "ECHO F | xcopy /Y /E C:\\Jenkins\\workspace\\ovms_oncommit_main\\dist\\windows\\ovms.zip \\\\${env.OV_SHARE_05_IP}\\data\\cv_bench_cache\\OVMS_do_not_remove\\ovms-windows-main-latest.zip")
+                    } else {
+                        echo "Not a main branch, skipping copying artifacts."
+                    }
                 }
             }
         }


### PR DESCRIPTION
### 🛠 Summary

https://jira.devtools.intel.com/browse/CVS-162510 
Added post action to build_test_OnCommit.groovy to store windows artifacts (ovms.zip) as latest. 
The latest package will be available at the link: http://ov-share-05.sclab.intel.com/cv_bench_cache/OVMS_do_not_remove/ovms-windows-main-latest.zip


### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

