### PR TITLE
Inferring GenAI servable type

### DIFF
--- a/demos/common/export_models/export_model.py
+++ b/demos/common/export_models/export_model.py
@@ -38,7 +38,7 @@ parser = argparse.ArgumentParser(description='Export Hugging face models to OVMS
 subparsers = parser.add_subparsers(help='subcommand help', required=True, dest='task')
 parser_text = subparsers.add_parser('text_generation', help='export model for chat and completion endpoints')
 add_common_arguments(parser_text)
-parser_text.add_argument('--pipeline_type', default='CONTINUOUS_BATCHING', help='Type of the pipeline to be used. Can be either CONTINUOUS_BATCHING or VISUAL_LANGUAGE_MODEL.', dest='pipeline_type')
+parser_text.add_argument('--pipeline_type', default=None, help='Type of the pipeline to be used. Can be either TEXT_CB or VLM_CB', dest='pipeline_type')
 parser_text.add_argument('--kv_cache_precision', default=None, choices=["u8"], help='u8 or empty (model default). Reduced kv cache precision to u8 lowers the cache size consumption.', dest='kv_cache_precision')
 parser_text.add_argument('--enable_prefix_caching', action='store_true', help='This algorithm is used to cache the prompt tokens.', dest='enable_prefix_caching')
 parser_text.add_argument('--disable_dynamic_split_fuse', action='store_false', help='The maximum number of tokens that can be batched together.', dest='dynamic_split_fuse')
@@ -144,7 +144,8 @@ node: {
   }
   node_options: {
       [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
-          pipeline_type: {{pipeline_type}},
+          {%- if pipeline_type %}
+          pipeline_type: {{pipeline_type}},{% endif %}
           models_path: "{{model_path}}",
           plugin_config: '{ {% if kv_cache_precision %}"KV_CACHE_PRECISION": "{{kv_cache_precision}}"{% endif %}}',
           enable_prefix_caching: {% if not enable_prefix_caching %}false{% else %} true{% endif%},

--- a/prepare_llm_models.sh
+++ b/prepare_llm_models.sh
@@ -54,7 +54,7 @@ fi
 if [ -d "$1/$VLM_MODEL" ]; then
   echo "Models directory $1/$VLM_MODEL exists. Skipping downloading models."
 else
-  python3 demos/common/export_models/export_model.py text_generation --pipeline_type VISUAL_LANGUAGE_MODEL --source_model "$VLM_MODEL" --weight-format int4 --kv_cache_precision u8 --model_repository_path $1
+  python3 demos/common/export_models/export_model.py text_generation --source_model "$VLM_MODEL" --weight-format int4 --kv_cache_precision u8 --model_repository_path $1
 fi
 
 if [ -d "$1/$EMBEDDING_MODEL" ]; then

--- a/src/BUILD
+++ b/src/BUILD
@@ -1897,6 +1897,7 @@ cc_test(
                 "test/llmtemplate_test.cpp",
                 "test/text_streamer_test.cpp",
                 "test/llm/visual_language_model/complete_flow_test.cpp",
+                "test/llm/visual_language_model/initialization_test.cpp",
             ],
             "//:disable_python" : [],
         }),

--- a/src/llm/continuous_batching/servable.cpp
+++ b/src/llm/continuous_batching/servable.cpp
@@ -64,6 +64,10 @@ std::shared_ptr<GenAiServableProperties> ContinuousBatchingServable::getProperti
     return properties;
 }
 
+bool ContinuousBatchingServable::supportsSpeculativeDecoding() const {
+    return true;
+}
+
 absl::Status ContinuousBatchingServable::scheduleExecution(std::shared_ptr<GenAiServableExecutionContext>& executionContext) {
     auto cbExecutionContext = std::static_pointer_cast<ContinuousBatchingServableExecutionContext>(executionContext);
     if (cbExecutionContext->payload.client->isDisconnected()) {

--- a/src/llm/continuous_batching/servable.hpp
+++ b/src/llm/continuous_batching/servable.hpp
@@ -53,6 +53,7 @@ public:
     // Interface methods
     std::shared_ptr<GenAiServableExecutionContext> createExecutionContext() override;
     std::shared_ptr<GenAiServableProperties> getProperties() override;
+    bool supportsSpeculativeDecoding() const override;
     absl::Status scheduleExecution(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
     absl::Status readCompleteExecutionResults(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
     absl::Status readPartialExecutionResults(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;

--- a/src/llm/llm_calculator.proto
+++ b/src/llm/llm_calculator.proto
@@ -27,12 +27,22 @@ message LLMCalculatorOptions {
     }
 
     enum PipelineType {
+      // Single modality (text only), text generation based on LLMPipeline
+      TEXT = 0;
+      // Multimodal (text and image), text generation based on LLMPipeline
+      VLM = 1;
+      // Single modality (text only), text generation based on ContinuousBatchingPipeline
+      TEXT_CB = 2;
+      // Multimodal (text and image), text generation based on ContinuousBatchingPipeline
+      VLM_CB = 3;
+      // Default option. If selected, pipeline type will be inferred by the serving
+      UNDEFINED_PIPELINE_TYPE = 4;
+
+      // Compatibility with current configurations, remove below in the next PR
       // Continuous batching pipeline
-      CONTINUOUS_BATCHING = 0;
+      CONTINUOUS_BATCHING = 5;
       // Visual language model pipeline
-      VISUAL_LANGUAGE_MODEL = 1;
-      // LLM pipeline
-      LLM = 2; // To be changed...
+      VISUAL_LANGUAGE_MODEL = 6;
     }
 
     optional string models_path = 1;
@@ -73,7 +83,7 @@ message LLMCalculatorOptions {
 
     optional bool draft_dynamic_split_fuse = 17;
 
-    optional PipelineType pipeline_type = 18 [default = CONTINUOUS_BATCHING];
+    optional PipelineType pipeline_type = 18 [default = UNDEFINED_PIPELINE_TYPE];
     
     // START EXPERIMENTAL OPTIONS
     message PipelineConfig {

--- a/src/llm/servable.cpp
+++ b/src/llm/servable.cpp
@@ -87,8 +87,12 @@ absl::Status GenAiServable::prepareInputs(std::shared_ptr<GenAiServableExecution
         return absl::Status(absl::StatusCode::kInvalidArgument, "API handler is not initialized");
     }
 
-    std::string inputText;
+    // Base servable cannot process images
+    if (executionContext->apiHandler->getImages().size() > 0) {
+        return absl::InternalError("This servable supports only text input, but image_url has been provided");
+    }
 
+    std::string inputText;
     switch (executionContext->endpoint) {
     case Endpoint::CHAT_COMPLETIONS: {
         bool success;

--- a/src/llm/servable.hpp
+++ b/src/llm/servable.hpp
@@ -185,6 +185,9 @@ public:
     // Returns properties of the servable
     virtual std::shared_ptr<GenAiServableProperties> getProperties() = 0;
 
+    // Return true if servable can load and use draft model in speculative decoding pipeline
+    virtual bool supportsSpeculativeDecoding() const = 0;
+
     /*
     parseRequest method implementation MUST fill executionContext apiHandler field and parse request.
     For streaming requests, it MUST initialize textStreamer and lastStreamerCallbackOutput fields of executionContext.

--- a/src/llm/servable_initializer.hpp
+++ b/src/llm/servable_initializer.hpp
@@ -28,21 +28,24 @@
 #include "src/llm/llm_calculator.pb.h"
 
 namespace ovms {
+
+// Defines what servable type should be initialized based on the pipeline type
+enum class PipelineType {
+    TEXT,     // Single modality (text only), text generation based on LLMPipeline
+    VLM,      // Multimodal (text and image), text generation based on LLMPipeline
+    TEXT_CB,  // Single modality (text only), text generation based on ContinuousBatchingPipeline
+    VLM_CB,   // Multimodal (text and image), text generation based on ContinuousBatchingPipeline
+
+    // Note that *_CB pipelines do not support execution on NPU
+};
+
 class Status;
 class GenAiServable;
 struct GenAiServableProperties;
 
 class GenAiServableInitializer {
-    std::string basePath;
-
-protected:
-    Status parseModelsPath(std::string modelsPath, std::string graphPath);
-
 public:
     virtual ~GenAiServableInitializer() = default;
-    std::string getBasePath() const {
-        return basePath;
-    }
     static void loadTextProcessor(std::shared_ptr<GenAiServableProperties> properties, const std::string& chatTemplateDirectory);
     /*
     initialize method implementation MUST fill servable with all required properties i.e. pipeline, tokenizer, configs etc. based on mediapipe node options.
@@ -51,6 +54,7 @@ public:
     */
     virtual Status initialize(std::shared_ptr<GenAiServable>& servable, const mediapipe::LLMCalculatorOptions& nodeOptions, std::string graphPath) = 0;
 };
-
+Status parseModelsPath(std::string& outPath, std::string modelsPath, std::string graphPath);
+Status determinePipelineType(PipelineType& pipelineType, const mediapipe::LLMCalculatorOptions& nodeOptions, const std::string& graphPath);
 Status initializeGenAiServable(std::shared_ptr<GenAiServable>& servable, const ::mediapipe::CalculatorGraphConfig::Node& graphNodeConfig, std::string graphPath);
 }  // namespace ovms

--- a/src/llm/visual_language_model/servable.cpp
+++ b/src/llm/visual_language_model/servable.cpp
@@ -41,6 +41,10 @@ std::shared_ptr<GenAiServableProperties> VisualLanguageModelServable::getPropert
     return properties;
 }
 
+bool VisualLanguageModelServable::supportsSpeculativeDecoding() const {
+    return false;
+}
+
 absl::Status VisualLanguageModelServable::prepareInputs(std::shared_ptr<GenAiServableExecutionContext>& executionContext) {
     auto vlmExecutionContext = std::static_pointer_cast<VisualLanguageModelServableExecutionContext>(executionContext);
     // Earlier we should validate that chat completion endpoint is used.

--- a/src/llm/visual_language_model/servable.hpp
+++ b/src/llm/visual_language_model/servable.hpp
@@ -50,6 +50,7 @@ public:
     // Interface methods
     std::shared_ptr<GenAiServableExecutionContext> createExecutionContext() override;
     std::shared_ptr<GenAiServableProperties> getProperties() override;
+    bool supportsSpeculativeDecoding() const override;
     absl::Status prepareInputs(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
 };
 }  // namespace ovms

--- a/src/test/llm/visual_language_model/complete_flow_test.cpp
+++ b/src/test/llm/visual_language_model/complete_flow_test.cpp
@@ -39,7 +39,7 @@
 
 using namespace ovms;
 
-class VLMServableFlowTest : public ::testing::Test {
+class VLMServableExecutionTest : public ::testing::Test {
 protected:
     static std::unique_ptr<std::thread> t;
 
@@ -84,7 +84,7 @@ public:
     }
 };
 
-std::unique_ptr<std::thread> VLMServableFlowTest::t;
+std::unique_ptr<std::thread> VLMServableExecutionTest::t;
 
 // This function wraps the same input data with the additional fields
 // specified in the fields parameter that control flow in the calculator, sampling etc.
@@ -119,7 +119,7 @@ std::string createRequestBody(const std::vector<std::pair<std::string, std::stri
     return oss.str();
 }
 
-TEST_F(VLMServableFlowTest, unaryBasic) {
+TEST_F(VLMServableExecutionTest, unaryBasic) {
     std::vector<std::pair<std::string, std::string>> fields = {
         {"temperature", "0.0"},
         {"stream", "false"},
@@ -153,7 +153,7 @@ TEST_F(VLMServableFlowTest, unaryBasic) {
     EXPECT_STREQ(parsedResponse["object"].GetString(), "chat.completion");
 }
 
-TEST_F(VLMServableFlowTest, streamBasic) {
+TEST_F(VLMServableExecutionTest, streamBasic) {
     std::vector<std::pair<std::string, std::string>> fields = {
         {"temperature", "0.0"},
         {"stream", "true"},

--- a/src/test/llm/visual_language_model/graph.pbtxt
+++ b/src/test/llm/visual_language_model/graph.pbtxt
@@ -28,7 +28,6 @@ node {
     }
     node_options: {
         [type.googleapis.com/mediapipe.LLMCalculatorOptions]: {
-          pipeline_type: VISUAL_LANGUAGE_MODEL
           models_path: "/ovms/src/test/llm_testing/OpenGVLab/InternVL2-1B"
           cache_size: 1
         }

--- a/src/test/llm/visual_language_model/initialization_test.cpp
+++ b/src/test/llm/visual_language_model/initialization_test.cpp
@@ -1,0 +1,204 @@
+//*****************************************************************************
+// Copyright 2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../../../llm/servable_initializer.hpp"
+#include "../../test_utils.hpp"
+
+using namespace ovms;
+
+Status callDeterminePipelineType(PipelineType& pipelineType, const std::string& testPbtxt) {
+    ::mediapipe::CalculatorGraphConfig config;
+    ::google::protobuf::TextFormat::ParseFromString(testPbtxt, &config);
+    const ::mediapipe::CalculatorGraphConfig::Node& graphNodeConfig = config.node(0);
+    mediapipe::LLMCalculatorOptions nodeOptions;
+    graphNodeConfig.node_options(0).UnpackTo(&nodeOptions);
+    return determinePipelineType(pipelineType, nodeOptions, "");
+}
+
+// Initialization tests
+class VLMServableInitializationTest : public ::testing::Test {
+public:
+    void SetUp() { py::initialize_interpreter(); }
+    void TearDown() { py::finalize_interpreter(); }
+};
+
+TEST_F(VLMServableInitializationTest, determinePipelineTypeDefault) {
+    std::string testPbtxt = R"(
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+
+        node: {
+        name: "VLMServable"
+        calculator: "HttpLLMCalculator"
+        input_stream: "LOOPBACK:loopback"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        input_side_packet: "LLM_NODE_RESOURCES:llm"
+        output_stream: "LOOPBACK:loopback"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+        input_stream_info: {
+            tag_index: 'LOOPBACK:0',
+            back_edge: true
+        }
+        node_options: {
+            [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
+                models_path: "/ovms/src/test/llm_testing/OpenGVLab/InternVL2-1B"
+            }
+        }
+        input_stream_handler {
+            input_stream_handler: "SyncSetInputStreamHandler",
+            options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                tag_index: "LOOPBACK:0"
+                }
+            }
+            }
+        }
+        }
+    )";
+    PipelineType pipelineType;
+    auto status = callDeterminePipelineType(pipelineType, testPbtxt);
+    ASSERT_EQ(status, StatusCode::OK);
+    ASSERT_EQ(pipelineType, PipelineType::VLM_CB);
+}
+
+TEST_F(VLMServableInitializationTest, determinePipelineType_VLM_CB_Specified) {
+    std::string testPbtxt = R"(
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+
+        node: {
+        name: "VLMServable"
+        calculator: "HttpLLMCalculator"
+        input_stream: "LOOPBACK:loopback"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        input_side_packet: "LLM_NODE_RESOURCES:llm"
+        output_stream: "LOOPBACK:loopback"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+        input_stream_info: {
+            tag_index: 'LOOPBACK:0',
+            back_edge: true
+        }
+        node_options: {
+            [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
+                pipeline_type: VLM_CB
+                models_path: "/ovms/src/test/llm_testing/OpenGVLab/InternVL2-1B"
+            }
+        }
+        input_stream_handler {
+            input_stream_handler: "SyncSetInputStreamHandler",
+            options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                tag_index: "LOOPBACK:0"
+                }
+            }
+            }
+        }
+        }
+    )";
+    PipelineType pipelineType;
+    auto status = callDeterminePipelineType(pipelineType, testPbtxt);
+    ASSERT_EQ(status, StatusCode::OK);
+    ASSERT_EQ(pipelineType, PipelineType::VLM_CB);
+}
+
+TEST_F(VLMServableInitializationTest, determinePipelineType_TEXT_CB_Specified) {
+    std::string testPbtxt = R"(
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+
+        node: {
+        name: "VLMServable"
+        calculator: "HttpLLMCalculator"
+        input_stream: "LOOPBACK:loopback"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        input_side_packet: "LLM_NODE_RESOURCES:llm"
+        output_stream: "LOOPBACK:loopback"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+        input_stream_info: {
+            tag_index: 'LOOPBACK:0',
+            back_edge: true
+        }
+        node_options: {
+            [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
+                pipeline_type: TEXT_CB
+                models_path: "/ovms/src/test/llm_testing/OpenGVLab/InternVL2-1B"
+            }
+        }
+        input_stream_handler {
+            input_stream_handler: "SyncSetInputStreamHandler",
+            options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                tag_index: "LOOPBACK:0"
+                }
+            }
+            }
+        }
+        }
+    )";
+    PipelineType pipelineType;
+    auto status = callDeterminePipelineType(pipelineType, testPbtxt);
+    ASSERT_EQ(status, StatusCode::INTERNAL_ERROR);
+}
+
+TEST_F(VLMServableInitializationTest, draftModelProvided) {
+    ConstructorEnabledModelManager manager;
+    std::string testPbtxt = R"(
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+
+        node: {
+        name: "VLMServable"
+        calculator: "HttpLLMCalculator"
+        input_stream: "LOOPBACK:loopback"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        input_side_packet: "LLM_NODE_RESOURCES:llm"
+        output_stream: "LOOPBACK:loopback"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+        input_stream_info: {
+            tag_index: 'LOOPBACK:0',
+            back_edge: true
+        }
+        node_options: {
+            [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
+                models_path: "/ovms/src/test/llm_testing/OpenGVLab/InternVL2-1B"
+                draft_models_path: "/ovms/src/test/llm_testing/OpenGVLab/InternVL2-1B"
+            }
+        }
+        input_stream_handler {
+            input_stream_handler: "SyncSetInputStreamHandler",
+            options {
+            [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+                sync_set {
+                tag_index: "LOOPBACK:0"
+                }
+            }
+            }
+        }
+        }
+    )";
+
+    ovms::MediapipeGraphConfig mgc{"mediaDummy", "", ""};
+    DummyMediapipeGraphDefinition mediapipeDummy("mediaDummy", mgc, testPbtxt, nullptr);
+    mediapipeDummy.inputConfig = testPbtxt;
+    ASSERT_EQ(mediapipeDummy.validate(manager), StatusCode::LLM_NODE_RESOURCE_STATE_INITIALIZATION_FAILED);
+}

--- a/src/test/llmnode_test.cpp
+++ b/src/test/llmnode_test.cpp
@@ -833,28 +833,7 @@ TEST_F(LLMFlowHttpTest, unaryChatCompletionsJsonContentArrayWithImage) {
 
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, writer),
-        ovms::StatusCode::OK);
-    parsedResponse.Parse(response.c_str());
-    ASSERT_TRUE(parsedResponse["choices"].IsArray());
-    ASSERT_EQ(parsedResponse["choices"].Capacity(), 1);
-    int i = 0;
-    for (auto& choice : parsedResponse["choices"].GetArray()) {
-        ASSERT_TRUE(choice["finish_reason"].IsString());
-        EXPECT_STREQ(choice["finish_reason"].GetString(), "length");
-        ASSERT_EQ(choice["index"], i++);
-        ASSERT_FALSE(choice["logprobs"].IsObject());
-        ASSERT_TRUE(choice["message"].IsObject());
-        ASSERT_TRUE(choice["message"]["content"].IsString());
-        EXPECT_STREQ(choice["message"]["role"].GetString(), "assistant");
-    }
-
-    ASSERT_TRUE(parsedResponse["usage"].IsObject());
-    ASSERT_TRUE(parsedResponse["usage"].GetObject()["prompt_tokens"].IsInt());
-    ASSERT_TRUE(parsedResponse["usage"].GetObject()["completion_tokens"].IsInt());
-    ASSERT_TRUE(parsedResponse["usage"].GetObject()["total_tokens"].IsInt());
-    ASSERT_EQ(parsedResponse["usage"].GetObject()["completion_tokens"].GetInt(), 5 /* max_tokens */);
-    EXPECT_STREQ(parsedResponse["model"].GetString(), "llmDummyKFS");
-    EXPECT_STREQ(parsedResponse["object"].GetString(), "chat.completion");
+        ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR);
 }
 
 TEST_F(LLMFlowHttpTest, unaryChatCompletionsJsonNMultipleStopStrings) {


### PR DESCRIPTION
### 🛠 Summary
 - By default we select pipeline type by checking models directory contents and device choice
 - We also give possibility to enforce pipeline type with limitation that it must still match models directory content (can't use text only pipeline on VLM model and vice-versa)
 - Added supportsSpeculativeDecoding method to servable interface and blocked SD in VLM pipeline
 - Added new tests for initialization

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] Change follows security best practices.
``

