### PR TITLE
Fix C-API no gRPC start

### DIFF
--- a/src/capi_frontend/server_settings.hpp
+++ b/src/capi_frontend/server_settings.hpp
@@ -43,6 +43,7 @@ struct ServerSettingsImpl {
     uint32_t resourcesCleanerPollWaitSeconds = 1;
     std::string cacheDir;
     bool withPython = false;
+    bool startedWithCLI = false;
 };
 
 struct ModelsSettingsImpl {

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -323,6 +323,7 @@ void CLIParser::prepare(ServerSettingsImpl* serverSettings, ModelsSettingsImpl* 
 
     if (result->count("config_path"))
         modelsSettings->configPath = result->operator[]("config_path").as<std::string>();
+    serverSettings->startedWithCLI = true;
 }
 
 }  // namespace ovms

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -163,7 +163,7 @@ bool Config::validate() {
         return false;
     }
     // both ports cannot be unset
-    if ((restPort() == 0) && (port() == 0)) {
+    if (startedFromCLI() && ((restPort() == 0) && (port() == 0))) {
         std::cerr << "port and rest_port cannot both be unset" << std::endl;
         return false;
     }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -316,5 +316,8 @@ public:
          * @return const std::string& 
          */
     const std::string cacheDir() const;
+    bool startedFromCLI() {
+        return serverSettings.startedWithCLI;
+    }
 };
 }  // namespace ovms

--- a/src/test/c_api_test_utils.hpp
+++ b/src/test/c_api_test_utils.hpp
@@ -95,9 +95,13 @@
     }
 
 struct ServerSettingsGuard {
-    ServerSettingsGuard(int port) {
+    ServerSettingsGuard(bool startGrpc = false) {
         THROW_ON_ERROR_CAPI(OVMS_ServerSettingsNew(&settings));
-        THROW_ON_ERROR_CAPI(OVMS_ServerSettingsSetGrpcPort(settings, port));
+        if (!startGrpc)
+            return;
+        std::string port = "9000";
+        randomizePort(port);
+        THROW_ON_ERROR_CAPI(OVMS_ServerSettingsSetGrpcPort(settings, std::stoi(port)));
     }
     ~ServerSettingsGuard() {
         if (settings)
@@ -118,10 +122,8 @@ struct ModelsSettingsGuard {
 };
 
 struct ServerGuard {
-    ServerGuard(const std::string configPath) {
-        std::string port = "9000";
-        randomizePort(port);
-        ServerSettingsGuard serverSettingsGuard(std::stoi(port));
+    ServerGuard(const std::string configPath, bool startGrpc = false) {
+        ServerSettingsGuard serverSettingsGuard(startGrpc);
         ModelsSettingsGuard modelsSettingsGuard(configPath);
         THROW_ON_ERROR_CAPI(OVMS_ServerNew(&server));
         THROW_ON_ERROR_CAPI(OVMS_ServerStartFromConfigurationFile(server, serverSettingsGuard.settings, modelsSettingsGuard.settings));


### PR DESCRIPTION
There was shared validation path for CLI start & C-API start.
This blocked starting C-API without gRPC or REST port set.
Existing test for exactly that scenario used ServerGuard which under the hood set gRPC port
so the fail was not detected earlier.

Ticket:CVS-164147

