### PR TITLE
Enable LLM tests for stateful pipeline

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -2771,6 +2771,7 @@ cc_test(
         "test/configs/emptyConfigWithMetrics.json",
         "test/llm/config.json",
         "test/llm/lm_cb_regular.pbtxt",
+        "test/llm/lm_legacy_regular.pbtxt",
         "test/llm/lm_cb_speculative.pbtxt",
         "test/llm/visual_language_model/config.json",
         "test/llm/visual_language_model/vlm_cb_regular.pbtxt",

--- a/src/llm/language_model/legacy/legacy_executor.cpp
+++ b/src/llm/language_model/legacy/legacy_executor.cpp
@@ -33,7 +33,9 @@ bool LegacyExecutor::requestsQueueSize() {
 void LegacyExecutor::processRequest() {
     OVMS_PROFILE_FUNCTION();
     SPDLOG_LOGGER_TRACE(llm_executor_logger, "Generation started");
+    pipe->start_chat();
     requests.front()->results = pipe->generate(requests.front()->inputIds, requests.front()->apiHandler->createGenerationConfig(), requests.front()->textStreamer);
+    pipe->finish_chat();
     SPDLOG_LOGGER_TRACE(llm_executor_logger, "Generation ended");
     requests.front()->readySignal.set_value();
     requests.front()->executionInProgress.notify_one();
@@ -47,7 +49,7 @@ void LegacyExecutor::waitForRequests(std::atomic<bool>* receivedEndSignal) {
 }
 
 void LegacyExecutor::addRequest(std::shared_ptr<LegacyServableExecutionContext> request) {
-    std::lock_guard<std::mutex> guard(queueMutex);
+    std::unique_lock<std::mutex> lock(queueMutex);
     requests.push(request);
     cv.notify_one();
 }

--- a/src/llm/language_model/legacy/servable_initializer.cpp
+++ b/src/llm/language_model/legacy/servable_initializer.cpp
@@ -70,9 +70,10 @@ Status LegacyServableInitializer::initialize(std::shared_ptr<GenAiServable>& ser
         return status;
     }
 
-    properties->tokenizerPluginConfig = {{"PERFORMANCE_HINT", "THROUGHPUT"}};
+    // properties->tokenizerPluginConfig = {{"PERFORMANCE_HINT", "THROUGHPUT"}};
+    properties->pluginConfig["ATTENTION_BACKEND"] = "SDPA";
     try {
-        properties->pipeline = std::make_shared<ov::genai::LLMPipeline>(parsedModelsPath, properties->device);
+        properties->pipeline = std::make_shared<ov::genai::LLMPipeline>(parsedModelsPath, properties->device, properties->pluginConfig);
         properties->tokenizer = properties->pipeline->get_tokenizer();
     } catch (const std::exception& e) {
         SPDLOG_ERROR("Error during llm node initialization for models_path: {} exception: {}", parsedModelsPath, e.what());

--- a/src/llm/language_model/legacy/servable_initializer.cpp
+++ b/src/llm/language_model/legacy/servable_initializer.cpp
@@ -70,7 +70,7 @@ Status LegacyServableInitializer::initialize(std::shared_ptr<GenAiServable>& ser
         return status;
     }
 
-    // properties->tokenizerPluginConfig = {{"PERFORMANCE_HINT", "THROUGHPUT"}};
+    // Enforce construction of stateful pipeline on any device selected (CPU and GPU by default construct CB pipeline through CB adapter)
     properties->pluginConfig["ATTENTION_BACKEND"] = "SDPA";
     try {
         properties->pipeline = std::make_shared<ov::genai::LLMPipeline>(parsedModelsPath, properties->device, properties->pluginConfig);

--- a/src/llm/llm_calculator.proto
+++ b/src/llm/llm_calculator.proto
@@ -28,21 +28,15 @@ message LLMCalculatorOptions {
 
     enum PipelineType {
       // Single modality (text only), text generation based on LLMPipeline
-      TEXT = 0;
+      LM = 0;
       // Multimodal (text and image), text generation based on LLMPipeline
       VLM = 1;
       // Single modality (text only), text generation based on ContinuousBatchingPipeline
-      TEXT_CB = 2;
+      LM_CB = 2;
       // Multimodal (text and image), text generation based on ContinuousBatchingPipeline
       VLM_CB = 3;
       // Default option. If selected, pipeline type will be inferred by the serving
       AUTO = 4;
-
-      // Compatibility with current configurations, remove below in the next PR
-      // Continuous batching pipeline
-      CONTINUOUS_BATCHING = 5;
-      // Visual language model pipeline
-      VISUAL_LANGUAGE_MODEL = 6;
     }
 
     optional string models_path = 1;

--- a/src/llm/servable_initializer.cpp
+++ b/src/llm/servable_initializer.cpp
@@ -244,6 +244,7 @@ Status initializeGenAiServable(std::shared_ptr<GenAiServable>& servable, const :
                 return status;
             }
         } else if (pipelineType == PipelineType::VLM) {
+            SPDLOG_LOGGER_INFO(modelmanager_logger, "Initializing Visual Language Model Legacy servable");
             VisualLanguageModelLegacyServableInitializer legacyServableInitializer;
             status = legacyServableInitializer.initialize(servable, nodeOptions, graphPath);
             if (status != StatusCode::OK) {

--- a/src/llm/servable_initializer.hpp
+++ b/src/llm/servable_initializer.hpp
@@ -31,10 +31,10 @@ namespace ovms {
 
 // Defines what servable type should be initialized based on the pipeline type
 enum class PipelineType {
-    TEXT,     // Single modality (text only), text generation based on LLMPipeline
-    VLM,      // Multimodal (text and image), text generation based on LLMPipeline
-    TEXT_CB,  // Single modality (text only), text generation based on ContinuousBatchingPipeline
-    VLM_CB,   // Multimodal (text and image), text generation based on ContinuousBatchingPipeline
+    LM,      // Single modality (text only), text generation based on LLMPipeline
+    VLM,     // Multimodal (text and image), text generation based on LLMPipeline
+    LM_CB,   // Single modality (text only), text generation based on ContinuousBatchingPipeline
+    VLM_CB,  // Multimodal (text and image), text generation based on ContinuousBatchingPipeline
 
     // Note that *_CB pipelines do not support execution on NPU
 };

--- a/src/test/llm/config.json
+++ b/src/test/llm/config.json
@@ -6,6 +6,10 @@
         "graph_path":"/ovms/src/test/llm/lm_cb_regular.pbtxt"
     },
     {
+        "name":"lm_legacy_regular",
+        "graph_path":"/ovms/src/test/llm/lm_legacy_regular.pbtxt"
+    },
+    {
         "name":"lm_cb_speculative",
         "graph_path":"/ovms/src/test/llm/lm_cb_speculative.pbtxt"
     },

--- a/src/test/llm/lm_legacy_regular.pbtxt
+++ b/src/test/llm/lm_legacy_regular.pbtxt
@@ -1,0 +1,46 @@
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+input_stream: "HTTP_REQUEST_PAYLOAD:input"
+output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+node {
+    name: "llmNode1"
+    calculator: "HttpLLMCalculator"
+    input_side_packet: "LLM_NODE_RESOURCES:llm"
+    input_stream: "LOOPBACK:loopback"
+    input_stream: "HTTP_REQUEST_PAYLOAD:input"
+    output_stream: "LOOPBACK:loopback"
+    output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+    input_stream_info: {
+      tag_index: 'LOOPBACK:0',
+      back_edge: true
+    }
+    node_options: {
+        [type.googleapis.com/mediapipe.LLMCalculatorOptions]: {
+          models_path: "/ovms/src/test/llm_testing/facebook/opt-125m"
+          cache_size: 1
+          pipeline_type: LM
+        }
+    }
+    input_stream_handler {
+      input_stream_handler: "SyncSetInputStreamHandler",
+      options {
+        [mediapipe.SyncSetInputStreamHandlerOptions.ext] {
+          sync_set {
+            tag_index: "LOOPBACK:0"
+          }
+        }
+      }
+    }
+}

--- a/src/test/llm/visual_language_model/initialization_test.cpp
+++ b/src/test/llm/visual_language_model/initialization_test.cpp
@@ -122,7 +122,7 @@ TEST_F(VLMServableInitializationTest, determinePipelineType_VLM_CB_Specified) {
     ASSERT_EQ(pipelineType, PipelineType::VLM_CB);
 }
 
-TEST_F(VLMServableInitializationTest, determinePipelineType_TEXT_CB_Specified) {
+TEST_F(VLMServableInitializationTest, determinePipelineType_LM_CB_Specified) {
     std::string testPbtxt = R"(
         input_stream: "HTTP_REQUEST_PAYLOAD:input"
         output_stream: "HTTP_RESPONSE_PAYLOAD:output"
@@ -141,7 +141,7 @@ TEST_F(VLMServableInitializationTest, determinePipelineType_TEXT_CB_Specified) {
         }
         node_options: {
             [type.googleapis.com / mediapipe.LLMCalculatorOptions]: {
-                pipeline_type: TEXT_CB
+                pipeline_type: LM_CB
                 models_path: "/ovms/src/test/llm_testing/OpenGVLab/InternVL2-1B"
             }
         }


### PR DESCRIPTION
Changes:
- add stateful servable to LLM tests suite and adjust tests wherever needed
- rename TEXT/TEXT_CB to LM/LM_CB in pipeline type and removed unused types
- fixed usage computation for streaming in LM pipeline 

