### PR TITLE
Retire loaded models before model destruction

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -33,6 +33,10 @@
 
 namespace ovms {
 
+Model::~Model() {
+    this->retireAllVersions();
+}
+
 static StatusCode downloadModels(std::shared_ptr<FileSystem>& fs, ModelConfig& config, std::shared_ptr<model_versions_t> versions) {
     if (versions->size() == 0) {
         return StatusCode::OK;

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -129,7 +129,7 @@ public:
          * @brief Destroy the Model object
          * 
          */
-    virtual ~Model() {}
+    virtual ~Model();
 
     /**
          * @brief Gets the model name


### PR DESCRIPTION
### 🛠 Summary

CVS-164617

### 🧪 Checklist

- [x] Unit tests added already in place (CAPIInference.AsyncWithCallbackDummy)
- [x] Change follows security best practices.


