### PR TITLE
Fix OVMS shutdown with C-API async callback

### DIFF
--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -93,10 +93,7 @@ const uint32_t MAX_NIREQ_COUNT = 100000;
 const uint32_t UNLOAD_AVAILABILITY_CHECKING_INTERVAL_MILLISECONDS = 10;
 
 ModelInstance::~ModelInstance() {
-    SPDLOG_ERROR("THIS:{}", (void*)this);
-        retireModel();
-    SPDLOG_ERROR("THIS:{}", (void*)this);
-    
+    retireModel();
 }
 ModelInstance::ModelInstance(const std::string& name, model_version_t version, ov::Core& ieCore, MetricRegistry* registry, const MetricConfig* metricConfig) :
     Servable(name, version),
@@ -104,8 +101,7 @@ ModelInstance::ModelInstance(const std::string& name, model_version_t version, o
     subscriptionManager(std::string("model: ") + name + std::string(" version: ") + std::to_string(version)),
     status(name, version),
     reporter(std::make_unique<ModelMetricReporter>(metricConfig, registry, name, version)) {
-    SPDLOG_ERROR("THIS:{}", (void*)this);
-            isCustomLoaderConfigChanged = false;
+    isCustomLoaderConfigChanged = false;
 }
 
 void ModelInstance::subscribe(NotifyReceiver& pd) {

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -92,14 +92,20 @@ void* globalVaDisplay = nullptr;
 const uint32_t MAX_NIREQ_COUNT = 100000;
 const uint32_t UNLOAD_AVAILABILITY_CHECKING_INTERVAL_MILLISECONDS = 10;
 
-ModelInstance::~ModelInstance() = default;
+ModelInstance::~ModelInstance() {
+    SPDLOG_ERROR("THIS:{}", (void*)this);
+        retireModel();
+    SPDLOG_ERROR("THIS:{}", (void*)this);
+    
+}
 ModelInstance::ModelInstance(const std::string& name, model_version_t version, ov::Core& ieCore, MetricRegistry* registry, const MetricConfig* metricConfig) :
     Servable(name, version),
     ieCore(ieCore),
     subscriptionManager(std::string("model: ") + name + std::string(" version: ") + std::to_string(version)),
     status(name, version),
     reporter(std::make_unique<ModelMetricReporter>(metricConfig, registry, name, version)) {
-    isCustomLoaderConfigChanged = false;
+    SPDLOG_ERROR("THIS:{}", (void*)this);
+            isCustomLoaderConfigChanged = false;
 }
 
 void ModelInstance::subscribe(NotifyReceiver& pd) {

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -106,7 +106,7 @@ protected:
     /**
          * @brief OpenVINO Runtime Model object
          */
-    std::shared_ptr<ov::Model> model; // check if used
+    std::shared_ptr<ov::Model> model;
 
     /**
          * @brief OpenVINO Runtime CompiledModel object

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -106,7 +106,7 @@ protected:
     /**
          * @brief OpenVINO Runtime Model object
          */
-    std::shared_ptr<ov::Model> model;
+    std::shared_ptr<ov::Model> model; // check if used
 
     /**
          * @brief OpenVINO Runtime CompiledModel object

--- a/src/test/c_api_tests.cpp
+++ b/src/test/c_api_tests.cpp
@@ -1354,6 +1354,9 @@ TEST_F(CAPIMetadata, Negative) {
 class CAPIState : public ::testing::Test {
 public:
     static std::shared_ptr<MockModelInstanceChangingStates> modelInstance;
+    static void TearDownTestSuite() {
+        modelInstance.reset();
+    }
     class MockModel : public Model {
     public:
         MockModel(const std::string& name, std::shared_ptr<ModelInstance> instance) :

--- a/src/test/modelinstance_test.cpp
+++ b/src/test/modelinstance_test.cpp
@@ -100,6 +100,8 @@ TEST_F(TestUnloadModel, CantUnloadModelWhilePredictPathAcquiredAndLockedInstance
     ASSERT_EQ(status, ovms::StatusCode::OK);
     modelInstance.increasePredictRequestsHandlesCount();
     EXPECT_FALSE(modelInstance.canUnloadInstance());
+    modelInstance.decreasePredictRequestsHandlesCount();
+    EXPECT_TRUE(modelInstance.canUnloadInstance());
 }
 
 TEST_F(TestUnloadModel, CanUnloadModelNotHoldingModelInstanceAtPredictPath) {
@@ -161,6 +163,7 @@ TEST_F(TestUnloadModel, UnloadWaitsUntilMetadataResponseIsBuilt) {
     EXPECT_EQ(outputs.size(), 1);
     EXPECT_EQ(inputs.begin()->second.name(), DUMMY_MODEL_INPUT_NAME);
     EXPECT_EQ(outputs.begin()->second.name(), DUMMY_MODEL_OUTPUT_NAME);
+    instance.reset();
 }
 
 TEST_F(TestUnloadModel, CheckIfCanUnload) {

--- a/src/test/modelmanager_test.cpp
+++ b/src/test/modelmanager_test.cpp
@@ -2093,6 +2093,7 @@ TEST_F(GetModelInstanceTest, WithRequestedUnexistingVersionShouldReturnModelVers
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> modelInstanceUnloadGuardPtr;
     auto status = manager.getModelInstance(config.getName(), 2, modelInstance, modelInstanceUnloadGuardPtr);
     EXPECT_EQ(status, ovms::StatusCode::MODEL_VERSION_MISSING) << "Should fail with no model with such name registered";
+    model.reset();
 }
 
 class MockModelInstanceFakeLoad : public ovms::ModelInstance {
@@ -2131,6 +2132,7 @@ TEST_F(GetModelInstanceTest, WithRequestedDefaultVersionUnloadedShouldReturnMode
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> modelInstanceUnloadGuardPtr;
     auto status = manager.getModelInstance(config.getName(), 0, modelInstance, modelInstanceUnloadGuardPtr);
     EXPECT_EQ(status, ovms::StatusCode::MODEL_VERSION_MISSING);
+    model.reset();
 }
 
 TEST_F(GetModelInstanceTest, WithRequestedVersion1ShouldReturnModelVersionNotLoadedAnymore) {
@@ -2145,6 +2147,7 @@ TEST_F(GetModelInstanceTest, WithRequestedVersion1ShouldReturnModelVersionNotLoa
     std::unique_ptr<ovms::ModelInstanceUnloadGuard> modelInstanceUnloadGuardPtr;
     auto status = manager.getModelInstance(config.getName(), 1, modelInstance, modelInstanceUnloadGuardPtr);
     EXPECT_EQ(status, ovms::StatusCode::MODEL_VERSION_NOT_LOADED_ANYMORE);
+    model.reset();
 }
 
 class ModelInstanceLoadedStuckInLoadingState : public ovms::ModelInstance {
@@ -2185,22 +2188,25 @@ public:
     ModelInstanceLoadedWaitInLoadingState(ov::Core& ieCore, const uint32_t modelInstanceLoadDelayInMilliseconds) :
         ModelInstance("UNUSED_NAME", UNUSED_MODEL_VERSION, ieCore),
         modelInstanceLoadDelayInMilliseconds(modelInstanceLoadDelayInMilliseconds) {}
+    ~ModelInstanceLoadedWaitInLoadingState() {
+        this->thread->join();
+    }
 
 protected:
     ovms::Status loadModel(const ovms::ModelConfig& config) override {
         this->status = ovms::ModelVersionStatus(name, version);
         this->status.setLoading();
-        std::thread([this]() {
+        this->thread = std::make_unique<std::thread>([this]() {
             std::this_thread::sleep_for(std::chrono::milliseconds(modelInstanceLoadDelayInMilliseconds));
             status.setAvailable();
             modelLoadedNotify.notify_all();
-        })
-            .detach();
+        });
         return ovms::StatusCode::OK;
     }
 
 private:
     const uint32_t modelInstanceLoadDelayInMilliseconds;
+    std::unique_ptr<std::thread> thread;
 };
 
 class ModelWithModelInstanceLoadedWaitInLoadingState : public ovms::Model {
@@ -2246,6 +2252,7 @@ TEST_F(ModelInstanceModelLoadedNotify, WhenChangedStateFromLoadingToAvailableInN
     auto status = manager.getModelInstance(config.getName(), 1, modelInstance, modelInstanceUnloadGuardPtr);
     ASSERT_EQ(status, ovms::StatusCode::OK);
     EXPECT_EQ(ovms::ModelVersionState::AVAILABLE, modelInstance->getStatus().getState());
+    modelWithModelInstanceLoadedWaitInLoadingState.reset();
 }
 
 TEST_F(ModelInstanceModelLoadedNotify, WhenChangedStateFromLoadingToAvailableInReachingTimeoutShouldReturnModelNotLoadedYet) {
@@ -2268,4 +2275,5 @@ TEST_F(ModelInstanceModelLoadedNotify, WhenChangedStateFromLoadingToAvailableInR
     EXPECT_EQ(ovms::ModelVersionState::LOADING, modelInstance->getStatus().getState()) << "State:" << (int)modelInstance->getStatus().getState();
     spdlog::error("State: {}", (int)modelInstance->getStatus().getState());
     EXPECT_EQ(status, ovms::StatusCode::MODEL_VERSION_NOT_LOADED_YET);
+    modelWithModelInstanceLoadedWaitInLoadingState.reset();
 }

--- a/src/test/ovinferrequestqueue_test.cpp
+++ b/src/test/ovinferrequestqueue_test.cpp
@@ -69,12 +69,12 @@ TEST(OVInferRequestQueue, FullQueue) {
     }
     timer.start(QUEUE);
     std::thread th(&releaseStream, std::ref(inferRequestsQueue));
-    th.detach();
     reqid = inferRequestsQueue.getIdleStream().get();  // it should wait 0.5s for released request
     timer.stop(QUEUE);
 
     EXPECT_GT(timer.elapsed<std::chrono::microseconds>(QUEUE), 500'000);
     EXPECT_EQ(reqid, 3);
+    th.join();
 }
 
 static void inferenceSimulate(ovms::OVInferRequestsQueue& ms, std::vector<int>& tv) {

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -366,6 +366,8 @@ TEST(Server, ProperShutdownInCaseOfStartError) {
     std::string restPort = "9000";
     randomizePort(port);
     randomizePort(restPort);
+    while (port == restPort)
+        randomizePort(restPort);
     char* argv[] = {
         (char*)"OpenVINO Model Server",
         (char*)"--model_name",


### PR DESCRIPTION
Issue was that in case of quick shutdown of OVMS when there was C-API async inference performed,
not all of the actions inside ov::InferRequest callback finished before destruction of OVInferRequestsQueue
from ModelInstance. Since Model destructor just calls erase() on its version instances map, existing synchronisation
failsafe (UnloadModelGuard) is omitted resulting in ov::InferRequest::set_completion_callback call being used on
already removed ov::InferRequest.

Issue visibility probably risen due to recent change in OVMS where we do not start (and hence stop) grpc servers which took enough time to stop this issue from being visible.

ov::InferRequest::set_completion_callbacke being used here:
https://github.com/openvinotoolkit/model_server/blob/main/src/inference_executor.hpp#L139

Ticket: CVS-164617


