### PR TITLE
Fix launching llm demo on NPU on Windows

### DIFF
--- a/demos/common/export_models/requirements.txt
+++ b/demos/common/export_models/requirements.txt
@@ -12,3 +12,4 @@ transformers<4.48
 einops
 torchvision==0.21.0
 timm==1.0.15
+markupsafe<2.1.0


### PR DESCRIPTION
packages\jinja2\nodes.py", line 19, in <module>
    from jinja2.utils import Markup
  File "C:\Program Files\Python39\lib\site-packages\jinja2\utils.py", line 624, in <module>
    from markupsafe import Markup, escape, soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe'

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

