### PR TITLE
Fix relative path

### DIFF
--- a/src/modelmanager.cpp
+++ b/src/modelmanager.cpp
@@ -230,14 +230,13 @@ Status ModelManager::startFromConfig() {
     // Check if config is present for mediapipe graph
     MediapipeGraphConfig mpConfig;
     mpConfig.setGraphName(config.modelName());
+    mpConfig.setRootDirectoryPath(this->rootDirectoryPath);
     if (config.modelPath().back() == FileSystem::getOsSeparator().back()) {
-        mpConfig.setRootDirectoryPath(config.modelPath());
         mpConfig.setBasePath(config.modelPath());
     } else {
-        mpConfig.setRootDirectoryPath(config.modelPath() + FileSystem::getOsSeparator());
         mpConfig.setBasePath(config.modelPath() + FileSystem::getOsSeparator());
     }
-    mpConfig.setGraphPath(mpConfig.getBasePath() + DEFAULT_GRAPH_FILENAME);
+    mpConfig.setGraphPath(DEFAULT_GRAPH_FILENAME);
     std::vector<MediapipeGraphConfig> mediapipesInConfigFile;
 
     std::ifstream ifs(mpConfig.getGraphPath());

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -117,11 +117,11 @@ public:
 };
 
 class MediapipeCliFlowTestDummyRelative : public MediapipeCliFlowTest {
-    public:
-        void SetUp() {
-            SetUpServer("src/test/mediapipe/cli", "graphkfspass");
-        }
-    };
+public:
+    void SetUp() {
+        SetUpServer("src/test/mediapipe/cli", "graphkfspass");
+    }
+};
 
 TEST_F(MediapipeCliFlowTestNegative, UnsupportedCliParamBatchSize) {
     server.setShutdownRequest(0);

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -118,8 +118,16 @@ public:
 
 class MediapipeCliFlowTestDummyRelative : public MediapipeCliFlowTest {
 public:
+    std::filesystem::path originalCwd;
     void SetUp() {
+        // Workaround for bazel test execution from /root/ or bazel-out directory
+        originalCwd = std::filesystem::current_path();
+#ifdef __linux__
+        std::filesystem::path newCwd = "/ovms";
+        std::filesystem::current_path(newCwd);
+#endif
         SetUpServer("src/test/mediapipe/cli", "graphkfspass");
+        std::filesystem::current_path(originalCwd);
     }
 };
 

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -116,6 +116,13 @@ public:
     }
 };
 
+class MediapipeCliFlowTestDummyRelative : public MediapipeCliFlowTest {
+    public:
+        void SetUp() {
+            SetUpServer("src/test/mediapipe/cli", "graphkfspass");
+        }
+    };
+
 TEST_F(MediapipeCliFlowTestNegative, UnsupportedCliParamBatchSize) {
     server.setShutdownRequest(0);
     randomizePort(this->port);
@@ -138,6 +145,25 @@ TEST_F(MediapipeCliFlowTestNegative, UnsupportedCliParamBatchSize) {
 }
 
 TEST_F(MediapipeCliFlowTestDummy, Infer) {
+    const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
+    KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
+    ::KFSRequest request;
+    ::KFSResponse response;
+    const std::string modelName = "graphkfspass";
+    request.Clear();
+    response.Clear();
+    inputs_info_t inputsMeta{
+        {"in", {DUMMY_MODEL_SHAPE, precision}}};
+    std::vector<float> requestData1{1., 1., 1., 1., 1., 1., 1., 1., 1., 1.};
+    std::vector<float> requestData2{0., 0., 0., 0., 0., 0., 0., 0., 0., 0.};
+    preparePredictRequest(request, inputsMeta, requestData1);
+    request.mutable_model_name()->assign(modelName);
+    ASSERT_EQ(impl.ModelInfer(nullptr, &request, &response).error_code(), grpc::StatusCode::OK);
+    // Checking that KFSPASS calculator copies requestData1 to the response so that we expect requestData1 on output
+    checkAddResponse("out", requestData1, requestData2, request, response, 1, 1, modelName);
+}
+
+TEST_F(MediapipeCliFlowTestDummyRelative, Infer) {
     const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
     KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
     ::KFSRequest request;


### PR DESCRIPTION
### 🛠 Summary
JIRA CVS-165014
Fix relative path for graph.pbtxt from single model cli.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

