### PR TITLE
Fix tests not ensuring OVMS loaded

### DIFF
--- a/src/test/disabled_mediapipe_test.cpp
+++ b/src/test/disabled_mediapipe_test.cpp
@@ -46,7 +46,7 @@ public:
         std::string port = "9173";
         randomizePort(port);
         ovms::Server& server = ovms::Server::instance();
-        ::EnsureSetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/configs/config_cpu_dummy.json").c_str(), 15);
+        ::SetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/configs/config_cpu_dummy.json").c_str());
     }
 
     void SetUp() {

--- a/src/test/embeddingsnode_test.cpp
+++ b/src/test/embeddingsnode_test.cpp
@@ -40,7 +40,7 @@ public:
 
     static void SetUpSuite(std::string& port, std::string& configPath, std::unique_ptr<std::thread>& t) {
         ovms::Server& server = ovms::Server::instance();
-        ::EnsureSetUpServer(t, server, port, configPath.c_str(), 15);
+        ::SetUpServer(t, server, port, configPath.c_str());
     }
     static void SetUpTestSuite() {
     }
@@ -368,12 +368,7 @@ public:
         t.reset(new std::thread([&argc, &argv, &server]() {
             EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
         }));
-        auto start = std::chrono::high_resolution_clock::now();
-        const int numberOfRetries = 15;
-        while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < numberOfRetries)) {
-        }
-        ASSERT_EQ(server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME), ovms::ModuleState::INITIALIZED);
+        EnsureServerStartedWithTimeout(server, 15);
     }
 
     void SetUp() {

--- a/src/test/http_openai_handler_test.cpp
+++ b/src/test/http_openai_handler_test.cpp
@@ -46,11 +46,7 @@ protected:
 
     void SetUpServer(const char* configPath) {
         ::SetUpServer(this->t, this->server, this->port, configPath);
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
-
+        EnsureServerStartedWithTimeout(this->server, 5);
         handler = std::make_unique<ovms::HttpRestApiHandler>(server, 5);
     }
 

--- a/src/test/kfs_rest_test.cpp
+++ b/src/test/kfs_rest_test.cpp
@@ -75,10 +75,7 @@ public:
             [&argv]() {
                 ASSERT_EQ(EXIT_SUCCESS, server->start(11, argv));
             });
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server->getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        EnsureServerStartedWithTimeout(*server, 5);
     }
     void SetUp() override {
         handler = std::make_unique<HttpRestApiHandler>(*server, 5);
@@ -117,10 +114,7 @@ public:
             [&argv]() {
                 ASSERT_EQ(EXIT_SUCCESS, server->start(9, argv));
             });
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server->getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        EnsureServerStartedWithTimeout(*server, 5);
     }
 };
 
@@ -147,10 +141,7 @@ public:
             [&argv]() {
                 ASSERT_EQ(EXIT_SUCCESS, server->start(11, argv));
             });
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server->getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        EnsureServerStartedWithTimeout(*server, 5);
     }
 };
 
@@ -175,10 +166,7 @@ public:
             [&argv]() {
                 ASSERT_EQ(EXIT_SUCCESS, server->start(9, argv));
             });
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server->getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        EnsureServerStartedWithTimeout(*server, 5);
     }
 };
 
@@ -246,11 +234,6 @@ protected:
 
     void SetUpServer(const char* configPath) {
         ::SetUpServer(this->t, this->server, this->port, configPath);
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server.getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
-
         handler = std::make_unique<HttpRestApiHandler>(server, 5);
     }
 

--- a/src/test/llm/llmnode_test.cpp
+++ b/src/test/llm/llmnode_test.cpp
@@ -81,7 +81,7 @@ public:
     static void SetUpTestSuite() {
         std::string port = "9173";
         ovms::Server& server = ovms::Server::instance();
-        ::SetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/llm/config.json").c_str());
+        ::SetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/llm/config.json").c_str(), 60);
 
         try {
             plugin_config_t tokenizerPluginConfig = {};

--- a/src/test/llm/llmnode_test.cpp
+++ b/src/test/llm/llmnode_test.cpp
@@ -81,9 +81,7 @@ public:
     static void SetUpTestSuite() {
         std::string port = "9173";
         ovms::Server& server = ovms::Server::instance();
-        ::EnsureSetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/llm/config.json").c_str(), 15);
-
-        ASSERT_EQ(server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME), ovms::ModuleState::INITIALIZED) << "Loading manager takes too long. Server cannot start in 20 seconds.";
+        ::SetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/llm/config.json").c_str());
 
         try {
             plugin_config_t tokenizerPluginConfig = {};

--- a/src/test/llm/llmtemplate_test.cpp
+++ b/src/test/llm/llmtemplate_test.cpp
@@ -620,7 +620,7 @@ protected:
         CreateSymbolicLinks(directoryPath);
         std::string port = "9173";
         ovms::Server& server = ovms::Server::instance();
-        ::EnsureSetUpServer(t, server, port, ovmsConfigFilePath.c_str(), 15);
+        ::SetUpServer(t, server, port, ovmsConfigFilePath.c_str());
     }
 
     void SetUp() override {

--- a/src/test/llm/visual_language_model/complete_flow_test.cpp
+++ b/src/test/llm/visual_language_model/complete_flow_test.cpp
@@ -56,7 +56,7 @@ public:
     static void SetUpTestSuite() {
         std::string port = "9173";
         ovms::Server& server = ovms::Server::instance();
-        ::EnsureSetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/llm/visual_language_model/config.json").c_str(), 15);
+        ::SetUpServer(t, server, port, getGenericFullPathForSrcTest("/ovms/src/test/llm/visual_language_model/config.json").c_str());
     }
 
     void SetUp() {

--- a/src/test/mediapipe_validation_test.cpp
+++ b/src/test/mediapipe_validation_test.cpp
@@ -53,11 +53,7 @@ public:
         thread.reset(new std::thread([&argc, &argv, &server]() {
             EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
         }));
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server.getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (!server.isReady()) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        EnsureServerStartedWithTimeout(server, 5);
     }
     void prepareSingleInput() {
         request.Clear();

--- a/src/test/mediapipeflow_test.cpp
+++ b/src/test/mediapipeflow_test.cpp
@@ -278,12 +278,7 @@ public:
 };
 
 TEST_F(MediapipeEmbeddingsTest, startup) {
-    auto start = std::chrono::high_resolution_clock::now();
-    const int timeout = 5;
-    while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < timeout)) {
-    }
-
+    EnsureServerStartedWithTimeout(server, 5);
     const ovms::Module* servableModule = server.getModule(ovms::SERVABLE_MANAGER_MODULE_NAME);
     ASSERT_TRUE(servableModule != nullptr);
     ModelManager* manager = &dynamic_cast<const ServableManagerModule*>(servableModule)->getServableManager();
@@ -293,12 +288,7 @@ TEST_F(MediapipeEmbeddingsTest, startup) {
 }
 
 TEST_F(MediapipeEmbeddingsTest, grpcInference) {
-    auto start = std::chrono::high_resolution_clock::now();
-    const int timeout = 5;
-    while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < timeout)) {
-    }
-
+    EnsureServerStartedWithTimeout(server, 5);
     const ovms::Module* grpcModule = server.getModule(ovms::GRPC_SERVER_MODULE_NAME);
     KFSInferenceServiceImpl& impl = dynamic_cast<const ovms::GRPCServerModule*>(grpcModule)->getKFSGrpcImpl();
     ::KFSRequest request;
@@ -2109,11 +2099,7 @@ protected:
         t.reset(new std::thread([&argc, &argv, this]() {
             EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
         }));
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((server.getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (!server.isReady()) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        EnsureServerStartedWithTimeout(server, 5);
     }
     void TearDown() {
         server.setShutdownRequest(1);

--- a/src/test/model_service_test.cpp
+++ b/src/test/model_service_test.cpp
@@ -415,10 +415,7 @@ TEST_F(TFSModelServiceTest, config_reload) {
     std::thread t([&argv, &server]() {
         ASSERT_EQ(EXIT_SUCCESS, server.start(9, argv));
     });
-    auto start = std::chrono::high_resolution_clock::now();
-    while ((server.getModuleState(ovms::GRPC_SERVER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-    }
+    EnsureServerStartedWithTimeout(server, 5);
     ModelServiceImpl s(server);
     tensorflow::serving::ReloadConfigRequest modelStatusRequest;
     tensorflow::serving::ReloadConfigResponse modelStatusResponse;

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -98,11 +98,7 @@ public:
         serverThread.reset(new std::thread([&argc, &argv]() {
             EXPECT_EQ(EXIT_SUCCESS, ovms::Server::instance().start(argc, argv));
         }));
-        auto start = std::chrono::high_resolution_clock::now();
-        while ((ovms::Server::instance().getModuleState(SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-               (!ovms::Server::instance().isReady()) &&
-               (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-        }
+        EnsureServerStartedWithTimeout(ovms::Server::instance(), 5);
     }
     static void TearDownTestSuite() {
         ovms::Server::instance().setShutdownRequest(1);

--- a/src/test/reranknode_test.cpp
+++ b/src/test/reranknode_test.cpp
@@ -43,7 +43,7 @@ public:
 
     static void SetUpSuite(std::string& port, std::string& configPath, std::unique_ptr<std::thread>& t) {
         ovms::Server& server = ovms::Server::instance();
-        ::EnsureSetUpServer(t, server, port, configPath.c_str(), 15);
+        ::SetUpServer(t, server, port, configPath.c_str());
     }
     static void SetUpTestSuite() {
     }

--- a/src/test/server_test.cpp
+++ b/src/test/server_test.cpp
@@ -347,11 +347,7 @@ TEST(Server, ServerMetadata) {
     std::thread t([&argv, &server]() {
         ASSERT_EQ(EXIT_SUCCESS, server.start(7, argv));
     });
-    auto start = std::chrono::high_resolution_clock::now();
-    while ((ovms::Server::instance().getModuleState(ovms::GRPC_SERVER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < 5)) {
-    }
-
+    EnsureServerStartedWithTimeout(server, 5);
     grpc::ChannelArguments args;
     std::string address = std::string("localhost:") + port;
     requestServerAlive(port.c_str(), grpc::StatusCode::OK, true);

--- a/src/test/test_utils.cpp
+++ b/src/test/test_utils.cpp
@@ -676,7 +676,7 @@ void randomizePorts(std::string& port1, std::string& port2) {
     }
 }
 
-const int64_t SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS = 5;
+const int64_t SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS = 15;
 
 void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath) {
     server.setShutdownRequest(0);
@@ -690,19 +690,14 @@ void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::str
     t.reset(new std::thread([&argc, &argv, &server]() {
         EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
     }));
-    auto start = std::chrono::high_resolution_clock::now();
-    while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-           (!server.isReady()) &&
-           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS)) {
-    }
+    EnsureServerStartedWithTimeout(server, SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS);
 }
-void EnsureSetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath, int timeoutSeconds) {
-    SetUpServer(t, server, port, configPath);
+void EnsureServerStartedWithTimeout(ovms::Server& server, int timeoutSeconds) {
     auto start = std::chrono::high_resolution_clock::now();
     while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
            (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < timeoutSeconds)) {
     }
-    ASSERT_EQ(server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME), ovms::ModuleState::INITIALIZED) << "OVMS did not fully load until allowed time. Check machine load";
+    ASSERT_EQ(server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME), ovms::ModuleState::INITIALIZED) << "OVMS did not fully load until allowed time:" << timeoutSeconds << "s. Check machine load";
 }
 
 void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* modelPath, const char* modelName) {
@@ -719,11 +714,7 @@ void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::str
     t.reset(new std::thread([&argc, &argv, &server]() {
         EXPECT_EQ(EXIT_SUCCESS, server.start(argc, argv));
     }));
-    auto start = std::chrono::high_resolution_clock::now();
-    while ((server.getModuleState(ovms::SERVABLE_MANAGER_MODULE_NAME) != ovms::ModuleState::INITIALIZED) &&
-           (!server.isReady()) &&
-           (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count() < SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS)) {
-    }
+    EnsureServerStartedWithTimeout(server, 15);
 }
 
 std::shared_ptr<const TensorInfo> createTensorInfoCopyWithPrecision(std::shared_ptr<const TensorInfo> src, ovms::Precision newPrecision) {

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -1032,10 +1032,8 @@ void EnsureServerStartedWithTimeout(ovms::Server& server, int timeoutSeconds);
 /*
  *  starts loading OVMS on separate thread but waits until it is ready
  */
-void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath);
-void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath);
-
-void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* modelPath, const char* modelName);
+void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath, int timeoutSeconds = SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS);
+void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* modelPath, const char* modelName, int timeoutSeconds = SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS);
 
 class ConstructorEnabledConfig : public ovms::Config {
 public:

--- a/src/test/test_utils.hpp
+++ b/src/test/test_utils.hpp
@@ -1025,9 +1025,15 @@ void randomizePorts(std::string& port1, std::string& port2);
 
 extern const int64_t SERVER_START_FROM_CONFIG_TIMEOUT_SECONDS;
 
-// legacy - avoid this to avoid data races in tests
+/*
+ *  Waits until server is ready
+ */
+void EnsureServerStartedWithTimeout(ovms::Server& server, int timeoutSeconds);
+/*
+ *  starts loading OVMS on separate thread but waits until it is ready
+ */
 void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath);
-void EnsureSetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath, int timeoutSeconds);
+void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* configPath);
 
 void SetUpServer(std::unique_ptr<std::thread>& t, ovms::Server& server, std::string& port, const char* modelPath, const char* modelName);
 


### PR DESCRIPTION
Some tests did rely on SetUpServer function which basically started OVMS, and gave control back after either server was ready or 5s has passed. In second case no expect/assert was used so this caused sporadic failures when machine was under load. This is extending previous fix to other tests that relied on similar mechanism.


