### PR TITLE
Remove diversity penalty

### DIFF
--- a/docs/model_server_rest_api_chat.md
+++ b/docs/model_server_rest_api_chat.md
@@ -107,7 +107,6 @@ curl http://localhost/v3/chat/completions \
 |-------|----------|----------|----------|---------|-----|
 | n | ✅ | ✅ | ✅ | integer (default: `1`) | Number of output sequences to return for the given prompt. This value must be between `1 <= N <= BEST_OF`. |
 | best_of | ✅ | ❌ | ✅ | integer (default: `1`) | Number of output sequences that are generated from the prompt. From these _best_of_ sequences, the top _n_ sequences are returned. _best_of_ must be greater than or equal to _n_. This is treated as the beam width for beam search sampling.  |
-| diversity_penalty | ✅ | ❌ | ❌ | float (default: `1.0`) | This value is subtracted from a beam's score if it generates the same token as any beam from other group at a particular time. See [arXiv 1909.05858](https://arxiv.org/pdf/1909.05858). |
 | length_penalty | ✅ | ❌ | ✅ | float (default: `1.0`) | Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent to the sequence length, which in turn is used to divide the score of the sequence. Since the score is the log likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences, while `length_penalty` < 0.0 encourages shorter sequences. |
 
 #### Multinomial sampling specific

--- a/docs/model_server_rest_api_completions.md
+++ b/docs/model_server_rest_api_completions.md
@@ -68,7 +68,6 @@ curl http://localhost/v3/completions \
 |-------|----------|----------|----------|---------|-----|
 | n | ✅ | ✅ | ✅ | integer (default: `1`) | Number of output sequences to return for the given prompt. This value must be between `1 <= N <= BEST_OF`. |
 | best_of | ✅ | ✅ | ✅ | integer (default: `1`) | Number of output sequences that are generated from the prompt. From these _best_of_ sequences, the top _n_ sequences are returned. _best_of_ must be greater than or equal to _n_. This is treated as the beam width for beam search sampling.  |
-| diversity_penalty | ✅ | ❌ | ❌ | float (default: `1.0`) | This value is subtracted from a beam's score if it generates the same token as any beam from other group at a particular time. See [arXiv 1909.05858](https://arxiv.org/pdf/1909.05858). |
 | length_penalty | ✅ | ❌ | ✅ | float (default: `1.0`) | Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent to the sequence length, which in turn is used to divide the score of the sequence. Since the score is the log likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences, while `length_penalty` < 0.0 encourages shorter sequences. |
 
 #### Multinomial sampling specific

--- a/src/llm/apis/openai_completions.cpp
+++ b/src/llm/apis/openai_completions.cpp
@@ -376,15 +376,6 @@ absl::Status OpenAIChatCompletionsHandler::parseCommonPart(std::optional<uint32_
         request.repetitionPenalty = it->value.GetDouble();
     }
 
-    // diversity_penalty: float; optional - defaults to 1.0
-    // Extension, unsupported by OpenAI API and vLLM, however available in CB lib
-    it = doc.FindMember("diversity_penalty");
-    if (it != doc.MemberEnd() && !it->value.IsNull()) {
-        if (!it->value.IsDouble() && !it->value.IsInt())
-            return absl::InvalidArgumentError("diversity_penalty is not a valid number");
-        request.diversityPenalty = it->value.GetDouble();
-    }
-
     // length_penalty: float; optional - defaults to 1.0
     // Extension, unsupported by OpenAI API however supported by vLLM and CB lib
     it = doc.FindMember("length_penalty");

--- a/src/llm/apis/openai_completions.hpp
+++ b/src/llm/apis/openai_completions.hpp
@@ -94,7 +94,6 @@ struct OpenAIChatCompletionsRequest {
     // Beam search specific
     std::optional<int> bestOf{std::nullopt};
     std::optional<float> lengthPenalty{std::nullopt};
-    std::optional<float> diversityPenalty{std::nullopt};
 
     // Speculative decoding specific (only with speculative decoding pipeline, see <docs> for reference)
     std::optional<int> numAssistantTokens{std::nullopt};
@@ -126,8 +125,6 @@ struct OpenAIChatCompletionsRequest {
         if (bestOf.has_value())
             config.num_beams = bestOf.value();
 
-        if (diversityPenalty.has_value())
-            config.diversity_penalty = diversityPenalty.value();  // TODO: Not available in OpenAI nor vLLM
         // TODO: stop_criteria = ?
         if (numReturnSequences.has_value())
             config.num_return_sequences = numReturnSequences.value();

--- a/src/test/http_openai_handler_test.cpp
+++ b/src/test/http_openai_handler_test.cpp
@@ -534,7 +534,7 @@ TEST_F(HttpOpenAIHandlerParsingTest, maxTokensValueDefualtToMaxTokensLimit) {
 }
 
 TEST_F(HttpOpenAIHandlerParsingTest, ParsingRequestWithNullParametersChat) {
-    std::vector<std::string> chatParamsThatAcceptNull = {"stream", "stream_options", "ignore_eos", "frequency_penalty", "presence_penalty", "repetition_penalty", "diversity_penalty",
+    std::vector<std::string> chatParamsThatAcceptNull = {"stream", "stream_options", "ignore_eos", "frequency_penalty", "presence_penalty", "repetition_penalty",
         "length_penalty", "temperature", "top_p", "top_k", "seed", "stop", "include_stop_str_in_output", "best_of", "n", "num_assistant_tokens", "assistant_confidence_threshold",
         "logprobs", "max_completion_tokens"};
     std::optional<uint32_t> maxTokensLimit;
@@ -565,7 +565,7 @@ TEST_F(HttpOpenAIHandlerParsingTest, ParsingRequestWithNullParametersChat) {
 }
 
 TEST_F(HttpOpenAIHandlerParsingTest, ParsingRequestWithNullParametersCompletions) {
-    std::vector<std::string> chatParamsThatAcceptNull = {"stream", "stream_options", "ignore_eos", "frequency_penalty", "presence_penalty", "repetition_penalty", "diversity_penalty",
+    std::vector<std::string> chatParamsThatAcceptNull = {"stream", "stream_options", "ignore_eos", "frequency_penalty", "presence_penalty", "repetition_penalty",
         "length_penalty", "temperature", "top_p", "top_k", "seed", "stop", "include_stop_str_in_output", "best_of", "n", "num_assistant_tokens", "assistant_confidence_threshold",
         "logprobs", "echo"};
     std::optional<uint32_t> maxTokensLimit;

--- a/src/test/llm/llmnode_test.cpp
+++ b/src/test/llm/llmnode_test.cpp
@@ -2687,24 +2687,6 @@ TEST_P(LLMHttpParametersValidationTest, repetitionPenaltyInvalid) {
         ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR);
 }
 
-TEST_P(LLMHttpParametersValidationTest, diversityPenaltyValid) {
-    auto params = GetParam();
-    std::string requestBody = validRequestBodyWithParameter(params.modelName, "diversity_penalty", "2.0");
-
-    ASSERT_EQ(
-        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, writer),
-        ovms::StatusCode::OK);
-}
-
-TEST_P(LLMHttpParametersValidationTest, diversityPenaltyInvalid) {
-    auto params = GetParam();
-    std::string requestBody = validRequestBodyWithParameter(params.modelName, "diversity_penalty", "\"INVALID\"");
-
-    ASSERT_EQ(
-        handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, writer),
-        ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR);
-}
-
 TEST_P(LLMHttpParametersValidationTest, lengthPenaltyValid) {
     auto params = GetParam();
     std::string requestBody = validRequestBodyWithParameter(params.modelName, "length_penalty", "2.0");


### PR DESCRIPTION
### 🛠 Summary

Diversity penalty has not been effectively applied in our case. Since ineffective, we remove it.

### 🧪 Checklist

- [ ] Unit tests removed.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

