### PR TITLE
CVS-165226_export_models_add_gptqmodel_package

### DIFF
--- a/demos/common/export_models/requirements.txt
+++ b/demos/common/export_models/requirements.txt
@@ -12,4 +12,4 @@ transformers<=4.49 # 4.50 has a bug
 einops
 torchvision==0.21.0
 timm==1.0.15
-gptqmodel==0.2.1
+auto-gptq==0.7.1

--- a/demos/common/export_models/requirements.txt
+++ b/demos/common/export_models/requirements.txt
@@ -12,3 +12,4 @@ transformers<=4.49 # 4.50 has a bug
 einops
 torchvision==0.21.0
 timm==1.0.15
+gptqmodel==0.2.1


### PR DESCRIPTION
### 🛠 Summary

CVS-165226
update requirements to allow gptq models export 

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

