### PR TITLE
CVS-165122 mkdir models moved to other part of demo

### DIFF
--- a/demos/common/export_models/README.md
+++ b/demos/common/export_models/README.md
@@ -7,6 +7,7 @@ In one step it prepares a complete set of resources in the models repository for
 git clone https://github.com/openvinotoolkit/model_server
 cd model_server/demos/common/export_models
 pip install -q -r requirements.txt
+mkdir models
 python export_model.py --help
 usage: export_model.py [-h] {text_generation,embeddings,rerank} ...
 
@@ -33,6 +34,7 @@ usage: export_model.py text_generation [-h]
                                        [--target_device TARGET_DEVICE]
                                        [--pipeline_type PIPELINE_TYPE]
                                        [--kv_cache_precision {u8}]
+                                       [--extra_quantization_params EXTRA_QUANTIZATION_PARAMS]
                                        [--enable_prefix_caching]
                                        [--disable_dynamic_split_fuse]
                                        [--max_num_batched_tokens MAX_NUM_BATCHED_TOKENS]
@@ -60,11 +62,16 @@ options:
   --target_device TARGET_DEVICE
                         CPU or GPU, default is CPU
   --pipeline_type PIPELINE_TYPE
-                        Type of the pipeline to be used. Can be either
-                        TEXT_CB or VLM_CB. When undefined, it will be autodetected
+                        Type of the pipeline to be used. Can be either TEXT_CB 
+                        or VLM_CB. When undefined, it will be autodetected
   --kv_cache_precision {u8}
                         u8 or empty (model default). Reduced kv cache
                         precision to u8 lowers the cache size consumption.
+  --extra_quantization_params EXTRA_QUANTIZATION_PARAMS
+                        Add advanced quantization parameters. Check optimum-
+                        intel documentation. Example: "--sym --group-size -1
+                        --ratio 1.0 --awq --scale-estimation --dataset
+                        wikitext2"
   --enable_prefix_caching
                         This algorithm is used to cache the prompt tokens.
   --disable_dynamic_split_fuse
@@ -93,45 +100,38 @@ options:
 
 Text generation for CPU target device:
 ```console
-mkdir models
 python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format fp16 --kv_cache_precision u8 --config_file_path models/config_all.json --model_repository_path models 
 ```
 
 Text generation for GPU target device with limited memory without dynamic split fuse algorithm (recommended for usage in low concurrency):
 ```console
-mkdir models
 python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format int4 --config_file_path models/config_all.json --model_repository_path models --target_device GPU --disable_dynamic_split_fuse --max_num_batched_tokens 8192 --cache_size 2
 ```
 
 Text generation for GPU target device with limited memory with enabled dynamic split fuse algorithm (recommended for usage in high concurrency):
 ```console
-mkdir models
 python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format int4 --config_file_path models/config_all.json --model_repository_path models --target_device GPU --cache_size 2
 ```
 
 Embeddings with deployment on a single CPU host:
 ```console
-mkdir models
 python export_model.py embeddings --source_model Alibaba-NLP/gte-large-en-v1.5 --weight-format int8  --config_file_path models/config_all.json
 ```
 
 Embeddings with deployment on a dual CPU host:
 ```console
-mkdir models
 python export_model.py embeddings --source_model Alibaba-NLP/gte-large-en-v1.5 --weight-format int8  --config_file_path models/config_all.json --num_streams 2
 ```
 
 By default, embeddings endpoint returns an error when the input exceed the maximum model context length.
 It is possible to change the behavior to truncate prompts automatically to fit the model. Add `--truncate` option in the export command.
 ```console
-mkdir models
 python export_model.py embeddings --source_model BAAI/bge-large-en-v1.5 --weight-format int8 --config_file_path models/config_all.json --truncate
 ```
 Note, that truncating input will prevent errors but the accuracy might be impacted as only part of the input will be analyzed.
 
 Reranking:
 ```console
-mkdir models
 python export_model.py rerank --source_model BAAI/bge-reranker-large --weight-format int8  --config_file_path models/config_all.json --num_streams 2
 ```
 


### PR DESCRIPTION
### 🛠 Summary
Update in demos/common/export_models/README.md:
- _mkdir models_ moved to new place
- output for help updated

Related jira: https://jira.devtools.intel.com/browse/CVS-165122
PR in main branch: https://github.com/openvinotoolkit/model_server/pull/3196

Test results:
Linux: http://validationreports.sclab.intel.com:8001/reports/build_number_report?test_session_build_number=ovms-c_uat_test_382&environment=ovms_icelake-ovms-c_uat_test-CPU
Windows: http://validationreports.sclab.intel.com:8001/reports/build_number_report?test_session_build_number=ovms-c_uat_test_382&environment=iotgwork09-ovms-c_uat_test-windows-CPU



### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

