### PR TITLE
simplified quick start demo for llm deployment

### DIFF
--- a/demos/common/export_models/README.md
+++ b/demos/common/export_models/README.md
@@ -130,3 +130,12 @@ For baremetal deployment, the equivalent command would be:
 ```console
 ovms --port 9000 --rest_port 8000 --config_path models/config_all.json
 ```
+
+**Note** Exporting large models might consume a lot of host memory. On client machines with limited RAM, export with quantization may fail. In such situation it is recommended to configure swap space or virtual memory. On Windows it can be set in steps like below:
+- Open System by clicking the Start button, right-clicking Computer, and then clicking Properties.
+- In the left pane, click Advanced system settings. Administrator permission required If you're prompted for an administrator password or confirmation, type the password or provide confirmation.
+- On the Advanced tab, under Performance, click Settings.
+- Click the Advanced tab, and then, under Virtual memory, click Change.
+- Clear the Automatically manage paging file size for all drives check box.
+- Under Drive [Volume Label], click the drive that contains the paging file you want to change.
+- Click Custom size, type a new size in megabytes in the Initial size (2000MB) or Maximum size (20000MB) box, click Set, and then click OK.

--- a/demos/common/export_models/README.md
+++ b/demos/common/export_models/README.md
@@ -26,7 +26,7 @@ positional arguments:
 ```
 For every use case subcommand there is adjusted list of parameters:
 
-```bash
+```console
 python export_model.py text_generation --help
 ```
 Expected Output:
@@ -81,68 +81,36 @@ options:
 ### Text Generation Models
 
 #### Text Generation CPU Deployment
-```bash
-python export_model.py text_generation \
-  --source_model meta-llama/Meta-Llama-3-8B-Instruct \
-  --weight-format fp16 \
-  --kv_cache_precision u8 \
-  --config_file_path models/config_all.json \
-  --model_repository_path models
+```console
+python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format fp16 --kv_cache_precision u8 --config_file_path models/config_all.json --model_repository_path models
 ```
 
 #### GPU Deployment (Low Concurrency, Limited Memory)
 Text generation for GPU target device with limited memory without dynamic split fuse algorithm (recommended for usage in low concurrency):
-```bash
-python export_model.py text_generation \
-  --source_model meta-llama/Meta-Llama-3-8B-Instruct \
-  --weight-format int4 \
-  --config_file_path models/config_all.json \
-  --model_repository_path models \
-  --target_device GPU \
-  --disable_dynamic_split_fuse \
-  --max_num_batched_tokens 8192 \
-  --cache_size 2
+```console
+python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format int4 --config_file_path models/config_all.json --model_repository_path models --target_device GPU --disable_dynamic_split_fuse --max_num_batched_tokens 8192 --cache_size 1
 ```
 #### GPU Deployment (High Concurrency, Dynamic Split Fuse Enabled)
 Text generation for GPU target device with limited memory with enabled dynamic split fuse algorithm (recommended for usage in high concurrency):
-```bash
-python export_model.py text_generation \
-  --source_model meta-llama/Meta-Llama-3-8B-Instruct \
-  --weight-format int4 \
-  --config_file_path models/config_all.json \
-  --model_repository_path models \
-  --target_device GPU \
-  --cache_size 2
+```console
+python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format int4 --config_file_path models/config_all.json --model_repository_path models --target_device GPU --cache_size 3
 ```
 #### NPU Deployment
 Text generation for NPU target device. Command below sets max allowed prompt size and configures model compilation directory to speedup initialization time:
-```bash
-python export_model.py text_generation \
-  --source_model meta-llama/Llama-3.2-3B-Instruct \
-  --config_file_path models/config_all.json \
-  --model_repository_path models \
-  --target_device NPU \
-  --max_prompt_len 2048 \
-  --ov_cache_dir ./models/.ov_cache
+```console
+python export_model.py text_generation --source_model meta-llama/Llama-3.2-3B-Instruct --config_file_path models/config_all.json --model_repository_path models --target_device NPU --max_prompt_len 2048 --ov_cache_dir ./models/.ov_cache
 ```
 
 ### Embedding Models
 
 #### Embeddings with deployment on a single CPU host:
-```bash
-python export_model.py embeddings \
-    --source_model Alibaba-NLP/gte-large-en-v1.5 \
-    --weight-format int8 \
-    --config_file_path models/config_all.json
+```console
+python export_model.py embeddings --source_model Alibaba-NLP/gte-large-en-v1.5 --weight-format int8 --config_file_path models/config_all.json
 ```
 
 #### Embeddings with deployment on a dual CPU host:
-```bash
-python export_model.py embeddings \
-    --source_model Alibaba-NLP/gte-large-en-v1.5 \
-    --weight-format int8 \
-    --config_file_path models/config_all.json \
-    --num_streams 2
+```console
+python export_model.py embeddings --source_model Alibaba-NLP/gte-large-en-v1.5 --weight-format int8 --config_file_path models/config_all.json --num_streams 2
 ```
 
 #### With Input Truncation
@@ -191,7 +159,7 @@ docker run -d --rm -p 8000:8000 \
 ```
 
 ### Baremetal Deployment
-```bash
+```bat
 ovms --port 9000 --rest_port 8000 --config_path models/config_all.json
 ```
 

--- a/demos/common/export_models/README.md
+++ b/demos/common/export_models/README.md
@@ -1,14 +1,18 @@
 # Exporting GEN AI Models {#ovms_demos_common_export}
 
-This script automates exporting models from Hugging Faces hub or fine-tuned in PyTorch format to the models repository for deployment for the model serving.
-In one step it prepares a complete set of resources in the models repository for a supported GenAI use case.
+This script automates exporting models from Hugging Faces hub or fine-tuned in PyTorch format to the `models` repository for deployment with OpenVINO Model Server. In one step it prepares a complete set of resources in the `models` repository for a supported GenAI use case.
 
-```console
+
+## Quick Start
+```bash
 git clone https://github.com/openvinotoolkit/model_server
 cd model_server/demos/common/export_models
 pip install -q -r requirements.txt
 mkdir models
 python export_model.py --help
+```
+Expected Output:
+```console
 usage: export_model.py [-h] {text_generation,embeddings,rerank} ...
 
 Export Hugging face models to OVMS models repository including all configuration for deployments
@@ -22,8 +26,11 @@ positional arguments:
 ```
 For every use case subcommand there is adjusted list of parameters:
 
-```console
+```bash
 python export_model.py text_generation --help
+```
+Expected Output:
+```console
 usage: export_model.py text_generation [-h] [--model_repository_path MODEL_REPOSITORY_PATH] --source_model SOURCE_MODEL [--model_name MODEL_NAME] [--weight-format PRECISION] [--config_file_path CONFIG_FILE_PATH] [--overwrite_models] [--target_device TARGET_DEVICE]
                                        [--ov_cache_dir OV_CACHE_DIR] [--pipeline_type {LM,LM_CB,VLM,VLM_CB,AUTO}] [--kv_cache_precision {u8}] [--extra_quantization_params EXTRA_QUANTIZATION_PARAMS] [--enable_prefix_caching] [--disable_dynamic_split_fuse]
                                        [--max_num_batched_tokens MAX_NUM_BATCHED_TOKENS] [--max_num_seqs MAX_NUM_SEQS] [--cache_size CACHE_SIZE] [--draft_source_model DRAFT_SOURCE_MODEL] [--draft_model_name DRAFT_MODEL_NAME] [--max_prompt_len MAX_PROMPT_LEN]
@@ -69,73 +76,150 @@ options:
                         Sets NPU specific property for maximum number of tokens in the prompt. Not effective if target device is not NPU
 ```
 
-## Examples how models can be exported
+## Model Export Examples
 
-Text generation for CPU target device:
-```console
-python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format fp16 --kv_cache_precision u8 --config_file_path models/config_all.json --model_repository_path models 
+### Text Generation Models
+
+#### Text Generation CPU Deployment
+```bash
+python export_model.py text_generation \
+  --source_model meta-llama/Meta-Llama-3-8B-Instruct \
+  --weight-format fp16 \
+  --kv_cache_precision u8 \
+  --config_file_path models/config_all.json \
+  --model_repository_path models
 ```
 
+#### GPU Deployment (Low Concurrency, Limited Memory)
 Text generation for GPU target device with limited memory without dynamic split fuse algorithm (recommended for usage in low concurrency):
-```console
-python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format int4 --config_file_path models/config_all.json --model_repository_path models --target_device GPU --disable_dynamic_split_fuse --max_num_batched_tokens 8192 --cache_size 2
+```bash
+python export_model.py text_generation \
+  --source_model meta-llama/Meta-Llama-3-8B-Instruct \
+  --weight-format int4 \
+  --config_file_path models/config_all.json \
+  --model_repository_path models \
+  --target_device GPU \
+  --disable_dynamic_split_fuse \
+  --max_num_batched_tokens 8192 \
+  --cache_size 2
 ```
-
+#### GPU Deployment (High Concurrency, Dynamic Split Fuse Enabled)
 Text generation for GPU target device with limited memory with enabled dynamic split fuse algorithm (recommended for usage in high concurrency):
-```console
-python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format int4 --config_file_path models/config_all.json --model_repository_path models --target_device GPU --cache_size 2
+```bash
+python export_model.py text_generation \
+  --source_model meta-llama/Meta-Llama-3-8B-Instruct \
+  --weight-format int4 \
+  --config_file_path models/config_all.json \
+  --model_repository_path models \
+  --target_device GPU \
+  --cache_size 2
 ```
-
+#### NPU Deployment
 Text generation for NPU target device. Command below sets max allowed prompt size and configures model compilation directory to speedup initialization time:
-```console
-python export_model.py text_generation --source_model meta-llama/Llama-3.2-3B-Instruct --config_file_path models/config_all.json --model_repository_path models --target_device NPU --max_prompt_len 2048 --ov_cache_dir ./models/.ov_cache
+```bash
+python export_model.py text_generation \
+  --source_model meta-llama/Llama-3.2-3B-Instruct \
+  --config_file_path models/config_all.json \
+  --model_repository_path models \
+  --target_device NPU \
+  --max_prompt_len 2048 \
+  --ov_cache_dir ./models/.ov_cache
 ```
 
-Embeddings with deployment on a single CPU host:
-```console
-python export_model.py embeddings --source_model Alibaba-NLP/gte-large-en-v1.5 --weight-format int8  --config_file_path models/config_all.json
+### Embedding Models
+
+#### Embeddings with deployment on a single CPU host:
+```bash
+python export_model.py embeddings \
+    --source_model Alibaba-NLP/gte-large-en-v1.5 \
+    --weight-format int8 \
+    --config_file_path models/config_all.json
 ```
 
-Embeddings with deployment on a dual CPU host:
-```console
-python export_model.py embeddings --source_model Alibaba-NLP/gte-large-en-v1.5 --weight-format int8  --config_file_path models/config_all.json --num_streams 2
+#### Embeddings with deployment on a dual CPU host:
+```bash
+python export_model.py embeddings \
+    --source_model Alibaba-NLP/gte-large-en-v1.5 \
+    --weight-format int8 \
+    --config_file_path models/config_all.json \
+    --num_streams 2
 ```
 
+#### With Input Truncation
 By default, embeddings endpoint returns an error when the input exceed the maximum model context length.
 It is possible to change the behavior to truncate prompts automatically to fit the model. Add `--truncate` option in the export command.
-```console
-python export_model.py embeddings --source_model BAAI/bge-large-en-v1.5 --weight-format int8 --config_file_path models/config_all.json --truncate
+```bash
+python export_model.py embeddings \
+    --source_model BAAI/bge-large-en-v1.5 \
+    --weight-format int8 \
+    --config_file_path models/config_all.json \
+    --truncate
 ```
-Note, that truncating input will prevent errors but the accuracy might be impacted as only part of the input will be analyzed.
+> **Note:** When using `--truncate`, inputs exceeding the model's context length will be automatically shortened rather than producing an error. While this prevents failures, it may impact accuracy as only a portion of the input is analyzed.
 
-Reranking:
-```console
-python export_model.py rerank --source_model BAAI/bge-reranker-large --weight-format int8  --config_file_path models/config_all.json --num_streams 2
+### Reranking Models
+```bash
+python export_model.py rerank \
+    --source_model BAAI/bge-reranker-large \
+    --weight-format int8 \
+    --config_file_path models/config_all.json \
+    --num_streams 2
 ```
 
 ## Deployment example
 
-The export commands above deploy the models in `models/` folder and the configuration file is created in `models/config_all.json`.
+After exporting models using the commands above (which use `--model_repository_path models` and `--config_file_path models/config_all.json`), you can deploy them with either with Docker or on Baremetal.
 
+### CPU Deployment with Docker
 ```bash
-docker run -d --rm -p 8000:8000 -v $(pwd)/models:/workspace:ro openvino/model_server:latest --port 9000 --rest_port 8000 --config_path /workspace/config_all.json
+docker run -d --rm -p 8000:8000 \
+    -v $(pwd)/models:/workspace:ro \
+    openvino/model_server:latest \
+    --port 9000 --rest_port 8000 \
+    --config_path /workspace/config_all.json
 ```
 
-In case GPU is the target device in any model, the following command can be applied:
+### GPU Deployment with Docker
 ```bash
-docker run -d --rm -p 8000:8000 --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -v $(pwd)/models:/workspace:ro openvino/model_server:latest-gpu --port 9000 --rest_port 8000 --config_path /workspace/config_all.json
+docker run -d --rm -p 8000:8000 \
+    --device /dev/dri \
+    --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) \
+    -v $(pwd)/models:/workspace:ro \
+    openvino/model_server:latest-gpu \
+    --port 9000 --rest_port 8000 \
+    --config_path /workspace/config_all.json
 ```
 
-For baremetal deployment, the equivalent command would be:
-```console
+### Baremetal Deployment
+```bash
 ovms --port 9000 --rest_port 8000 --config_path models/config_all.json
 ```
 
-**Note** Exporting large models might consume a lot of host memory. On client machines with limited RAM, export with quantization may fail. In such situation it is recommended to configure swap space or virtual memory. On Windows it can be set in steps like below:
-- Open System by clicking the Start button, right-clicking Computer, and then clicking Properties.
-- In the left pane, click Advanced system settings. Administrator permission required If you're prompted for an administrator password or confirmation, type the password or provide confirmation.
-- On the Advanced tab, under Performance, click Settings.
-- Click the Advanced tab, and then, under Virtual memory, click Change.
-- Clear the Automatically manage paging file size for all drives check box.
-- Under Drive [Volume Label], click the drive that contains the paging file you want to change.
-- Click Custom size, type a new size in megabytes in the Initial size (2000MB) or Maximum size (20000MB) box, click Set, and then click OK.
+## Memory Requirements
+
+Exporting large models requires substantial host memory, especially during quantization. For systems with limited RAM, consider configuring additional swap space or virtual memory.
+
+:::{dropdown} Virtual Memory Configuration in Windows
+
+  1.  Open System Properties. Right-click on Start, click on System, then Click "Advanced system settings"
+  3.  Under "Performance", click "Settings"
+  4.  Navigate to the "Advanced" tab → click "Change" under Virtual Memory
+  5.  Uncheck "Automatically manage paging file size for all drives"
+  6.  Select the desired drive and choose "Custom size:"
+  7.  Set:
+  - Initial size (MB): 2000 
+  - Maximum size (MB): 20000 MB (adjust depending on model size)
+  8.  Click "Set", then "OK"
+  9.  You may need to Restart your computer for changes to take effect
+
+:::
+
+
+
+
+
+
+
+
+
+

--- a/demos/common/export_models/README.md
+++ b/demos/common/export_models/README.md
@@ -24,81 +24,49 @@ For every use case subcommand there is adjusted list of parameters:
 
 ```console
 python export_model.py text_generation --help
-usage: export_model.py text_generation [-h]
-                                       [--model_repository_path MODEL_REPOSITORY_PATH]
-                                       --source_model SOURCE_MODEL
-                                       [--model_name MODEL_NAME]
-                                       [--weight-format PRECISION]
-                                       [--config_file_path CONFIG_FILE_PATH]
-                                       [--overwrite_models]
-                                       [--target_device TARGET_DEVICE]
-                                       [--pipeline_type {LM,LM_CB,VLM,VLM_CB,AUTO}]
-                                       [--kv_cache_precision {u8}]
-                                       [--extra_quantization_params EXTRA_QUANTIZATION_PARAMS]
-                                       [--enable_prefix_caching]
-                                       [--disable_dynamic_split_fuse]
-                                       [--max_num_batched_tokens MAX_NUM_BATCHED_TOKENS]
-                                       [--max_num_seqs MAX_NUM_SEQS]
-                                       [--cache_size CACHE_SIZE]
-                                       [--draft_source_model DRAFT_SOURCE_MODEL]
-                                       [--draft_model_name DRAFT_MODEL_NAME]
-                                       [--max_prompt_len MAX_PROMPT_LEN]
+usage: export_model.py text_generation [-h] [--model_repository_path MODEL_REPOSITORY_PATH] --source_model SOURCE_MODEL [--model_name MODEL_NAME] [--weight-format PRECISION] [--config_file_path CONFIG_FILE_PATH] [--overwrite_models] [--target_device TARGET_DEVICE]
+                                       [--ov_cache_dir OV_CACHE_DIR] [--pipeline_type {LM,LM_CB,VLM,VLM_CB,AUTO}] [--kv_cache_precision {u8}] [--extra_quantization_params EXTRA_QUANTIZATION_PARAMS] [--enable_prefix_caching] [--disable_dynamic_split_fuse]
+                                       [--max_num_batched_tokens MAX_NUM_BATCHED_TOKENS] [--max_num_seqs MAX_NUM_SEQS] [--cache_size CACHE_SIZE] [--draft_source_model DRAFT_SOURCE_MODEL] [--draft_model_name DRAFT_MODEL_NAME] [--max_prompt_len MAX_PROMPT_LEN]
 
 options:
   -h, --help            show this help message and exit
   --model_repository_path MODEL_REPOSITORY_PATH
                         Where the model should be exported to
   --source_model SOURCE_MODEL
-                        HF model name or path to the local folder with PyTorch
-                        or OpenVINO model
+                        HF model name or path to the local folder with PyTorch or OpenVINO model
   --model_name MODEL_NAME
-                        Model name that should be used in the deployment.
-                        Equal to source_model if HF model name is used
+                        Model name that should be used in the deployment. Equal to source_model if HF model name is used
   --weight-format PRECISION
                         precision of the exported model
   --config_file_path CONFIG_FILE_PATH
                         path to the config file
-  --overwrite_models    Overwrite the model if it already exists in the models
-                        repository
+  --overwrite_models    Overwrite the model if it already exists in the models repository
   --target_device TARGET_DEVICE
                         CPU, GPU, NPU or HETERO, default is CPU
+  --ov_cache_dir OV_CACHE_DIR
+                        Folder path for compilation cache to speedup initialization time
   --pipeline_type {LM,LM_CB,VLM,VLM_CB,AUTO}
-                        Type of the pipeline to be used. AUTO is used by
-                        default
+                        Type of the pipeline to be used. AUTO is used by default
   --kv_cache_precision {u8}
-                        u8 or empty (model default). Reduced kv cache
-                        precision to u8 lowers the cache size consumption.
+                        u8 or empty (model default). Reduced kv cache precision to u8 lowers the cache size consumption.
   --extra_quantization_params EXTRA_QUANTIZATION_PARAMS
-                        Add advanced quantization parameters. Check optimum-
-                        intel documentation. Example: "--sym --group-size -1
-                        --ratio 1.0 --awq --scale-estimation --dataset
-                        wikitext2"
+                        Add advanced quantization parameters. Check optimum-intel documentation. Example: "--sym --group-size -1 --ratio 1.0 --awq --scale-estimation --dataset wikitext2"
   --enable_prefix_caching
                         This algorithm is used to cache the prompt tokens.
   --disable_dynamic_split_fuse
-                        The maximum number of tokens that can be batched
-                        together.
+                        The maximum number of tokens that can be batched together.
   --max_num_batched_tokens MAX_NUM_BATCHED_TOKENS
-                        empty or integer. The maximum number of tokens that
-                        can be batched together.
+                        empty or integer. The maximum number of tokens that can be batched together.
   --max_num_seqs MAX_NUM_SEQS
-                        256 by default. The maximum number of sequences that
-                        can be processed together.
+                        256 by default. The maximum number of sequences that can be processed together.
   --cache_size CACHE_SIZE
-                        cache size in GB
+                        KV cache size in GB
   --draft_source_model DRAFT_SOURCE_MODEL
-                        HF model name or path to the local folder with PyTorch
-                        or OpenVINO draft model. Using this option will create
-                        configuration for speculative decoding
+                        HF model name or path to the local folder with PyTorch or OpenVINO draft model. Using this option will create configuration for speculative decoding
   --draft_model_name DRAFT_MODEL_NAME
-                        Draft model name that should be used in the
-                        deployment. Equal to draft_source_model if HF model
-                        name is used. Available only in draft_source_model has
-                        been specified.
+                        Draft model name that should be used in the deployment. Equal to draft_source_model if HF model name is used. Available only in draft_source_model has been specified.
   --max_prompt_len MAX_PROMPT_LEN
-                        Sets NPU specific property for maximum number of
-                        tokens in the prompt. Not effective if target device
-                        is not NPU
+                        Sets NPU specific property for maximum number of tokens in the prompt. Not effective if target device is not NPU
 ```
 
 ## Examples how models can be exported
@@ -116,6 +84,11 @@ python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B
 Text generation for GPU target device with limited memory with enabled dynamic split fuse algorithm (recommended for usage in high concurrency):
 ```console
 python export_model.py text_generation --source_model meta-llama/Meta-Llama-3-8B-Instruct --weight-format int4 --config_file_path models/config_all.json --model_repository_path models --target_device GPU --cache_size 2
+```
+
+Text generation for NPU target device. Command below sets max allowed prompt size and configures model compilation directory to speedup initialization time:
+```console
+python export_model.py text_generation --source_model meta-llama/Llama-3.2-3B-Instruct --config_file_path models/config_all.json --model_repository_path models --target_device NPU --max_prompt_len 2048 --ov_cache_dir ./models/.ov_cache
 ```
 
 Embeddings with deployment on a single CPU host:

--- a/demos/common/export_models/README.md
+++ b/demos/common/export_models/README.md
@@ -4,7 +4,7 @@ This script automates exporting models from Hugging Faces hub or fine-tuned in P
 
 
 ## Quick Start
-```bash
+```console
 git clone https://github.com/openvinotoolkit/model_server
 cd model_server/demos/common/export_models
 pip install -q -r requirements.txt
@@ -116,7 +116,7 @@ python export_model.py embeddings --source_model Alibaba-NLP/gte-large-en-v1.5 -
 #### With Input Truncation
 By default, embeddings endpoint returns an error when the input exceed the maximum model context length.
 It is possible to change the behavior to truncate prompts automatically to fit the model. Add `--truncate` option in the export command.
-```bash
+```console
 python export_model.py embeddings \
     --source_model BAAI/bge-large-en-v1.5 \
     --weight-format int8 \
@@ -126,7 +126,7 @@ python export_model.py embeddings \
 > **Note:** When using `--truncate`, inputs exceeding the model's context length will be automatically shortened rather than producing an error. While this prevents failures, it may impact accuracy as only a portion of the input is analyzed.
 
 ### Reranking Models
-```bash
+```console
 python export_model.py rerank \
     --source_model BAAI/bge-reranker-large \
     --weight-format int8 \

--- a/demos/common/export_models/README.md
+++ b/demos/common/export_models/README.md
@@ -182,12 +182,3 @@ Exporting large models requires substantial host memory, especially during quant
 
 :::
 
-
-
-
-
-
-
-
-
-

--- a/demos/common/export_models/export_model.py
+++ b/demos/common/export_models/export_model.py
@@ -32,6 +32,7 @@ def add_common_arguments(parser):
     parser.add_argument('--config_file_path', default='config.json', help='path to the config file', dest='config_file_path')
     parser.add_argument('--overwrite_models', default=False, action='store_true', help='Overwrite the model if it already exists in the models repository', dest='overwrite_models')
     parser.add_argument('--target_device', default="CPU", help='CPU, GPU, NPU or HETERO, default is CPU', dest='target_device')
+    parser.add_argument('--ov_cache_dir', default=None, help='Folder path for compilation cache to speedup initialization time', dest='ov_cache_dir')
 
 parser = argparse.ArgumentParser(description='Export Hugging face models to OVMS models repository including all configuration for deployments')
 
@@ -45,7 +46,7 @@ parser_text.add_argument('--enable_prefix_caching', action='store_true', help='T
 parser_text.add_argument('--disable_dynamic_split_fuse', action='store_false', help='The maximum number of tokens that can be batched together.', dest='dynamic_split_fuse')
 parser_text.add_argument('--max_num_batched_tokens', default=None, help='empty or integer. The maximum number of tokens that can be batched together.', dest='max_num_batched_tokens')
 parser_text.add_argument('--max_num_seqs', default=None, help='256 by default. The maximum number of sequences that can be processed together.', dest='max_num_seqs')
-parser_text.add_argument('--cache_size', default=10, type=int, help='cache size in GB', dest='cache_size')
+parser_text.add_argument('--cache_size', default=10, type=int, help='KV cache size in GB', dest='cache_size')
 parser_text.add_argument('--draft_source_model', required=False, default=None, help='HF model name or path to the local folder with PyTorch or OpenVINO draft model. '
                          'Using this option will create configuration for speculative decoding', dest='draft_source_model')
 parser_text.add_argument('--draft_model_name', required=False, default=None, help='Draft model name that should be used in the deployment. '
@@ -270,9 +271,15 @@ def add_servable_to_config(config_path, mediapipe_name, base_path):
 def export_text_generation_model(model_repository_path, source_model, model_name, precision, task_parameters, config_file_path):
     model_path = "./"
     ### Export model
-    if os.path.isfile(os.path.join(source_model, 'openvino_model.xml')):
-            print("OV model is source folder. Skipping conversion.")
-            model_path = source_model
+    if os.path.isfile(os.path.join(source_model, 'openvino_model.xml')) or os.path.isfile(os.path.join(source_model, 'openvino_language_model.xml')):
+        print("OV model is source folder. Skipping conversion.")
+        model_path = source_model
+    elif source_model.startswith("OpenVINO/"):
+        if precision:
+            print("Precision change is not supported for OpenVINO models. Parameter --weight-format {} will be ignored.".format(precision))
+        hugging_face_cmd = "huggingface-cli download {} --local-dir {} ".format(source_model, os.path.join(model_repository_path, model_name))
+        if os.system(hugging_face_cmd):
+            raise ValueError("Failed to download llm model", source_model)
     else: # assume HF model name or local pytorch model folder
         llm_model_path = os.path.join(model_repository_path, model_name)
         print("Exporting LLM model to ", llm_model_path)
@@ -296,7 +303,13 @@ def export_text_generation_model(model_repository_path, source_model, model_name
         draft_model_dir_name = draft_source_model.replace("/", "-") # flatten the name so we don't create nested directory structure
         draft_llm_model_path = os.path.join(model_repository_path, model_name, draft_model_dir_name)
         if os.path.isfile(os.path.join(draft_llm_model_path, 'openvino_model.xml')):
-                print("OV model is source folder. Skipping conversion.")
+            print("OV model is source folder. Skipping conversion.")
+        elif source_model.startswith("OpenVINO/"):
+            if precision:
+                print("Precision change is not supported for OpenVINO models. Parameter --weight-format {} will be ignored.".format(precision))
+            hugging_face_cmd = "huggingface-cli download {} --local-dir {} ".format(source_model, os.path.join(model_repository_path, model_name))
+            if os.system(hugging_face_cmd):
+                raise ValueError("Failed to download llm model", source_model)    
         else: # assume HF model name or local pytorch model folder
             print("Exporting draft LLM model to ", draft_llm_model_path)
             if not os.path.isdir(draft_llm_model_path) or args['overwrite_models']:
@@ -314,6 +327,8 @@ def export_text_generation_model(model_repository_path, source_model, model_name
         if task_parameters['max_prompt_len'] <= 0:
             raise ValueError("max_prompt_len should be a positive integer")
         plugin_config['MAX_PROMPT_LEN'] = task_parameters['max_prompt_len']
+    if task_parameters['ov_cache_dir'] is not None:
+        plugin_config['CACHE_DIR'] = task_parameters['ov_cache_dir']
     
     # Additional plugin properties for HETERO
     if "HETERO" in task_parameters['target_device']:

--- a/demos/llm_npu/README.md
+++ b/demos/llm_npu/README.md
@@ -27,7 +27,7 @@ LLM engine parameters will be defined inside the `graph.pbtxt` file.
 
 Download export script, install it's dependencies and create directory for the models:
 ```console
-curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/releases/2025/1/demos/common/export_models/export_model.py -o export_model.py
+curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/simpler-quick-start-llm/demos/common/export_models/export_model.py -o export_model.py
 pip3 install -r https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/releases/2025/1/demos/common/export_models/requirements.txt
 mkdir models
 ```
@@ -38,8 +38,10 @@ Run `export_model.py` script to download and quantize the model:
 
 **LLM**
 ```console
-python export_model.py text_generation --source_model meta-llama/Llama-3.1-8B-Instruct --target_device NPU --config_file_path models/config.json --model_repository_path models  --overwrite_models
+python export_model.py text_generation --source_model meta-llama/Llama-3.1-8B-Instruct --target_device NPU --config_file_path models/config.json --ov_cache_dir ./models/.ov_cache --model_repository_path models  --overwrite_models
 ```
+**Note:** The parameter `--ov_cache` stores the model compilation cache to speedup initialization time for sequential startup. Drop this parameter if you don't want to store the compilation cache.
+
 Below is a list of tested models:
 - meta-llama/Meta-Llama-3-8B-Instruct
 - meta-llama/Llama-3.1-8B
@@ -84,7 +86,7 @@ Run the script with `--help` argument to check available parameters and see the 
 Running this command starts the container with NPU enabled:
 ```bash
 docker run -d --rm --device /dev/accel --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
--p 8000:8000 -v $(pwd)/models:/workspace:ro openvino/model_server:latest-gpu --rest_port 8000 --config_path /workspace/config.json
+-p 8000:8000 -v $(pwd)/models:/models:rw openvino/model_server:latest-gpu --rest_port 8000 --config_path /workspace/config.json
 ```
 :::
 

--- a/demos/llm_npu/README.md
+++ b/demos/llm_npu/README.md
@@ -86,7 +86,7 @@ Run the script with `--help` argument to check available parameters and see the 
 Running this command starts the container with NPU enabled:
 ```bash
 docker run -d --rm --device /dev/accel --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) -u $(id -u):$(id -g) \
--p 8000:8000 -v $(pwd)/models:/models:rw openvino/model_server:latest-gpu --rest_port 8000 --config_path /workspace/config.json
+-p 8000:8000 -v $(pwd)/models:/models:rw openvino/model_server:latest-gpu --rest_port 8000 --config_path /models/config.json
 ```
 :::
 

--- a/demos/llm_npu/README.md
+++ b/demos/llm_npu/README.md
@@ -27,7 +27,7 @@ LLM engine parameters will be defined inside the `graph.pbtxt` file.
 
 Download export script, install it's dependencies and create directory for the models:
 ```console
-curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/simpler-quick-start-llm/demos/common/export_models/export_model.py -o export_model.py
+curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/main/demos/common/export_models/export_model.py -o export_model.py
 pip3 install -r https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/releases/2025/1/demos/common/export_models/requirements.txt
 mkdir models
 ```

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -4,25 +4,27 @@ Let's deploy [OpenVINO/Phi-3.5-mini-instruct-int4-ov](https://huggingface.co/Ope
 It is [microsoft/Phi-3.5-mini-instruct](https://huggingface.co/microsoft/Phi-3.5-mini-instruct) quantized to INT4 precision and converted to IR format.
 
 ## Requirements
-- Linux or Windows11
+- Linux or Windows 11
 - Docker Engine or `ovms` binary package [installed](../deploying_server_baremetal.md)
 - Intel iGPU or ARC GPU 
 
 ## Deployment Steps
 
 ### 1. Install Python dependencies:
-```console
-pip3 install huggingface_hub jinj2
+```bash
+pip3 install huggingface_hub jinja2
 ```
 
 ### 2. Download and Prepare the Model:
 Using `export_model.py` script, download the OpenVINO model and prepare models repository including all configuration required for deployment with OpenVINO Model Server. For details, see [Exporting GEN AI Models](../../demos/common/export_models/README.md).
 
-```console
+```bash
 curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/simpler-quick-start-llm/demos/common/export_models/export_model.py -o export_model.py
 mkdir models
 python export_model.py text_generation --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --model_repository_path models --target_device GPU --cache 2
 ```
+LLM engine parameters will be defined inside the `graph.pbtxt` file.
+
 > **Note:** The users in China need to set environment variable `HF_ENDPOINT="https://hf-mirror.com"` before running the export script to connect to the HF Hub.
 > **Note:** If you want to export models outside of the `OpenVINO` organization in HuggingFace, you need to install additional Python dependencies:
 > ```console
@@ -53,7 +55,7 @@ ovms --rest_port 8000 --model_name Phi-3.5-mini-instruct --model_path /models/Op
 
 Wait for the model to load. You can check the status with a simple command:
 
-```console
+```bash
 curl http://localhost:8000/v1/config
 ```
 
@@ -90,22 +92,26 @@ curl -s http://localhost:8000/v3/chat/completions \
     "temperature": 0,
     "stream": false,
     "messages": [
-      {
-        "role": "system",
-        "content": "You are a helpful assistant."
-      },
-      {
-        "role": "user",
-        "content": "What are the 3 main tourist attractions in Paris?"
-      }
+      { "role": "system", "content": "You are a helpful assistant." },
+      { "role": "user", "content": "What are the 3 main tourist attractions in Paris?" }
     ]
   }' | jq .
 ```
 :::
 
 :::{tab-item} Windows
+
+Windows Powershell
 ```bat
-curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/json" -d "{\"model\": \"Phi-3.5-mini-instruct\", \"max_tokens\": 30, \"temperature\": 0, \"stream\": false, \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"What are the 3 main tourist attractions in Paris?\"}]}" 
+(Invoke-WebRequest -Uri "http://localhost:8000/v3/chat/completions" `
+ -Method POST `
+ -Headers @{ "Content-Type" = "application/json" } `
+ -Body '{"model": "Phi-3.5-mini-instruct", "max_tokens": 30, "temperature": 0, "stream": false, "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "What are the 3 main tourist attractions in Paris?"}]}').Content
+```
+
+Windows Command Prompt
+```bat
+curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/json" -d "{\"model\": \"Phi-3.5-mini-instruct\", \"max_tokens\": 30, \"temperature\": 0, \"stream\": false, \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"What are the 3 main tourist attractions in Paris?\"}]}") 
 ```
 :::
 
@@ -140,7 +146,7 @@ curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/
 #### Using OpenAI Python Client:
 
 First, install the openai client library:
-```console
+```bash
 pip3 install openai
 ```
 Then run the following Python code:
@@ -170,7 +176,6 @@ Expected output:
 ```console
 Paris, the charming City of Light, is renowned for its rich history, iconic landmarks, architectural splendor, and artistic
 ```
-
 
 ## References
 - [Efficient LLM Serving - reference](reference.md)

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -173,7 +173,7 @@ for chunk in stream:
 ```
 
 Expected output:
-```console
+```
 Paris, the charming City of Light, is renowned for its rich history, iconic landmarks, architectural splendor, and artistic
 ```
 

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -19,7 +19,7 @@ pip3 install huggingface_hub jinja2
 Using `export_model.py` script, download the OpenVINO model and prepare models repository including all configuration required for deployment with OpenVINO Model Server. For details, see [Exporting GEN AI Models](../../demos/common/export_models/README.md).
 
 ```console
-curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/simpler-quick-start-llm/demos/common/export_models/export_model.py -o export_model.py
+curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/main/demos/common/export_models/export_model.py -o export_model.py
 mkdir models
 python export_model.py text_generation --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --model_repository_path models --target_device GPU --cache 2
 ```

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -30,7 +30,7 @@ python export_model.py text_generation --source_model OpenVINO/Phi-3.5-mini-inst
 > ```
  
 ### 3. Deploy the Model
-:::{tab-set}
+::::{tab-set}
 
 :::{tab-item} With Docker
 **Required:** Docker Engine installed
@@ -47,8 +47,7 @@ docker run -d --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render*) --r
 ovms --rest_port 8000 --model_name Phi-3.5-mini-instruct --model_path /models/OpenVINO/Phi-3.5-mini-instruct-int4-ov
 ```
 :::
-
-:::
+::::
 
 ### 4. Check Model Readiness
 
@@ -79,10 +78,10 @@ curl http://localhost:8000/v1/config
 
 ### 5. Run Generation
 
-:::{tab-set}
+::::{tab-set}
 
 :::{tab-item} Linux
-```console
+```bash
 curl -s http://localhost:8000/v3/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
@@ -105,12 +104,12 @@ curl -s http://localhost:8000/v3/chat/completions \
 :::
 
 :::{tab-item} Windows
-```console
+```bat
 curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/json" -d "{\"model\": \"Phi-3.5-mini-instruct\", \"max_tokens\": 30, \"temperature\": 0, \"stream\": false, \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"What are the 3 main tourist attractions in Paris?\"}]}" 
 ```
 :::
 
-:::
+::::
 
 :::{dropdown} Expected Response
 ```json

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -12,7 +12,7 @@ It is [microsoft/Phi-3.5-mini-instruct](https://huggingface.co/microsoft/Phi-3.5
 
 ### 1. Install Python dependencies:
 ```console
-pip3 install huggingface_hub
+pip3 install huggingface_hub jinj2
 ```
 
 ### 2. Download and Prepare the Model:

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -111,7 +111,7 @@ Windows Powershell
 
 Windows Command Prompt
 ```bat
-curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/json" -d "{\"model\": \"Phi-3.5-mini-instruct\", \"max_tokens\": 30, \"temperature\": 0, \"stream\": false, \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"What are the 3 main tourist attractions in Paris?\"}]}") 
+curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/json" -d "{\"model\": \"Phi-3.5-mini-instruct\", \"max_tokens\": 30, \"temperature\": 0, \"stream\": false, \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"What are the 3 main tourist attractions in Paris?\"}]}"
 ```
 :::
 

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -1,7 +1,7 @@
 # QuickStart - LLM models {#ovms_docs_llm_quickstart}
 
 Let's deploy [OpenVINO/Phi-3.5-mini-instruct-int4-ov](https://huggingface.co/OpenVINO/Phi-3.5-mini-instruct-int4-ov) model on Intel iGPU or ARC GPU.
-It is quantized to INT4 precision and converted it IR format.
+It is [microsoft/Phi-3.5-mini-instruct](https://huggingface.co/microsoft/Phi-3.5-mini-instruct) quantized to INT4 precision and converted to IR format.
 
 Requirements:
 - Linux or Windows11
@@ -18,10 +18,10 @@ pip3 install huggingface_hub
 ```console
 curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/simpler-quick-start-llm/demos/common/export_models/export_model.py -o export_model.py
 mkdir models
-python export_model.py text_generation --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --config_file_path models/config.json --model_repository_path models --target_device GPU --cache 2
+python export_model.py text_generation --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --model_repository_path models --target_device GPU --cache 2
 ```
 **Note:** The users in China need to set environment variable HF_ENDPOINT="https://hf-mirror.com" before running the export script to connect to the HF Hub.
-**Note:** If you want to export models outside of `OpenVINO` organization in HuggingFace, you need to install also the python dependencies via `pip3 install -r https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/relases/2025/1/demos/common/export_models/requirements.txt` before running the export_models.py script.
+**Note:** If you want to export models outside of `OpenVINO` organization in HuggingFace, you need to install also the python dependencies via `pip3 install -r https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/releases/2025/1/demos/common/export_models/requirements.txt` before running the export_models.py script.
  
 3. Deploy:
 
@@ -93,7 +93,38 @@ curl -s http://localhost:8000/v3/chat/completions   -H "Content-Type: applicatio
 }
 
 ```
-**Note:** If you want to get the response chunks streamed back as they are generated change `stream` parameter in the request to `true`.
+
+Alternatively, use OpenAI python client:
+
+Install the client library:
+```console
+pip3 install openai
+```
+```python
+from openai import OpenAI
+
+client = OpenAI(
+  base_url="http://localhost:8000/v3",
+  api_key="unused"
+)
+
+stream = client.chat.completions.create(
+    model="Phi-3.5-mini-instruct",
+    messages=[{"role": "system", "content": "You are a helpful assistant."},
+              {"role": "user", "content": "What are the 3 main tourist attractions in Paris?"}
+    ],
+    max_tokens=30,
+    stream=True
+)
+for chunk in stream:
+    if chunk.choices[0].delta.content is not None:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+Output:
+```
+Paris, the charming City of Light, is renowned for its rich history, iconic landmarks, architectural splendor, and artistic
+```
 
 
 ## References

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -3,51 +3,62 @@
 Let's deploy [OpenVINO/Phi-3.5-mini-instruct-int4-ov](https://huggingface.co/OpenVINO/Phi-3.5-mini-instruct-int4-ov) model on Intel iGPU or ARC GPU.
 It is [microsoft/Phi-3.5-mini-instruct](https://huggingface.co/microsoft/Phi-3.5-mini-instruct) quantized to INT4 precision and converted to IR format.
 
-Requirements:
+## Requirements
 - Linux or Windows11
 - Docker Engine or `ovms` binary package [installed](../deploying_server_baremetal.md)
 - Intel iGPU or ARC GPU 
 
+## Deployment Steps
 
-1. Install python dependencies for the conversion script:
+### 1. Install Python dependencies:
 ```console
 pip3 install huggingface_hub
 ```
 
-2. Run optimum-cli to download and quantize the model:
+### 2. Download and Prepare the Model:
+Using `export_model.py` script, download the OpenVINO model and prepare models repository including all configuration required for deployment with OpenVINO Model Server. For details, see [Exporting GEN AI Models](../../demos/common/export_models/README.md).
+
 ```console
 curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/simpler-quick-start-llm/demos/common/export_models/export_model.py -o export_model.py
 mkdir models
 python export_model.py text_generation --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --model_repository_path models --target_device GPU --cache 2
 ```
-**Note:** The users in China need to set environment variable HF_ENDPOINT="https://hf-mirror.com" before running the export script to connect to the HF Hub.
-**Note:** If you want to export models outside of `OpenVINO` organization in HuggingFace, you need to install also the python dependencies via `pip3 install -r https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/releases/2025/1/demos/common/export_models/requirements.txt` before running the export_models.py script.
+> **Note:** The users in China need to set environment variable `HF_ENDPOINT="https://hf-mirror.com"` before running the export script to connect to the HF Hub.
+> **Note:** If you want to export models outside of the `OpenVINO` organization in HuggingFace, you need to install additional Python dependencies:
+> ```console
+> pip3 install -r https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/releases/2025/1/demos/common/export_models/requirements.txt
+> ```
  
-3. Deploy:
+### 3. Deploy the Model
+:::{tab-set}
 
-:::{dropdown} With Docker
-
-> Required: Docker Engine installed
+:::{tab-item} With Docker
+**Required:** Docker Engine installed
 
 ```bash
 docker run -d --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render*) --rm -p 8000:8000 -v $(pwd)/models:/models:ro openvino/model_server:latest-gpu --rest_port 8000 --model_name Phi-3.5-mini-instruct --model_path /models/OpenVINO/Phi-3.5-mini-instruct-int4-ov
 ```
 :::
 
-:::{dropdown} On Baremetal Host
+:::{tab-item} On Baremetal Host
+**Required:** OpenVINO Model Server package - see [deployment instructions](../deploying_server_baremetal.md) for details.
 
-> Required: OpenVINO Model Server package - see [deployment instruction](../deploying_server_baremetal.md) for details.
-
-```bat
+```bash
 ovms --rest_port 8000 --model_name Phi-3.5-mini-instruct --model_path /models/OpenVINO/Phi-3.5-mini-instruct-int4-ov
 ```
 :::
 
-4. Check readiness
+:::
+
+### 4. Check Model Readiness
+
 Wait for the model to load. You can check the status with a simple command:
+
 ```console
 curl http://localhost:8000/v1/config
 ```
+
+:::{dropdown} Expected Response
 ```json
 {
   "Phi-3.5-mini-instruct": {
@@ -64,11 +75,44 @@ curl http://localhost:8000/v1/config
   }
 }
 ```
+:::
 
-5. Run generation
+### 5. Run Generation
+
+:::{tab-set}
+
+:::{tab-item} Linux
 ```console
-curl -s http://localhost:8000/v3/chat/completions   -H "Content-Type: application/json" -d "{\"model\": \"Phi-3.5-mini-instruct\",\"max_tokens\":30, \"messages\": [{\"role\": \"system\",\"content\": \"You are a helpful assistant.\" }, {\"role\": \"user\",\"content\": \"What are the 3 main tourist attractions in Paris?\"}]}"
+curl -s http://localhost:8000/v3/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Phi-3.5-mini-instruct",
+    "max_tokens": 30,
+    "temperature": 0,
+    "stream": false,
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "What are the 3 main tourist attractions in Paris?"
+      }
+    ]
+  }' | jq .
 ```
+:::
+
+:::{tab-item} Windows
+```console
+curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/json" -d "{\"model\": \"Phi-3.5-mini-instruct\", \"max_tokens\": 30, \"temperature\": 0, \"stream\": false, \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"What are the 3 main tourist attractions in Paris?\"}]}" 
+```
+:::
+
+:::
+
+:::{dropdown} Expected Response
 ```json
 {
   "choices": [
@@ -91,15 +135,17 @@ curl -s http://localhost:8000/v3/chat/completions   -H "Content-Type: applicatio
     "total_tokens": 54
   }
 }
-
 ```
+:::
 
-Alternatively, use OpenAI python client:
+#### Using OpenAI Python Client:
 
-Install the client library:
+First, install the openai client library:
 ```console
 pip3 install openai
 ```
+Then run the following Python code:
+
 ```python
 from openai import OpenAI
 
@@ -121,14 +167,15 @@ for chunk in stream:
         print(chunk.choices[0].delta.content, end="", flush=True)
 ```
 
-Output:
-```
+Expected output:
+```console
 Paris, the charming City of Light, is renowned for its rich history, iconic landmarks, architectural splendor, and artistic
 ```
 
 
 ## References
 - [Efficient LLM Serving - reference](reference.md)
+- [Exporting GEN AI Models](../../demos/common/export_models/README.md)
 - [Chat Completions API](../model_server_rest_api_chat.md)
 - [Completions API](../model_server_rest_api_completions.md)
 - [Demo with Llama3 serving](../../demos/continuous_batching/README.md)

--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -11,14 +11,14 @@ It is [microsoft/Phi-3.5-mini-instruct](https://huggingface.co/microsoft/Phi-3.5
 ## Deployment Steps
 
 ### 1. Install Python dependencies:
-```bash
+```console
 pip3 install huggingface_hub jinja2
 ```
 
 ### 2. Download and Prepare the Model:
 Using `export_model.py` script, download the OpenVINO model and prepare models repository including all configuration required for deployment with OpenVINO Model Server. For details, see [Exporting GEN AI Models](../../demos/common/export_models/README.md).
 
-```bash
+```console
 curl https://raw.githubusercontent.com/openvinotoolkit/model_server/refs/heads/simpler-quick-start-llm/demos/common/export_models/export_model.py -o export_model.py
 mkdir models
 python export_model.py text_generation --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --model_repository_path models --target_device GPU --cache 2
@@ -45,7 +45,7 @@ docker run -d --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render*) --r
 :::{tab-item} On Baremetal Host
 **Required:** OpenVINO Model Server package - see [deployment instructions](../deploying_server_baremetal.md) for details.
 
-```bash
+```bat
 ovms --rest_port 8000 --model_name Phi-3.5-mini-instruct --model_path /models/OpenVINO/Phi-3.5-mini-instruct-int4-ov
 ```
 :::
@@ -55,7 +55,7 @@ ovms --rest_port 8000 --model_name Phi-3.5-mini-instruct --model_path /models/Op
 
 Wait for the model to load. You can check the status with a simple command:
 
-```bash
+```console
 curl http://localhost:8000/v1/config
 ```
 
@@ -102,7 +102,6 @@ curl -s http://localhost:8000/v3/chat/completions \
 :::{tab-item} Windows
 
 Windows Powershell
-```bat
 (Invoke-WebRequest -Uri "http://localhost:8000/v3/chat/completions" `
  -Method POST `
  -Headers @{ "Content-Type" = "application/json" } `
@@ -146,7 +145,7 @@ curl -s http://localhost:8000/v3/chat/completions -H "Content-Type: application/
 #### Using OpenAI Python Client:
 
 First, install the openai client library:
-```bash
+```console
 pip3 install openai
 ```
 Then run the following Python code:


### PR DESCRIPTION
### 🛠 Summary

CVS-165885
Enable download of models in IR format
Enable OV compilation cache
Simplify quick start guide with LLM models
Example for using ov compilation cache 
https://openvino-doc.iotg.sclab.intel.com/quick_start_llm/model-server/ovms_docs_llm_quickstart.html

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

