### PR TITLE
Allow IPv6 addresses

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -76,16 +76,18 @@ bool Config::check_hostname_or_ip(const std::string& input) {
     }
     bool all_numeric = true;
     for (char c : input) {
-        if (c == '.') {
+        if (c == '.' || c == ':') {
             continue;
         }
-        if (!::isdigit(c)) {
+        if (!::isxdigit(c)) {
             all_numeric = false;
         }
     }
     if (all_numeric) {
-        std::regex valid_ip_regex("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
-        return std::regex_match(input, valid_ip_regex);
+        static const std::regex valid_ipv4_regex("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
+        static const std::regex valid_ipv6_regex(R"(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))");
+        return std::regex_match(input, valid_ipv4_regex) ||
+		std::regex_match(input, valid_ipv6_regex);
     } else {
         std::regex valid_hostname_regex("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
         return std::regex_match(input, valid_hostname_regex);

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -337,23 +337,23 @@ TEST_F(OvmsParamsTest, hostname_ip_regex) {
     EXPECT_EQ(ovms::Config::check_hostname_or_ip(too_long), false);
     // Uncompressed IPv6 address
     EXPECT_EQ(ovms::Config::check_hostname_or_ip(
-                "fe80:0000:0000:0000:0202:b3ff:fe1e:8329", true);
+                "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"), true);
     // Zero compressed IPv6 address
     EXPECT_EQ(ovms::Config::check_hostname_or_ip(
-                "2001:db8:85a3::8a2e:370:7334", true);
-    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::1", true);
-    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::", true);
+                "2001:db8:85a3::8a2e:370:7334"), true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::1"), true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::"), true);
     // Link-local IPv6 with zone index (RFC 4007 § 11) - unsupported
-    EXPECT_EQ(ovms::Config::check_hostname_or_ip("fe80::1234%eth0", false);
-    EXPECT_EQ(ovms::Config::check_hostname_or_ip("fe80::1234%1", false);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("fe80::1234%eth0"), false);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("fe80::1234%1"), false);
     // IPv4-Embedded IPv6 addresses
-    EXPECT_EQ(ovms::Config::check_hostname_or_ip("64:ff9b::192.0.2.33", true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("64:ff9b::192.0.2.33"), true);
     EXPECT_EQ(ovms::Config::check_hostname_or_ip(
-                "2001:db8:122:344::192.0.2.33", true);
+                "2001:db8:122:344::192.0.2.33"), true);
     // IPv4-mapped IPv6 addresses
-    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::ffff:192.0.2.128", true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::ffff:192.0.2.128"), true);
     //  IPv4-translated IPv6 addresses
-    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::ffff:0:192.0.2.128", true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::ffff:0:192.0.2.128"), true);
 }
 
 TEST(OvmsConfigTest, positiveMulti) {

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -335,6 +335,25 @@ TEST_F(OvmsParamsTest, hostname_ip_regex) {
     EXPECT_EQ(ovms::Config::check_hostname_or_ip("(%$#*F"), false);
     std::string too_long(256, 'a');
     EXPECT_EQ(ovms::Config::check_hostname_or_ip(too_long), false);
+    // Uncompressed IPv6 address
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip(
+                "fe80:0000:0000:0000:0202:b3ff:fe1e:8329", true);
+    // Zero compressed IPv6 address
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip(
+                "2001:db8:85a3::8a2e:370:7334", true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::1", true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::", true);
+    // Link-local IPv6 with zone index (RFC 4007 § 11) - unsupported
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("fe80::1234%eth0", false);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("fe80::1234%1", false);
+    // IPv4-Embedded IPv6 addresses
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("64:ff9b::192.0.2.33", true);
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip(
+                "2001:db8:122:344::192.0.2.33", true);
+    // IPv4-mapped IPv6 addresses
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::ffff:192.0.2.128", true);
+    //  IPv4-translated IPv6 addresses
+    EXPECT_EQ(ovms::Config::check_hostname_or_ip("::ffff:0:192.0.2.128", true);
 }
 
 TEST(OvmsConfigTest, positiveMulti) {


### PR DESCRIPTION
The REST API works with IPv6 addresses. But the address validation only supports IPv4. gRPC on the other hand is supposed to work with IPv6, but has some kind of problem with the current version of gPRC. It does support IN6ADDR_ANY, though.

The origin of the regex is here:
https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses

Tested with:
podman network create --subnet 2001:db8::/64 --ipv6 ipv6_network
podman run -it --rm -p 8000:8000 --network ipv6_network --ip 2001:db8::10 --ipc=host -u 0 -v ~/models:/models --entrypoint=/bin/bash model_server:2025.0-ipv6

Then inside the container:
/ovms/bin/ovms --log_level DEBUG --log_path /root/ovms.log --model_path /models/resnet/ --model_name resnet  --port 9000 --rest_bind_address "2001:db8::10" --rest_port 8000

```
netstat -taunp
    Proto Recv-Q Send-Q Local Address       Foreign Address      State       PID/Program name
    tcp6       0      0 :::9000             :::*                 LISTEN      56/ovms
    tcp6       0      0 2001:db8::10:8000   :::*                 LISTEN      56/ovms
```