### PR TITLE
Increase stress iterations limit

### DIFF
--- a/src/test/stress_test_utils.hpp
+++ b/src/test/stress_test_utils.hpp
@@ -1096,7 +1096,7 @@ protected:
     const uint32_t loadThreadCount = 20;
     const uint32_t beforeConfigChangeLoadTimeMs = 30;
     const uint32_t afterConfigChangeLoadTimeMs = 50;
-    const int stressIterationsLimit = 5000;
+    const int stressIterationsLimit = 10000;
 
     std::string configFilePath;
     std::string ovmsConfig;
@@ -1773,7 +1773,6 @@ public:
                 SPDLOG_DEBUG("Create:[{}]={}:{}", static_cast<uint32_t>(retCode), ovms::Status(retCode).string(), counter);
             }
         }
-        EXPECT_GT(stressIterationsCounter, 0) << "Reaching 0 means that we might not test enough \"after config change\" operation was applied";
         std::stringstream ss;
         ss << "Executed: " << stressIterationsLimit - stressIterationsCounter << " inferences by thread id: " << std::this_thread::get_id() << std::endl;
         SPDLOG_INFO(ss.str());


### PR DESCRIPTION
Iteration limit works as an additional timeout, and may indicate that test did not actually observer required condition
but does not mean the test actually fails. Required status codes are checked anyway. Stressing threads should in most cases
finish when they receive signal from thread triggering config change. Since not getting instance of pipeline to infer is much faster than positive scenario it will reach limit more often.

Ticket:CVS-168916
