### PR TITLE
Update git to  2.49.0

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -35,7 +35,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
             autoconf \
             curl \
             ca-certificates \
-            git \
             gpg \
             libcurl4-openssl-dev \
             libssl-dev \
@@ -45,11 +44,17 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
             pkg-config \
             wget \
             zlib1g-dev \
-            git-lfs && \
+            software-properties-common \
+            gpg-agent \
             update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9 && \
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9 && \
             apt-get clean && \
             rm -rf /var/lib/apt/lists/*
+
+RUN add-apt-repository ppa:git-core/ppa -y
+RUN apt-get update && apt-get install --no-install-recommends -y \
+            git \
+            git-lfs
 
 ####### Azure SDK needs new boost:
 WORKDIR /boost

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -54,7 +54,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN add-apt-repository ppa:git-core/ppa -y
 RUN apt-get update && apt-get install --no-install-recommends -y \
             git \
-            git-lfs
+            git-lfs \
+            apt-get clean && \
+            rm -rf /var/lib/apt/lists/*
 
 ####### Azure SDK needs new boost:
 WORKDIR /boost


### PR DESCRIPTION
### 🛠 Summary

Update git for bdba.
redhat already has:
git version 2.43.5
windows:
updated git on windows hosts.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

