### PR TITLE
Include reasoning in the response 

### DIFF
--- a/src/llm/apis/openai_completions.cpp
+++ b/src/llm/apis/openai_completions.cpp
@@ -280,7 +280,7 @@ absl::Status OpenAIChatCompletionsHandler::parseMessages(std::optional<std::stri
 absl::Status OpenAIChatCompletionsHandler::parseTools() {
     auto tool_choice_it = doc.FindMember("tool_choice");
     std::string tool_choice{"auto"};
-    if (tool_choice_it != doc.MemberEnd()) {
+    if (tool_choice_it != doc.MemberEnd() && !tool_choice_it->value.IsNull()) {
         if (tool_choice_it->value.IsString()) {
             tool_choice = tool_choice_it->value.GetString();
             if (tool_choice != "none" && tool_choice != "auto")
@@ -311,7 +311,7 @@ absl::Status OpenAIChatCompletionsHandler::parseTools() {
         jsonChanged = true;
     }
     auto it = doc.FindMember("tools");
-    if (it != doc.MemberEnd()) {
+    if (it != doc.MemberEnd() && !it->value.IsNull()) {
         if (!it->value.IsArray())
             return absl::InvalidArgumentError("Tools are not an array");
         for (size_t i = 0; i < it->value.GetArray().Size();) {
@@ -839,6 +839,11 @@ std::string OpenAIChatCompletionsHandler::serializeUnaryResponse(const std::vect
             // content: string; Actual content of the text produced
             writer.String("content");
             writer.String(parsedResponse.content.c_str());
+
+            if (!parsedResponse.reasoning.empty()) {
+                writer.String("reasoning_content");
+                writer.String(parsedResponse.reasoning.c_str());
+            }
             // role: string; Role of the text producer
             // Will make sense once we have chat templates? TODO(atobisze)
             writer.String("role");

--- a/src/test/http_openai_handler_test.cpp
+++ b/src/test/http_openai_handler_test.cpp
@@ -805,7 +805,7 @@ TEST_F(HttpOpenAIHandlerParsingTest, maxTokensValueDefualtToMaxTokensLimit) {
 TEST_F(HttpOpenAIHandlerParsingTest, ParsingRequestWithNullParametersChat) {
     std::vector<std::string> chatParamsThatAcceptNull = {"stream", "stream_options", "ignore_eos", "frequency_penalty", "presence_penalty", "repetition_penalty",
         "length_penalty", "temperature", "top_p", "top_k", "seed", "stop", "include_stop_str_in_output", "best_of", "n", "num_assistant_tokens", "assistant_confidence_threshold",
-        "logprobs", "max_completion_tokens"};
+        "logprobs", "max_completion_tokens", "tools", "tool_choice"};
     std::optional<uint32_t> maxTokensLimit;
     uint32_t bestOfLimit = 0;
     std::optional<uint32_t> maxModelLength;


### PR DESCRIPTION
Summary:
- exposing `reasoning_content` if model provides reasoning output (now only Qwen3)
- ignoring null values for tools and tool choice

