### PR TITLE
Fix global curl cleanup

### DIFF
--- a/src/httpservermodule.cpp
+++ b/src/httpservermodule.cpp
@@ -80,6 +80,7 @@ void HTTPServerModule::shutdown() {
     drogonServer->terminate();
     drogonServer.reset();
 #endif
+    curl_global_cleanup();
     SPDLOG_INFO("Shutdown HTTP server");
     state = ModuleState::SHUTDOWN;
 }

--- a/src/llm/apis/openai_completions.cpp
+++ b/src/llm/apis/openai_completions.cpp
@@ -214,7 +214,6 @@ absl::Status OpenAIChatCompletionsHandler::parseMessages(std::optional<std::stri
                                 if (status != absl::OkStatus()) {
                                     return status;
                                 }
-                                curl_global_cleanup();
                                 try {
                                     tensor = loadImageStbiFromMemory(decoded);
                                 } catch (std::runtime_error& e) {


### PR DESCRIPTION
### 🛠 Summary

curl_global_cleanup() should be called only once in ovms

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

