### PR TITLE
No usage in streaming mode for legacy

### DIFF
--- a/docs/llm/reference.md
+++ b/docs/llm/reference.md
@@ -271,6 +271,7 @@ Some servable types introduce additional limitations:
 - sequential request processing (only one request is handled at a time),
 - only a single response can be returned. Parameter `n` is not supported.
 - prompt lookup decoding is not supported
+- `usage` is not supported in streaming mode
 - **[NPU only]** beam_search algorithm is not supported with NPU. Greedy search and multinomial algorithms are supported.
 - **[NPU only]** models must be exported with INT4 precision and `--sym --ratio 1.0 --group-size -1` params. This is enforced in the export_model.py script when the target_device in NPU.
 

--- a/src/llm/language_model/legacy/servable.cpp
+++ b/src/llm/language_model/legacy/servable.cpp
@@ -179,8 +179,10 @@ absl::Status LegacyServable::preparePartialResponse(std::shared_ptr<GenAiServabl
         if (!executionContext->lastStreamerCallbackOutput.empty())
             lastTextChunk = lastTextChunk + executionContext->lastStreamerCallbackOutput;
         executionContext->response = wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingChunk(lastTextChunk, ov::genai::GenerationFinishReason::STOP));
+        // Disabling usage in streaming mode in legacy servable due to the issue with token counting.
         if (executionContext->apiHandler->getStreamOptions().includeUsage)
-            executionContext->response += wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingUsageChunk());
+            return absl::InvalidArgumentError("Usage is not supported in legacy servable in streaming mode.");
+            // executionContext->response += wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingUsageChunk());
 
         executionContext->response += wrapTextInServerSideEventMessage("[DONE]");
 

--- a/src/llm/visual_language_model/legacy/servable.cpp
+++ b/src/llm/visual_language_model/legacy/servable.cpp
@@ -182,8 +182,10 @@ absl::Status VisualLanguageModelLegacyServable::preparePartialResponse(std::shar
         if (!executionContext->lastStreamerCallbackOutput.empty())
             lastTextChunk = lastTextChunk + executionContext->lastStreamerCallbackOutput;
         executionContext->response = wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingChunk(lastTextChunk, ov::genai::GenerationFinishReason::STOP));
+        // Disabling usage in streaming mode in legacy servable due to the issue with token counting.
         if (executionContext->apiHandler->getStreamOptions().includeUsage)
-            executionContext->response += wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingUsageChunk());
+            return absl::InvalidArgumentError("Usage is not supported in legacy servable in streaming mode.");
+            // executionContext->response += wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingUsageChunk());
 
         executionContext->response += wrapTextInServerSideEventMessage("[DONE]");
 

--- a/src/test/llm/llmnode_test.cpp
+++ b/src/test/llm/llmnode_test.cpp
@@ -1842,9 +1842,18 @@ TEST_P(LLMFlowHttpTestParameterized, streamChatCompletionsUsage) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointChatCompletions, requestBody, &response, comp, responseComponents, writer, multiPartParser),
         ovms::StatusCode::PARTIAL_END);
-    ASSERT_TRUE(responses.back().find("\"completion_tokens\":5") != std::string::npos);
-    ASSERT_TRUE(responses.back().find("\"prompt_tokens\"") != std::string::npos);
-    ASSERT_TRUE(responses.back().find("\"total_tokens\"") != std::string::npos);
+
+    // For streaming endpoint only continuous batching servables support usage
+    if (params.modelName.find("cb") != std::string::npos) {
+        ASSERT_TRUE(responses.back().find("\"completion_tokens\":5") != std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"prompt_tokens\"") != std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"total_tokens\"") != std::string::npos);
+    } else {
+        ASSERT_TRUE(responses.back().find("\"completion_tokens\"") == std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"prompt_tokens\"") == std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"total_tokens\"") == std::string::npos);
+    }
+
     if (params.checkFinishReason) {
         ASSERT_TRUE(responses.back().find("\"finish_reason\":\"length\"") != std::string::npos);
     }
@@ -1879,9 +1888,18 @@ TEST_P(LLMFlowHttpTestParameterized, streamCompletionsUsage) {
     ASSERT_EQ(
         handler->dispatchToProcessor(endpointCompletions, requestBody, &response, comp, responseComponents, writer, multiPartParser),
         ovms::StatusCode::PARTIAL_END);
-    ASSERT_TRUE(responses.back().find("\"completion_tokens\":5") != std::string::npos);
-    ASSERT_TRUE(responses.back().find("\"prompt_tokens\"") != std::string::npos);
-    ASSERT_TRUE(responses.back().find("\"total_tokens\"") != std::string::npos);
+    
+    // For streaming endpoint only continuous batching servables support usage
+    if (params.modelName.find("cb") != std::string::npos) {
+        ASSERT_TRUE(responses.back().find("\"completion_tokens\":5") != std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"prompt_tokens\"") != std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"total_tokens\"") != std::string::npos);
+    } else {
+        ASSERT_TRUE(responses.back().find("\"completion_tokens\"") == std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"prompt_tokens\"") == std::string::npos);
+        ASSERT_TRUE(responses.back().find("\"total_tokens\"") == std::string::npos);
+    }
+
     if (params.checkFinishReason) {
         ASSERT_TRUE(responses.back().find("\"finish_reason\":\"length\"") != std::string::npos);
     }


### PR DESCRIPTION
### 🛠 Summary

Disable including usage statistics in legacy servables when streaming


