### PR TITLE
Partial JSON parser

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -2496,6 +2496,7 @@ cc_test(
                 "test/llm/response_parsers/qwen3_response_parser_test.cpp",
                 "test/llm/response_parsers/hermes3_response_parser_test.cpp",
                 "test/llm/response_parsers/phi4_response_parser_test.cpp",
+                "test/llm/response_parsers/partial_json_parser_test.cpp",
             ],
             "//:disable_python" : [],
         }) + select({

--- a/src/llm/BUILD
+++ b/src/llm/BUILD
@@ -101,6 +101,7 @@ cc_library(
             "response_parsers/phi4_response_parser.hpp",
             "response_parsers/qwen3_response_parser.hpp",
             "response_parsers/response_parser.hpp",
+            "response_parsers/partial_json_parser.hpp",
             "response_parsers/utils.hpp"],
     srcs = ["response_parsers/hermes3_response_parser.cpp",
             "response_parsers/llama3_response_parser.cpp",

--- a/src/llm/response_parsers/partial_json_parser.hpp
+++ b/src/llm/response_parsers/partial_json_parser.hpp
@@ -1,0 +1,164 @@
+//*****************************************************************************
+// Copyright 2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+#pragma warning(push)
+#pragma warning(disable : 6313)
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#pragma warning(pop)
+
+// Partial parsing of the chunk to JSON.
+// This function is used to handle the case where the chunk is not a complete JSON object,
+// but we still want to extract content from it.
+// It modifies the chunk to be a valid JSON by adding closures and dropping incomplete elements.
+rapidjson::Document partialParseToJson(const std::string& input) {
+    bool insideString = false;
+    bool insideArray = false;
+    bool insideObject = false;
+    bool awaitingValue = false; // Indicates if we are waiting for a value after a key
+    bool processingValue = false;
+    bool processingKey = false;
+    bool recentlyFinishedKey = false;
+    size_t lastSeparatorPos = std::string::npos;
+    std::vector<char> openCloseStack;
+    std::string closedInput = input; // Start with the original input
+    for (auto it = closedInput.begin(); it != closedInput.end(); ++it) {
+        char c = *it;
+        if (!insideString) { 
+            if (awaitingValue) {
+                if (!std::isspace(static_cast<unsigned char>(c))) {
+                    processingValue = true;
+                    awaitingValue = false;
+                }
+            }
+            // JSON openings and closures can be counted only when we are not inside a string
+            if (c == '{') {
+                openCloseStack.push_back(c);
+                insideObject = true;
+                insideArray = false;
+            } else if (c == '[') {
+                openCloseStack.push_back(c);
+                insideArray = true;
+                insideObject = false;
+            } else if (c == '}') {
+                if (!openCloseStack.empty() && openCloseStack.back() == '{') {
+                    openCloseStack.pop_back();
+                    if (!openCloseStack.empty() && openCloseStack.back() == '[') {
+                        insideArray = true; // We are still inside an array
+                    } else {
+                        insideObject = false; // We are exiting an object
+                    }
+                }
+            } else if (c == ']') {
+                if (!openCloseStack.empty() && openCloseStack.back() == '[') {
+                    openCloseStack.pop_back();
+                    insideArray = false; // We are exiting an array
+                    if (!openCloseStack.empty() && openCloseStack.back() == '{') {
+                        insideObject = true; // We are still inside an object
+                    } else if (!openCloseStack.empty() && openCloseStack.back() == '[') {
+                        insideArray = true; // We are still inside an array
+                    } else {
+                        processingValue = false; // We are not processing a value anymore
+                    }
+                }
+            } else if (c == ':') {
+                // Encountering a colon outside of a string indicates a key-value pair
+                awaitingValue = true;
+                recentlyFinishedKey = false; // We are now awaiting a value for the key
+            } else if (c == ',') {
+                // Store the position of the last comma
+                lastSeparatorPos = std::distance(closedInput.begin(), it);
+                if (insideObject) {
+                    // If we are inside an object, comma indicates the end of a key-value pair
+                    processingValue = false;
+                    processingKey = true; // Next part should be a key
+                }
+            } else if (c == '"') {
+                // If we encounter a quote outside of a string, we set insideString to true
+                insideString = true;
+                if (processingValue) {
+                    // We start a string inside value part
+                    processingKey = false;
+                } else {
+                    // If we are not processing a value, we are starting a new key
+                    processingKey = true;
+                }
+            }
+        } else {
+            if (c == '"') {
+                // Check if the quote is escaped
+                if (it != closedInput.begin() && *(it - 1) == '\\') {
+                    // If the quote is escaped, we ignore it as it is valid part of the string
+                    continue;
+                } else {
+                    // If the quote is not escaped we are exiting the string
+                    insideString = false;
+                    if (processingValue && !insideArray) {
+                        // If we were processing a string that was not in the array, we are done with it
+                        processingValue = false;
+                    } else if (processingKey) {
+                        // If we were processing a key, we are done with it
+                        processingKey = false;
+                        recentlyFinishedKey = true; // We just finished processing a key
+                    }
+                }
+            }
+        }
+    }
+
+    if (processingValue && insideString) {
+        // The partial JSON ends with a string value that is not closed
+        // We can close it by adding a closing quote
+        openCloseStack.push_back('"');
+    } else if ((processingValue && insideArray) || processingKey || recentlyFinishedKey || awaitingValue) {
+        /*  
+            Handling cases when:
+            - partial JSON ends with incomplete array
+            - partial JSON ends during or immediately after key processing
+            - partial JSON ends when we are awaiting a value after a key
+            In such cases we need to drop the incomplete part, get back to the last separator position and remove 
+            all the content after it, including the last comma if it exists.
+        */
+        if (lastSeparatorPos != std::string::npos && lastSeparatorPos < closedInput.size()) {
+            closedInput.erase(lastSeparatorPos);
+        }
+    }
+    
+    // Close any unclosed objects/arrays/strings in reverse order
+    for (auto it = openCloseStack.rbegin(); it != openCloseStack.rend(); ++it) {
+        if (*it == '{') {
+            closedInput += '}';
+        } else if (*it == '[') {
+            closedInput += ']';
+        } else if (*it == '"') {
+            closedInput += '"';
+        }
+    }
+
+    rapidjson::Document doc;
+    std::cout << "Parsed partial JSON: " << closedInput << std::endl;
+    doc.Parse(closedInput.c_str());
+    if (doc.HasParseError()) {
+        // Throw an exception to indicate an internal error
+        throw std::runtime_error("Internal error: Failed to parse partial JSON.");
+    }
+    return doc;
+}

--- a/src/llm/response_parsers/qwen3_response_parser.cpp
+++ b/src/llm/response_parsers/qwen3_response_parser.cpp
@@ -121,4 +121,23 @@ ParsedResponse Qwen3ResponseParser::parse(const std::vector<int64_t>& generatedT
     }
     return parsedResponse;
 }
+
+void Qwen3ResponseParser::parseChunk(const std::string& chunk) {
+    // Case: tool call has not started yet
+    if(!streamingState.isToolCallStarted) {
+        // Search for the start tag of the tool call in the chunk
+        auto toolCallStartPos = chunk.find(toolCallStartTag);
+
+        // Tool call start tag in the chunk, we begin processing a new tool call
+        if (toolCallStartPos != std::string::npos) {
+            // Tool call has started
+            streamingState.isToolCallStarted = true;
+            // Store the content after the start tag
+            streamingState.toolCallContent = chunk.substr(toolCallStartPos + toolCallStartTag.size());
+            // Apply partial parsing to the content
+        }
+    } 
+}
+
 }  // namespace ovms
+

--- a/src/llm/response_parsers/qwen3_response_parser.hpp
+++ b/src/llm/response_parsers/qwen3_response_parser.hpp
@@ -21,7 +21,15 @@
 #include "base_response_parser.hpp"
 
 namespace ovms {
+struct StreamingState {
+    bool isToolCallStarted = false; // Indicates if the tool call has started
+    bool isToolCallEnded = false;   // Indicates if the tool call has ended
+    std::string toolCallContent;     // Content of the tool call
+    std::string toolCallArgumentsContent; // Arguments of the tool call
+};
+
 class Qwen3ResponseParser : public BaseResponseParser {
+    StreamingState streamingState;  // State for streaming responses
 protected:
     // Tool calls are wrapped in <tool_call> and </tool_call> tags
     std::string toolCallStartTag = "<tool_call>";
@@ -40,5 +48,6 @@ public:
         BaseResponseParser(tokenizer) {}
 
     ParsedResponse parse(const std::vector<int64_t>& generatedTokens) override;
+    void parseChunk(const std::string& chunk);
 };
 }  // namespace ovms

--- a/src/test/llm/response_parsers/partial_json_parser_test.cpp
+++ b/src/test/llm/response_parsers/partial_json_parser_test.cpp
@@ -1,0 +1,142 @@
+//*****************************************************************************
+// Copyright 2025 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//*****************************************************************************
+
+#include <string>
+#include "../../../llm/response_parsers/partial_json_parser.hpp"
+
+#include <gtest/gtest.h>
+
+class PartialJsonParserTest : public ::testing::Test {};
+
+TEST_F(PartialJsonParserTest, simpleCompleteJsonWithStringValue) {
+    std::string input = "{\"name\": \"OpenVINO\"}";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("name"));
+    ASSERT_TRUE(parsedJson["name"].IsString());
+    ASSERT_EQ(parsedJson["name"].GetString(), std::string("OpenVINO"));
+}
+
+TEST_F(PartialJsonParserTest, simpleUncompleteJsonWithStringValue) {
+    std::string input = "{\"name\": \"Open";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("name"));
+    ASSERT_TRUE(parsedJson["name"].IsString());
+    ASSERT_EQ(parsedJson["name"].GetString(), std::string("Open"));
+}
+
+TEST_F(PartialJsonParserTest, simpleCompleteJsonWithNumberValue) {
+    std::string input = "{\"age\": 5}";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("age"));
+    ASSERT_TRUE(parsedJson["age"].IsInt());
+    ASSERT_EQ(parsedJson["age"].GetInt(), 5);
+}
+
+TEST_F(PartialJsonParserTest, simpleUncompleteJsonWithNumberValue) {
+    std::string input = "{\"age\": 5";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("age"));
+    ASSERT_TRUE(parsedJson["age"].IsInt());
+    ASSERT_EQ(parsedJson["age"].GetInt(), 5);
+}
+
+TEST_F(PartialJsonParserTest, simpleCompleteJsonWithArrayValue) {
+    std::string input = "{\"numbers\": [1, 2, 3]}";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("numbers"));
+    ASSERT_TRUE(parsedJson["numbers"].IsArray());
+    ASSERT_EQ(parsedJson["numbers"].Size(), 3);
+}
+
+TEST_F(PartialJsonParserTest, simpleUncompleteJsonWithArrayValue) {
+    std::string input = "{\"numbers\": [1, 2, 3";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("numbers"));
+    ASSERT_TRUE(parsedJson["numbers"].IsArray());
+    // Last number might not be completed, so we do not include it and close the array earlier
+    ASSERT_EQ(parsedJson["numbers"].Size(), 2);
+}
+
+TEST_F(PartialJsonParserTest, simpleUncompleteJsonWithArrayValueMultipleNesting) {
+    std::string input = "{\"numbers\": [[[1,2,3], [4,5,6";
+    // If below method returns it means the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("numbers"));
+    ASSERT_TRUE(parsedJson["numbers"].IsArray());
+    ASSERT_TRUE(parsedJson["numbers"][0].IsArray());
+    // The first inner array ([1,2,3]) is complete, the second ([4,5,6) is incomplete, so we expect two elements
+    ASSERT_EQ(parsedJson["numbers"][0].Size(), 2);
+
+    // First element: [1,2,3]
+    ASSERT_TRUE(parsedJson["numbers"][0][0].IsArray());
+    ASSERT_EQ(parsedJson["numbers"][0][0].Size(), 3);
+    ASSERT_EQ(parsedJson["numbers"][0][0][0].GetInt(), 1);
+    ASSERT_EQ(parsedJson["numbers"][0][0][1].GetInt(), 2);
+    ASSERT_EQ(parsedJson["numbers"][0][0][2].GetInt(), 3);
+
+    // Second element: [4,5]
+    ASSERT_TRUE(parsedJson["numbers"][0][1].IsArray());
+    ASSERT_EQ(parsedJson["numbers"][0][1].Size(), 2);
+    ASSERT_EQ(parsedJson["numbers"][0][1][0].GetInt(), 4);
+    ASSERT_EQ(parsedJson["numbers"][0][1][1].GetInt(), 5);
+}
+
+TEST_F(PartialJsonParserTest, simpleUncompleteJsonWithStringValueWithExtraCharacters) {
+    std::string input = "{\"arguments\": \"{\\\"location\\\": \\\"Tokyo, ";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("arguments"));
+    ASSERT_TRUE(parsedJson["arguments"].IsString());
+    ASSERT_EQ(parsedJson["arguments"].GetString(), std::string("{\"location\": \"Tokyo, "));
+}
+
+TEST_F(PartialJsonParserTest, simpleJsonWithKeyWithoutValue) {
+    std::string input = "{\"name\": \"OpenVINO\", \"age\": ";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("name"));
+    ASSERT_TRUE(parsedJson["name"].IsString());
+    ASSERT_EQ(parsedJson["name"].GetString(), std::string("OpenVINO"));
+    // The "age" key is incomplete, so it should not be present in the parsed JSON
+    ASSERT_FALSE(parsedJson.HasMember("age"));
+}
+
+TEST_F(PartialJsonParserTest, simpleJsonWithIncompleteKey) {
+    std::string input = "{\"name\": \"OpenVINO\", \"ag";
+    // If below method returns it means it the parsedJson is valid JSON, otherwise it would throw an exception
+    auto parsedJson = partialParseToJson(input);
+    ASSERT_TRUE(parsedJson.IsObject());
+    ASSERT_TRUE(parsedJson.HasMember("name"));
+    ASSERT_TRUE(parsedJson["name"].IsString());
+    ASSERT_EQ(parsedJson["name"].GetString(), std::string("OpenVINO"));
+    // The "age" key is incomplete, so it should not be present in the parsed JSON
+    ASSERT_FALSE(parsedJson.HasMember("ag"));
+}


### PR DESCRIPTION
### 🛠 Summary

In order to stream structured output in JSON format (like tool calls) we need to be able to find deltas between structures as model produces tokens. For example for:

``` 
Model output #1
<tool_call>{"name": "get_weather", "arguments": "\"location\": \"New
Model output #2
<tool_call>{"name": "get_weather", "arguments": "\"location\": \"New York
```

We need to produce response similar to:
```
data: {"id":"abcd1234","object":"chat.completion.chunk","created":1750764695,"model":"Qwen/Qwen3-8B","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" York"}}]},"logprobs":null,"finish_reason":null}]}
```

This PR introduces partial JSON parser that closes incomplete JSONs so they can be compared and we could extract delta in the next phases.

```
Incomplete object
{"name": "get_weather", "arguments": "\"location\": \"New
is changed to:
{"name": "get_weather", "arguments": "\"location\": \"New"}
```


