### PR TITLE
Update UBI to 9.6 in C-API demo

### DIFF
--- a/demos/c_api_minimal_app/capi_files/Dockerfile.redhat
+++ b/demos/c_api_minimal_app/capi_files/Dockerfile.redhat
@@ -29,7 +29,7 @@ RUN mkdir /licenses && ln -s /ovms/LICENSE /licenses && ln -s /ovms/thirdparty-l
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 as release
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 as release
 SHELL ["/bin/bash", "-c"]
 
 RUN microdnf upgrade -y


### PR DESCRIPTION
Missing part for:
https://github.com/openvinotoolkit/model_server/pull/3297

Ticket:CVS-169863

