### PR TITLE
Fix export models for image generation

### DIFF
--- a/demos/image_generation/README.md
+++ b/demos/image_generation/README.md
@@ -178,6 +178,8 @@ Run `export_model.py` script to download and quantize the model:
 
 > **Note:** The users in China need to set environment variable HF_ENDPOINT="https://hf-mirror.com" before running the export script to connect to the HF Hub.
 
+> **Note:** The `--extra_quantization_params` parameter is used to pass additional parameters to the optimum-cli. It may be required to set the `--group-size` parameter when quantizing the model when encountering errors like: `Channel size 64 should be divisible by size of group 128.`
+
 ### Export model for CPU
 ```console
 python export_model.py image_generation \
@@ -185,6 +187,7 @@ python export_model.py image_generation \
   --weight-format int4 \
   --config_file_path models/config.json \
   --model_repository_path models \
+  --extra_quantization_params "--group-size 64" \
   --overwrite_models
 ```
 
@@ -196,6 +199,7 @@ python export_model.py image_generation \
   --target_device GPU \
   --config_file_path models/config.json \
   --model_repository_path models \
+  --extra_quantization_params "--group-size 64" \
   --overwrite_models
 ```
 

--- a/demos/image_generation/README.md
+++ b/demos/image_generation/README.md
@@ -284,7 +284,7 @@ In case you want to use GPU device to run the generation, add extra docker param
 to `docker run` command, use the image with GPU support. Export the models with precision matching the GPU capacity and adjust pipeline configuration.
 It can be applied using the commands below:
 ```bash
-docker run -d --rm -p 8000:8000 -v $(pwd)/models:/workspace:ro \
+docker run -d --rm -p 8000:8000 -v $(pwd)/models:/models:ro \
   --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) \
   openvino/model_server:2025.2-gpu \
     --rest_port 8000 \
@@ -322,7 +322,7 @@ In this specific case, we also need to use `--device /dev/dri`, because we also 
 
 It can be applied using the commands below:
 ```bash
-docker run -d --rm -p 8000:8000 -v $(pwd)/models:/workspace:ro \
+docker run -d --rm -p 8000:8000 -v $(pwd)/models:/models:ro \
   --device /dev/accel --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) \
   openvino/model_server:latest-gpu \
     --rest_port 8000 \


### PR DESCRIPTION
Fixing issue introduced with: d981ff0e68d27e1bd0efb7a8997562584766fcc7. When performing quantization after switching from int8 to int4 in export_models.py we encountered issue:
"Channel size 64 should be divisible by size of group 128."

Ticket:CVS-169363
