### PR TITLE
rollback transformers version to 4.52 to fix accuracy

### DIFF
--- a/demos/common/export_models/requirements.txt
+++ b/demos/common/export_models/requirements.txt
@@ -7,7 +7,7 @@ nncf>=2.11.0
 sentence_transformers==5.0.0
 sentencepiece==0.2.0
 openai 
-transformers<4.53
+transformers<4.52
 einops==0.8.1
 torchvision
 timm==1.0.15


### PR DESCRIPTION
### 🛠 Summary

CVS-172356
Rollback transformers version to improve accuracy in LLM models

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

