### PR TITLE
Include Tokenizers and GenAI python bindings in Linux packages

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -228,7 +228,8 @@ RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \
     cp build/python/* /opt/intel/openvino/python/openvino_tokenizers/ ; \
     mkdir -p /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info ; \
     echo $'Metadata-Version: 1.0\nName: openvino-tokenizers\nVersion: 2025.4\nRequires-Python: >=3.9\nRequires-Dist: openvino~=2025.4.0' > /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info/METADATA ; \
-    ln -s /ovms/lib/libopenvino_tokenizers.so /opt/intel/openvino/python/openvino_tokenizers/lib/libopenvino_tokenizers.so ; fi
+    ln -s /ovms/lib/libopenvino_tokenizers.so /opt/intel/openvino/python/openvino_tokenizers/lib/libopenvino_tokenizers.so ; \
+    fi
 
 # Build OpenVINO Model Server
 WORKDIR /ovms

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -218,7 +218,7 @@ WORKDIR /openvino_tokenizers/
 ARG ov_tokenizers_branch=85be884a69f10270703f81f970a5ee596a4c8df7
 # hadolint ignore=DL3003
 RUN git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -S ./ -B ./build/  && cmake --build ./build/ --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -S ./ -B ./build/  && cmake --build ./build/ --parallel $JOBS && cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
 
 WORKDIR /openvino_tokenizers/
 # Install the openvino_tokenizers python bindings and copy to OpenVINO location

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -213,16 +213,15 @@ RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel
 ENV OpenVINO_DIR=/opt/intel/openvino/runtime/cmake
 ENV OPENVINO_TOKENIZERS_PATH_GENAI=/opt/intel/openvino/runtime/lib/intel64/libopenvino_tokenizers.so
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/runtime/lib/intel64/:/opt/opencv/lib/:/opt/intel/openvino/runtime/3rdparty/tbb/lib/
+WORKDIR /openvino_tokenizers/
 
 ARG ov_tokenizers_branch=85be884a69f10270703f81f970a5ee596a4c8df7
 # hadolint ignore=DL3003
 RUN git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-WORKDIR /openvino_tokenizers/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}"  && cmake --build . --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -S ./ -B ./build/  && cmake --build ./build/ --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
 
 WORKDIR /openvino_tokenizers/
-# Install the openvino_tokenizers python bindings and use a symlink to point
-# to the shared object in it's final location.
+# Install the openvino_tokenizers python bindings and copy to OpenVINO location
 RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \
     mkdir -p /opt/intel/openvino/python/openvino_tokenizers/lib ; \
     cp -r python/* /opt/intel/openvino/python/ ; \

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -218,7 +218,7 @@ WORKDIR /openvino_tokenizers/
 ARG ov_tokenizers_branch=85be884a69f10270703f81f970a5ee596a4c8df7
 # hadolint ignore=DL3003
 RUN git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -S ./ -B ./build/  && cmake --build ./build/ --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -S ./ -B ./build/  && cmake --build ./build/ --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
 
 WORKDIR /openvino_tokenizers/
 # Install the openvino_tokenizers python bindings and copy to OpenVINO location

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -193,21 +193,22 @@ RUN if [ -f /opt/intel/openvino/samples/cpp/build_samples.sh ];  then /opt/intel
 ENV OpenVINO_DIR=/opt/intel/openvino/runtime/cmake
 ENV OPENVINO_TOKENIZERS_PATH_GENAI=/opt/intel/openvino/runtime/lib/intel64/libopenvino_tokenizers.so
 WORKDIR /openvino_tokenizers/
-# Install the openvino_tokenizers python bindings and use a symlink to point
-# to the shared object in it's final location.
-RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \
-    mkdir -p /opt/intel/openvino/python/openvino_tokenizers/lib ; \
-    cp -r python/* /opt/intel/openvino/python/ ; \
-    cp build/python/* /opt/intel/openvino/python/openvino_tokenizers/ ; \
-    mkdir -p /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info ; \
-    echo $'Metadata-Version: 1.0\nName: openvino-tokenizers\nVersion: 2025.4\nRequires-Python: >=3.9\nRequires-Dist: openvino~=2025.4.0' > /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info/METADATA ; \
-    ln -s /ovms/lib/libopenvino_tokenizers.so /opt/intel/openvino/python/openvino_tokenizers/lib/libopenvino_tokenizers.so ; fi
 
 ARG ov_tokenizers_branch=master
 # hadolint ignore=DL3003
 RUN  git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-WORKDIR /openvino_tokenizers/build
 RUN cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE && cmake --build . --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
+
+# Install the openvino_tokenizers python bindings and use a symlink to point
+# to the shared object in it's final location.
+RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \
+    mkdir -p /opt/intel/openvino/python/openvino_tokenizers/lib ; \
+    cp -r python/* /opt/intel/openvino/python/openvino_tokenizers/ ; \
+    cp build/python/* /opt/intel/openvino/python/openvino_tokenizers/ ; \
+    mkdir -p /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info ; \
+    echo $'Metadata-Version: 1.0\nName: openvino-tokenizers\nVersion: 2025.4\nRequires-Python: >=3.9\nRequires-Dist: openvino~=2025.4.0' > /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info/METADATA ; \
+    # ln -s /ovms/lib/libopenvino_tokenizers.so /opt/intel/openvino/python/openvino_tokenizers/lib/libopenvino_tokenizers.so ; \
+    fi
 
 # Add Nvidia dev tool if needed
 RUN apt-get update ; \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -197,7 +197,7 @@ WORKDIR /openvino_tokenizers/
 ARG ov_tokenizers_branch=master
 # hadolint ignore=DL3003
 RUN  git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-RUN cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -S ./ -B ./build/ && cmake --build ./build/ --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
+RUN cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -S ./ -B ./build/ && cmake --build ./build/ --parallel $JOBS && cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
 
 # Install the openvino_tokenizers python bindings and copy to OpenVINO location
 RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -197,13 +197,13 @@ WORKDIR /openvino_tokenizers/
 ARG ov_tokenizers_branch=master
 # hadolint ignore=DL3003
 RUN  git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
-RUN cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE && cmake --build . --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
+RUN cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -S ./ -B ./build/ && cmake --build ./build/ --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
 
 # Install the openvino_tokenizers python bindings and use a symlink to point
 # to the shared object in it's final location.
 RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \
     mkdir -p /opt/intel/openvino/python/openvino_tokenizers/lib ; \
-    cp -r python/* /opt/intel/openvino/python/openvino_tokenizers/ ; \
+    cp -r python/* /opt/intel/openvino/python/ ; \
     cp build/python/* /opt/intel/openvino/python/openvino_tokenizers/ ; \
     mkdir -p /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info ; \
     echo $'Metadata-Version: 1.0\nName: openvino-tokenizers\nVersion: 2025.4\nRequires-Python: >=3.9\nRequires-Dist: openvino~=2025.4.0' > /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info/METADATA ; \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -199,8 +199,7 @@ ARG ov_tokenizers_branch=master
 RUN  git clone https://github.com/openvinotoolkit/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout $ov_tokenizers_branch && git submodule update --init --recursive
 RUN cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -S ./ -B ./build/ && cmake --build ./build/ --parallel $JOBS ; cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/
 
-# Install the openvino_tokenizers python bindings and use a symlink to point
-# to the shared object in it's final location.
+# Install the openvino_tokenizers python bindings and copy to OpenVINO location
 RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \
     mkdir -p /opt/intel/openvino/python/openvino_tokenizers/lib ; \
     cp -r python/* /opt/intel/openvino/python/ ; \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -206,7 +206,7 @@ RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \
     cp build/python/* /opt/intel/openvino/python/openvino_tokenizers/ ; \
     mkdir -p /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info ; \
     echo $'Metadata-Version: 1.0\nName: openvino-tokenizers\nVersion: 2025.4\nRequires-Python: >=3.9\nRequires-Dist: openvino~=2025.4.0' > /opt/intel/openvino/python/openvino_tokenizers-2025.4.dist-info/METADATA ; \
-    # ln -s /ovms/lib/libopenvino_tokenizers.so /opt/intel/openvino/python/openvino_tokenizers/lib/libopenvino_tokenizers.so ; \
+    ln -s /ovms/lib/libopenvino_tokenizers.so /opt/intel/openvino/python/openvino_tokenizers/lib/libopenvino_tokenizers.so ; \
     fi
 
 # Add Nvidia dev tool if needed

--- a/create_package.sh
+++ b/create_package.sh
@@ -64,6 +64,7 @@ if [ -f /ovms_release/lib/libsrc_Slibovms_Ushared.so ] ; then \
 	/ovms_release/lib/libovms_shared.so-2.params ; \
 fi
 
+# Add Python bindings for pyovms, openvino, openvino_tokenizers and openvino_genai, so they are all available for OVMS Python servables
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /opt/intel/openvino/python /ovms_release/lib/python ; fi
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then mv /ovms_release/lib/pyovms.so /ovms_release/lib/python ; fi
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then echo $'#!/bin/bash\npython3 -m openvino_tokenizers.cli "$@"' > /ovms_release/bin/convert_tokenizer ; \

--- a/create_package.sh
+++ b/create_package.sh
@@ -68,7 +68,7 @@ if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /opt/intel/openvino/pyt
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then mv /ovms_release/lib/pyovms.so /ovms_release/lib/python ; fi
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then echo $'#!/bin/bash\npython3 -m openvino_tokenizers.cli "$@"' > /ovms_release/bin/convert_tokenizer ; \
    chmod +x /ovms_release/bin/convert_tokenizer ; fi
-if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /openvino_tokenizers/python/openvino_tokenizers/ /ovms_release/lib/python/ ; fi
+if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /ovms/bazel-out/k8-opt/bin/external/llm_engine/libopenvino_genai/python/* /ovms_release/lib/python/ ; fi
 
 if [ -f /opt/intel/openvino/runtime/lib/intel64/plugins.xml ]; then cp /opt/intel/openvino/runtime/lib/intel64/plugins.xml /ovms_release/lib/ ; fi
 find /opt/intel/openvino/runtime/lib/intel64/ -iname '*.mvcmd*' -exec cp -v {} /ovms_release/lib/ \;

--- a/create_package.sh
+++ b/create_package.sh
@@ -68,7 +68,9 @@ if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /opt/intel/openvino/pyt
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then mv /ovms_release/lib/pyovms.so /ovms_release/lib/python ; fi
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then echo $'#!/bin/bash\npython3 -m openvino_tokenizers.cli "$@"' > /ovms_release/bin/convert_tokenizer ; \
    chmod +x /ovms_release/bin/convert_tokenizer ; fi
-if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /ovms/bazel-out/k8-opt/bin/external/llm_engine/libopenvino_genai/python/* /ovms_release/lib/python/ ; fi
+if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /ovms/bazel-out/k8-opt/bin/external/llm_engine/libopenvino_genai/python/* /ovms_release/lib/python/ ; \
+	mkdir -p /ovms_release/lib/python/openvino_genai-2025.3.dist-info ; \
+	echo $'Metadata-Version: 1.0\nName: openvino-genai\nVersion: 2025.3\nRequires-Python: >=3.9\nRequires-Dist: openvino-genai~=2025.3.0' > /ovms_release/lib/python/openvino_genai-2025.3.dist-info/METADATA; fi
 
 if [ -f /opt/intel/openvino/runtime/lib/intel64/plugins.xml ]; then cp /opt/intel/openvino/runtime/lib/intel64/plugins.xml /ovms_release/lib/ ; fi
 find /opt/intel/openvino/runtime/lib/intel64/ -iname '*.mvcmd*' -exec cp -v {} /ovms_release/lib/ \;

--- a/create_package.sh
+++ b/create_package.sh
@@ -70,8 +70,8 @@ if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then mv /ovms_release/lib/pyovms.s
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then echo $'#!/bin/bash\npython3 -m openvino_tokenizers.cli "$@"' > /ovms_release/bin/convert_tokenizer ; \
    chmod +x /ovms_release/bin/convert_tokenizer ; fi
 if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then cp -r /ovms/bazel-out/k8-opt/bin/external/llm_engine/libopenvino_genai/python/* /ovms_release/lib/python/ ; \
-	mkdir -p /ovms_release/lib/python/openvino_genai-2025.3.dist-info ; \
-	echo $'Metadata-Version: 1.0\nName: openvino-genai\nVersion: 2025.3\nRequires-Python: >=3.9\nRequires-Dist: openvino-genai~=2025.3.0' > /ovms_release/lib/python/openvino_genai-2025.3.dist-info/METADATA; fi
+	mkdir -p /ovms_release/lib/python/openvino_genai-2025.4.dist-info ; \
+	echo $'Metadata-Version: 1.0\nName: openvino-genai\nVersion: 2025.4\nRequires-Python: >=3.9\nRequires-Dist: openvino-genai~=2025.4.0' > /ovms_release/lib/python/openvino_genai-2025.4.dist-info/METADATA; fi
 
 if [ -f /opt/intel/openvino/runtime/lib/intel64/plugins.xml ]; then cp /opt/intel/openvino/runtime/lib/intel64/plugins.xml /ovms_release/lib/ ; fi
 find /opt/intel/openvino/runtime/lib/intel64/ -iname '*.mvcmd*' -exec cp -v {} /ovms_release/lib/ \;

--- a/docs/deploying_server_baremetal.md
+++ b/docs/deploying_server_baremetal.md
@@ -35,9 +35,16 @@ export PATH=$PATH:${PWD}/ovms/bin
 In case of the version with python run also:
 ```{code} sh
 export PYTHONPATH=${PWD}/ovms/lib/python
-sudo apt -y install libpython3.10
+sudo apt -y install python3-pip
 pip3 install "Jinja2==3.1.6" "MarkupSafe==3.0.2"
 ```
+and if you plan to use Python nodes with OpenVINO or OpenVINO GenAI, you will also need to install NumPy:
+```{code} sh
+pip3 install numpy
+```
+**Do not install openvino, openvino-tokenizers or openvino-genai via pip**.
+Model server version with Python is shipped with those packages and new installation with pip will likely result in broken dependencies.
+
 :::
 :::{tab-item} Ubuntu 24.04
 :sync: ubuntu-24-04
@@ -63,9 +70,16 @@ export PATH=$PATH:${PWD}/ovms/bin
 In case of the version with python run also:
 ```{code} sh
 export PYTHONPATH=${PWD}/ovms/lib/python
-sudo apt -y install libpython3.12
+sudo apt -y install python3-pip
 pip3 install "Jinja2==3.1.6" "MarkupSafe==3.0.2"
 ```
+and if you plan to use Python nodes with OpenVINO or OpenVINO GenAI, you will also need to install NumPy:
+```{code} sh
+pip3 install numpy
+```
+**Do not install openvino, openvino-tokenizers or openvino-genai via pip**.
+Model server version with Python is shipped with those packages and new installation with pip will likely result in broken dependencies.
+
 :::
 :::{tab-item} RHEL 9.6
 :sync: rhel-9.6
@@ -91,9 +105,17 @@ export PATH=$PATH:${PWD}/ovms/bin
 In case of the version with python run also:
 ```{code} sh
 export PYTHONPATH=${PWD}/ovms/lib/python
-sudo yum install -y python39-libs
+sudo yum install -y python3-pip
 pip3 install "Jinja2==3.1.6" "MarkupSafe==3.0.2"
 ```
+
+and if you plan to use Python nodes with OpenVINO or OpenVINO GenAI, you will also need to install NumPy:
+```{code} sh
+pip3 install numpy
+```
+**Do not install openvino, openvino-tokenizers or openvino-genai via pip**.
+Model server version with Python is shipped with those packages and new installation with pip will likely result in broken dependencies.
+
 :::
 :::{tab-item} Windows
 :sync: windows


### PR DESCRIPTION
Making both openvino-tokenizers and openvino-genai python packages available in Ubuntu and Redhat packages.
With that change it will be possible to use GenAI and Tokenizers in Python nodes as OVMS will ship python bindings as well.

That should fix: https://github.com/openvinotoolkit/model_server/issues/3606

