### PR TITLE
Whitelist and demo validation updates

### DIFF
--- a/demos/rerank/README.md
+++ b/demos/rerank/README.md
@@ -178,7 +178,7 @@ documents = [
     document_template.format(doc=doc, suffix=suffix) for doc in documents
 ]
 
-response = requests.post("http://127.0.0.1:8125/v3/rerank",
+response = requests.post("http://localhost:8125/v3/rerank",
                          json={
                              "model": "tomaarsen/Qwen3-Reranker-0.6B-seq-cls",
                              "query": query,

--- a/tests/sdl/whitelists.py
+++ b/tests/sdl/whitelists.py
@@ -141,7 +141,7 @@ libraries = {
         'icudt70.dll',
         'icuuc70.dll',
         'libcurl-x64.dll',
-        'opencv_world4100.dll',
+        'opencv_world4120.dll',
         'openvino.dll',
         'openvino_auto_batch_plugin.dll',
         'openvino_auto_plugin.dll',
@@ -230,7 +230,9 @@ packages = {
         'libpython3.8-stdlib',
         'mime-support',
     },
-    OvmsBaseType.UBUNTU22: {'libicu70'},
+    OvmsBaseType.UBUNTU22: {
+        'libicu70'
+    },
     OvmsBaseType.UBUNTU22_PYTHON: {
         'libmpdec3',
         'libreadline8',
@@ -239,7 +241,8 @@ packages = {
         'libpython3.10-stdlib',
         'media-types',
     },
-    OvmsBaseType.UBUNTU24: {'libicu74',
+    OvmsBaseType.UBUNTU24: {
+        'libicu74',
         'tzdata',
         'netbase',
         'libreadline8t64'},
@@ -254,8 +257,8 @@ packages = {
         'intel-fw-npu',
         'intel-igc-core-2',
         'intel-igc-opencl-2',
-        'intel-level-zero-gpu',
         'intel-level-zero-npu',
+        'intel-ocloc',
         'intel-opencl-icd',
         'level-zero',
         'libhwloc15',
@@ -264,6 +267,7 @@ packages = {
         'libtbb12',
         'libtbbbind-2-5',
         'libtbbmalloc2',
+        'libze-intel-gpu1',
         'ocl-icd-libopencl1',
     },
     OvmsBaseType.UBUNTU_NGINX: {


### PR DESCRIPTION
### 🛠 Summary

Whitelists changes after GPU driver update
Rerank demo: 127.0.0.1 changed to localhost for automatic tests

Tests:
Whitelist:
http://validationreports.sclab.intel.com:8001/reports/build_number_report?test_session_build_number=ci-ai-test-14587&environment=dtp2_IOTG-WORK-08
Rerank:
http://validationreports.sclab.intel.com:8001/reports/build_number_report?test_session_build_number=ovms-c_uat_test_511&environment=ovms_icelake-ovms-c_uat_test-CPU
http://validationreports.sclab.intel.com:8001/reports/build_number_report?test_session_build_number=ovms-c_uat_test_511&environment=ovms-c_gpu_a770_worker-ovms-c_uat_test-GPU

Related jira issues:
https://jira.devtools.intel.com/browse/CVS-173166
https://jira.devtools.intel.com/browse/CVS-172835
https://jira.devtools.intel.com/browse/CVS-173146

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

