### PR TITLE
changed occurence of ovmsclient to tfs

### DIFF
--- a/docs/tf_model_binary_input.md
+++ b/docs/tf_model_binary_input.md
@@ -60,7 +60,7 @@ docker run -d -p 9000:9000 -v ${PWD}/resnet_v2/models:/models openvino/model_ser
 
 ```bash
 git clone https://github.com/openvinotoolkit/model_server.git
-cd client/python/tensorflow-serving-api/samples
+cd model_server/client/python/tensorflow-serving-api/samples
 virtualenv .venv
 . .venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
### 🛠 Summary

[CVS-173309](https://jira.devtools.intel.com/browse/CVS-173309)
ovmsclient has been removed, but it's usage was left in one document. It needed to be changed to any other client.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

