### PR TITLE
Fix add_to_config invalid json on windows

### DIFF
--- a/src/config_export_module/config_export.cpp
+++ b/src/config_export_module/config_export.cpp
@@ -50,13 +50,27 @@ Status loadJsonConfig(const std::string& jsonFilename, rapidjson::Document& conf
 
 Status createModelConfig(const std::string& fullPath, const ModelsSettingsImpl& modelSettings) {
     std::ostringstream oss;
+    
+    auto escapeBackslashes = [](const std::string& path) -> std::string {
+        std::string result;
+        result.reserve(path.size());
+        for (char c : path) {
+            if (c == '\\') {
+                result += "\\\\";
+            } else {
+                result += c;
+            }
+        }
+        return result;
+    };
+
     // clang-format off
     oss << R"({
     "model_config_list": [
         { 
             "config": {
                 "name": ")" << modelSettings.modelName << R"(",
-                "base_path": ")" << modelSettings.modelPath << R"("
+                "base_path": ")" << escapeBackslashes(modelSettings.modelPath) << R"("
             }
         }
     ]

--- a/src/test/config_export_test.cpp
+++ b/src/test/config_export_test.cpp
@@ -41,6 +41,18 @@ const std::string expectedConfigContents = R"({
 }
 )";
 
+const std::string expectedConfigContentsWindows = R"({
+    "model_config_list": [
+        { 
+            "config": {
+                "name": "model1",
+                "base_path": "model1\\\\Path"
+            }
+        }
+    ]
+}
+)";
+
 const std::string expectedConfigContentsTwoModels = R"({
     "model_config_list": [
         {
@@ -192,11 +204,21 @@ TEST_F(ConfigCreationTest, negativeRemoveModelWithDirectConfigFilePathNotExistin
 }
 
 TEST_F(ConfigCreationTest, positiveAddModel) {
+    #ifdef _WIN32
+    this->modelsSettings.modelPath = "model1\\Path";
+    #endif
     auto status = ovms::updateConfig(this->modelsSettings, ovms::ENABLE_MODEL);
     ASSERT_EQ(status, ovms::StatusCode::OK);
 
     std::string configContents = GetFileContents(this->modelsSettings.configPath);
-    ASSERT_EQ(expectedConfigContents, configContents) << configContents;
+    
+    #ifdef _WIN32
+    const std::string* expectedConfig = &expectedConfigContentsWindows;
+    #elif __linux___
+    const std::string* expectedConfig = &expectedConfigContents;
+    #endif
+    
+    ASSERT_EQ(*expectedConfig, configContents) << configContents;
 }
 
 TEST_F(ConfigCreationTest, positiveRemoveOneModelToEmptyConfig) {


### PR DESCRIPTION
### 🛠 Summary

[CVS-173488](https://jira.devtools.intel.com/browse/CVS-173488)
Json path on windows was invalidly saved to the file

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

