### PR TITLE
Relax target device validation in HF pulling mode

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -145,7 +145,20 @@ bool Config::validate() {
             }
 
             std::vector allowedTargetDevices = {"CPU", "GPU", "NPU", "AUTO"};
-            if (std::find(allowedTargetDevices.begin(), allowedTargetDevices.end(), settings.targetDevice) == allowedTargetDevices.end() && settings.targetDevice.rfind("HETERO", 0) != 0) {
+            bool validDeviceSelected = false;
+            if (settings.targetDevice.rfind("GPU.", 0) == 0) {
+                // Accept GPU.x where x is a number to select specific GPU card
+                std::string indexPart = settings.targetDevice.substr(4);
+                validDeviceSelected = !indexPart.empty() && std::all_of(indexPart.begin(), indexPart.end(), ::isdigit);
+            } else if (settings.targetDevice.rfind("HETERO", 0) == 0) {
+                // Accept HETERO:<device1>,<device2>,... to select specific devices in the list
+                validDeviceSelected = true;
+            } else if (std::find(allowedTargetDevices.begin(), allowedTargetDevices.end(), settings.targetDevice) != allowedTargetDevices.end()) {
+                // Accept CPU, GPU, NPU, AUTO as valid devices
+                validDeviceSelected = true;
+            }
+
+            if (!validDeviceSelected) {
                 std::cerr << "target_device: " << settings.targetDevice << " is not allowed. Supported devices: CPU, GPU, NPU, HETERO, AUTO" << std::endl;
                 return false;
             }

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -1341,6 +1341,30 @@ TEST(OvmsGraphConfigTest, positiveTargetDeviceHetero) {
     ASSERT_EQ(graphSettings.targetDevice, "HETERO");
 }
 
+TEST(OvmsGraphConfigTest, positiveTargetDeviceSpecificGPU) {
+    std::string modelName = "OpenVINO/Phi-3-mini-FastDraft-50M-int8-ov";
+    std::string downloadPath = "test/repository";
+    char* n_argv[] = {
+        (char*)"ovms",
+        (char*)"--pull",
+        (char*)"--source_model",
+        (char*)modelName.c_str(),
+        (char*)"--model_repository_path",
+        (char*)downloadPath.c_str(),
+        (char*)"--task",
+        (char*)"text_generation",
+        (char*)"--target_device",
+        (char*)"GPU.1",
+    };
+
+    int arg_count = 10;
+    ConstructorEnabledConfig config;
+    config.parse(arg_count, n_argv);
+    auto& hfSettings = config.getServerSettings().hfSettings;
+    ovms::TextGenGraphSettingsImpl graphSettings = std::get<ovms::TextGenGraphSettingsImpl>(hfSettings.graphSettings);
+    ASSERT_EQ(graphSettings.targetDevice, "HETERO");
+}
+
 TEST(OvmsGraphConfigTest, negativePipelineType) {
     std::string modelName = "OpenVINO/Phi-3-mini-FastDraft-50M-int8-ov";
     std::string downloadPath = "test/repository";

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -1362,7 +1362,7 @@ TEST(OvmsGraphConfigTest, positiveTargetDeviceSpecificGPU) {
     config.parse(arg_count, n_argv);
     auto& hfSettings = config.getServerSettings().hfSettings;
     ovms::TextGenGraphSettingsImpl graphSettings = std::get<ovms::TextGenGraphSettingsImpl>(hfSettings.graphSettings);
-    ASSERT_EQ(graphSettings.targetDevice, "HETERO");
+    ASSERT_EQ(graphSettings.targetDevice, "GPU.1");
 }
 
 TEST(OvmsGraphConfigTest, negativePipelineType) {


### PR DESCRIPTION
In HF pulling mode for text generation we should also accept specific GPU (specified via index like: GPU.0, GPU.1, GPU.2 ...)

