### PR TITLE
Fix quickstart multiple devices

### DIFF
--- a/docs/llm/quickstart.md
+++ b/docs/llm/quickstart.md
@@ -19,7 +19,7 @@ You can use another model from [OpenVINO organization on HuggingFace](https://hu
 
 ```bash
 mkdir models
-docker run --user $(id -u):$(id -g) -d --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render*) --rm -p 8000:8000 -v $(pwd)/models:/models:rw openvino/model_server:latest-gpu --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --model_repository_path models --task text_generation --rest_port 8000 --target_device GPU --cache_size 2
+docker run --user $(id -u):$(id -g) -d --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* | head -n 1) --rm -p 8000:8000 -v $(pwd)/models:/models:rw openvino/model_server:latest-gpu --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov --model_repository_path models --task text_generation --rest_port 8000 --target_device GPU --cache_size 2
 ```
 :::
 


### PR DESCRIPTION
Readme command not accommodating multiple devices in /dev/dri. Alternative is to add:
`$(for g in $(echo 992 992 998 | sort -u); do echo --group-add=$g; done)`
But that would look less elegant in readme.

Ticket:CVS-174480
