### PR TITLE
move printing info about missing api key

### DIFF
--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -520,9 +520,6 @@ void CLIParser::prepareServer(ServerSettingsImpl& serverSettings) {
         if (envApiKey != nullptr) {
             serverSettings.apiKey = envApiKey;
         }
-        if (serverSettings.apiKey.empty()) {
-            std::cout << "Info: API key not provided via --api_key_file or API_KEY environment variable. Authentication will be disabled." << std::endl;
-        }
     }
 }
 

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -242,6 +242,9 @@ std::unique_ptr<DrogonHttpServer> createAndStartDrogonHttpServer(const std::stri
         SPDLOG_ERROR("Failed to start Drogon server");
         return nullptr;
     }
+    if (config.apiKey().empty()) {
+        SPDLOG_INFO("API key not provided via --api_key_file or API_KEY environment variable. Authentication will be disabled.");
+    }
     return server;
 }
 


### PR DESCRIPTION
### 🛠 Summary

Change printing info about missing API key. It should show up only when staring rest server and should be omitted for other situations.
### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

