### PR TITLE
Not using cache in open-webui

### DIFF
--- a/demos/integration_with_OpenWebUI/README.md
+++ b/demos/integration_with_OpenWebUI/README.md
@@ -61,7 +61,7 @@ curl http://localhost:8000/v3/chat/completions -H "Content-Type: application/jso
 Install Open WebUI:
 
 ```bash
-pip install open-webui
+pip install --no-cache-dir open-webui
 ```
 
 Running Open WebUI:


### PR DESCRIPTION
### 🛠 Summary

[CVS-174068](https://jira.devtools.intel.com/browse/CVS-174068)
not using cached libs with missing module 

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

