### PR TITLE
Adding lib to enable exporting Qwen3 models

### DIFF
--- a/demos/common/export_models/requirements.txt
+++ b/demos/common/export_models/requirements.txt
@@ -19,3 +19,4 @@ timm==1.0.22
 torchvision
 torch==2.9.1+cpu
 transformers==4.55.4
+datasets


### PR DESCRIPTION
### 🛠 Summary

Exporting Qwen3 models with optimum-intel library was failing with no datasets package error. I am adding this package to enable it. 

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

