### PR TITLE
Improve multipart GGUF validation

### DIFF
--- a/src/pull_module/gguf_downloader.cpp
+++ b/src/pull_module/gguf_downloader.cpp
@@ -306,6 +306,15 @@ std::variant<Status, std::vector<std::string>> GGUFDownloader::createGGUFFilenam
     // we need to extract N
     // note that it could be 00001-of-00002, it could be 00001-of-00212 etc
     // note that it has to be exactly 5 digits for part number and 5 digits for total parts
+    // we first should check if this at least tries to be multipart with regex "-of-" as not to
+    // try to use web with curl unnecessarily
+    std::string multipartPreCheckPattern = R"(.*-of-.*$)";
+    std::smatch preCheckMatch;
+    if (!std::regex_match(ggufFilename, preCheckMatch, std::regex(multipartPreCheckPattern))) {
+        // not multipart
+        filesToDownload.push_back(ggufFilename);
+        return filesToDownload;
+    }
     std::string multipartExactPattern = R"(.*-(\d{5})-of-(\d{5})\.gguf$)";
     std::smatch match;
     if (std::regex_match(ggufFilename, match, std::regex(multipartExactPattern))) {
@@ -335,7 +344,8 @@ std::variant<Status, std::vector<std::string>> GGUFDownloader::createGGUFFilenam
             filesToDownload.push_back(std::get<std::string>(partFilenameOrStatus));
         }
     } else {
-        filesToDownload.push_back(ggufFilename);
+        SPDLOG_ERROR("Invalid multipart gguf filename format: {}", ggufFilename);
+        return StatusCode::PATH_INVALID;
     }
     return filesToDownload;
 }

--- a/src/test/pull_gguf_hf_model_test.cpp
+++ b/src/test/pull_gguf_hf_model_test.cpp
@@ -521,6 +521,17 @@ TEST_F(GGUFDownloaderMultipartUtils, PreparePartFilenameNegative) {
     EXPECT_EQ(std::get<Status>(GGUFDownloader::preparePartFilename(ggufFilename, 1, 100000)).getCode(), StatusCode::INTERNAL_ERROR);
     EXPECT_EQ(std::get<Status>(GGUFDownloader::preparePartFilename(ggufFilename, 100000, 99999)).getCode(), StatusCode::INTERNAL_ERROR);
 }
+TEST_F(GGUFDownloaderMultipartUtils, CreateGGUFFilenamesToDownloadNegative) {
+    // too much zeros
+    auto statusOrFilenames = GGUFDownloader::createGGUFFilenamesToDownload("qwen2.5-7b-instruct-q4_k_m-0000001-of-00002.gguf");
+    // ---------------------------------------------------------------------------------------------------^
+    ASSERT_TRUE(std::holds_alternative<Status>(statusOrFilenames));
+    ASSERT_EQ(std::get<Status>(statusOrFilenames).getCode(), StatusCode::PATH_INVALID);
+    statusOrFilenames = GGUFDownloader::createGGUFFilenamesToDownload("qwen2.5-7b-instruct-q4_k_m-00001-of-000002.gguf");
+    // -------------------------------------------------------------------------------------------------------^
+    ASSERT_TRUE(std::holds_alternative<Status>(statusOrFilenames));
+    ASSERT_EQ(std::get<Status>(statusOrFilenames).getCode(), StatusCode::PATH_INVALID);
+}
 
 void find_file_in_tree(git_repository* repo, git_tree* tree,
     const std::regex& pattern,


### PR DESCRIPTION
Don't use curl to check with remote if the file exist when from filename we could predict it doesn't. This makes negative tests for GGUF more reliable in CI especially for modelscope.cn

Ticket:CVS-177618
