### PR TITLE
[wip] [redhat] RUN_TESTS=1 Install python3.12 before exporting unit test models

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -326,8 +326,14 @@ RUN bazel build --jobs=$JOBS ${debug_bazel_flags} ${minitrace_flags} //src:ovms 
 COPY ci/check_coverage.bat /ovms/
 ARG CHECK_COVERAGE=0
 ARG RUN_TESTS=0
+
+# Install python3.12 because UBI9 provides 3.9 which is not supported by openvino-tokenizers anymore
+RUN if [ "$RUN_TESTS" == "1" ] ; then dnf install python3.12 python3.12-devel python3.12-pip -y && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    alternatives --set python3 /usr/bin/python3.12 && python3 --version ; fi
 COPY run_unit_tests.sh prepare_llm_models.sh prepare_gpu_models.sh demos/common/export_models/export_model.py /ovms/
-RUN if [ "$RUN_TESTS" == "1" ] ; then mkdir -p demos/common/export_models/ && mv export_model.py demos/common/export_models/ && ./prepare_llm_models.sh /ovms/src/test/llm_testing docker && ./run_unit_tests.sh ; fi
+RUN if [ "$RUN_TESTS" == "1" ] ; then mkdir -p demos/common/export_models/ && mv export_model.py demos/common/export_models/ && \
+    ./prepare_llm_models.sh /ovms/src/test/llm_testing docker && ./run_unit_tests.sh ; fi
 
 ARG ovms_metadata_file
 


### PR DESCRIPTION
It fixes issue with openvino-tokenizer support missing for python 3.9 and below, however export_models.py still fails with:

```
Traceback (most recent call last):
  File "/usr/local/bin/optimum-cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/optimum/commands/optimum_cli.py", line 219, in main
    service.run()
  File "/usr/local/lib/python3.12/site-packages/optimum/commands/export/openvino.py", line 345, in run
    from ...exporters.openvino.__main__ import infer_task, main_export, maybe_convert_tokenizers
  File "/usr/local/lib/python3.12/site-packages/optimum/exporters/openvino/__init__.py", line 17, in <module>
    from .__main__ import main_export
  File "/usr/local/lib/python3.12/site-packages/optimum/exporters/openvino/__main__.py", line 28, in <module>
    from openvino import Core, Type, save_model
  File "/opt/intel/openvino/python/openvino/__init__.py", line 21, in <module>
    from openvino._pyopenvino import AxisSet
ImportError: cannot import name 'AxisSet' from 'openvino._pyopenvino' (unknown location)
Traceback (most recent call last):
  File "/ovms/demos/common/export_models/export_model.py", line 640, in <module>
    export_text_generation_model(args['model_repository_path'], args['source_model'], args['model_name'], args['precision'], template_parameters, args['config_file_path'])
  File "/ovms/demos/common/export_models/export_model.py", line 409, in export_text_generation_model
    raise ValueError("Failed to export llm model", source_model)
ValueError: ('Failed to export llm model', 'facebook/opt-125m')
```

https://github.com/openvinotoolkit/model_server/issues/3844