### PR TITLE
Fix opencl-header installation

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -111,8 +111,8 @@ ARG VERBOSE_LOGS=OFF
 ARG LTO_ENABLE=OFF
 
 # hadolint ignore=DL3041
-RUN dnf install -y https://rpmfind.net/linux/almalinux/8.10/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm && \
-            dnf update -d6 -y && dnf install -d6 -y \
+RUN dnf install -y -d6 \
+            https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm \
             gdb \
             java-11-openjdk-devel \
             tzdata-java \


### PR DESCRIPTION
The code "as is" installs opencl-headers from rhel8 because the rhel9 one leads to compilation failures. However, it immediately does a dnf -y update which upgrades the opencl package to the rhel 9 version that was being avoided. Compilation failures follow at 64% of the way through openvino's code.

The fix is to get rid of the dnf -y update because the image was already updated back at the first use of dnf.