### PR TITLE
fix plugin config usage in audio endpoints

### DIFF
--- a/src/audio/speech_to_text/BUILD
+++ b/src/audio/speech_to_text/BUILD
@@ -38,6 +38,7 @@ ovms_cc_library(
         ":s2t_servable",
         "//third_party:genai",
         "//src/audio:audio_utils",
+        "//src:libmodelconfigjsonparser",
     ],
     visibility = ["//visibility:public"],
     alwayslink = 1,

--- a/src/audio/speech_to_text/s2t_servable.hpp
+++ b/src/audio/speech_to_text/s2t_servable.hpp
@@ -39,14 +39,14 @@ struct SttServable {
     std::shared_ptr<ov::genai::WhisperPipeline> sttPipeline;
     std::mutex sttPipelineMutex;
 
-    SttServable(const std::string& modelDir, const std::string& targetDevice, const std::string& graphPath) {
+    SttServable(const std::string& modelDir, const S2TNodeOptions& nodeOptions, const std::string& graphPath) {
         auto fsModelsPath = std::filesystem::path(modelDir);
         if (fsModelsPath.is_relative()) {
             parsedModelsPath = (std::filesystem::path(graphPath) / fsModelsPath);
         } else {
-            parsedModelsPath = fsModelsPath.string();
+            parsedModelsPath = fsModelsPath;
         }
-        sttPipeline = std::make_shared<ov::genai::WhisperPipeline>(parsedModelsPath.string(), targetDevice);
+        sttPipeline = std::make_shared<ov::genai::WhisperPipeline>(parsedModelsPath.string(), nodeOptions.target_device(), nodeOptions.plugin_config());
     }
 };
 

--- a/src/audio/speech_to_text/s2t_servable.hpp
+++ b/src/audio/speech_to_text/s2t_servable.hpp
@@ -49,7 +49,7 @@ struct SttServable {
         } else {
             parsedModelsPath = fsModelsPath;
         }
-        plugin_config_t config;
+        ov::AnyMap config;
         auto status = JsonParser::parsePluginConfig(nodeOptions.plugin_config(), config);
         if (!status.ok()) {
             SPDLOG_ERROR("Error during llm node plugin_config option parsing to JSON: {}", nodeOptions.plugin_config());

--- a/src/audio/text_to_speech/BUILD
+++ b/src/audio/text_to_speech/BUILD
@@ -38,6 +38,7 @@ ovms_cc_library(
         ":t2s_servable",
         "//third_party:genai",
         "//src/audio:audio_utils",
+        "//src:libmodelconfigjsonparser",
     ],
     visibility = ["//visibility:public"],
     alwayslink = 1,

--- a/src/audio/text_to_speech/t2s_servable.hpp
+++ b/src/audio/text_to_speech/t2s_servable.hpp
@@ -39,14 +39,14 @@ struct TtsServable {
     std::shared_ptr<ov::genai::Text2SpeechPipeline> ttsPipeline;
     std::mutex ttsPipelineMutex;
 
-    TtsServable(const std::string& modelDir, const std::string& targetDevice, const std::string& graphPath) {
+    TtsServable(const std::string& modelDir, const T2SNodeOptions& nodeOptions, const std::string& graphPath) {
         auto fsModelsPath = std::filesystem::path(modelDir);
         if (fsModelsPath.is_relative()) {
             parsedModelsPath = (std::filesystem::path(graphPath) / fsModelsPath);
         } else {
-            parsedModelsPath = fsModelsPath.string();
+            parsedModelsPath = fsModelsPath;
         }
-        ttsPipeline = std::make_shared<ov::genai::Text2SpeechPipeline>(parsedModelsPath.string(), targetDevice);
+        ttsPipeline = std::make_shared<ov::genai::Text2SpeechPipeline>(parsedModelsPath.string(), nodeOptions.target_device(), nodeOptions.plugin_config());
     }
 };
 

--- a/src/audio/text_to_speech/t2s_servable.hpp
+++ b/src/audio/text_to_speech/t2s_servable.hpp
@@ -50,7 +50,7 @@ struct TtsServable {
         } else {
             parsedModelsPath = fsModelsPath;
         }
-        std::map<std::string, ov::Any> config;
+        ov::AnyMap config;
         Status status = JsonParser::parsePluginConfig(nodeOptions.plugin_config(), config);
         if (!status.ok()) {
             SPDLOG_ERROR("Error during llm node plugin_config option parsing to JSON: {}", nodeOptions.plugin_config());

--- a/src/json_parser.hpp
+++ b/src/json_parser.hpp
@@ -13,9 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
-#ifndef SRC_JSON_PARSER_HPP_
-#define SRC_JSON_PARSER_HPP_
-#endif  // SRC_JSON_PARSER_HPP_
+
+#pragma once
 #include <map>
 #include <string>
 

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -585,8 +585,12 @@ Status MediapipeGraphDefinition::initializeNodes() {
                 return StatusCode::LLM_NODE_NAME_ALREADY_EXISTS;
             }
             mediapipe::S2tCalculatorOptions nodeOptions;
-            config.node(i).node_options(0).UnpackTo(&nodeOptions);
-            std::shared_ptr<SttServable> servable = std::make_shared<SttServable>(nodeOptions.models_path(), nodeOptions, mgconfig.getBasePath());
+            auto& calculatorOptions = config.node(i).node_options(0);
+            if (!calculatorOptions.UnpackTo(&nodeOptions)) {
+                SPDLOG_LOGGER_ERROR(modelmanager_logger, "Failed to unpack calculator options");
+                return StatusCode::MEDIAPIPE_GRAPH_CONFIG_FILE_INVALID;
+            }
+            std::shared_ptr<SttServable> servable = std::make_shared<SttServable>(nodeOptions, mgconfig.getBasePath());
             sttServableMap.insert(std::pair<std::string, std::shared_ptr<SttServable>>(nodeName, std::move(servable)));
             sttServablesCleaningGuard.disableCleaning();
         }
@@ -607,8 +611,12 @@ Status MediapipeGraphDefinition::initializeNodes() {
                 return StatusCode::LLM_NODE_NAME_ALREADY_EXISTS;
             }
             mediapipe::T2sCalculatorOptions nodeOptions;
-            config.node(i).node_options(0).UnpackTo(&nodeOptions);
-            std::shared_ptr<TtsServable> servable = std::make_shared<TtsServable>(nodeOptions.models_path(), nodeOptions, mgconfig.getBasePath());
+            auto& calculatorOptions = config.node(i).node_options(0);
+            if (!calculatorOptions.UnpackTo(&nodeOptions)) {
+                SPDLOG_LOGGER_ERROR(modelmanager_logger, "Failed to unpack calculator options");
+                return StatusCode::MEDIAPIPE_GRAPH_CONFIG_FILE_INVALID;
+    }
+            std::shared_ptr<TtsServable> servable = std::make_shared<TtsServable>(nodeOptions, mgconfig.getBasePath());
             ttsServableMap.insert(std::pair<std::string, std::shared_ptr<TtsServable>>(nodeName, std::move(servable)));
             ttsServablesCleaningGuard.disableCleaning();
         }

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -586,7 +586,7 @@ Status MediapipeGraphDefinition::initializeNodes() {
             }
             mediapipe::S2tCalculatorOptions nodeOptions;
             config.node(i).node_options(0).UnpackTo(&nodeOptions);
-            std::shared_ptr<SttServable> servable = std::make_shared<SttServable>(nodeOptions.models_path(), nodeOptions.target_device(), mgconfig.getBasePath());
+            std::shared_ptr<SttServable> servable = std::make_shared<SttServable>(nodeOptions.models_path(), nodeOptions, mgconfig.getBasePath());
             sttServableMap.insert(std::pair<std::string, std::shared_ptr<SttServable>>(nodeName, std::move(servable)));
             sttServablesCleaningGuard.disableCleaning();
         }
@@ -608,7 +608,7 @@ Status MediapipeGraphDefinition::initializeNodes() {
             }
             mediapipe::T2sCalculatorOptions nodeOptions;
             config.node(i).node_options(0).UnpackTo(&nodeOptions);
-            std::shared_ptr<TtsServable> servable = std::make_shared<TtsServable>(nodeOptions.models_path(), nodeOptions.target_device(), mgconfig.getBasePath());
+            std::shared_ptr<TtsServable> servable = std::make_shared<TtsServable>(nodeOptions.models_path(), nodeOptions, mgconfig.getBasePath());
             ttsServableMap.insert(std::pair<std::string, std::shared_ptr<TtsServable>>(nodeName, std::move(servable)));
             ttsServablesCleaningGuard.disableCleaning();
         }

--- a/src/mediapipe_internal/mediapipegraphdefinition.cpp
+++ b/src/mediapipe_internal/mediapipegraphdefinition.cpp
@@ -615,7 +615,7 @@ Status MediapipeGraphDefinition::initializeNodes() {
             if (!calculatorOptions.UnpackTo(&nodeOptions)) {
                 SPDLOG_LOGGER_ERROR(modelmanager_logger, "Failed to unpack calculator options");
                 return StatusCode::MEDIAPIPE_GRAPH_CONFIG_FILE_INVALID;
-    }
+            }
             std::shared_ptr<TtsServable> servable = std::make_shared<TtsServable>(nodeOptions, mgconfig.getBasePath());
             ttsServableMap.insert(std::pair<std::string, std::shared_ptr<TtsServable>>(nodeName, std::move(servable)));
             ttsServablesCleaningGuard.disableCleaning();


### PR DESCRIPTION
### 🛠 Summary

CVS-178771 - correct passing plugin config to audio models. It resolves compilation cache usage in audio models

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

