### PR TITLE
Updates to the Red Hat Dockerfile for Konflux

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -347,6 +347,7 @@ ARG LTO_ENABLE=OFF
 WORKDIR /ovms
 # Konflux has a hard time locating the built binaries. Need to put it
 # in a known location.
+# hadolint ignore=DL4006 
 RUN mkdir -p /tmp/bazel-output && \
     bazel --output_base=/tmp/bazel-output \
         build --jobs=$JOBS ${CAPI_FLAGS} //src:ovms_shared && \
@@ -363,6 +364,7 @@ RUN bazel build --jobs $JOBS ${CAPI_FLAGS} //src:capi_cpp_example
 # C-API benchmark app
 # Konflux has a hard time locating the built binaries. Need to put it
 # in a known location.
+# hadolint ignore=DL4006 
 RUN mkdir -p /tmp/bazel-output && \
     bazel --output_base=/tmp/bazel-output \
         build --jobs=$JOBS ${CAPI_FLAGS} //src:capi_benchmark && \


### PR DESCRIPTION
The konflux build system has trouble in 2 areas.

1) It cuts of network access at certain times. The solution was to build a group of the software in one shot.

2) Konflux causes bazel to do things differently which results in not being able to find libovms_shared.so or capi_benchmark. So, it was changed to try to put it in a known spot for searching.

These changes do not affect the build done by Docker or podman.