### PR TITLE
Disabling verbose logging after sign

### DIFF
--- a/ci/windows_sign.bat
+++ b/ci/windows_sign.bat
@@ -18,7 +18,7 @@ if /I "%RELEASE_TYPE%"=="RELEASE" (
     set "RELEASE_OPT="
 )
 
-python check_signing.py --user=%OVMS_USER% --path=%OVMS_FILES% %PYTHON_OPT% %RELEASE_OPT% --auto --verbose --print_all 2>&1 | tee ..\..\win_sign.log
+python check_signing.py --user=%OVMS_USER% --path=%OVMS_FILES% %PYTHON_OPT% %RELEASE_OPT% --auto --print_all 2>&1 | tee ..\..\win_sign.log
 python check_signing.py --zip --path=%OVMS_FILES% %PYTHON_OPT% --auto
 
 for %%f in (ovms_windows_python_*) do (


### PR DESCRIPTION
### 🛠 Summary

Disabling verbose logging in signing script

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

