### PR TITLE
CVS-181973_windows_build_add_tag_option

### DIFF
--- a/ci/build_test_OnCommitWin.groovy
+++ b/ci/build_test_OnCommitWin.groovy
@@ -21,7 +21,6 @@ pipeline {
                           windows.build()
                           windows.unit_test()
                           windows.check_tests()
-                          println("test=${env.USE_BRANCH_NAME_IN_PACKAGE_NAME}")
                           if (env.USE_BRANCH_NAME_IN_PACKAGE_NAME == "true") {
                             def safeBranchName = env.BRANCH_NAME.replaceAll('/', '_')
                             tag = "${safeBranchName}-${env.CUSTOM_TAG}"


### PR DESCRIPTION
### 🛠 Summary

Add option to use custom tag in windows build pipelines

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

