### PR TITLE
[release] [github issue] Unmatched curl versions (#4036)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,7 +138,7 @@ cc_library(
 
 new_local_repository(
     name = "windows_curl",
-    path = "C:\\opt\\curl-8.14.1_1-win64-mingw",
+    path = "C:\\opt\\curl-8.18.0_4-win64-mingw",
     build_file_content = """
 cc_import(
     name = "curl_lib",

--- a/third_party/libgit2/libgit2_engine.bzl
+++ b/third_party/libgit2/libgit2_engine.bzl
@@ -59,7 +59,7 @@ def _impl(repository_ctx):
         "BUILD_EXAMPLES": "OFF",
         "BUILD_TESTS": "OFF",
         "BUILD_CLI": "OFF",
-        "CURL_DEPENDENCIES_DIR": "C:/opt/curl-8.14.1_1-win64-mingw",
+        "CURL_DEPENDENCIES_DIR": "C:/opt/curl-8.18.0_4-win64-mingw",
         """
     else:
         lib_name = "libgit2"

--- a/windows_install_build_dependencies.bat
+++ b/windows_install_build_dependencies.bat
@@ -500,11 +500,13 @@ exit /b 0
 :install_curl
 echo [INFO] Installing curl ...
 
-set "curl_dir=curl-8.18.0_4-win64-mingw"
-set "curl_ver=curl-8.18.0_4-win64-mingw.zip"
-set "curl_http=https://curl.se/windows/dl-8.18.0_4/"
+set "curl_version=8.18.0_4"
+set "curl_dir=curl-%curl_version%-win64-mingw"
+set "curl_ver=%curl_dir%.zip"
+set "curl_http=https://curl.se/windows/dl-%curl_version%/"
 
 set "curl_zip=%opt_install_dir%\%curl_ver%"
+set "curl_path=%opt_install_dir%\%curl_dir%"
 
 :: Download curl
 IF /I EXIST %curl_zip% (
@@ -520,13 +522,13 @@ IF /I EXIST %curl_zip% (
     if !errorlevel! neq 0 exit /b !errorlevel!
 )
 :: Extract curl
-IF /I EXIST %opt_install_dir%\%curl_dir% (
+IF /I EXIST %curl_path% (
      if %expunge% EQU 1 (
-        rmdir /S /Q %opt_install_dir%\%curl_dir%
+        rmdir /S /Q %curl_path%
         if !errorlevel! neq 0 exit /b !errorlevel!
         C:\Windows\System32\tar.exe -xf "%curl_zip%" -C %opt_install_dir%
         if !errorlevel! neq 0 exit /b !errorlevel!
-    ) else ( echo [INFO] directory exists %opt_install_dir%\%curl_dir% )
+    ) else ( echo [INFO] directory exists %curl_path% )
     
 ) ELSE (
     C:\Windows\System32\tar.exe -xf "%curl_zip%" -C %opt_install_dir%
@@ -534,7 +536,7 @@ IF /I EXIST %opt_install_dir%\%curl_dir% (
 )
 
 :: Create lib file for libgit2 linking
-set "curl_lib=C:\opt\curl-8.18.0_4-win64-mingw\bin\libcurl-x64.lib"
+set "curl_lib=%curl_path%\bin\libcurl-x64.lib"
 IF /I EXIST %curl_lib% (
     echo [INFO] file exists %curl_lib% 
 ) ELSE (
@@ -549,7 +551,7 @@ IF /I EXIST %curl_lib% (
     exit /b
     :create_lib
 	IF /I EXIST !LIB_EXE! (
-		set "curl_def=C:\opt\curl-8.18.0_4-win64-mingw\bin\libcurl-x64.def"
+		set "curl_def=%curl_path%\bin\libcurl-x64.def"
 		"!LIB_EXE!" /def:!curl_def! /out:%curl_lib% /MACHINE:x64
 		if !errorlevel! neq 0 exit /b !errorlevel!
         echo [INFO] !LIB_EXE! created.


### PR DESCRIPTION
### 🛠 Summary

Changing curl version in WORKSPACE to match dependency installation script to enable building without error.
It's related to [github
issue](https://github.com/openvinotoolkit/model_server/issues/4026)

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices. ``


