### PR TITLE
CVS-185120 sentence-transformers fixed to 5.3.0

### DIFF
--- a/demos/common/export_models/requirements.txt
+++ b/demos/common/export_models/requirements.txt
@@ -12,7 +12,7 @@ numpy
 openvino-tokenizers==2026.2.0.dev20260414
 openvino==2026.2.0.dev20260414
 pillow
-sentence_transformers
+sentence_transformers==5.3.0
 sentencepiece  # Required by: transformers`
 timm==1.0.22
 torchvision


### PR DESCRIPTION
### 🛠 Summary 
Related jira: https://jira.devtools.intel.com/browse/CVS-185120
sentence-transformers set to 5.3.0 in export_models requirements

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

