### PR TITLE
CVS-185120 sentence-transformers fixed to 5.3.0 (#4144)

### DIFF
--- a/demos/common/export_models/requirements.txt
+++ b/demos/common/export_models/requirements.txt
@@ -12,7 +12,7 @@ numpy
 openvino-tokenizers==2026.1.0.0rc2
 openvino==2026.1.0rc2
 pillow
-sentence_transformers
+sentence_transformers==5.3.0
 sentencepiece  # Required by: transformers`
 timm==1.0.22
 torchvision


### PR DESCRIPTION
### 🛠 Summary

Related jira: https://jira.devtools.intel.com/browse/CVS-185120
sentence-transformers set to 5.3.0 in export_models requirements
cherrypick from: https://github.com/openvinotoolkit/model_server/commit/ce9e9c74c38d59565fd2a3cbcd1bdf2c8018f796

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

