### PR TITLE
Python chat template application fix

### DIFF
--- a/src/llm/servable_initializer.cpp
+++ b/src/llm/servable_initializer.cpp
@@ -253,6 +253,8 @@ void GenAiServableInitializer::loadPyTemplateProcessor(std::shared_ptr<GenAiServ
             jinja_env.globals["raise_exception"] = raise_exception
             jinja_env.globals["strftime_now"] = strftime_now
             jinja_env.filters["from_json"] = json.loads
+            # Override tojson to return plain str instead of Markup to prevent HTML escaping in LLM prompts
+            jinja_env.filters["tojson"] = lambda value, indent=None: json.dumps(value, ensure_ascii=False) if indent is None else json.dumps(value, ensure_ascii=False, indent=indent)
 
             # Try to read data from tokenizer_config.json to get additional tool chat template if present
             tokenizer_config_file = Path(templates_directory + "/tokenizer_config.json")

--- a/src/llm/servable_initializer.cpp
+++ b/src/llm/servable_initializer.cpp
@@ -254,7 +254,7 @@ void GenAiServableInitializer::loadPyTemplateProcessor(std::shared_ptr<GenAiServ
             jinja_env.globals["strftime_now"] = strftime_now
             jinja_env.filters["from_json"] = json.loads
             # Override tojson to return plain str instead of Markup to prevent HTML escaping in LLM prompts
-            jinja_env.filters["tojson"] = lambda value, indent=None: json.dumps(value, ensure_ascii=False) if indent is None else json.dumps(value, ensure_ascii=False, indent=indent)
+            jinja_env.filters["tojson"] = lambda value, indent=None: json.dumps(value, ensure_ascii=False, indent=indent)
 
             # Try to read data from tokenizer_config.json to get additional tool chat template if present
             tokenizer_config_file = Path(templates_directory + "/tokenizer_config.json")

--- a/src/test/llm/llmtemplate_test.cpp
+++ b/src/test/llm/llmtemplate_test.cpp
@@ -368,6 +368,49 @@ TEST_F(LLMChatTemplateTest, ChatTemplateKwargsNegative) {
     ASSERT_EQ(finalPrompt, expectedOutput);
 }
 
+TEST_F(LLMChatTemplateTest, ChatTemplateTojsonNoHtmlEscaping) {
+    // Simulates Granite/DeepSeek-R1 style tool_call templates that use tojson
+    // The tojson filter must return plain JSON, not HTML-escaped Markup.
+    // Without the override, Jinja2's default tojson wraps output in Markup,
+    // causing < > & " to be escaped as &lt; &gt; &amp; &quot; when
+    // concatenated with plain strings via + in {% set %} blocks.
+    //
+    // Key: the bug only manifests when tojson output (Markup) is concatenated
+    // with a plain str inside {% set %}, because Markup.__radd__ escapes the
+    // str operand. Direct {{ tojson }} rendering does NOT trigger the bug.
+    std::string jinjaTemplate =
+        "{%- set ns = namespace(tool_text='<tools>') %}"
+        "{%- if tools %}"
+        "  {%- for tool in tools %}"
+        "    {%- set ns.tool_text = ns.tool_text + '\\n' + (tool | tojson) %}"
+        "  {%- endfor %}"
+        "  {%- set ns.tool_text = ns.tool_text + '\\n</tools>' %}"
+        "{%- endif %}"
+        "{{ ns.tool_text }}";
+    ASSERT_EQ(CreateJinjaConfig(jinjaTemplate), true);
+    LoadTemplateProcessor();
+
+    std::string finalPrompt = "";
+    std::string payloadBody = R"(
+        {
+            "model": "gpt",
+            "stream": false,
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object"}}}]
+        }
+    )";
+    ASSERT_EQ(PyJinjaTemplateProcessor::applyChatTemplate(servable->getProperties()->templateProcessor, servable->getProperties()->modelsPath, payloadBody, finalPrompt), true);
+    // Must contain literal <tools> tags, NOT &lt;tools&gt;
+    EXPECT_THAT(finalPrompt, ::testing::HasSubstr("<tools>"));
+    EXPECT_THAT(finalPrompt, ::testing::HasSubstr("</tools>"));
+    // Must not contain any HTML-escaped entities
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&lt;")));
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&gt;")));
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&quot;")));
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&amp;")));
+    EXPECT_THAT(finalPrompt, ::testing::HasSubstr("get_weather"));
+}
+
 std::string configTemplate = R"(
         {
             "model_config_list": [],

--- a/src/test/llm/llmtemplate_test.cpp
+++ b/src/test/llm/llmtemplate_test.cpp
@@ -411,6 +411,44 @@ TEST_F(LLMChatTemplateTest, ChatTemplateTojsonNoHtmlEscaping) {
     EXPECT_THAT(finalPrompt, ::testing::HasSubstr("get_weather"));
 }
 
+TEST_F(LLMChatTemplateTest, ChatTemplateTojsonIndentWorks) {
+    // Verifies that tojson(indent=2) still produces indented JSON output
+    // after the tojson override that prevents HTML escaping.
+    std::string jinjaTemplate =
+        "{%- set ns = namespace(tool_text='<tools>') %}"
+        "{%- if tools %}"
+        "  {%- for tool in tools %}"
+        "    {%- set ns.tool_text = ns.tool_text + '\\n' + (tool | tojson(indent=2)) %}"
+        "  {%- endfor %}"
+        "  {%- set ns.tool_text = ns.tool_text + '\\n</tools>' %}"
+        "{%- endif %}"
+        "{{ ns.tool_text }}";
+    ASSERT_EQ(CreateJinjaConfig(jinjaTemplate), true);
+    LoadTemplateProcessor();
+
+    std::string finalPrompt = "";
+    std::string payloadBody = R"(
+        {
+            "model": "gpt",
+            "stream": false,
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object"}}}]
+        }
+    )";
+    ASSERT_EQ(PyJinjaTemplateProcessor::applyChatTemplate(servable->getProperties()->templateProcessor, servable->getProperties()->modelsPath, payloadBody, finalPrompt), true);
+    // Must contain literal <tools> tags, NOT &lt;tools&gt;
+    EXPECT_THAT(finalPrompt, ::testing::HasSubstr("<tools>"));
+    EXPECT_THAT(finalPrompt, ::testing::HasSubstr("</tools>"));
+    // Must not contain any HTML-escaped entities
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&lt;")));
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&gt;")));
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&quot;")));
+    EXPECT_THAT(finalPrompt, ::testing::Not(::testing::HasSubstr("&amp;")));
+    EXPECT_THAT(finalPrompt, ::testing::HasSubstr("get_weather"));
+    // Verify indentation is present — indent=2 produces newlines and spaces inside JSON
+    EXPECT_THAT(finalPrompt, ::testing::HasSubstr("  \"type\": \"function\""));
+}
+
 std::string configTemplate = R"(
         {
             "model_config_list": [],


### PR DESCRIPTION
### 🛠 Summary

Fixes ibm granite 4, deep-seek R1 and potentially other

Without this change, chat template applied by Python's jinja causes wrong escaping:
```
&lt;tool_call&gt;
{"name": "get_weather", "arguments": "{\n  \"location\": \"Paris\"\n}"}
&lt;/tool_call&gt;
```

After the change it is correct:
```
<tool_call>
{"name": "get_weather", "arguments": "{
  \"location\": \"Paris\"
}"}
</tool_call>
```