### PR TITLE
Readiness improvements

### DIFF
--- a/src/http_rest_api_handler.cpp
+++ b/src/http_rest_api_handler.cpp
@@ -240,7 +240,7 @@ Status HttpRestApiHandler::processServerReadyKFSRequest(const HttpRequestCompone
     if (isReady) {
         return StatusCode::OK;
     }
-    return StatusCode::MODEL_NOT_LOADED;
+    return StatusCode::SERVER_NOT_READY;
 }
 
 Status HttpRestApiHandler::processServerLiveKFSRequest(const HttpRequestComponents& request_components, std::string& response, const std::string& request_body) {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -81,6 +81,7 @@ static const ovms::HTTPStatusCode http(const ovms::Status& status) {
         {StatusCode::FILE_INVALID, ovms::HTTPStatusCode::ERROR},
         {StatusCode::NO_MODEL_VERSION_AVAILABLE, ovms::HTTPStatusCode::ERROR},
         {StatusCode::MODEL_NOT_LOADED, ovms::HTTPStatusCode::ERROR},
+        {StatusCode::SERVER_NOT_READY, ovms::HTTPStatusCode::SERVICE_UNAV},
         {StatusCode::JSON_INVALID, ovms::HTTPStatusCode::PRECOND_FAILED},
         {StatusCode::MODELINSTANCE_NOT_FOUND, ovms::HTTPStatusCode::ERROR},
         {StatusCode::SHAPE_WRONG_FORMAT, ovms::HTTPStatusCode::ERROR},

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -427,7 +427,6 @@ Status Server::startModules(ovms::Config& config) {
         if (!status.ok()) {
             return status;
         }
-
     }
     GET_MODULE(SERVABLE_MANAGER_MODULE_NAME, it);
     START_MODULE(it);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -380,14 +380,9 @@ Status Server::startModules(ovms::Config& config) {
     if (config.getServerSettings().serverMode == HF_PULL_MODE) {
         INSERT_MODULE(HF_MODEL_PULL_MODULE_NAME, it);
         START_MODULE(it);
-        if (!status.ok()) {
-            return status;
-        }
         auto hfModule = dynamic_cast<const HfPullModelModule*>(it->second.get());
         status = hfModule->clone();
-        // Return from modules only in --pull mode or error, otherwise start the rest of modules
-        if (config.getServerSettings().serverMode == HF_PULL_MODE || !status.ok())
-            return status;
+        return status;
     }
 
 #if (PYTHON_DISABLE == 0)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -377,7 +377,7 @@ Status Server::startModules(ovms::Config& config) {
         START_MODULE(it);
         return status;
     }
-    if (config.getServerSettings().serverMode == HF_PULL_MODE || config.getServerSettings().serverMode == HF_PULL_AND_START_MODE) {
+    if (config.getServerSettings().serverMode == HF_PULL_MODE) {
         INSERT_MODULE(HF_MODEL_PULL_MODULE_NAME, it);
         START_MODULE(it);
         if (!status.ok()) {
@@ -415,6 +415,19 @@ Status Server::startModules(ovms::Config& config) {
     if (config.restPort() != 0) {
         INSERT_MODULE(HTTP_SERVER_MODULE_NAME, it);
         START_MODULE(it);
+    }
+    if (config.getServerSettings().serverMode == HF_PULL_AND_START_MODE) {
+        INSERT_MODULE(HF_MODEL_PULL_MODULE_NAME, it);
+        START_MODULE(it);
+        if (!status.ok()) {
+            return status;
+        }
+        auto hfModule = dynamic_cast<const HfPullModelModule*>(it->second.get());
+        status = hfModule->clone();
+        if (!status.ok()) {
+            return status;
+        }
+
     }
     GET_MODULE(SERVABLE_MANAGER_MODULE_NAME, it);
     START_MODULE(it);

--- a/src/test/kfs_rest_test.cpp
+++ b/src/test/kfs_rest_test.cpp
@@ -46,6 +46,17 @@ namespace {
 class MockedServer : public Server {
 public:
     MockedServer() = default;
+    std::unique_ptr<Module> extractModule(const std::string& name) {
+        auto it = modules.find(name);
+        if (it == modules.end())
+            return nullptr;
+        auto mod = std::move(it->second);
+        modules.erase(it);
+        return mod;
+    }
+    void insertModule(const std::string& name, std::unique_ptr<Module> mod) {
+        modules[name] = std::move(mod);
+    }
 };
 }  // namespace
 
@@ -1613,6 +1624,25 @@ TEST_F(HttpRestApiHandlerTest, serverReady) {
     ovms::Status status = handler->dispatchToProcessor("", request, &response, comp, responseComponents, writer, multiPartParser);
 
     ASSERT_EQ(status, ovms::StatusCode::OK);
+}
+
+TEST_F(HttpRestApiHandlerTest, serverNotReady) {
+    // Temporarily remove servable manager module to make isReady() return false
+    auto mod = server->extractModule(ovms::SERVABLE_MANAGER_MODULE_NAME);
+
+    ovms::HttpRequestComponents comp;
+    comp.type = ovms::KFS_GetServerReady;
+    std::string request;
+    std::string response;
+    ovms::HttpResponseComponents responseComponents;
+    std::shared_ptr<ovms::HttpAsyncWriter> writer{nullptr};
+    std::shared_ptr<ovms::MultiPartParser> multiPartParser{nullptr};
+    ovms::Status status = handler->dispatchToProcessor("", request, &response, comp, responseComponents, writer, multiPartParser);
+
+    ASSERT_EQ(status, ovms::StatusCode::SERVER_NOT_READY);
+
+    // Restore the module so other tests are not affected
+    server->insertModule(ovms::SERVABLE_MANAGER_MODULE_NAME, std::move(mod));
 }
 
 TEST_F(HttpRestApiHandlerTest, serverLive) {

--- a/src/test/pull_hf_model_test.cpp
+++ b/src/test/pull_hf_model_test.cpp
@@ -1034,6 +1034,6 @@ TEST(ServerModulesBehaviorTests, PullAndStartModeErrorAndExpectFailAndNoOtherMod
     serverGuard = std::make_unique<ServerShutdownGuard>(server);
     EXPECT_TRUE(server.getModule(ovms::HF_MODEL_PULL_MODULE_NAME) != nullptr);
     ASSERT_EQ(server.getModule(ovms::HF_MODEL_PULL_MODULE_NAME)->getState(), ovms::ModuleState::INITIALIZED);
-    ASSERT_EQ(server.getModule(ovms::SERVABLE_MANAGER_MODULE_NAME), nullptr);
+    ASSERT_NE(server.getModule(ovms::SERVABLE_MANAGER_MODULE_NAME), nullptr);
     ASSERT_EQ(server.getModule(ovms::SERVABLES_CONFIG_MANAGER_MODULE_NAME), nullptr);
 }

--- a/src/test/pull_hf_model_test.cpp
+++ b/src/test/pull_hf_model_test.cpp
@@ -1022,7 +1022,7 @@ TEST(ServerModulesBehaviorTests, PullModeErrorAndExpectFailAndNoOtherModulesStar
     ASSERT_EQ(server.getModule(ovms::SERVABLES_CONFIG_MANAGER_MODULE_NAME), nullptr);
 }
 
-TEST(ServerModulesBehaviorTests, PullAndStartModeErrorAndExpectFailAndNoOtherModulesStarted) {
+TEST(ServerModulesBehaviorTests, PullAndStartModeErrorAndExpectFailAndCheckOtherModules) {
     std::unique_ptr<ServerShutdownGuard> serverGuard;
     ovms::Server& server = ovms::Server::instance();
     DefaultEmptyValuesConfig config;
@@ -1034,6 +1034,6 @@ TEST(ServerModulesBehaviorTests, PullAndStartModeErrorAndExpectFailAndNoOtherMod
     serverGuard = std::make_unique<ServerShutdownGuard>(server);
     EXPECT_TRUE(server.getModule(ovms::HF_MODEL_PULL_MODULE_NAME) != nullptr);
     ASSERT_EQ(server.getModule(ovms::HF_MODEL_PULL_MODULE_NAME)->getState(), ovms::ModuleState::INITIALIZED);
-    ASSERT_NE(server.getModule(ovms::SERVABLE_MANAGER_MODULE_NAME), nullptr);
+    ASSERT_NE(server.getModule(ovms::SERVABLE_MANAGER_MODULE_NAME), nullptr);  // expected to be started
     ASSERT_EQ(server.getModule(ovms::SERVABLES_CONFIG_MANAGER_MODULE_NAME), nullptr);
 }


### PR DESCRIPTION
### 🛠 Summary

Starting http server before model pulling from HF - this is needed to report correctly readiness state while the model is downloaded
Corrected error status and message when server is not ready

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

