### PR TITLE
Non blocking non git

### DIFF
--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -343,7 +343,8 @@ public:
      * Opens a git repository at the specified filesystem path.
      *
      * @param path Absolute or relative path to the git repository directory.
-     * @note Works on specific git repository location (searches for .git directory).
+     * @note Opens the repository only at the provided path; parent directories
+     * are not searched for a .git directory.
      */
     explicit GitRepositoryGuard(const std::string& path) {
         // GIT_REPOSITORY_OPEN_NO_SEARCH: open the repository ONLY at `path`.

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -346,7 +346,12 @@ public:
      * @note Works on specific git repository location (searches for .git directory).
      */
     explicit GitRepositoryGuard(const std::string& path) {
-        int error = git_repository_open_ext(&repo, path.c_str(), 0, nullptr);
+        // GIT_REPOSITORY_OPEN_NO_SEARCH: open the repository ONLY at `path`.
+        // Without this flag (i.e. flags=0) libgit2 walks up the parent directory
+        // tree looking for a .git, which on hosts where the model directory is
+        // nested under another git checkout (e.g. Jenkins workspace) would
+        // misidentify the outer repo as ours and skip the download silently.
+        int error = git_repository_open_ext(&repo, path.c_str(), GIT_REPOSITORY_OPEN_NO_SEARCH, nullptr);
         if (error < 0) {
             const git_error* err = git_error_last();
             if (err) {

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -341,11 +341,11 @@ public:
 
     /**
      * Opens a git repository at the specified filesystem path.
-     * 
+     *
      * @param path Absolute or relative path to the git repository directory.
      * @note Works on specific git repository location (searches for .git directory).
      */
-    GitRepositoryGuard(const std::string& path) {
+    explicit GitRepositoryGuard(const std::string& path) {
         int error = git_repository_open_ext(&repo, path.c_str(), 0, nullptr);
         if (error < 0) {
             const git_error* err = git_error_last();
@@ -395,6 +395,16 @@ public:
     }
 };
 
+namespace {
+Status mapRepositoryOpenFailureToStatus(const GitRepositoryGuard& repoGuard) {
+    if (repoGuard.git_error_class == GIT_ERROR_OS)
+        return StatusCode::HF_GIT_STATUS_FAILED_TO_RESOLVE_PATH;
+    if (repoGuard.git_error_class == GIT_ERROR_INVALID)
+        return StatusCode::HF_GIT_LIBGIT2_NOT_INITIALIZED;
+    return StatusCode::HF_GIT_STATUS_FAILED;
+}
+}  // namespace
+
 /**
  * Verifies the cleanliness of a git repository after clone or download operations.
  * Checks for staged changes, unstaged modifications, untracked files, and merge conflicts.
@@ -412,12 +422,7 @@ Status HfDownloader::CheckRepositoryStatus(bool checkUntracked) {
 
     GitRepositoryGuard repoGuard(this->downloadPath);
     if (!repoGuard.get()) {
-        if (repoGuard.git_error_class == GIT_ERROR_OS)
-            return StatusCode::HF_GIT_STATUS_FAILED_TO_RESOLVE_PATH;
-        else if (repoGuard.git_error_class == GIT_ERROR_INVALID)
-            return StatusCode::HF_GIT_LIBGIT2_NOT_INITIALIZED;
-        else
-            return StatusCode::HF_GIT_STATUS_FAILED;
+        return mapRepositoryOpenFailureToStatus(repoGuard);
     }
     // HEAD state info
     bool is_detached = git_repository_head_detached(repoGuard.get()) == 1;
@@ -1070,14 +1075,6 @@ struct ResumeCandidates {
     std::vector<fs::path> missingNonLfsMatches;
 };
 
-Status mapRepositoryOpenFailureToStatus(const GitRepositoryGuard& repoGuard) {
-    if (repoGuard.git_error_class == GIT_ERROR_OS)
-        return StatusCode::HF_GIT_STATUS_FAILED_TO_RESOLVE_PATH;
-    if (repoGuard.git_error_class == GIT_ERROR_INVALID)
-        return StatusCode::HF_GIT_LIBGIT2_NOT_INITIALIZED;
-    return StatusCode::HF_GIT_STATUS_FAILED;
-}
-
 /**
  * Builds resume candidate lists based on interruption markers and repository scan.
  * 
@@ -1223,29 +1220,28 @@ Status resumeExistingRepository(git_repository* repo,
 
 Status handleExistingRepositoryWithoutOverwrite(const std::string& downloadPath,
     const std::function<Status(bool)>& checkRepositoryStatusFn) {
-    GitRepositoryGuard repoGuard(downloadPath);
-    if (!repoGuard.get()) {
-        // libgit2 not being initialized is a configuration issue, but we still want
-        // model loading to proceed against whatever files are already on disk.
-        // Surface it as an additional warning rather than a hard error.
-        if (repoGuard.git_error_class == GIT_ERROR_INVALID) {
-            SPDLOG_WARN("libgit2 is not initialized; cannot inspect existing path \"{}\" for model pull. "
-                        "Skipping pull and using existing files.",
-                downloadPath);
-            std::cout << "Warning: libgit2 is not initialized. Skipping pull and using existing files at: "
-                      << downloadPath << std::endl;
-            return StatusCode::OK;
-        }
-        // The path exists (caller verified is_directory) but it is not a git repository.
-        // Treat it as a user-provided model directory: warn and let model loading proceed
-        // against whatever files are already on disk.
-        SPDLOG_WARN("Path \"{}\" already exists but is not a git repository. Skipping pull and using existing files. "
-                    "Use --overwrite_models to replace the directory with a fresh download.",
+    // If the directory does not contain a .git entry, treat it as a user-provided model directory.
+    // The user has copied model files in by hand; skip the pull and let model loading proceed
+    // against whatever files are already on disk. Use --overwrite_models to replace it with a
+    // fresh download.
+    std::error_code ec;
+    if (!fs::exists(fs::path(downloadPath) / ".git", ec)) {
+        SPDLOG_INFO("Path \"{}\" exists but is not a git repository. "
+                    "Skipping download and using existing files.",
             downloadPath);
         std::cout << "Path already exists on local filesystem and is not a git repository. "
                      "Skipping download and using existing files at: "
                   << downloadPath << std::endl;
         return StatusCode::OK;
+    }
+
+    GitRepositoryGuard repoGuard(downloadPath);
+    if (!repoGuard.get()) {
+        // .git was present but libgit2 still could not open the repository: surface the real error
+        // so the operator can act (re-clone, fix permissions, init libgit2, ...).
+        std::cout << "Path already exists on local filesystem. Cannot download model to: " << downloadPath << std::endl;
+        std::cout << "Use --override to start download from scratch." << std::endl;
+        return mapRepositoryOpenFailureToStatus(repoGuard);
     }
 
     auto candidates = buildResumeCandidates(repoGuard.get(), downloadPath);

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -1225,9 +1225,27 @@ Status handleExistingRepositoryWithoutOverwrite(const std::string& downloadPath,
     const std::function<Status(bool)>& checkRepositoryStatusFn) {
     GitRepositoryGuard repoGuard(downloadPath);
     if (!repoGuard.get()) {
-        std::cout << "Path already exists on local filesystem. Cannot download model to: " << downloadPath << std::endl;
-        std::cout << "Use --override to start download from scratch." << std::endl;
-        return mapRepositoryOpenFailureToStatus(repoGuard);
+        // libgit2 not being initialized is a configuration issue, but we still want
+        // model loading to proceed against whatever files are already on disk.
+        // Surface it as an additional warning rather than a hard error.
+        if (repoGuard.git_error_class == GIT_ERROR_INVALID) {
+            SPDLOG_WARN("libgit2 is not initialized; cannot inspect existing path \"{}\" for model pull. "
+                        "Skipping pull and using existing files.",
+                downloadPath);
+            std::cout << "Warning: libgit2 is not initialized. Skipping pull and using existing files at: "
+                      << downloadPath << std::endl;
+            return StatusCode::OK;
+        }
+        // The path exists (caller verified is_directory) but it is not a git repository.
+        // Treat it as a user-provided model directory: warn and let model loading proceed
+        // against whatever files are already on disk.
+        SPDLOG_WARN("Path \"{}\" already exists but is not a git repository. Skipping pull and using existing files. "
+                    "Use --overwrite_models to replace the directory with a fresh download.",
+            downloadPath);
+        std::cout << "Path already exists on local filesystem and is not a git repository. "
+                     "Skipping download and using existing files at: "
+                  << downloadPath << std::endl;
+        return StatusCode::OK;
     }
 
     auto candidates = buildResumeCandidates(repoGuard.get(), downloadPath);

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -1236,17 +1236,12 @@ Status handleExistingRepositoryWithoutOverwrite(const std::string& downloadPath,
         // Probe itself failed (permission denied, I/O error, ...). Do not silently fall through
         // to the "not a git repository" branch, that would mask real filesystem problems.
         SPDLOG_ERROR("Failed to probe \"{}/.git\": {}", downloadPath, ec.message());
-        std::cout << "Failed to access path on local filesystem: " << downloadPath
-                  << " (" << ec.message() << ")" << std::endl;
         return StatusCode::HF_GIT_STATUS_FAILED_TO_RESOLVE_PATH;
     }
     if (!gitEntryExists) {
         SPDLOG_INFO("Path \"{}\" exists but is not a git repository. "
                     "Skipping download and using existing files.",
             downloadPath);
-        std::cout << "Path already exists on local filesystem and is not a git repository. "
-                     "Skipping download and using existing files at: "
-                  << downloadPath << std::endl;
         return StatusCode::OK;
     }
 
@@ -1254,15 +1249,15 @@ Status handleExistingRepositoryWithoutOverwrite(const std::string& downloadPath,
     if (!repoGuard.get()) {
         // .git was present but libgit2 still could not open the repository: surface the real error
         // so the operator can act (re-clone, fix permissions, init libgit2, ...).
-        std::cout << "Model is corrupted: " << downloadPath << std::endl;
-        std::cout << "Use --overwrite_models to start download from scratch." << std::endl;
+        SPDLOG_ERROR("Model is corrupted: {}", downloadPath);
+        SPDLOG_ERROR("Use --overwrite_models to start download from scratch.");
         return mapRepositoryOpenFailureToStatus(repoGuard);
     }
 
     auto candidates = buildResumeCandidates(repoGuard.get(), downloadPath);
     if (!candidates.interruptionLikely) {
         SPDLOG_DEBUG("Model pull operation found no interruption signals for this path: {}", downloadPath);
-        std::cout << "Path already exists on local filesystem. Skipping download to path: " << downloadPath << std::endl;
+        SPDLOG_INFO("Path already exists on local filesystem. Skipping download to path: {}", downloadPath);
         return StatusCode::OK;
     }
 

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -1206,7 +1206,7 @@ Status resumeExistingRepository(git_repository* repo,
 
     // Checking if git status is ok but we are left with LFS errors recorded by libgit2 patch in repository root.
     if (libgit2::ifHasLfsErrorFileLogContentAndRemove(downloadPath)) {
-        SPDLOG_ERROR("Model download resume failed: LFS errors recorded above. Re-run the same command to retry, or use --override to restart from scratch.");
+        SPDLOG_ERROR("Model download resume failed: LFS errors recorded above. Re-run the same command to retry, or use --overwrite_models to restart from scratch.");
         return StatusCode::HF_GIT_LIBGIT2_LFS_DOWNLOAD_FAILED;
     }
 
@@ -1215,7 +1215,7 @@ Status resumeExistingRepository(git_repository* repo,
     auto status = checkRepositoryStatusFn(false);
     if (!status.ok()) {
         SPDLOG_ERROR("Model repository status check failed after resuming download. Status: {}", status.string());
-        SPDLOG_ERROR("Consider --override to start download from scratch.");
+        SPDLOG_ERROR("Consider --overwrite_models to start download from scratch.");
         return status;
     }
     SPDLOG_DEBUG("Model repository status check passed after resuming download.");
@@ -1336,7 +1336,7 @@ Status finalizeAfterClone(const std::string& downloadPath,
     const std::function<Status(const std::string&)>& removeReadonlyFn) {
     // Checking if git status is ok but we are left with LFS errors recorded by libgit2 patch in repository root.
     if (libgit2::ifHasLfsErrorFileLogContentAndRemove(downloadPath)) {
-        SPDLOG_ERROR("Model download failed: LFS errors recorded above. Re-run the same command to resume, or use --override to restart from scratch.");
+        SPDLOG_ERROR("Model download failed: LFS errors recorded above. Re-run the same command to resume, or use --overwrite_models to restart from scratch.");
         return StatusCode::HF_GIT_LIBGIT2_LFS_DOWNLOAD_FAILED;
     }
 
@@ -1345,7 +1345,7 @@ Status finalizeAfterClone(const std::string& downloadPath,
     if (!status.ok()) {
         SPDLOG_ERROR("Model repository status check failed after model download. Status: {}", status.string());
         SPDLOG_ERROR("Consider rerunning the command to resume the download after network issues.");
-        SPDLOG_ERROR("Consider --override flag to start download from scratch.");
+        SPDLOG_ERROR("Consider --overwrite_models flag to start download from scratch.");
         return status;
     }
     SPDLOG_DEBUG("Model repository status check passed after model download.");

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -1230,7 +1230,16 @@ Status handleExistingRepositoryWithoutOverwrite(const std::string& downloadPath,
     // against whatever files are already on disk. Use --overwrite_models to replace it with a
     // fresh download.
     std::error_code ec;
-    if (!fs::exists(fs::path(downloadPath) / ".git", ec)) {
+    const bool gitEntryExists = fs::exists(fs::path(downloadPath) / ".git", ec);
+    if (ec) {
+        // Probe itself failed (permission denied, I/O error, ...). Do not silently fall through
+        // to the "not a git repository" branch, that would mask real filesystem problems.
+        SPDLOG_ERROR("Failed to probe \"{}/.git\": {}", downloadPath, ec.message());
+        std::cout << "Failed to access path on local filesystem: " << downloadPath
+                  << " (" << ec.message() << ")" << std::endl;
+        return StatusCode::HF_GIT_STATUS_FAILED_TO_RESOLVE_PATH;
+    }
+    if (!gitEntryExists) {
         SPDLOG_INFO("Path \"{}\" exists but is not a git repository. "
                     "Skipping download and using existing files.",
             downloadPath);

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -1239,7 +1239,7 @@ Status handleExistingRepositoryWithoutOverwrite(const std::string& downloadPath,
     if (!repoGuard.get()) {
         // .git was present but libgit2 still could not open the repository: surface the real error
         // so the operator can act (re-clone, fix permissions, init libgit2, ...).
-        std::cout << "Path already exists on local filesystem. Cannot download model to: " << downloadPath << std::endl;
+        std::cout << "Model is corrupted: " << downloadPath << std::endl;
         std::cout << "Use --override to start download from scratch." << std::endl;
         return mapRepositoryOpenFailureToStatus(repoGuard);
     }

--- a/src/pull_module/libgit2.cpp
+++ b/src/pull_module/libgit2.cpp
@@ -1245,7 +1245,7 @@ Status handleExistingRepositoryWithoutOverwrite(const std::string& downloadPath,
         // .git was present but libgit2 still could not open the repository: surface the real error
         // so the operator can act (re-clone, fix permissions, init libgit2, ...).
         std::cout << "Model is corrupted: " << downloadPath << std::endl;
-        std::cout << "Use --override to start download from scratch." << std::endl;
+        std::cout << "Use --overwrite_models to start download from scratch." << std::endl;
         return mapRepositoryOpenFailureToStatus(repoGuard);
     }
 

--- a/src/test/pull_hf_model_test.cpp
+++ b/src/test/pull_hf_model_test.cpp
@@ -683,6 +683,76 @@ TEST_F(HfPullCache, PullNonGit) {
     EXPECT_FALSE(std::filesystem::exists(gitDir));
 }
 
+// PullAgainstDirectoryWithEmptyDotGitFailsWithRepositoryError
+//
+// Companion to HfPullCache.PullNonGit. Verifies that when .git IS present but is
+// empty (a corrupt / partially-initialized repository) handleExistingRepositoryWithoutOverwrite()
+// does NOT silently succeed: the .git probe passes, GitRepositoryGuard then fails to open
+// the repository and the real error is propagated via mapRepositoryOpenFailureToStatus()
+// so the operator can act (re-clone, fix permissions, --overwrite_models, ...).
+TEST_F(HfPullCache, PullEmptyGitDir) {
+    std::string modelName = "OpenVINO/Phi-3-mini-FastDraft-50M-int8-ov";
+    std::string downloadPath = ovms::FileSystem::joinPath({this->directoryPath, "repository"});
+    std::string task = "text_generation";
+
+    std::string basePath = ovms::FileSystem::joinPath({downloadPath, "OpenVINO", "Phi-3-mini-FastDraft-50M-int8-ov"});
+    std::string modelPath = ovms::FileSystem::appendSlash(basePath) + "openvino_model.bin";
+    std::string tokenizerPath = ovms::FileSystem::appendSlash(basePath) + "openvino_tokenizer.bin";
+    std::string gitDir = ovms::FileSystem::appendSlash(basePath) + ".git";
+
+    ASSERT_TRUE(std::filesystem::exists(modelPath));
+    ASSERT_TRUE(std::filesystem::exists(tokenizerPath));
+    ASSERT_TRUE(std::filesystem::is_directory(gitDir));
+
+    // Capture pre-pull file fingerprints so we can confirm pull did not modify them.
+    std::error_code ec;
+    const std::uintmax_t modelSizeBefore = std::filesystem::file_size(modelPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    const std::uintmax_t tokenizerSizeBefore = std::filesystem::file_size(tokenizerPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    std::string modelDigestBefore = sha256File(modelPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    std::string tokenizerDigestBefore = sha256File(tokenizerPath, ec);
+    ASSERT_EQ(ec, std::errc());
+
+    // Replace the cached .git with an empty directory to simulate corruption / partial init.
+    // Drop readonly attributes first so std::filesystem::remove_all succeeds on Windows.
+    RemoveReadonlyFileAttributeFromDir(gitDir);
+    ec.clear();
+    std::filesystem::remove_all(gitDir, ec);
+    ASSERT_EQ(ec, std::errc()) << "Failed to remove .git from cached repository: " << ec.message();
+    ec.clear();
+    std::filesystem::create_directory(gitDir, ec);
+    ASSERT_EQ(ec, std::errc()) << "Failed to recreate empty .git directory: " << ec.message();
+    ASSERT_TRUE(std::filesystem::is_directory(gitDir));
+    ASSERT_TRUE(std::filesystem::is_empty(gitDir));
+
+    // Pull must NOT silently succeed: handleExistingRepositoryWithoutOverwrite should
+    // surface the libgit2 open failure (mapRepositoryOpenFailureToStatus -> non-OK).
+    this->ServerPullHfModel(modelName, downloadPath, task, EXIT_FAILURE);
+
+    // No work-in-progress marker should be created next to the model directory.
+    const std::string lfsWipPath = ovms::libgit2::getLfsWipMarkerPath(basePath).string();
+    EXPECT_FALSE(std::filesystem::exists(lfsWipPath));
+
+    // Files must be left exactly as they were on disk.
+    ASSERT_TRUE(std::filesystem::exists(modelPath));
+    ASSERT_TRUE(std::filesystem::exists(tokenizerPath));
+    EXPECT_EQ(std::filesystem::file_size(modelPath), modelSizeBefore);
+    EXPECT_EQ(std::filesystem::file_size(tokenizerPath), tokenizerSizeBefore);
+
+    std::string modelDigestAfter = sha256File(modelPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    std::string tokenizerDigestAfter = sha256File(tokenizerPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    EXPECT_EQ(modelDigestBefore, modelDigestAfter);
+    EXPECT_EQ(tokenizerDigestBefore, tokenizerDigestAfter);
+
+    // .git is still present (we left an empty directory there); no fresh clone happened.
+    EXPECT_TRUE(std::filesystem::is_directory(gitDir));
+    EXPECT_TRUE(std::filesystem::is_empty(gitDir));
+}
+
 #ifdef _WIN32
 // Helper test used only as a child process launched by HfPull.ResumeTerminate.
 TEST(HfPullWindowsWorker, ResumeTerminateChildProcess) {

--- a/src/test/pull_hf_model_test.cpp
+++ b/src/test/pull_hf_model_test.cpp
@@ -605,6 +605,84 @@ TEST_F(HfPullCache, UserEdited) {
     EXPECT_NE(originalDigest2, editedDigestAfterRerun2);
 }
 
+// PullAgainstNonGitDirectoryWarnsAndSucceedsWithoutChangingFiles
+//
+// Verifies the production behavior of handleExistingRepositoryWithoutOverwrite()
+// when --model_repository_path/<source_model> already contains a user-prepared
+// model directory that is NOT a git repository. The expected behavior is:
+//   * pull returns success (so subsequent model loading proceeds),
+//   * existing files are left untouched (no clone, no resume, no overwrite),
+//   * no .lfswip work-in-progress marker is created next to the directory,
+//   * the user-facing warning is emitted to stdout.
+//
+// We simulate the non-git directory by removing the .git folder from the cached
+// HfPullCache repository. The model artifacts (openvino_model.bin, tokenizer*,
+// graph.pbtxt, etc.) remain in place exactly as a user-supplied directory would.
+TEST_F(HfPullCache, PullNonGit) {
+    std::string modelName = "OpenVINO/Phi-3-mini-FastDraft-50M-int8-ov";
+    std::string downloadPath = ovms::FileSystem::joinPath({this->directoryPath, "repository"});
+    std::string task = "text_generation";
+
+    std::string basePath = ovms::FileSystem::joinPath({downloadPath, "OpenVINO", "Phi-3-mini-FastDraft-50M-int8-ov"});
+    std::string modelPath = ovms::FileSystem::appendSlash(basePath) + "openvino_model.bin";
+    std::string tokenizerPath = ovms::FileSystem::appendSlash(basePath) + "openvino_tokenizer.bin";
+    std::string gitDir = ovms::FileSystem::appendSlash(basePath) + ".git";
+
+    ASSERT_TRUE(std::filesystem::exists(modelPath));
+    ASSERT_TRUE(std::filesystem::exists(tokenizerPath));
+    ASSERT_TRUE(std::filesystem::is_directory(gitDir));
+
+    // Capture pre-pull file fingerprints so we can confirm pull did not modify them.
+    std::error_code ec;
+    const std::uintmax_t modelSizeBefore = std::filesystem::file_size(modelPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    const std::uintmax_t tokenizerSizeBefore = std::filesystem::file_size(tokenizerPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    std::string modelDigestBefore = sha256File(modelPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    std::string tokenizerDigestBefore = sha256File(tokenizerPath, ec);
+    ASSERT_EQ(ec, std::errc());
+
+    // Turn the cached repository into an opaque user-provided model directory by
+    // removing .git. Drop readonly attributes first so std::filesystem::remove_all
+    // succeeds on Windows where libgit2 marks pack files read-only.
+    RemoveReadonlyFileAttributeFromDir(gitDir);
+    ec.clear();
+    std::filesystem::remove_all(gitDir, ec);
+    ASSERT_EQ(ec, std::errc()) << "Failed to remove .git from cached repository: " << ec.message();
+    ASSERT_FALSE(std::filesystem::exists(gitDir));
+
+    testing::internal::CaptureStdout();
+    this->ServerPullHfModel(modelName, downloadPath, task);
+    std::string out = testing::internal::GetCapturedStdout();
+
+    EXPECT_NE(out.find("not a git repository"), std::string::npos)
+        << "Expected non-git-repository warning in stdout, got:\n"
+        << out;
+    EXPECT_EQ(out.find("LFS file(s) to resume"), std::string::npos);
+    EXPECT_EQ(out.find(" Resuming "), std::string::npos);
+
+    // No work-in-progress marker should be created next to the model directory.
+    const std::string lfsWipPath = ovms::libgit2::getLfsWipMarkerPath(basePath).string();
+    EXPECT_FALSE(std::filesystem::exists(lfsWipPath));
+
+    // Files must be left exactly as the user provided them.
+    ASSERT_TRUE(std::filesystem::exists(modelPath));
+    ASSERT_TRUE(std::filesystem::exists(tokenizerPath));
+    EXPECT_EQ(std::filesystem::file_size(modelPath), modelSizeBefore);
+    EXPECT_EQ(std::filesystem::file_size(tokenizerPath), tokenizerSizeBefore);
+
+    std::string modelDigestAfter = sha256File(modelPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    std::string tokenizerDigestAfter = sha256File(tokenizerPath, ec);
+    ASSERT_EQ(ec, std::errc());
+    EXPECT_EQ(modelDigestBefore, modelDigestAfter);
+    EXPECT_EQ(tokenizerDigestBefore, tokenizerDigestAfter);
+
+    // .git must NOT have been recreated (no fresh clone happened).
+    EXPECT_FALSE(std::filesystem::exists(gitDir));
+}
+
 #ifdef _WIN32
 // Helper test used only as a child process launched by HfPull.ResumeTerminate.
 TEST(HfPullWindowsWorker, ResumeTerminateChildProcess) {


### PR DESCRIPTION
### 🛠 Summary

Make --pull ignore non-git local repository. Add check if the target directory already contains .git and then run additional repository checks and fail on error.
If the target path does not contain .git repository do not check anything and continue with success.

Fixed scenario:
Running pull and start mode on a model path already downloaded with optimum-cli or user copied model files.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

