### PR TITLE
Negative temperature should lead to genai error in STT path

### DIFF
--- a/docs/model_server_rest_api_speech_to_text.md
+++ b/docs/model_server_rest_api_speech_to_text.md
@@ -47,7 +47,7 @@ curl -X POST http://localhost:8000/v3/audio/translations \
 | prompt | ❌ | ✅ | string | An optional text to guide the model's style or continue a previous audio segment. |
 | response_format | ❌ | ✅ | string | The format of the output. |
 | stream | ❌ | ✅ | boolean | Generate the response in streaming mode. |
-| temperature | ⚠️ | ✅ | number | The sampling temperature, between 0 and 1. |
+| temperature | ✅ | ✅ | float (default: `1.0`) | The sampling temperature, cannot be negative. |
 | timestamp_granularities | ⚠️ | ✅ | array | The timestamp granularities to populate for this transcription. Supported values: "word" and "segment" (⚠️**Note**: To enable word timestamps `enable_word_timestamps: true` need to be set in graph.pbtxt) |
 
 
@@ -58,7 +58,7 @@ curl -X POST http://localhost:8000/v3/audio/translations \
 | file | ⚠️ | ✅ | file (required) | The audio file object to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. (⚠️**Note**: For now supported formats are mp3 and wav) |
 | prompt | ❌ | ✅ | string | An optional text to guide the model's style or continue a previous audio segment. |
 | response_format | ❌ | ✅ | string | The format of the output. |
-| temperature | ❌ | ✅ | number | The sampling temperature, between 0 and 1. |
+| temperature |  ✅ | ✅ | float (default: `1.0`) | The sampling temperature, cannot be negative. |
 
 ## Response
 ### Transcription

--- a/src/audio/speech_to_text/s2t_servable.cpp
+++ b/src/audio/speech_to_text/s2t_servable.cpp
@@ -77,7 +77,7 @@ absl::Status SttServable::parseTemperature(const HttpPayload& payload, ov::genai
                 return absl::InvalidArgumentError("Invalid temperature type.");
         }
         config.temperature = temp.value();
-        if (config.temperature > 0) {
+        if (config.temperature != 0) {
             config.do_sample = true;
         }
     }

--- a/src/test/audio/speech2text_test.cpp
+++ b/src/test/audio/speech2text_test.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<std::thread> Speech2TextHttpTest::t;
 std::string Speech2TextHttpTest::body;
 std::string Speech2TextHttpTest::modelNameForm;
 
-TEST(SttServableParseTemperatureTest, negativeTemperatureDoesNotEnableSampling) {
+TEST(SttServableParseTemperatureTest, negativeTemperatureEnableSampling) {
     HttpPayload payload;
     std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
     payload.multipartParser = multipartParser;

--- a/src/test/audio/speech2text_test.cpp
+++ b/src/test/audio/speech2text_test.cpp
@@ -21,6 +21,8 @@
 #include <drogon/drogon.h>
 #include "../../http_frontend/multi_part_parser_drogon_impl.hpp"
 #include "../../audio/audio_utils.hpp"
+#include "../../audio/speech_to_text/s2t_servable.hpp"
+#include "../../http_payload.hpp"
 #include "../../http_rest_api_handler.hpp"
 #include "../../server.hpp"
 #include "rapidjson/document.h"
@@ -76,6 +78,54 @@ public:
 std::unique_ptr<std::thread> Speech2TextHttpTest::t;
 std::string Speech2TextHttpTest::body;
 std::string Speech2TextHttpTest::modelNameForm;
+
+TEST(SttServableParseTemperatureTest, negativeTemperatureDoesNotEnableSampling) {
+    HttpPayload payload;
+    std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
+    payload.multipartParser = multipartParser;
+    EXPECT_CALL(*multipartParser, getFieldByName("temperature"))
+        .WillOnce(::testing::Return("-1.0"));
+
+    ov::genai::WhisperGenerationConfig config;
+    config.do_sample = false;
+
+    auto status = SttServable::parseTemperature(payload, config);
+    EXPECT_TRUE(status.ok());
+    EXPECT_FLOAT_EQ(config.temperature, -1.0f);
+    EXPECT_TRUE(config.do_sample);
+}
+
+TEST(SttServableParseTemperatureTest, zeroTemperatureDoesNotEnableSampling) {
+    HttpPayload payload;
+    std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
+    payload.multipartParser = multipartParser;
+    EXPECT_CALL(*multipartParser, getFieldByName("temperature"))
+        .WillOnce(::testing::Return("0"));
+
+    ov::genai::WhisperGenerationConfig config;
+    config.do_sample = false;
+
+    auto status = SttServable::parseTemperature(payload, config);
+    EXPECT_TRUE(status.ok());
+    EXPECT_FLOAT_EQ(config.temperature, 0.0f);
+    EXPECT_FALSE(config.do_sample);
+}
+
+TEST(SttServableParseTemperatureTest, positiveTemperatureEnablesSampling) {
+    HttpPayload payload;
+    std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
+    payload.multipartParser = multipartParser;
+    EXPECT_CALL(*multipartParser, getFieldByName("temperature"))
+        .WillOnce(::testing::Return("1.0"));
+
+    ov::genai::WhisperGenerationConfig config;
+    config.do_sample = false;
+
+    auto status = SttServable::parseTemperature(payload, config);
+    EXPECT_TRUE(status.ok());
+    EXPECT_FLOAT_EQ(config.temperature, 1.0f);
+    EXPECT_TRUE(config.do_sample);
+}
 
 // ====================== Speech2Text Streaming Tests ======================
 


### PR DESCRIPTION
### 🛠 Summary

If STT request contains negative temperature value, it should be passed to genai pipeline and be validated 

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

