### PR TITLE
fix bug with windows handling for backslashes and docs updates

### DIFF
--- a/docs/deploying_server_docker.md
+++ b/docs/deploying_server_docker.md
@@ -75,16 +75,3 @@ python predict.py
 zebra
 ```
 If everything is set up correctly, you will see 'zebra' prediction in the output.
-
-### Build Image From Source
-
-In case you want to try out features that have not been released yet, you can build the image from source code yourself. 
-```bash
-git clone https://github.com/openvinotoolkit/model_server.git
-cd model_server
-make release_image GPU=1
-```
-It will create an image called `openvino/model_server:latest`.
-> **Note:** This operation might take 40min or more depending on your build host.
-> **Note:** `GPU` parameter in image build command is needed to include dependencies for GPU device.
-> **Note:** The public image from the last release might be not compatible with models exported using the the latest export script. We recommend using export script and docker image from the same release to avoid compatibility issues.

--- a/docs/starting_server.md
+++ b/docs/starting_server.md
@@ -37,6 +37,26 @@ ovms --model_path <path_to_model> --model_name <model_name> --port 9000 --rest_p
 
 Server will detect the type of requested servable (classic model, generative model or mediapipe graph) and load it accordingly. This detection is based on the presence of a `graph.pbtxt` file, which defines the Mediapipe graph structure, presence of versions directory for classic models.
 
+When the model is generative, like copied from Hugging Faces or exported using optimum-cli, all the pipeline runtime parameters can be defined with --tasks <TASK> followed by task specific options.
+
+```text
+docker run -d --rm -v $(pwd)/<model>>:/model -p 8000:8000 openvino/model_server:latest \
+--model_path /model --model_name <model_name> --rest_port 8000 --log_level DEBUG \
+--task <TASK> --target_device <DEVICE> ........
+```
+:::
+
+:::{tab-item} On Baremetal Host
+:sync: baremetal
+**Required:** OpenVINO Model Server package - see [deployment instructions](./deploying_server_baremetal.md) for details.
+
+```text
+ovms --model_path <path_to_model> --model_name <model_name> --rest_port 8000 --log_level DEBUG --task <TASK> --target_device <DEVICE> .....
+```
+:::
+::::
+
+
 **Example using a ResNet model:**
 
 ```bash
@@ -62,6 +82,35 @@ docker run -d --rm -v ${PWD}/models:/models -p 9000:9000 -p 8000:8000 openvino/m
 :sync: baremetal
 ```text
 ovms --model_path models/resnet/ --model_name resnet --port 9000 --rest_port 8000 --log_level DEBUG
+```
+:::
+::::
+
+
+**Example using OpenVINO/gemma-4-E4B-it-int4-ov model :**
+
+```bash
+pip install huggingface_hub
+hf download OpenVINO/gemma-4-E4B-it-int4-ov
+```
+
+::::{tab-set}
+:::{tab-item} With Docker
+:sync: docker
+**Required:** Docker Engine installed
+
+```bash
+docker run -d --rm -v ${PWD}/OpenVINO/gemma-4-E4B-it-int4-ov:/model -p 8000:8000 openvino/model_server:latest \
+--model_path /model/ --model_name gemma4 --rest_port 8000 --task text_generation --target_device CPU
+```
+
+- Expose the container ports to **open ports** on your host or virtual machine. 
+:::
+
+:::{tab-item} On Baremetal Host
+:sync: baremetal
+```text
+ovms --model_path OpenVINO/gemma-4-E4B-it-int4-ov --model_name gemma4 --rest_port 8000 --task text_generation --target_device CPU
 ```
 :::
 ::::

--- a/docs/starting_server.md
+++ b/docs/starting_server.md
@@ -37,10 +37,10 @@ ovms --model_path <path_to_model> --model_name <model_name> --port 9000 --rest_p
 
 Server will detect the type of requested servable (classic model, generative model or mediapipe graph) and load it accordingly. This detection is based on the presence of a `graph.pbtxt` file, which defines the Mediapipe graph structure, presence of versions directory for classic models.
 
-When the model is generative, like copied from Hugging Faces or exported using optimum-cli, all the pipeline runtime parameters can be defined with --tasks <TASK> followed by task specific options.
+When the model is generative, like copied from Hugging Face or exported using optimum-cli, all the pipeline runtime parameters can be defined with --tasks <TASK> followed by task specific options.
 
 ```text
-docker run -d --rm -v $(pwd)/<model>>:/model -p 8000:8000 openvino/model_server:latest \
+docker run -d --rm -v ${PWD}/<model>:/model -p 8000:8000 openvino/model_server:latest \
 --model_path /model --model_name <model_name> --rest_port 8000 --log_level DEBUG \
 --task <TASK> --target_device <DEVICE> ........
 ```

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -310,7 +310,7 @@ std::variant<bool, std::pair<int, std::string>> CLIParser::parse(int argc, char*
 
         options->add_options("generative task (applies to: pull hf model, single model)")
             ("task",
-                "Specifies the generative task for the local model. It should be followed by task specific parameters. Supported tasks: text_generation, embeddings, rerank, image_generation, text2speech, speech2text. It creates the pipeline graph in memory based on provided with task specific options.",
+                "Specifies the generative task for the local model. It should be followed by task specific parameters. Supported tasks: text_generation, embeddings, rerank, image_generation, text2speech, speech2text. It creates the pipeline graph in memory based on the provided task-specific options.",
                 cxxopts::value<std::string>(),
                 "TASK");
         configOptions->custom_help("");

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -310,7 +310,11 @@ std::variant<bool, std::pair<int, std::string>> CLIParser::parse(int argc, char*
             ("max_sequence_number",
                 "Determines how many sequences can be processed concurrently by one model instance. When that value is reached, attempt to start a new sequence will result in error.",
                 cxxopts::value<uint32_t>(),
-                "MAX_SEQUENCE_NUMBER");
+                "MAX_SEQUENCE_NUMBER")
+            ("task",
+                "Specifies the generative task for the local model. It should be followed by task specific parameters. Supported tasks: text_generation, embeddings, rerank, image_generation, text2speech, speech2text. It creates the pipeline graph in memory based on provided with task specific options.",
+                cxxopts::value<std::string>(),
+                "TASK");
         configOptions->custom_help("");
         configOptions->add_options(CONFIG_MANAGEMENT_HELP_GROUP)
             ("list_models",

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -225,10 +225,6 @@ std::variant<bool, std::pair<int, std::string>> CLIParser::parse(int argc, char*
             "HF model destination download path",
             cxxopts::value<std::string>()->default_value(defaultModelRepoPath),
             "MODEL_REPOSITORY_PATH")
-            ("task",
-                "Choose type of model export: text_generation - chat and completion endpoints, embeddings - embeddings endpoint, rerank - rerank endpoint, image_generation - image generation/edit/inpainting endpoints, text2speech - audio/speech endpoint, speech2text - audio/transcriptions endpoint.",
-                cxxopts::value<std::string>(),
-                "TASK")
             ("weight-format",
             "Model precision used in optimum-cli export with conversion",
             cxxopts::value<std::string>()->default_value("int8"),
@@ -310,7 +306,9 @@ std::variant<bool, std::pair<int, std::string>> CLIParser::parse(int argc, char*
             ("max_sequence_number",
                 "Determines how many sequences can be processed concurrently by one model instance. When that value is reached, attempt to start a new sequence will result in error.",
                 cxxopts::value<uint32_t>(),
-                "MAX_SEQUENCE_NUMBER")
+                "MAX_SEQUENCE_NUMBER");
+
+        options->add_options("generative task (applies to: pull hf model, single model)")
             ("task",
                 "Specifies the generative task for the local model. It should be followed by task specific parameters. Supported tasks: text_generation, embeddings, rerank, image_generation, text2speech, speech2text. It creates the pipeline graph in memory based on provided with task specific options.",
                 cxxopts::value<std::string>(),

--- a/src/graph_export/graph_export.cpp
+++ b/src/graph_export/graph_export.cpp
@@ -72,17 +72,17 @@ static std::string constructModelsPath(const std::string& modelPath, const std::
     std::string modelsPath;
     if (ggufFilenameOpt.has_value()) {
         modelsPath = FileSystem::joinPath({modelPath, ggufFilenameOpt.value()});
-#if _WIN32
-        // On Windows, file paths use backslashes ('\') as separators. However, the graph parser used in this project expects Unix-style paths with forward slashes ('/').
-        // If Windows-style backslashes are present, the parser may fail to locate files or misinterpret the path. To ensure compatibility, we replace all backslashes with forward slashes.
-        // This is safe because Windows APIs accept forward slashes in file paths.
-        if (FileSystem::getOsSeparator() != "/") {
-            std::replace(modelsPath.begin(), modelsPath.end(), '\\', '/');
-        }
-#endif
     } else {
         modelsPath = modelPath;
     }
+#if _WIN32
+    // On Windows, file paths use backslashes ('\') as separators. However, the graph parser used in this project expects Unix-style paths with forward slashes ('/').
+    // If Windows-style backslashes are present, the parser may fail to locate files or misinterpret the path. To ensure compatibility, we replace all backslashes with forward slashes.
+    // This is safe because Windows APIs accept forward slashes in file paths.
+    if (FileSystem::getOsSeparator() != "/") {
+        std::replace(modelsPath.begin(), modelsPath.end(), '\\', '/');
+    }
+#endif
     SPDLOG_TRACE("Models path: {}, modelPath:{}, ggufFilenameOpt:{}", modelsPath, modelPath, ggufFilenameOpt.value_or("std::nullopt"));
     return modelsPath;
 }

--- a/src/test/graph_export_test.cpp
+++ b/src/test/graph_export_test.cpp
@@ -1098,6 +1098,42 @@ TEST_F(GraphCreationTest, imageGenerationPositiveFull) {
     std::string graphContents = GetFileContents(graphPath);
     ASSERT_EQ(expectedImageGenerationGraphContents, removeVersionString(graphContents)) << graphContents;
 }
+
+#ifdef _WIN32
+TEST_F(GraphCreationTest, windowsBackslashesInModelPathAreNormalized) {
+    // On Windows, model_path may contain backslashes. The graph parser expects forward slashes,
+    // so constructModelsPath must convert them. Verify the written pbtxt uses forward slashes.
+    ovms::HFSettingsImpl hfSettings;
+    hfSettings.task = ovms::TEXT_GENERATION_GRAPH;
+    ovms::TextGenGraphSettingsImpl graphSettings;
+    hfSettings.exportSettings.modelPath = "c:\\models\\Qwen3-35B";
+    hfSettings.graphSettings = std::move(graphSettings);
+    std::string graphPath = ovms::FileSystem::appendSlash(this->directoryPath) + "graph.pbtxt";
+    std::unique_ptr<ovms::GraphExport> graphExporter = std::make_unique<ovms::GraphExport>();
+    auto status = graphExporter->createServableConfig(this->directoryPath, hfSettings);
+    ASSERT_EQ(status, ovms::StatusCode::OK);
+
+    std::string graphContents = GetFileContents(graphPath);
+    EXPECT_NE(std::string::npos, graphContents.find("models_path: \"c:/models/Qwen3-35B\"")) << graphContents;
+    EXPECT_EQ(std::string::npos, graphContents.find("models_path: \"c:\\models")) << "Backslashes must not appear in models_path";
+}
+
+TEST_F(GraphCreationTest, windowsBackslashesInGGUFModelPathAreNormalized) {
+    // Same as above but for GGUF paths, where a filename is joined to the model path.
+    ovms::HFSettingsImpl hfSettings;
+    hfSettings.task = ovms::TEXT_GENERATION_GRAPH;
+    hfSettings.exportSettings.modelPath = "c:\\models\\Qwen3-35B";
+    hfSettings.ggufFilename = "model.gguf";
+    std::string graphPath = ovms::FileSystem::appendSlash(this->directoryPath) + "graph.pbtxt";
+    std::unique_ptr<ovms::GraphExport> graphExporter = std::make_unique<ovms::GraphExport>();
+    auto status = graphExporter->createServableConfig(this->directoryPath, hfSettings);
+    ASSERT_EQ(status, ovms::StatusCode::OK);
+
+    std::string graphContents = GetFileContents(graphPath);
+    EXPECT_NE(std::string::npos, graphContents.find("models_path: \"c:/models/Qwen3-35B/model.gguf\"")) << graphContents;
+    EXPECT_EQ(std::string::npos, graphContents.find("models_path: \"c:\\models")) << "Backslashes must not appear in models_path";
+}
+#endif  // _WIN32
 TEST_F(GraphCreationTest, pluginConfigAsString) {
     ovms::ExportSettings exportSettings;
 


### PR DESCRIPTION
### 🛠 Summary

CVS-186554
Handle backslashes in model path on windows. Add documentation.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

