### PR TITLE
Tokenize endpoint  empty array crash fix  

### DIFF
--- a/src/test/embeddingsnode_test.cpp
+++ b/src/test/embeddingsnode_test.cpp
@@ -819,3 +819,14 @@ TEST_F(EmbeddingsTokenizeHttpTest, tokenizeMultipleEmptyNestedArraysAndOneNonEmp
     Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
+
+TEST_F(EmbeddingsTokenizeHttpTest, tokenizeEmptyWithArrayMultipleLevelsOfNesting) {
+    std::string requestBody = R"(
+        {
+            "model": "embeddings_ov",
+            "text": [[[[[]]]]]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}

--- a/src/test/embeddingsnode_test.cpp
+++ b/src/test/embeddingsnode_test.cpp
@@ -808,3 +808,14 @@ TEST_F(EmbeddingsTokenizeHttpTest, tokenizeMultipleEmptyNestedArrays) {
     Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
+
+TEST_F(EmbeddingsTokenizeHttpTest, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
+    std::string requestBody = R"(
+        {
+            "model": "embeddings_ov",
+            "text": [[], ["hello world"], []]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}

--- a/src/test/embeddingsnode_test.cpp
+++ b/src/test/embeddingsnode_test.cpp
@@ -788,45 +788,17 @@ TEST_F(EmbeddingsTokenizeHttpTest, tokenizeBatchWithPadToMaxLen) {
 }
 
 TEST_F(EmbeddingsTokenizeHttpTest, tokenizeEmptyNestedArray) {
-    std::string requestBody = R"(
-        {
-            "model": "embeddings_ov",
-            "text": [[]]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "embeddings_ov", "[[]]", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_F(EmbeddingsTokenizeHttpTest, tokenizeMultipleEmptyNestedArrays) {
-    std::string requestBody = R"(
-        {
-            "model": "embeddings_ov",
-            "text": [[], [], []]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "embeddings_ov", "[[], [], []]", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_F(EmbeddingsTokenizeHttpTest, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
-    std::string requestBody = R"(
-        {
-            "model": "embeddings_ov",
-            "text": [[], ["hello world"], []]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "embeddings_ov", R"([[], ["hello world"], []])", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_F(EmbeddingsTokenizeHttpTest, tokenizeEmptyWithArrayMultipleLevelsOfNesting) {
-    std::string requestBody = R"(
-        {
-            "model": "embeddings_ov",
-            "text": [[[[[]]]]]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "embeddings_ov", "[[[[[]]]]]", response, comp, responseComponents, writer, multiPartParser);
 }

--- a/src/test/embeddingsnode_test.cpp
+++ b/src/test/embeddingsnode_test.cpp
@@ -786,3 +786,25 @@ TEST_F(EmbeddingsTokenizeHttpTest, tokenizeBatchWithPadToMaxLen) {
         ovms::StatusCode::OK);
     AssertTokenizationResult(response, expectedTokens);
 }
+
+TEST_F(EmbeddingsTokenizeHttpTest, tokenizeEmptyNestedArray) {
+    std::string requestBody = R"(
+        {
+            "model": "embeddings_ov",
+            "text": [[]]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}
+
+TEST_F(EmbeddingsTokenizeHttpTest, tokenizeMultipleEmptyNestedArrays) {
+    std::string requestBody = R"(
+        {
+            "model": "embeddings_ov",
+            "text": [[], [], []]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}

--- a/src/test/llm/tokenize_endpoint_test.cpp
+++ b/src/test/llm/tokenize_endpoint_test.cpp
@@ -445,7 +445,7 @@ TEST_P(LLMTokenizeTests, tokenizeEmptyNestedArray) {
 
     std::string requestBody = R"(
         {
-            "model": ")"+ params.modelName +
+            "model": ")" + params.modelName +
                               R"(",
             "text": [[]]
         }
@@ -458,7 +458,7 @@ TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArrays) {
     auto params = GetParam();
     std::string requestBody = R"(
         {
-            "model": ")"+ params.modelName +
+            "model": ")" + params.modelName +
                               R"(",
             "text": [[], [], []]
         }
@@ -466,6 +466,20 @@ TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArrays) {
     Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
+
+TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
+    auto params = GetParam();
+    std::string requestBody = R"(
+        {
+            "model": ")" + params.modelName +
+                              R"(",
+            "text": [[], ["hello world"], []]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}
+
 
 INSTANTIATE_TEST_SUITE_P(
     LLMTokenizeTestInstances,

--- a/src/test/llm/tokenize_endpoint_test.cpp
+++ b/src/test/llm/tokenize_endpoint_test.cpp
@@ -480,6 +480,21 @@ TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
 
+TEST_P(LLMTokenizeTests, tokenizeEmptyWithArrayMultipleLevelsOfNesting) {
+    auto params = GetParam();
+    std::string requestBody = R"(
+        {
+            "model": ")" + params.modelName +
+                              R"(",
+            "text": [[[[[]]]]]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}
+
+
+
 INSTANTIATE_TEST_SUITE_P(
     LLMTokenizeTestInstances,
     LLMTokenizeTests,

--- a/src/test/llm/tokenize_endpoint_test.cpp
+++ b/src/test/llm/tokenize_endpoint_test.cpp
@@ -417,9 +417,6 @@ TEST_P(LLMTokenizeTests, tokenizeArrayOfStringsWithPaddingSideLeft) {
 
 TEST_P(LLMTokenizeTests, tokenizeStringWithAddSpecialTokens) {
     auto params = GetParam();
-    if (params.modelName == "vlm_cb_regular" || params.modelName == "vlm_legacy_regular") {
-        GTEST_SKIP() << "Skipping test for " << params.modelName;
-    }
 
     std::string requestBody = R"(
         {
@@ -441,6 +438,33 @@ TEST_P(LLMTokenizeTests, tokenizeStringWithAddSpecialTokens) {
     const auto& tokens = parsedResponse["tokens"];
     ASSERT_TRUE(tokens.IsArray());
     ASSERT_GE(tokens.Size(), params.expectedTokens.size());
+}
+
+TEST_P(LLMTokenizeTests, tokenizeEmptyNestedArray) {
+    auto params = GetParam();
+
+    std::string requestBody = R"(
+        {
+            "model": ")"+ params.modelName +
+                              R"(",
+            "text": [[]]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}
+
+TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArrays) {
+    auto params = GetParam();
+    std::string requestBody = R"(
+        {
+            "model": ")"+ params.modelName +
+                              R"(",
+            "text": [[], [], []]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/test/llm/tokenize_endpoint_test.cpp
+++ b/src/test/llm/tokenize_endpoint_test.cpp
@@ -493,8 +493,6 @@ TEST_P(LLMTokenizeTests, tokenizeEmptyWithArrayMultipleLevelsOfNesting) {
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
 
-
-
 INSTANTIATE_TEST_SUITE_P(
     LLMTokenizeTestInstances,
     LLMTokenizeTests,

--- a/src/test/llm/tokenize_endpoint_test.cpp
+++ b/src/test/llm/tokenize_endpoint_test.cpp
@@ -442,55 +442,22 @@ TEST_P(LLMTokenizeTests, tokenizeStringWithAddSpecialTokens) {
 
 TEST_P(LLMTokenizeTests, tokenizeEmptyNestedArray) {
     auto params = GetParam();
-
-    std::string requestBody = R"(
-        {
-            "model": ")" + params.modelName +
-                              R"(",
-            "text": [[]]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), params.modelName, "[[]]", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArrays) {
     auto params = GetParam();
-    std::string requestBody = R"(
-        {
-            "model": ")" + params.modelName +
-                              R"(",
-            "text": [[], [], []]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), params.modelName, "[[], [], []]", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
     auto params = GetParam();
-    std::string requestBody = R"(
-        {
-            "model": ")" + params.modelName +
-                              R"(",
-            "text": [[], ["hello world"], []]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), params.modelName, R"([[], ["hello world"], []])", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_P(LLMTokenizeTests, tokenizeEmptyWithArrayMultipleLevelsOfNesting) {
     auto params = GetParam();
-    std::string requestBody = R"(
-        {
-            "model": ")" + params.modelName +
-                              R"(",
-            "text": [[[[[]]]]]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), params.modelName, "[[[[[]]]]]", response, comp, responseComponents, writer, multiPartParser);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/test/llm/tokenize_endpoint_test.cpp
+++ b/src/test/llm/tokenize_endpoint_test.cpp
@@ -480,7 +480,6 @@ TEST_P(LLMTokenizeTests, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
 
-
 INSTANTIATE_TEST_SUITE_P(
     LLMTokenizeTestInstances,
     LLMTokenizeTests,

--- a/src/test/reranknode_test.cpp
+++ b/src/test/reranknode_test.cpp
@@ -627,3 +627,14 @@ TEST_F(RerankTokenizeHttpTest, tokenizeMultipleEmptyNestedArrays) {
     Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
+
+TEST_F(RerankTokenizeHttpTest, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
+    std::string requestBody = R"(
+        {
+            "model": "rerank_ov",
+            "text": [[], ["hello world"], []]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}

--- a/src/test/reranknode_test.cpp
+++ b/src/test/reranknode_test.cpp
@@ -638,3 +638,14 @@ TEST_F(RerankTokenizeHttpTest, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) 
     Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
     ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
 }
+
+TEST_F(RerankTokenizeHttpTest, tokenizeEmptyWithArrayMultipleLevelsOfNesting) {
+    std::string requestBody = R"(
+        {
+            "model": "rerank_ov",
+            "text": [[[[[]]]]]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}

--- a/src/test/reranknode_test.cpp
+++ b/src/test/reranknode_test.cpp
@@ -605,3 +605,25 @@ TEST_F(RerankTokenizeHttpTest, tokenizeIgnoreAddSpecialTokensParameter) {
         ovms::StatusCode::OK);
     AssertTokenizationResult(response, expectedTokens);
 }
+
+TEST_F(RerankTokenizeHttpTest, tokenizeEmptyNestedArray) {
+    std::string requestBody = R"(
+        {
+            "model": "rerank_ov",
+            "text": [[]]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}
+
+TEST_F(RerankTokenizeHttpTest, tokenizeMultipleEmptyNestedArrays) {
+    std::string requestBody = R"(
+        {
+            "model": "rerank_ov",
+            "text": [[], [], []]
+        }
+    )";
+    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}

--- a/src/test/reranknode_test.cpp
+++ b/src/test/reranknode_test.cpp
@@ -607,45 +607,17 @@ TEST_F(RerankTokenizeHttpTest, tokenizeIgnoreAddSpecialTokensParameter) {
 }
 
 TEST_F(RerankTokenizeHttpTest, tokenizeEmptyNestedArray) {
-    std::string requestBody = R"(
-        {
-            "model": "rerank_ov",
-            "text": [[]]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "rerank_ov", "[[]]", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_F(RerankTokenizeHttpTest, tokenizeMultipleEmptyNestedArrays) {
-    std::string requestBody = R"(
-        {
-            "model": "rerank_ov",
-            "text": [[], [], []]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "rerank_ov", "[[], [], []]", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_F(RerankTokenizeHttpTest, tokenizeMultipleEmptyNestedArraysAndOneNonEmpty) {
-    std::string requestBody = R"(
-        {
-            "model": "rerank_ov",
-            "text": [[], ["hello world"], []]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "rerank_ov", R"([[], ["hello world"], []])", response, comp, responseComponents, writer, multiPartParser);
 }
 
 TEST_F(RerankTokenizeHttpTest, tokenizeEmptyWithArrayMultipleLevelsOfNesting) {
-    std::string requestBody = R"(
-        {
-            "model": "rerank_ov",
-            "text": [[[[[]]]]]
-        }
-    )";
-    Status status = handler->dispatchToProcessor(endpointTokenize, requestBody, &response, comp, responseComponents, writer, multiPartParser);
-    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+    assertTokenizeWithInvalidTextReturnsError(handler.get(), "rerank_ov", "[[[[[]]]]]", response, comp, responseComponents, writer, multiPartParser);
 }

--- a/src/test/test_http_utils.hpp
+++ b/src/test/test_http_utils.hpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //*****************************************************************************
 #pragma once
+#include <functional>
 #include <memory>
 #include <set>
 #include <string>
@@ -89,3 +90,18 @@ public:
         handler.reset();
     }
 };
+
+inline void assertTokenizeWithInvalidTextReturnsError(
+    ovms::HttpRestApiHandler* handler,
+    const std::string& modelName,
+    const std::string& textJson,
+    std::string& response,
+    ovms::HttpRequestComponents& comp,
+    ovms::HttpResponseComponents& responseComponents,
+    std::shared_ptr<MockedServerRequestInterface>& writer,
+    std::shared_ptr<MockedMultiPartParser>& multiPartParser) {
+    std::string requestBody = R"({"model": ")" + modelName + R"(", "text": )" + textJson + R"(})";
+    std::string endpoint = "/v3/tokenize";
+    ovms::Status status = handler->dispatchToProcessor(endpoint, requestBody, &response, comp, responseComponents, writer, multiPartParser);
+    ASSERT_EQ(status, ovms::StatusCode::MEDIAPIPE_EXECUTION_ERROR) << status.string();
+}

--- a/src/tokenize/tokenize_parser.cpp
+++ b/src/tokenize/tokenize_parser.cpp
@@ -147,28 +147,32 @@ std::variant<TokenizeRequest::InputDataType, std::string> TokenizeParser::parseI
             InputType input_type = InputType::NONE;
             for (auto& input : it->value.GetArray()) {
                 if (input.IsArray()) {
+                    auto array = input.GetArray();
+                    if (array.Size() == 0) {
+                        return "inner arrays in " + field_name + " should not be empty";
+                    }
                     if (input_type != InputType::NONE && input_type != InputType::INT_VEC && input_type != InputType::STRING_VEC)
                         return field_name + " must be homogeneous";
-                    if (input.GetArray()[0].IsInt()) {
+                    if (array[0].IsInt()) {
                         if (input_type == InputType::STRING_VEC)
                             return field_name + " must be homogeneous";
                         input_type = InputType::INT_VEC;
                         std::vector<int64_t> ints;
-                        ints.reserve(input.GetArray().Size());
-                        for (auto& val : input.GetArray()) {
+                        ints.reserve(array.Size());
+                        for (auto& val : array) {
                             if (val.IsInt())
                                 ints.push_back(val.GetInt());
                             else
                                 return field_name + " must be homogeneous";
                         }
                         input_tokens.emplace_back(std::move(ints));
-                    } else if (input.GetArray()[0].IsString()) {
+                    } else if (array[0].IsString()) {
                         if (input_type == InputType::INT_VEC)
                             return field_name + " must be homogeneous";
                         input_type = InputType::STRING_VEC;
                         std::vector<std::string> strings;
-                        strings.reserve(input.GetArray().Size());
-                        for (auto& val : input.GetArray()) {
+                        strings.reserve(array.Size());
+                        for (auto& val : array) {
                             if (val.IsString())
                                 strings.push_back(val.GetString());
                             else

--- a/src/tokenize/tokenize_parser.cpp
+++ b/src/tokenize/tokenize_parser.cpp
@@ -147,7 +147,7 @@ std::variant<TokenizeRequest::InputDataType, std::string> TokenizeParser::parseI
             InputType input_type = InputType::NONE;
             for (auto& input : it->value.GetArray()) {
                 if (input.IsArray()) {
-                    auto array = input.GetArray();
+                    const auto array = input.GetArray();
                     if (array.Size() == 0) {
                         return "inner arrays in " + field_name + " should not be empty";
                     }


### PR DESCRIPTION
### 🛠 Summary

[CVS-186166](https://jira.devtools.intel.com/browse/CVS-186166)
Adding checks for empty nested array, which was making OVMS crash

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

