### PR TITLE
[WIP] HTTP payload support in PyTensorOvTensorConverterCalculator

### DIFF
--- a/src/python/BUILD
+++ b/src/python/BUILD
@@ -86,7 +86,10 @@ ovms_cc_library(
     deps = PYBIND_DEPS + [
         "//third_party:openvino",
         "@mediapipe//mediapipe/framework:calculator_framework",
+        "@com_github_tencent_rapidjson//:rapidjson",
         "//src:libovmsprecision",
+        "//src:httppayload",
+        "//src:libmultipart_parser",
         "ovmspytensor",
         "pytensorovtensorconvertercalculator_cc_proto",
         "pythonbackend",

--- a/src/python/pytensor_ovtensor_converter_calculator.cc
+++ b/src/python/pytensor_ovtensor_converter_calculator.cc
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //*****************************************************************************
+#include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include <openvino/openvino.hpp>
@@ -31,6 +33,15 @@
 #include <pybind11/stl.h>
 #pragma warning(pop)
 
+#pragma warning(push)
+#pragma warning(disable : 6313)
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#pragma warning(pop)
+
+#include "../http_payload.hpp"
+#include "../multi_part_parser.hpp"
 #include "../precision.hpp"
 #include "python_backend.hpp"
 #include "src/python/ovms_py_tensor.hpp"
@@ -95,24 +106,38 @@ class PyTensorOvTensorConverterCalculator : public CalculatorBase {
     mediapipe::Timestamp outputTimestamp;
     static const std::string OV_TENSOR_TAG_NAME;
     static const std::string OVMS_PY_TENSOR_TAG_NAME;
+    static const std::string HTTP_REQUEST_TAG_NAME;
+    static const std::string HTTP_RESPONSE_TAG_NAME;
 
 public:
     static absl::Status GetContract(CalculatorContract* cc) {
         LOG(INFO) << "PyTensorOvTensorConverterCalculator [Node: " << cc->GetNodeName() << "] GetContract start";
         RET_CHECK(cc->Inputs().GetTags().size() == 1);
         RET_CHECK(cc->Outputs().GetTags().size() == 1);
-        RET_CHECK((*(cc->Inputs().GetTags().begin()) == OV_TENSOR_TAG_NAME && *(cc->Outputs().GetTags().begin()) == OVMS_PY_TENSOR_TAG_NAME) || (*(cc->Inputs().GetTags().begin()) == OVMS_PY_TENSOR_TAG_NAME && *(cc->Outputs().GetTags().begin()) == OV_TENSOR_TAG_NAME));
-        if (*(cc->Inputs().GetTags().begin()) == OV_TENSOR_TAG_NAME) {
+        const std::string inputTag = *(cc->Inputs().GetTags().begin());
+        const std::string outputTag = *(cc->Outputs().GetTags().begin());
+        const bool ovToPy = (inputTag == OV_TENSOR_TAG_NAME && outputTag == OVMS_PY_TENSOR_TAG_NAME);
+        const bool pyToOv = (inputTag == OVMS_PY_TENSOR_TAG_NAME && outputTag == OV_TENSOR_TAG_NAME);
+        const bool httpToPy = (inputTag == HTTP_REQUEST_TAG_NAME && outputTag == OVMS_PY_TENSOR_TAG_NAME);
+        const bool pyToHttp = (inputTag == OVMS_PY_TENSOR_TAG_NAME && outputTag == HTTP_RESPONSE_TAG_NAME);
+        RET_CHECK(ovToPy || pyToOv || httpToPy || pyToHttp);
+        if (ovToPy) {
             RET_CHECK(cc->Options<PyTensorOvTensorConverterCalculatorOptions>().tag_to_output_tensor_names().count(OVMS_PY_TENSOR_TAG_NAME) > 0);
             if (cc->Options<PyTensorOvTensorConverterCalculatorOptions>().tag_to_output_tensor_names().count(OVMS_PY_TENSOR_TAG_NAME) > 1)
                 LOG(INFO) << "PyTensorOvTensorConverterCalculator [Node: " << cc->GetNodeName() << "] tag_to_output_tensor_names map contains some keys that will be ignored";
             cc->Inputs().Tag(OV_TENSOR_TAG_NAME).Set<ov::Tensor>();
             cc->Outputs().Tag(OVMS_PY_TENSOR_TAG_NAME).Set<PyObjectWrapper<py::object>>();
-        } else {
+        } else if (pyToOv) {
             if (cc->Options<PyTensorOvTensorConverterCalculatorOptions>().tag_to_output_tensor_names().count(OVMS_PY_TENSOR_TAG_NAME) > 0)
                 LOG(INFO) << "PyTensorOvTensorConverterCalculator [Node: " << cc->GetNodeName() << "] tag_to_output_tensor_names map contains some keys that will be ignored";
             cc->Inputs().Tag(OVMS_PY_TENSOR_TAG_NAME).Set<PyObjectWrapper<py::object>>();
             cc->Outputs().Tag(OV_TENSOR_TAG_NAME).Set<ov::Tensor>();
+        } else if (httpToPy) {
+            cc->Inputs().Tag(HTTP_REQUEST_TAG_NAME).Set<ovms::HttpPayload>();
+            cc->Outputs().Tag(OVMS_PY_TENSOR_TAG_NAME).Set<PyObjectWrapper<py::object>>();
+        } else {  // pyToHttp
+            cc->Inputs().Tag(OVMS_PY_TENSOR_TAG_NAME).Set<PyObjectWrapper<py::object>>();
+            cc->Outputs().Tag(HTTP_RESPONSE_TAG_NAME).Set<std::string>();
         }
 
         LOG(INFO) << "PyTensorOvTensorConverterCalculator [Node: " << cc->GetNodeName() << "] GetContract end";
@@ -144,7 +169,57 @@ public:
                 }
             }
 
-            if (*(cc->Inputs().GetTags().begin()) == OV_TENSOR_TAG_NAME) {
+            const std::string inputTag = *(cc->Inputs().GetTags().begin());
+            const std::string outputTag = *(cc->Outputs().GetTags().begin());
+
+            if (inputTag == HTTP_REQUEST_TAG_NAME) {
+                const ovms::HttpPayload& payload = cc->Inputs().Tag(HTTP_REQUEST_TAG_NAME).Get<ovms::HttpPayload>();
+                py::object pyPayload;
+                if (payload.multipartParser && !payload.multipartParser->hasParseError() && !payload.multipartParser->getAllFieldNames().empty()) {
+                    py::module_ numpy = py::module_::import("numpy");
+                    py::object uint8 = numpy.attr("uint8");
+                    py::dict result;
+                    const std::set<std::string> fieldNames = payload.multipartParser->getAllFieldNames();
+                    for (const std::string& fieldName : fieldNames) {
+                        const std::string_view fileContent = payload.multipartParser->getFileContentByFieldName(fieldName);
+                        if (!fileContent.empty()) {
+                            py::bytes raw(fileContent.data(), fileContent.size());
+                            result[py::str(fieldName)] = numpy.attr("frombuffer")(raw, "dtype"_a = uint8);
+                        } else {
+                            result[py::str(fieldName)] = py::str(payload.multipartParser->getFieldByName(fieldName));
+                        }
+                    }
+                    pyPayload = std::move(result);
+                } else if (payload.parsedJson && !payload.parsedJson->HasParseError()) {
+                    rapidjson::StringBuffer buffer;
+                    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+                    payload.parsedJson->Accept(writer);
+                    py::module_ jsonModule = py::module_::import("json");
+                    pyPayload = jsonModule.attr("loads")(py::str(buffer.GetString(), buffer.GetSize()));
+                } else {
+                    py::module_ jsonModule = py::module_::import("json");
+                    try {
+                        pyPayload = jsonModule.attr("loads")(py::str(payload.body));
+                    } catch (const pybind11::error_already_set&) {
+                        pyPayload = py::str(payload.body);
+                    }
+                }
+                std::unique_ptr<PyObjectWrapper<py::object>> outputPtr = std::make_unique<PyObjectWrapper<py::object>>(pyPayload);
+                cc->Outputs().Tag(OVMS_PY_TENSOR_TAG_NAME).Add(outputPtr.release(), cc->InputTimestamp());
+            } else if (outputTag == HTTP_RESPONSE_TAG_NAME) {
+                const py::object& pyInput = cc->Inputs().Tag(OVMS_PY_TENSOR_TAG_NAME).Get<PyObjectWrapper<py::object>>().getObject();
+                std::unique_ptr<std::string> response;
+                if (py::isinstance<py::str>(pyInput)) {
+                    response = std::make_unique<std::string>(pyInput.cast<std::string>());
+                } else if (py::isinstance<py::bytes>(pyInput)) {
+                    response = std::make_unique<std::string>(pyInput.cast<std::string>());
+                } else {
+                    py::module_ jsonModule = py::module_::import("json");
+                    py::object dumped = jsonModule.attr("dumps")(pyInput);
+                    response = std::make_unique<std::string>(dumped.cast<std::string>());
+                }
+                cc->Outputs().Tag(HTTP_RESPONSE_TAG_NAME).Add(response.release(), cc->InputTimestamp());
+            } else if (inputTag == OV_TENSOR_TAG_NAME) {
                 auto& inputTensor = cc->Inputs().Tag(OV_TENSOR_TAG_NAME).Get<ov::Tensor>();
 
                 std::unique_ptr<PyObjectWrapper<py::object>> outputPyTensor;
@@ -223,6 +298,8 @@ public:
 
 const std::string PyTensorOvTensorConverterCalculator::OV_TENSOR_TAG_NAME{"OVTENSOR"};
 const std::string PyTensorOvTensorConverterCalculator::OVMS_PY_TENSOR_TAG_NAME{"OVMS_PY_TENSOR"};
+const std::string PyTensorOvTensorConverterCalculator::HTTP_REQUEST_TAG_NAME{"HTTP_REQUEST_PAYLOAD"};
+const std::string PyTensorOvTensorConverterCalculator::HTTP_RESPONSE_TAG_NAME{"HTTP_RESPONSE_PAYLOAD"};
 
 REGISTER_CALCULATOR(PyTensorOvTensorConverterCalculator);
 }  // namespace mediapipe

--- a/src/python/pytensor_ovtensor_converter_calculator.cc
+++ b/src/python/pytensor_ovtensor_converter_calculator.cc
@@ -120,7 +120,13 @@ public:
         const bool pyToOv = (inputTag == OVMS_PY_TENSOR_TAG_NAME && outputTag == OV_TENSOR_TAG_NAME);
         const bool httpToPy = (inputTag == HTTP_REQUEST_TAG_NAME && outputTag == OVMS_PY_TENSOR_TAG_NAME);
         const bool pyToHttp = (inputTag == OVMS_PY_TENSOR_TAG_NAME && outputTag == HTTP_RESPONSE_TAG_NAME);
-        RET_CHECK(ovToPy || pyToOv || httpToPy || pyToHttp);
+        RET_CHECK(ovToPy || pyToOv || httpToPy || pyToHttp)
+            << "PyTensorOvTensorConverterCalculator supports only the following input/output tag pairings: "
+            << OV_TENSOR_TAG_NAME << "->" << OVMS_PY_TENSOR_TAG_NAME << ", "
+            << OVMS_PY_TENSOR_TAG_NAME << "->" << OV_TENSOR_TAG_NAME << ", "
+            << HTTP_REQUEST_TAG_NAME << "->" << OVMS_PY_TENSOR_TAG_NAME << ", "
+            << OVMS_PY_TENSOR_TAG_NAME << "->" << HTTP_RESPONSE_TAG_NAME
+            << ". Received: " << inputTag << "->" << outputTag;
         if (ovToPy) {
             RET_CHECK(cc->Options<PyTensorOvTensorConverterCalculatorOptions>().tag_to_output_tensor_names().count(OVMS_PY_TENSOR_TAG_NAME) > 0);
             if (cc->Options<PyTensorOvTensorConverterCalculatorOptions>().tag_to_output_tensor_names().count(OVMS_PY_TENSOR_TAG_NAME) > 1)

--- a/src/python/pytensor_ovtensor_converter_calculator.cc
+++ b/src/python/pytensor_ovtensor_converter_calculator.cc
@@ -160,8 +160,6 @@ public:
         LOG(INFO) << "PyTensorOvTensorConverterCalculator [Node: " << cc->NodeName() << "] Process start";
         py::gil_scoped_acquire acquire;
         try {
-            PythonBackend pythonBackend;
-
             for (const std::string& tag : cc->Inputs().GetTags()) {
                 if (cc->Inputs().Tag(tag).IsEmpty()) {
                     LOG(INFO) << "PyTensorOvTensorConverterCalculator [Node: " << cc->NodeName() << "] Error occurred during reading inputs. Unexpected empty packet received on input: " << tag;
@@ -181,8 +179,9 @@ public:
                     py::dict result;
                     const std::set<std::string> fieldNames = payload.multipartParser->getAllFieldNames();
                     for (const std::string& fieldName : fieldNames) {
-                        const std::string_view fileContent = payload.multipartParser->getFileContentByFieldName(fieldName);
-                        if (!fileContent.empty()) {
+                        const std::vector<std::string_view> files = payload.multipartParser->getFilesArrayByFieldName(fieldName);
+                        if (!files.empty()) {
+                            const std::string_view fileContent = files.front();
                             py::bytes raw(fileContent.data(), fileContent.size());
                             result[py::str(fieldName)] = numpy.attr("frombuffer")(raw, "dtype"_a = uint8);
                         } else {
@@ -243,6 +242,7 @@ public:
                            << "Undefined precision in input tensor: " << inputTensor.get_element_type();
                 }
 
+                PythonBackend pythonBackend;
                 pythonBackend.createOvmsPyTensor(
                     outputName,
                     const_cast<void*>((const void*)inputTensor.data()),
@@ -255,6 +255,7 @@ public:
             } else {
                 if (*(cc->Inputs().GetTags().begin()) == OVMS_PY_TENSOR_TAG_NAME) {
                     auto& inputTensor = cc->Inputs().Tag(OVMS_PY_TENSOR_TAG_NAME).Get<PyObjectWrapper<py::object>>();
+                    PythonBackend pythonBackend;
                     pythonBackend.validateOvmsPyTensor(inputTensor.getObject());
                     const auto precision = ovmsPrecisionToIE2Precision(fromKfsString(inputTensor.getProperty<std::string>("datatype")));
                     if (precision == ov::element::Type_t::dynamic) {

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -60,6 +60,26 @@
 #include "platform_utils.hpp"
 #include "test_utils.hpp"
 
+#include "../http_payload.hpp"
+#include "../multi_part_parser.hpp"
+#pragma warning(push)
+#pragma warning(disable : 6313)
+#include <rapidjson/document.h>
+#pragma warning(pop)
+
+namespace {
+class LocalMockedMultiPartParser final : public ovms::MultiPartParser {
+public:
+    MOCK_METHOD(bool, parse, (), (override));
+    MOCK_METHOD(bool, hasParseError, (), (const override));
+    MOCK_METHOD(std::vector<std::string>, getArrayFieldByName, (const std::string&), (const override));
+    MOCK_METHOD(std::string, getFieldByName, (const std::string&), (const override));
+    MOCK_METHOD(std::string_view, getFileContentByFieldName, (const std::string&), (const override));
+    MOCK_METHOD(std::vector<std::string_view>, getFilesArrayByFieldName, (const std::string&), (const override));
+    MOCK_METHOD(std::set<std::string>, getAllFieldNames, (), (const, override));
+};
+}  // namespace
+
 namespace py = pybind11;
 using namespace ovms;
 using namespace py::literals;
@@ -2315,6 +2335,242 @@ TEST_F(PythonFlowTest, ConverterCalculator_PyTensorBufferMismatch) {
     } catch (const pybind11::error_already_set& e) {
         ASSERT_EQ(1, 0) << e.what();
     }
+}
+
+// ---- HTTP_REQUEST_PAYLOAD / HTTP_RESPONSE_PAYLOAD conversion tests --------
+
+TEST_F(PythonFlowTest, ConverterCalculator_HttpJsonRequestToPyDict) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "OVMS_PY_TENSOR:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    auto payload = std::make_unique<ovms::HttpPayload>();
+    payload->body = R"({"prompt":"hello","temperature":0.5,"n":3})";
+    payload->parsedJson = std::make_shared<rapidjson::Document>();
+    payload->parsedJson->Parse(payload->body.c_str());
+    ASSERT_FALSE(payload->parsedJson->HasParseError());
+
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
+        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const PyObjectWrapper<py::object>& out =
+        runner.Outputs().Tag("OVMS_PY_TENSOR").packets[0].Get<PyObjectWrapper<py::object>>();
+    const py::object& obj = out.getObject();
+    ASSERT_TRUE(py::isinstance<py::dict>(obj));
+    py::dict d = obj.cast<py::dict>();
+    EXPECT_EQ(d["prompt"].cast<std::string>(), "hello");
+    EXPECT_DOUBLE_EQ(d["temperature"].cast<double>(), 0.5);
+    EXPECT_EQ(d["n"].cast<int>(), 3);
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_HttpRawJsonBodyToPyDict) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "OVMS_PY_TENSOR:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    auto payload = std::make_unique<ovms::HttpPayload>();
+    payload->body = R"({"a":1,"b":[2,3]})";
+    // parsedJson left null - exercise the json.loads(body) fallback.
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
+        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const PyObjectWrapper<py::object>& out =
+        runner.Outputs().Tag("OVMS_PY_TENSOR").packets[0].Get<PyObjectWrapper<py::object>>();
+    const py::object& obj = out.getObject();
+    ASSERT_TRUE(py::isinstance<py::dict>(obj));
+    py::dict d = obj.cast<py::dict>();
+    EXPECT_EQ(d["a"].cast<int>(), 1);
+    py::list l = d["b"].cast<py::list>();
+    ASSERT_EQ(l.size(), 2u);
+    EXPECT_EQ(l[0].cast<int>(), 2);
+    EXPECT_EQ(l[1].cast<int>(), 3);
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_HttpRawNonJsonBodyToPyString) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "OVMS_PY_TENSOR:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    auto payload = std::make_unique<ovms::HttpPayload>();
+    payload->body = "not json at all";
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
+        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const PyObjectWrapper<py::object>& out =
+        runner.Outputs().Tag("OVMS_PY_TENSOR").packets[0].Get<PyObjectWrapper<py::object>>();
+    const py::object& obj = out.getObject();
+    ASSERT_TRUE(py::isinstance<py::str>(obj));
+    EXPECT_EQ(obj.cast<std::string>(), "not json at all");
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_HttpMultipartToPyDict) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "OVMS_PY_TENSOR:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    // Lifetime of file content must outlive runner.Run() because parser returns string_view.
+    static const std::string fileBytes{"\x01\x02\x03\x04\x05", 5};
+    auto parser = std::make_shared<LocalMockedMultiPartParser>();
+    EXPECT_CALL(*parser, hasParseError()).WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*parser, getAllFieldNames())
+        .WillRepeatedly(::testing::Return(std::set<std::string>{"file", "model"}));
+    EXPECT_CALL(*parser, getFileContentByFieldName(::testing::Eq("file")))
+        .WillRepeatedly(::testing::Return(std::string_view{fileBytes}));
+    EXPECT_CALL(*parser, getFileContentByFieldName(::testing::Eq("model")))
+        .WillRepeatedly(::testing::Return(std::string_view{}));
+    EXPECT_CALL(*parser, getFieldByName(::testing::Eq("model")))
+        .WillRepeatedly(::testing::Return(std::string{"my-model"}));
+
+    auto payload = std::make_unique<ovms::HttpPayload>();
+    payload->multipartParser = parser;
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
+        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const PyObjectWrapper<py::object>& out =
+        runner.Outputs().Tag("OVMS_PY_TENSOR").packets[0].Get<PyObjectWrapper<py::object>>();
+    const py::object& obj = out.getObject();
+    ASSERT_TRUE(py::isinstance<py::dict>(obj));
+    py::dict d = obj.cast<py::dict>();
+    ASSERT_TRUE(d.contains("file"));
+    ASSERT_TRUE(d.contains("model"));
+
+    py::module_ numpy = py::module_::import("numpy");
+    py::object ndarray = d["file"];
+    ASSERT_TRUE(py::isinstance(ndarray, numpy.attr("ndarray")));
+    EXPECT_EQ(ndarray.attr("dtype").attr("name").cast<std::string>(), "uint8");
+    EXPECT_EQ(ndarray.attr("size").cast<size_t>(), fileBytes.size());
+    auto bytesOut = ndarray.attr("tobytes")().cast<std::string>();
+    EXPECT_EQ(bytesOut, fileBytes);
+
+    EXPECT_EQ(d["model"].cast<std::string>(), "my-model");
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_PyDictToHttpResponse) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "OVMS_PY_TENSOR:input"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::dict d;
+        d["status"] = py::str("ok");
+        d["count"] = py::int_(7);
+        runner.MutableInputs()->Tag("OVMS_PY_TENSOR").packets.push_back(
+            mediapipe::Adopt<PyObjectWrapper<py::object>>(
+                new PyObjectWrapper<py::object>(static_cast<py::object>(d)))
+                .At(mediapipe::Timestamp(0)));
+    }
+
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const std::string& response =
+        runner.Outputs().Tag("HTTP_RESPONSE_PAYLOAD").packets[0].Get<std::string>();
+    // Validate by re-parsing instead of relying on key ordering.
+    rapidjson::Document doc;
+    doc.Parse(response.c_str());
+    ASSERT_FALSE(doc.HasParseError()) << response;
+    ASSERT_TRUE(doc.IsObject());
+    ASSERT_TRUE(doc.HasMember("status"));
+    ASSERT_TRUE(doc.HasMember("count"));
+    EXPECT_STREQ(doc["status"].GetString(), "ok");
+    EXPECT_EQ(doc["count"].GetInt(), 7);
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_PyStringToHttpResponse) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "OVMS_PY_TENSOR:input"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::object s = py::str("raw response body");
+        runner.MutableInputs()->Tag("OVMS_PY_TENSOR").packets.push_back(
+            mediapipe::Adopt<PyObjectWrapper<py::object>>(
+                new PyObjectWrapper<py::object>(s))
+                .At(mediapipe::Timestamp(0)));
+    }
+
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const std::string& response =
+        runner.Outputs().Tag("HTTP_RESPONSE_PAYLOAD").packets[0].Get<std::string>();
+    EXPECT_EQ(response, "raw response body");
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_InvalidTagPairRejected) {
+    // HTTP_REQUEST_PAYLOAD as input must pair with OVMS_PY_TENSOR output.
+    // Pairing with OVTENSOR is unsupported and GetContract should reject it.
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "OVTENSOR:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+    py::gil_scoped_acquire acquire;
+    py::gil_scoped_release release;
+    auto status = runner.Run();
+    EXPECT_FALSE(status.ok());
 }
 
 TEST_F(PythonFlowTest, PythonCalculatorTestSingleInSingleOutMultiRunWithErrors) {

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -54,31 +54,19 @@
 #pragma GCC diagnostic pop
 #include "opencv2/opencv.hpp"
 
+#include "../http_payload.hpp"
+#include "../http_rest_api_handler.hpp"
 #include "../python/python_backend.hpp"
 #include "c_api_test_utils.hpp"
 #include "constructor_enabled_model_manager.hpp"
 #include "platform_utils.hpp"
+#include "test_http_utils.hpp"
 #include "test_utils.hpp"
 
-#include "../http_payload.hpp"
-#include "../multi_part_parser.hpp"
 #pragma warning(push)
 #pragma warning(disable : 6313)
 #include <rapidjson/document.h>
 #pragma warning(pop)
-
-namespace {
-class LocalMockedMultiPartParser final : public ovms::MultiPartParser {
-public:
-    MOCK_METHOD(bool, parse, (), (override));
-    MOCK_METHOD(bool, hasParseError, (), (const override));
-    MOCK_METHOD(std::vector<std::string>, getArrayFieldByName, (const std::string&), (const override));
-    MOCK_METHOD(std::string, getFieldByName, (const std::string&), (const override));
-    MOCK_METHOD(std::string_view, getFileContentByFieldName, (const std::string&), (const override));
-    MOCK_METHOD(std::vector<std::string_view>, getFilesArrayByFieldName, (const std::string&), (const override));
-    MOCK_METHOD(std::set<std::string>, getAllFieldNames, (), (const, override));
-};
-}  // namespace
 
 namespace py = pybind11;
 using namespace ovms;
@@ -2444,14 +2432,14 @@ TEST_F(PythonFlowTest, ConverterCalculator_HttpMultipartToPyDict) {
 
     // Lifetime of file content must outlive runner.Run() because parser returns string_view.
     static const std::string fileBytes{"\x01\x02\x03\x04\x05", 5};
-    auto parser = std::make_shared<LocalMockedMultiPartParser>();
+    auto parser = std::make_shared<MockedMultiPartParser>();
     EXPECT_CALL(*parser, hasParseError()).WillRepeatedly(::testing::Return(false));
     EXPECT_CALL(*parser, getAllFieldNames())
         .WillRepeatedly(::testing::Return(std::set<std::string>{"file", "model"}));
-    EXPECT_CALL(*parser, getFileContentByFieldName(::testing::Eq("file")))
-        .WillRepeatedly(::testing::Return(std::string_view{fileBytes}));
-    EXPECT_CALL(*parser, getFileContentByFieldName(::testing::Eq("model")))
-        .WillRepeatedly(::testing::Return(std::string_view{}));
+    EXPECT_CALL(*parser, getFilesArrayByFieldName(::testing::Eq("file")))
+        .WillRepeatedly(::testing::Return(std::vector<std::string_view>{std::string_view{fileBytes}}));
+    EXPECT_CALL(*parser, getFilesArrayByFieldName(::testing::Eq("model")))
+        .WillRepeatedly(::testing::Return(std::vector<std::string_view>{}));
     EXPECT_CALL(*parser, getFieldByName(::testing::Eq("model")))
         .WillRepeatedly(::testing::Return(std::string{"my-model"}));
 
@@ -2483,6 +2471,47 @@ TEST_F(PythonFlowTest, ConverterCalculator_HttpMultipartToPyDict) {
     EXPECT_EQ(bytesOut, fileBytes);
 
     EXPECT_EQ(d["model"].cast<std::string>(), "my-model");
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_HttpMultipartEmptyFileToPyEmptyArray) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "HTTP_REQUEST_PAYLOAD:input"
+        output_stream: "OVMS_PY_TENSOR:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    auto parser = std::make_shared<MockedMultiPartParser>();
+    EXPECT_CALL(*parser, hasParseError()).WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*parser, getAllFieldNames())
+        .WillRepeatedly(::testing::Return(std::set<std::string>{"file"}));
+    // File is present in the multipart upload but its content is empty.
+    EXPECT_CALL(*parser, getFilesArrayByFieldName(::testing::Eq("file")))
+        .WillRepeatedly(::testing::Return(std::vector<std::string_view>{std::string_view{}}));
+
+    auto payload = std::make_unique<ovms::HttpPayload>();
+    payload->multipartParser = parser;
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const PyObjectWrapper<py::object>& out =
+        runner.Outputs().Tag("OVMS_PY_TENSOR").packets[0].Get<PyObjectWrapper<py::object>>();
+    const py::object& obj = out.getObject();
+    ASSERT_TRUE(py::isinstance<py::dict>(obj));
+    py::dict d = obj.cast<py::dict>();
+    ASSERT_TRUE(d.contains("file"));
+    py::module_ numpy = py::module_::import("numpy");
+    py::object ndarray = d["file"];
+    ASSERT_TRUE(py::isinstance(ndarray, numpy.attr("ndarray")));
+    EXPECT_EQ(ndarray.attr("dtype").attr("name").cast<std::string>(), "uint8");
+    EXPECT_EQ(ndarray.attr("size").cast<size_t>(), 0u);
 }
 
 TEST_F(PythonFlowTest, ConverterCalculator_PyDictToHttpResponse) {
@@ -2545,6 +2574,36 @@ TEST_F(PythonFlowTest, ConverterCalculator_PyStringToHttpResponse) {
     const std::string& response =
         runner.Outputs().Tag("HTTP_RESPONSE_PAYLOAD").packets[0].Get<std::string>();
     EXPECT_EQ(response, "raw response body");
+}
+
+TEST_F(PythonFlowTest, ConverterCalculator_PyBytesToHttpResponse) {
+    std::string testPbtxt = R"(
+        calculator: "PyTensorOvTensorConverterCalculator"
+        name: "conversionNode"
+        input_stream: "OVMS_PY_TENSOR:input"
+        output_stream: "HTTP_RESPONSE_PAYLOAD:output"
+    )";
+    mediapipe::CalculatorRunner runner(testPbtxt);
+
+    // Binary payload: embedded NUL plus high (non-UTF-8) bytes. Must round-trip byte-for-byte.
+    const std::string expected{"\x00\x01\xff\x80\x7f\x00" "ABC\xfe", 10};
+
+    py::gil_scoped_acquire acquire;
+    {
+        py::object b = py::bytes(expected.data(), expected.size());
+        runner.MutableInputs()->Tag("OVMS_PY_TENSOR").packets.push_back(mediapipe::Adopt<PyObjectWrapper<py::object>>(new PyObjectWrapper<py::object>(b)).At(mediapipe::Timestamp(0)));
+    }
+
+    {
+        py::gil_scoped_release release;
+        auto status = runner.Run();
+        ASSERT_TRUE(status.ok()) << status.code() << " " << status.message();
+    }
+
+    const std::string& response =
+        runner.Outputs().Tag("HTTP_RESPONSE_PAYLOAD").packets[0].Get<std::string>();
+    ASSERT_EQ(response.size(), expected.size());
+    EXPECT_EQ(response, expected);
 }
 
 TEST_F(PythonFlowTest, ConverterCalculator_InvalidTagPairRejected) {

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -2586,7 +2586,9 @@ TEST_F(PythonFlowTest, ConverterCalculator_PyBytesToHttpResponse) {
     mediapipe::CalculatorRunner runner(testPbtxt);
 
     // Binary payload: embedded NUL plus high (non-UTF-8) bytes. Must round-trip byte-for-byte.
-    const std::string expected{"\x00\x01\xff\x80\x7f\x00" "ABC\xfe", 10};
+    const std::string expected{"\x00\x01\xff\x80\x7f\x00"
+                               "ABC\xfe",
+        10};
 
     py::gil_scoped_acquire acquire;
     {

--- a/src/test/pythonnode_test.cpp
+++ b/src/test/pythonnode_test.cpp
@@ -2354,8 +2354,7 @@ TEST_F(PythonFlowTest, ConverterCalculator_HttpJsonRequestToPyDict) {
     payload->parsedJson->Parse(payload->body.c_str());
     ASSERT_FALSE(payload->parsedJson->HasParseError());
 
-    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
-        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
 
     py::gil_scoped_acquire acquire;
     {
@@ -2386,8 +2385,7 @@ TEST_F(PythonFlowTest, ConverterCalculator_HttpRawJsonBodyToPyDict) {
     auto payload = std::make_unique<ovms::HttpPayload>();
     payload->body = R"({"a":1,"b":[2,3]})";
     // parsedJson left null - exercise the json.loads(body) fallback.
-    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
-        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
 
     py::gil_scoped_acquire acquire;
     {
@@ -2419,8 +2417,7 @@ TEST_F(PythonFlowTest, ConverterCalculator_HttpRawNonJsonBodyToPyString) {
 
     auto payload = std::make_unique<ovms::HttpPayload>();
     payload->body = "not json at all";
-    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
-        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
 
     py::gil_scoped_acquire acquire;
     {
@@ -2460,8 +2457,7 @@ TEST_F(PythonFlowTest, ConverterCalculator_HttpMultipartToPyDict) {
 
     auto payload = std::make_unique<ovms::HttpPayload>();
     payload->multipartParser = parser;
-    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(
-        mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
+    runner.MutableInputs()->Tag("HTTP_REQUEST_PAYLOAD").packets.push_back(mediapipe::Adopt<ovms::HttpPayload>(payload.release()).At(mediapipe::Timestamp(0)));
 
     py::gil_scoped_acquire acquire;
     {
@@ -2503,10 +2499,7 @@ TEST_F(PythonFlowTest, ConverterCalculator_PyDictToHttpResponse) {
         py::dict d;
         d["status"] = py::str("ok");
         d["count"] = py::int_(7);
-        runner.MutableInputs()->Tag("OVMS_PY_TENSOR").packets.push_back(
-            mediapipe::Adopt<PyObjectWrapper<py::object>>(
-                new PyObjectWrapper<py::object>(static_cast<py::object>(d)))
-                .At(mediapipe::Timestamp(0)));
+        runner.MutableInputs()->Tag("OVMS_PY_TENSOR").packets.push_back(mediapipe::Adopt<PyObjectWrapper<py::object>>(new PyObjectWrapper<py::object>(static_cast<py::object>(d))).At(mediapipe::Timestamp(0)));
     }
 
     {
@@ -2540,10 +2533,7 @@ TEST_F(PythonFlowTest, ConverterCalculator_PyStringToHttpResponse) {
     py::gil_scoped_acquire acquire;
     {
         py::object s = py::str("raw response body");
-        runner.MutableInputs()->Tag("OVMS_PY_TENSOR").packets.push_back(
-            mediapipe::Adopt<PyObjectWrapper<py::object>>(
-                new PyObjectWrapper<py::object>(s))
-                .At(mediapipe::Timestamp(0)));
+        runner.MutableInputs()->Tag("OVMS_PY_TENSOR").packets.push_back(mediapipe::Adopt<PyObjectWrapper<py::object>>(new PyObjectWrapper<py::object>(s)).At(mediapipe::Timestamp(0)));
     }
 
     {


### PR DESCRIPTION
### 🛠 Summary
Adds two new tag pairings to the converter so Python MediaPipe nodes can directly consume HTTP requests and emit HTTP responses:

HTTP_REQUEST_PAYLOAD → OVMS_PY_TENSOR: multipart parts become a dict of numpy.ndarray(uint8) (files) and str (form fields); JSON bodies become native Python objects; non-JSON bodies pass through as str.
OVMS_PY_TENSOR → HTTP_RESPONSE_PAYLOAD: str/bytes forwarded verbatim, anything else json.dumps-ed.
Existing OVTENSOR ↔ OVMS_PY_TENSOR paths and the tag_to_output_tensor_names option are unchanged. Drive-by fix: removed a dangling reference to a temporary in GetContract/Process. Covered by 7 new gtests.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

