### PR TITLE
Log VLM perf metrics at DEBUG level for legacy and continuous batchin…

### DIFF
--- a/src/llm/language_model/continuous_batching/servable.cpp
+++ b/src/llm/language_model/continuous_batching/servable.cpp
@@ -42,6 +42,23 @@
 
 namespace ovms {
 
+void ContinuousBatchingServable::logPerfMetrics(ov::genai::PerfMetrics& perfMetrics) {
+    const size_t inputTokenCount = perfMetrics.get_num_input_tokens();
+    const size_t outputTokenCount = perfMetrics.get_num_generated_tokens();
+    // GenerationHandle metrics are scoped to this request; TTFT contains one sample.
+    const double ttftMs = perfMetrics.get_ttft().mean;
+    const double prefillSpeedTps = calculatePrefillSpeed(inputTokenCount, ttftMs);
+
+    SPDLOG_LOGGER_DEBUG(
+        llm_calculator_logger,
+        "Request processing metrics | input_token_count: {} | output_token_count: {} | total_token_count: {} | ttft_ms: {:.3f} | prefill_speed_tps: {:.3f}",
+        inputTokenCount,
+        outputTokenCount,
+        inputTokenCount + outputTokenCount,
+        ttftMs,
+        prefillSpeedTps);
+}
+
 void ContinuousBatchingServable::notifyExecutorThread() {
     SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Notifying executor thread");
     if (properties->llmExecutorWrapper == nullptr) {
@@ -142,6 +159,28 @@ absl::Status ContinuousBatchingServable::readPartialExecutionResults(std::shared
         }
     }
     return absl::OkStatus();
+}
+
+absl::Status ContinuousBatchingServable::prepareCompleteResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) {
+    auto status = GenAiServable::prepareCompleteResponse(executionContext);
+    if (status.ok() && llm_calculator_logger->should_log(spdlog::level::debug)) {
+        auto cbExecutionContext = std::static_pointer_cast<ContinuousBatchingServableExecutionContext>(executionContext);
+        auto perfMetrics = cbExecutionContext->generationHandle->get_perf_metrics();
+        logPerfMetrics(perfMetrics);
+    }
+    return status;
+}
+
+absl::Status ContinuousBatchingServable::preparePartialResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) {
+    auto status = GenAiServable::preparePartialResponse(executionContext);
+    if (status.ok() &&
+        !executionContext->sendLoopbackSignal &&
+        llm_calculator_logger->should_log(spdlog::level::debug)) {
+        auto cbExecutionContext = std::static_pointer_cast<ContinuousBatchingServableExecutionContext>(executionContext);
+        auto perfMetrics = cbExecutionContext->generationHandle->get_perf_metrics();
+        logPerfMetrics(perfMetrics);
+    }
+    return status;
 }
 
 }  // namespace ovms

--- a/src/llm/language_model/continuous_batching/servable.hpp
+++ b/src/llm/language_model/continuous_batching/servable.hpp
@@ -40,6 +40,7 @@ class ContinuousBatchingServable : public GenAiServable {
 protected:
     std::shared_ptr<ContinuousBatchingServableProperties> properties;
     void notifyExecutorThread();
+    void logPerfMetrics(ov::genai::PerfMetrics& perfMetrics);
 
 public:
     ContinuousBatchingServable() {
@@ -56,5 +57,7 @@ public:
     absl::Status scheduleExecution(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
     absl::Status readCompleteExecutionResults(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
     absl::Status readPartialExecutionResults(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
+    absl::Status prepareCompleteResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
+    absl::Status preparePartialResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
 };
 }  // namespace ovms

--- a/src/llm/language_model/legacy/servable.cpp
+++ b/src/llm/language_model/legacy/servable.cpp
@@ -46,6 +46,22 @@
 
 namespace ovms {
 
+void LegacyServable::logPerfMetrics(ov::genai::PerfMetrics& perfMetrics) {
+    const size_t inputTokenCount = perfMetrics.get_num_input_tokens();
+    const size_t outputTokenCount = perfMetrics.get_num_generated_tokens();
+    const double ttftMs = perfMetrics.get_ttft().mean;
+    const double prefillSpeedTps = calculatePrefillSpeed(inputTokenCount, ttftMs);
+
+    SPDLOG_LOGGER_DEBUG(
+        llm_calculator_logger,
+        "Request processing metrics | input_token_count: {} | output_token_count: {} | total_token_count: {} | ttft_ms: {:.3f} | prefill_speed_tps: {:.3f}",
+        inputTokenCount,
+        outputTokenCount,
+        inputTokenCount + outputTokenCount,
+        ttftMs,
+        prefillSpeedTps);
+}
+
 absl::Status LegacyServable::validateInputComplianceWithProperties(const ov::Tensor& inputIds) const {
     if (properties->device == "NPU") {
         int64_t inputLength = inputIds.get_size();
@@ -188,6 +204,9 @@ absl::Status LegacyServable::prepareCompleteResponse(std::shared_ptr<GenAiServab
         return absl::CancelledError();
     }
     executionContext->response = executionContext->apiHandler->serializeUnaryResponse(legacyExecutionContext->results);
+    if (llm_calculator_logger->should_log(spdlog::level::debug)) {
+        logPerfMetrics(legacyExecutionContext->results.perf_metrics);
+    }
     SPDLOG_LOGGER_DEBUG(llm_calculator_logger, "Complete unary response: {}", executionContext->response);
     return absl::OkStatus();
 }
@@ -275,6 +294,9 @@ absl::Status LegacyServable::preparePartialResponse(std::shared_ptr<GenAiServabl
         if (executionContext->apiHandler->getStreamOptions().includeUsage)
             executionContext->response += wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingUsageChunk());
         executionContext->response += wrapTextInServerSideEventMessage("[DONE]");
+        if (llm_calculator_logger->should_log(spdlog::level::debug)) {
+            logPerfMetrics(legacyExecutionContext->results.perf_metrics);
+        }
         SPDLOG_LOGGER_DEBUG(llm_calculator_logger, "Generated complete streaming response: {}", executionContext->response);
         executionContext->sendLoopbackSignal = false;
     }

--- a/src/llm/language_model/legacy/servable.hpp
+++ b/src/llm/language_model/legacy/servable.hpp
@@ -52,6 +52,7 @@ struct LegacyServableProperties : public GenAiServableProperties {
 
 class LegacyServable : public GenAiServable {
     std::shared_ptr<LegacyServableProperties> properties;
+    void logPerfMetrics(ov::genai::PerfMetrics& perfMetrics);
 
 protected:
     void notifyExecutorThread();

--- a/src/llm/servable.cpp
+++ b/src/llm/servable.cpp
@@ -45,6 +45,10 @@
 
 namespace ovms {
 
+double calculatePrefillSpeed(size_t inputTokenCount, double ttftMs) {
+    return ttftMs > 0.0 ? (1000.0 * inputTokenCount) / ttftMs : 0.0;
+}
+
 void GenAiServable::determineDecodingMethod() {
     getProperties()->decodingMethod = DecodingMethod::STANDARD;
     auto& pluginConfig = getProperties()->pluginConfig;

--- a/src/llm/servable.hpp
+++ b/src/llm/servable.hpp
@@ -48,6 +48,8 @@ namespace ovms {
 // Some pipelines internals rely on request_id, so for now we provide increasing ID
 static std::atomic<uint64_t> currentRequestId = 0;
 
+double calculatePrefillSpeed(size_t inputTokenCount, double ttftMs);
+
 /*
 GenAiServable support.
 

--- a/src/llm/visual_language_model/continuous_batching/servable.cpp
+++ b/src/llm/visual_language_model/continuous_batching/servable.cpp
@@ -35,6 +35,28 @@
 
 namespace ovms {
 
+void VisualLanguageModelServable::logPerfMetrics(ov::genai::VLMPerfMetrics& perfMetrics) {
+    const size_t inputTokenCount = perfMetrics.get_num_input_tokens();
+    const size_t outputTokenCount = perfMetrics.get_num_generated_tokens();
+    const double prepareEmbeddingsTimeMs = perfMetrics.get_prepare_embeddings_duration().mean;
+    // Continuous batching starts request timing after embeddings preparation.
+    const double llmTtftMs = perfMetrics.get_ttft().mean;
+    const double ttftMs = llmTtftMs + prepareEmbeddingsTimeMs;
+    const double prefillSpeedTps = calculatePrefillSpeed(inputTokenCount, llmTtftMs);
+
+    SPDLOG_LOGGER_DEBUG(
+        llm_calculator_logger,
+        "Request processing metrics | input_token_count: {} | output_token_count: {} | total_token_count: {} | prepare_embeddings_time_ms: {:.3f} | llm_ttft_ms: {:.3f} | ttft_ms: {:.3f} | prefill_speed_tps: {:.3f} | image_slice_count: {}",
+        inputTokenCount,
+        outputTokenCount,
+        inputTokenCount + outputTokenCount,
+        prepareEmbeddingsTimeMs,
+        llmTtftMs,
+        ttftMs,
+        prefillSpeedTps,
+        perfMetrics.get_total_image_slice_count());
+}
+
 absl::Status VisualLanguageModelServable::addRequestToPipeline(std::shared_ptr<ContinuousBatchingServableExecutionContext>& executionContext) {
     auto vlmExecutionContext = std::static_pointer_cast<VisualLanguageModelServableExecutionContext>(executionContext);
     vlmExecutionContext->generationHandle = properties->pipeline->add_request(currentRequestId++,  // to be removed from API?
@@ -56,6 +78,28 @@ std::shared_ptr<GenAiServableExecutionContext> VisualLanguageModelServable::crea
 
 std::shared_ptr<GenAiServableProperties> VisualLanguageModelServable::getProperties() {
     return properties;
+}
+
+absl::Status VisualLanguageModelServable::prepareCompleteResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) {
+    auto status = GenAiServable::prepareCompleteResponse(executionContext);
+    if (status.ok() && llm_calculator_logger->should_log(spdlog::level::debug)) {
+        auto vlmExecutionContext = std::static_pointer_cast<VisualLanguageModelServableExecutionContext>(executionContext);
+        auto perfMetrics = vlmExecutionContext->generationHandle->get_vlm_perf_metrics();
+        logPerfMetrics(perfMetrics);
+    }
+    return status;
+}
+
+absl::Status VisualLanguageModelServable::preparePartialResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) {
+    auto status = GenAiServable::preparePartialResponse(executionContext);
+    if (status.ok() &&
+        !executionContext->sendLoopbackSignal &&
+        llm_calculator_logger->should_log(spdlog::level::debug)) {
+        auto vlmExecutionContext = std::static_pointer_cast<VisualLanguageModelServableExecutionContext>(executionContext);
+        auto perfMetrics = vlmExecutionContext->generationHandle->get_vlm_perf_metrics();
+        logPerfMetrics(perfMetrics);
+    }
+    return status;
 }
 
 }  // namespace ovms

--- a/src/llm/visual_language_model/continuous_batching/servable.hpp
+++ b/src/llm/visual_language_model/continuous_batching/servable.hpp
@@ -35,6 +35,8 @@ struct VisualLanguageModelServableExecutionContext : public ContinuousBatchingSe
 };
 
 class VisualLanguageModelServable : public ContinuousBatchingServable {
+    void logPerfMetrics(ov::genai::VLMPerfMetrics& perfMetrics);
+
 public:
     VisualLanguageModelServable() {
         properties = std::make_shared<VisualLanguageModelServableProperties>();
@@ -48,5 +50,7 @@ public:
     absl::Status validateEndpoint(Endpoint endpoint) const override;
     std::shared_ptr<GenAiServableExecutionContext> createExecutionContext() override;
     std::shared_ptr<GenAiServableProperties> getProperties() override;
+    absl::Status prepareCompleteResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
+    absl::Status preparePartialResponse(std::shared_ptr<GenAiServableExecutionContext>& executionContext) override;
 };
 }  // namespace ovms

--- a/src/llm/visual_language_model/legacy/servable.cpp
+++ b/src/llm/visual_language_model/legacy/servable.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //*****************************************************************************
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <stdexcept>
@@ -51,6 +52,28 @@
 #include "servable.hpp"
 
 namespace ovms {
+
+void VisualLanguageModelLegacyServable::logPerfMetrics(ov::genai::VLMPerfMetrics& perfMetrics) {
+    const size_t inputTokenCount = perfMetrics.get_num_input_tokens();
+    const size_t outputTokenCount = perfMetrics.get_num_generated_tokens();
+    const double prepareEmbeddingsTimeMs = perfMetrics.get_prepare_embeddings_duration().mean;
+    const double ttftMs = perfMetrics.get_ttft().mean;
+    // Legacy VLM measures TTFT from the beginning of generate(), including embeddings preparation.
+    const double llmTtftMs = std::max(ttftMs - prepareEmbeddingsTimeMs, 0.0);
+    const double prefillSpeedTps = calculatePrefillSpeed(inputTokenCount, llmTtftMs);
+
+    SPDLOG_LOGGER_DEBUG(
+        llm_calculator_logger,
+        "Request processing metrics | input_token_count: {} | output_token_count: {} | total_token_count: {} | prepare_embeddings_time_ms: {:.3f} | llm_ttft_ms: {:.3f} | ttft_ms: {:.3f} | prefill_speed_tps: {:.3f} | image_slice_count: {}",
+        inputTokenCount,
+        outputTokenCount,
+        inputTokenCount + outputTokenCount,
+        prepareEmbeddingsTimeMs,
+        llmTtftMs,
+        ttftMs,
+        prefillSpeedTps,
+        perfMetrics.get_total_image_slice_count());
+}
 
 absl::Status VisualLanguageModelLegacyServable::validateEndpoint(Endpoint endpoint) const {
     if (endpoint == Endpoint::COMPLETIONS) {
@@ -211,6 +234,9 @@ absl::Status VisualLanguageModelLegacyServable::prepareCompleteResponse(std::sha
     const std::string& completeText = legacyExecutionContext->accumulatedUnaryText;
     executionContext->response = executionContext->apiHandler->serializeUnaryResponse(
         legacyExecutionContext->results, completeText);
+    if (llm_calculator_logger->should_log(spdlog::level::debug)) {
+        logPerfMetrics(legacyExecutionContext->results.perf_metrics);
+    }
     SPDLOG_LOGGER_DEBUG(llm_calculator_logger, "Complete unary response: {}", executionContext->response);
     return absl::OkStatus();
 }
@@ -305,6 +331,9 @@ absl::Status VisualLanguageModelLegacyServable::preparePartialResponse(std::shar
         if (executionContext->apiHandler->getStreamOptions().includeUsage)
             executionContext->response += wrapTextInServerSideEventMessage(executionContext->apiHandler->serializeStreamingUsageChunk());
         executionContext->response += wrapTextInServerSideEventMessage("[DONE]");
+        if (llm_calculator_logger->should_log(spdlog::level::debug)) {
+            logPerfMetrics(legacyExecutionContext->results.perf_metrics);
+        }
         SPDLOG_LOGGER_DEBUG(llm_calculator_logger, "Generated complete streaming response: {}", executionContext->response);
         executionContext->sendLoopbackSignal = false;
     }

--- a/src/llm/visual_language_model/legacy/servable.hpp
+++ b/src/llm/visual_language_model/legacy/servable.hpp
@@ -55,6 +55,7 @@ struct VisualLanguageModelLegacyServableProperties : public GenAiServablePropert
 
 class VisualLanguageModelLegacyServable : public GenAiServable {
     std::shared_ptr<VisualLanguageModelLegacyServableProperties> properties;
+    void logPerfMetrics(ov::genai::VLMPerfMetrics& perfMetrics);
 
 protected:
     void notifyExecutorThread();


### PR DESCRIPTION
…g pipelines

Add debug-level logging of VLM performance metrics including:
- input_token_count, prepare_embeddings_time_ms, ttft_ms, prefill_speed_tps
- image_slice_count (from GenAI VLMPerfMetrics)
- For CB pipeline: output_token_count, llm_ttft_ms, total_token_count

Legacy VLM pipeline logs metrics after unary and streaming responses. Continuous batching VLM pipeline retrieves request-level metrics via GenerationHandle::get_vlm_perf_metrics() (requires openvinotoolkit/openvino.genai#3860).

CVS-186710

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

