### PR TITLE
fix ubuntu22 in versions.mk

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -30,6 +30,6 @@ OV_TOKENIZERS_ORG ?= openvinotoolkit
 
 # Binary package URLs for each supported platform.
 DLDT_PACKAGE_URL_UBUNTU24 ?= https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/pre-release/2026.2.0.0rc1/openvino_genai_ubuntu24_2026.2.0.0rc1_x86_64.tar.gz
-DLDT_PACKAGE_URL_UBUNTU22 ?= https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/pre-release/2026.2.0.0rc1/openvino_genai_ubuntu22_2026.2.0.0rc1_arm64.tar.gz
+DLDT_PACKAGE_URL_UBUNTU22 ?= https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/pre-release/2026.2.0.0rc1/openvino_genai_ubuntu22_2026.2.0.0rc1_x86_64.tar.gz
 DLDT_PACKAGE_URL_RHEL ?= https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/pre-release/2026.2.0.0rc1/openvino_genai_rhel8_2026.2.0.0rc1_x86_64.tar.gz
 GENAI_PACKAGE_URL_WINDOWS ?= https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/pre-release/2026.2.0.0rc1/openvino_genai_windows_2026.2.0.0rc1_x86_64.zip


### PR DESCRIPTION
Incorrect version of ubuntu22 file in versions.mk, brakes recompile job: https://ci.iotg.sclab.intel.com/job/ovmsc/job/OVMS_Validation/job/daily/job/ovms-c_recompile_daily/633/

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

