### PR TITLE
avoid too high number of threads on multi socket system and with HT

### DIFF
--- a/src/ov_utils.cpp
+++ b/src/ov_utils.cpp
@@ -186,8 +186,7 @@ Status applyDefaultCpuProperties(ov::AnyMap& properties) {
             if (isThroughput) {
                 numThreads = static_cast<int>(coreCount);
             } else {
-                const uint16_t sockets = getNumberOfSockets();
-                numThreads = std::max(1, std::min(static_cast<int>(coreCount), static_cast<int>(getNumberOfPhysicalCores() / sockets)));
+                numThreads = std::min(static_cast<int>(coreCount), static_cast<int>(getPhysicalCoresPerSocket()));
             }
             properties[ov::inference_num_threads.name()] = numThreads;
             SPDLOG_DEBUG("applyDefaultCpuProperties: setting inference_num_threads to {}", numThreads);

--- a/src/ov_utils.cpp
+++ b/src/ov_utils.cpp
@@ -187,7 +187,7 @@ Status applyDefaultCpuProperties(ov::AnyMap& properties) {
                 numThreads = static_cast<int>(coreCount);
             } else {
                 const uint16_t sockets = getNumberOfSockets();
-                numThreads = std::max(1, static_cast<int>(getNumberOfPhysicalCores() / sockets));
+                numThreads = std::max(1, std::min(static_cast<int>(coreCount), static_cast<int>(getNumberOfPhysicalCores() / sockets)));
             }
             properties[ov::inference_num_threads.name()] = numThreads;
             SPDLOG_DEBUG("applyDefaultCpuProperties: setting inference_num_threads to {}", numThreads);

--- a/src/ov_utils.cpp
+++ b/src/ov_utils.cpp
@@ -151,28 +151,22 @@ Status validatePluginConfiguration(const plugin_config_t& pluginConfig, const st
 }
 
 Status applyDefaultCpuProperties(ov::AnyMap& properties) {
-    try {
-        const uint16_t coreCount = getCoreCount();
-        const uint16_t sanitizedCoreCount = coreCount > 0 ? coreCount : 1;
-
-        if (properties.find(ov::inference_num_threads.name()) == properties.end()) {
-            properties[ov::inference_num_threads.name()] = static_cast<int>(sanitizedCoreCount);
-            SPDLOG_DEBUG("applyDefaultCpuProperties: setting inference_num_threads to {}", sanitizedCoreCount);
-        }
-
 #ifdef __linux__
-        if (properties.find(ov::hint::enable_cpu_pinning.name()) == properties.end()) {
-            if (isRunningInDocker()) {
-                const bool cpuPinning = getDockerCpuQuota() <= 0;
-                properties[ov::hint::enable_cpu_pinning.name()] = cpuPinning;
-                SPDLOG_DEBUG("applyDefaultCpuProperties: setting enable_cpu_pinning to {}", cpuPinning);
-            }
+    try {
+        if (!isRunningInDocker()) {
+            return StatusCode::OK;
         }
-#endif
+        const uint16_t coreCount = getCoreCount();
 
+        if (properties.find(ov::hint::enable_cpu_pinning.name()) == properties.end()) {
+            const bool cpuPinning = getDockerCpuQuota() <= 0;
+            properties[ov::hint::enable_cpu_pinning.name()] = cpuPinning;
+            SPDLOG_DEBUG("applyDefaultCpuProperties: setting enable_cpu_pinning to {}", cpuPinning);
+        }
+
+        bool isThroughput = false;
         const auto perfIt = properties.find(ov::hint::performance_mode.name());
         if (perfIt != properties.end()) {
-            bool isThroughput = false;
             try {
                 isThroughput = (perfIt->second.as<ov::hint::PerformanceMode>() == ov::hint::PerformanceMode::THROUGHPUT);
             } catch (...) {
@@ -186,13 +180,24 @@ Status applyDefaultCpuProperties(ov::AnyMap& properties) {
                 SPDLOG_DEBUG("applyDefaultCpuProperties: setting num_streams to {} (THROUGHPUT hint active)", coreCount);
             }
         }
+
+        if (properties.find(ov::inference_num_threads.name()) == properties.end()) {
+            int numThreads;
+            if (isThroughput) {
+                numThreads = static_cast<int>(coreCount);
+            } else {
+                const uint16_t sockets = getNumberOfSockets();
+                numThreads = std::max(1, static_cast<int>(getNumberOfPhysicalCores() / sockets));
+            }
+            properties[ov::inference_num_threads.name()] = numThreads;
+            SPDLOG_DEBUG("applyDefaultCpuProperties: setting inference_num_threads to {}", numThreads);
+        }
     } catch (const std::exception& ex) {
-        SPDLOG_ERROR("Exception while applying default CPU properties: {}", ex.what());
-        return StatusCode::INTERNAL_ERROR;
+        SPDLOG_WARN("Exception while applying default CPU properties: {}", ex.what());
     } catch (...) {
-        SPDLOG_ERROR("Unknown exception while applying default CPU properties");
-        return StatusCode::INTERNAL_ERROR;
+        SPDLOG_WARN("Unknown exception while applying default CPU properties");
     }
+#endif
     return StatusCode::OK;
 }
 

--- a/src/systeminfo.cpp
+++ b/src/systeminfo.cpp
@@ -101,7 +101,6 @@ uint16_t getCpuAffinityCount() {
     return static_cast<uint16_t>(cpu_count);
 }
 
-
 uint16_t getDockerCpuQuota() {
     // Try cgroup v2 cpu.max (format: "quota period")
     std::ifstream cpu_max_v2("/sys/fs/cgroup/cpu.max");

--- a/src/systeminfo.cpp
+++ b/src/systeminfo.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <fstream>
 #include <limits>
+#include <set>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -100,6 +101,7 @@ uint16_t getCpuAffinityCount() {
     return static_cast<uint16_t>(cpu_count);
 }
 
+
 uint16_t getDockerCpuQuota() {
     // Try cgroup v2 cpu.max (format: "quota period")
     std::ifstream cpu_max_v2("/sys/fs/cgroup/cpu.max");
@@ -150,6 +152,42 @@ uint16_t getDockerCpuQuota() {
     }
 
     return 0;  // No quota set
+}
+
+uint16_t getNumberOfPhysicalCores() {
+    std::set<std::string> uniqueCores;
+    std::ifstream cpuInfo("/proc/cpuinfo");
+    if (!cpuInfo.is_open()) {
+        return std::max<uint16_t>(static_cast<uint16_t>(std::thread::hardware_concurrency()), 1);
+    }
+    std::string line;
+    while (std::getline(cpuInfo, line)) {
+        if (line.find("core id") != std::string::npos) {
+            uniqueCores.insert(line);
+        }
+    }
+    if (uniqueCores.empty()) {
+        return std::max<uint16_t>(static_cast<uint16_t>(std::thread::hardware_concurrency()), 1);
+    }
+    return static_cast<uint16_t>(uniqueCores.size());
+}
+
+uint16_t getNumberOfSockets() {
+    std::set<std::string> uniqueSockets;
+    std::ifstream cpuInfo("/proc/cpuinfo");
+    if (!cpuInfo.is_open()) {
+        return 1;
+    }
+    std::string line;
+    while (std::getline(cpuInfo, line)) {
+        if (line.find("physical id") != std::string::npos) {
+            uniqueSockets.insert(line);
+        }
+    }
+    if (uniqueSockets.empty()) {
+        return 1;
+    }
+    return static_cast<uint16_t>(uniqueSockets.size());
 }
 
 #endif  // __linux__

--- a/src/systeminfo.cpp
+++ b/src/systeminfo.cpp
@@ -154,7 +154,7 @@ uint16_t getDockerCpuQuota() {
     return 0;  // No quota set
 }
 
-uint16_t getNumberOfPhysicalCores() {
+uint16_t getPhysicalCoresPerSocket() {
     std::set<std::string> uniqueCores;
     std::ifstream cpuInfo("/proc/cpuinfo");
     if (!cpuInfo.is_open()) {
@@ -170,24 +170,6 @@ uint16_t getNumberOfPhysicalCores() {
         return std::max<uint16_t>(static_cast<uint16_t>(std::thread::hardware_concurrency()), 1);
     }
     return static_cast<uint16_t>(uniqueCores.size());
-}
-
-uint16_t getNumberOfSockets() {
-    std::set<std::string> uniqueSockets;
-    std::ifstream cpuInfo("/proc/cpuinfo");
-    if (!cpuInfo.is_open()) {
-        return 1;
-    }
-    std::string line;
-    while (std::getline(cpuInfo, line)) {
-        if (line.find("physical id") != std::string::npos) {
-            uniqueSockets.insert(line);
-        }
-    }
-    if (uniqueSockets.empty()) {
-        return 1;
-    }
-    return static_cast<uint16_t>(uniqueSockets.size());
 }
 
 #endif  // __linux__

--- a/src/systeminfo.hpp
+++ b/src/systeminfo.hpp
@@ -39,11 +39,6 @@ uint16_t getDockerCpuQuota();
  * @brief Get number of physical (non-hyperthreaded) CPU cores
  * @return uint16_t Number of physical cores, or hardware_concurrency if detection fails
  */
-uint16_t getNumberOfPhysicalCores();
-/**
- * @brief Get number of CPU sockets in the system
- * @return uint16_t Number of sockets, or 1 if detection fails
- */
-uint16_t getNumberOfSockets();
+uint16_t getPhysicalCoresPerSocket();
 #endif
 }  // namespace ovms

--- a/src/systeminfo.hpp
+++ b/src/systeminfo.hpp
@@ -35,5 +35,15 @@ uint16_t getCpuAffinityCount();
  * @return uint16_t Number of CPUs allowed by quota, or 0 if no quota is set
  */
 uint16_t getDockerCpuQuota();
+/**
+ * @brief Get number of physical (non-hyperthreaded) CPU cores
+ * @return uint16_t Number of physical cores, or hardware_concurrency if detection fails
+ */
+uint16_t getNumberOfPhysicalCores();
+/**
+ * @brief Get number of CPU sockets in the system
+ * @return uint16_t Number of sockets, or 1 if detection fails
+ */
+uint16_t getNumberOfSockets();
 #endif
 }  // namespace ovms


### PR DESCRIPTION
### 🛠 Summary

Problems to solve:
on dual socket host with HT, number of threads was too high in latency model. Optimal is number of physical cores on one socket.
Without docker on linux, OV should apply all defaults
When container has quota, number of threads should be like number of allocated cores.


### 🧪 Checklist

- [ ] The documentation updated.
- [ ] Unit tests added.
- [ ] Change follows security best practices.
``

