### PR TITLE
Audio validation copilot suggested improvements

### DIFF
--- a/src/audio/audio_utils.cpp
+++ b/src/audio/audio_utils.cpp
@@ -29,10 +29,10 @@
 #include <algorithm>
 #pragma warning(push)
 #define PIPELINE_SUPPORTED_SAMPLE_RATE 16000
-#define DEFAULT_MIN_SAMPLE_RATE 4000u
-#define DEFAULT_MAX_SAMPLE_RATE 384000u
 
 using namespace ovms;
+
+static void validateAudioFileSizeAgainstMaxValue(size_t fileSize);
 
 bool isWavBuffer(const std::string buf) {
     // RIFF ref: https://en.wikipedia.org/wiki/Resource_Interchange_File_Format
@@ -157,8 +157,12 @@ std::vector<float> readMp3(const std::string_view& mp3Data) {
         drmp3_uninit(&mp3);
         throw std::runtime_error("MP3 file must be mono or stereo");
     }
-    // Validate expected output buffer size before any allocation or decoding, using metadata
-    validateAudioFileSize(mp3.totalPCMFrameCount, mp3.sampleRate, PIPELINE_SUPPORTED_SAMPLE_RATE, mp3.channels, sizeof(float));
+    // Validate expected output buffer size before any allocation or decoding, using metadata.
+    // dr_mp3 sets totalPCMFrameCount to UINT64_MAX when no Xing/VBRI tag is present (unknown length).
+    // In that case skip metadata-based validation; post-decode validation will guard against OOM.
+    if (mp3.totalPCMFrameCount != std::numeric_limits<uint64_t>::max()) {
+        validateAudioFileSize(mp3.totalPCMFrameCount, mp3.sampleRate, PIPELINE_SUPPORTED_SAMPLE_RATE, mp3.channels, sizeof(float));
+    }
     constexpr size_t MP3_DECODE_CHUNK_FRAMES = 1152;  // 1152 is the maximum number of PCM samples per channel produced by a single MPEG-1 Layer III MP3 frame. Reference: ISO/IEC 11172-3
     // We cannot know the decoded sample count up front, but we can check the maximum possible size based on file size and sample rate
     // For safety, check the decoded buffer after filling
@@ -177,12 +181,13 @@ std::vector<float> readMp3(const std::string_view& mp3Data) {
     timer.stop(TENSOR_PREPARATION);
     auto tensorPreparationTime = (timer.elapsed<std::chrono::microseconds>(TENSOR_PREPARATION)) / 1000;
     SPDLOG_LOGGER_DEBUG(s2t_calculator_logger, "Tensor preparation time: {} ms size: {}", tensorPreparationTime, pcmf32.size());
+    validateAudioFileSizeAgainstMaxValue(pcmf32.size() * sizeof(float));
     if (mp3.sampleRate == PIPELINE_SUPPORTED_SAMPLE_RATE) {
         return pcmf32;
     }
     timer.start(RESAMPLING);
     size_t outputLength = (size_t)(pcmf32.size() * PIPELINE_SUPPORTED_SAMPLE_RATE / mp3.sampleRate);
-    // Validate resampled buffer size before allocation
+    validateAudioFileSizeAgainstMaxValue(outputLength * sizeof(float));
     std::vector<float> output(outputLength);
     resample_audio(reinterpret_cast<float*>(pcmf32.data()), pcmf32.size(), mp3.sampleRate, PIPELINE_SUPPORTED_SAMPLE_RATE, output);
     timer.stop(RESAMPLING);
@@ -220,7 +225,7 @@ void prepareAudioOutput(void** ppData, size_t& pDataSize, uint16_t bitsPerSample
     auto outputPreparationTime = (timer.elapsed<std::chrono::microseconds>(OUTPUT_PREPARATION)) / 1000;
     SPDLOG_LOGGER_DEBUG(t2s_calculator_logger, "Output preparation time: {} ms", outputPreparationTime);
 }
-void validateAudioFileSizeAgainstMaxValue(size_t fileSize) {
+static void validateAudioFileSizeAgainstMaxValue(size_t fileSize) {
     constexpr size_t DEFAULT_MAX_FILE_SIZE = 1024ull * 1024 * 1024; // 1GB
     size_t maxFileSize = DEFAULT_MAX_FILE_SIZE;
     const char* env = std::getenv("OVMS_AUDIO_MAX_FILE_SIZE_BYTES");
@@ -234,22 +239,32 @@ void validateAudioFileSizeAgainstMaxValue(size_t fileSize) {
             // Ignore invalid env, use default
         }
     }
-    SPDLOG_ERROR("{} : {}", maxFileSize, fileSize);
+    SPDLOG_DEBUG("{} : {}", maxFileSize, fileSize);
     if (fileSize > maxFileSize) {
         throw std::runtime_error("Audio file size " + std::to_string(fileSize) +
             " exceeds maximum allowed size (" + std::to_string(maxFileSize) + ")");
     }
 }
 
-// Returns true if the estimated resampled audio buffer size is within the maximum allowed size
+// Throws if the estimated resampled audio buffer size would exceed the maximum allowed size
 void validateAudioFileSize(
     size_t inputSamples,
     uint32_t inputRate,
     uint32_t targetRate,
     uint32_t channels,
     size_t bytesPerSample) {
+    // Detect overflow: if inputSamples is large enough that inputSamples * targetRate
+    // would overflow size_t, the output is certainly too large.
+    if (inputSamples > std::numeric_limits<size_t>::max() / targetRate) {
+        throw std::runtime_error("Audio file estimated output size overflows maximum representable value");
+    }
+    size_t product = inputSamples * targetRate;
+    // Guard the ceiling-division addition against overflow as well.
+    if (product > std::numeric_limits<size_t>::max() - (inputRate - 1)) {
+        throw std::runtime_error("Audio file estimated output size overflows maximum representable value");
+    }
     // Estimate output samples after resampling (ceil division)
-    size_t outputSamples = (inputSamples * targetRate + inputRate - 1) / inputRate;
+    size_t outputSamples = (product + inputRate - 1) / inputRate;
     size_t expectedSize = outputSamples * channels * bytesPerSample;
-    return validateAudioFileSizeAgainstMaxValue(expectedSize);
+    validateAudioFileSizeAgainstMaxValue(expectedSize);
 }

--- a/src/test/audio/audio_utils_test.cpp
+++ b/src/test/audio/audio_utils_test.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <limits>
 #if defined(_WIN32)
 #include <stdlib.h>
 #endif
@@ -187,6 +188,74 @@ TEST_F(AudioUtilsSampleRateTest, mp3FileAcceptedWhenAtMaxFileSizeEnv) {
     SetEnvironmentVar("OVMS_AUDIO_MAX_FILE_SIZE_BYTES", std::to_string(expectedDecodedSize));
     std::vector<float> decoded;
     EXPECT_NO_THROW({ decoded = readMp3(view); });
+    UnSetEnvironmentVar("OVMS_AUDIO_MAX_FILE_SIZE_BYTES");
+}
+
+// Validates that validateAudioFileSize correctly rejects when inputSamples * targetRate
+// would overflow size_t. This guards against the case where dr_mp3 provides an inflated
+// totalPCMFrameCount (e.g. from a malicious Xing tag or UINT64_MAX sentinel).
+TEST_F(AudioUtilsSampleRateTest, validateAudioFileSizeRejectsOnOverflow) {
+    // Use a value large enough to cause overflow when multiplied by targetRate (16000)
+    size_t hugeInputSamples = std::numeric_limits<size_t>::max() / 16000 + 1;
+    EXPECT_THROW(
+        validateAudioFileSize(hugeInputSamples, /*inputRate=*/44100, /*targetRate=*/16000, /*channels=*/1, /*bytesPerSample=*/sizeof(float)),
+        std::runtime_error);
+}
+
+TEST_F(AudioUtilsSampleRateTest, validateAudioFileSizeAcceptsBelowOverflowThreshold) {
+    // Just below the overflow threshold — should not throw due to overflow detection,
+    // but may still throw if the estimated size exceeds the 1GB default limit.
+    size_t belowOverflow = std::numeric_limits<size_t>::max() / 16000;
+    // This produces an enormous output (still ~1.15e15 bytes), so it should be rejected
+    // by the max-file-size check, not the overflow check.
+    EXPECT_THROW(
+        validateAudioFileSize(belowOverflow, /*inputRate=*/44100, /*targetRate=*/16000, /*channels=*/1, /*bytesPerSample=*/sizeof(float)),
+        std::runtime_error);
+}
+
+// Builds a CBR MP3 frame without a Xing/VBRI tag. dr_mp3 sets totalPCMFrameCount
+// to UINT64_MAX in this case. Before the overflow fix, validateAudioFileSize would
+// compute expectedSize=0 due to unsigned wrap-around, completely bypassing the guard.
+// The post-decode validation must still enforce the size limit.
+TEST_F(AudioUtilsSampleRateTest, mp3WithoutXingTagRejectedByPostDecodeValidation) {
+    // Build a minimal valid CBR MPEG-1 Layer III frame (no Xing tag).
+    // Header: 0xFF 0xFB 0x90 0x00 => MPEG-1, Layer III, 128kbps, 44.1kHz, mono, no padding.
+    std::string mp3;
+    mp3.push_back(static_cast<char>(0xFF));
+    mp3.push_back(static_cast<char>(0xFB));
+    mp3.push_back(static_cast<char>(0x90));
+    mp3.push_back(static_cast<char>(0x00));
+    // MPEG-1 Layer III mono side-info is 17 bytes, then granule data.
+    // Frame length at 128kbps/44.1kHz/no-padding = 417 bytes (including header).
+    mp3.append(413, '\0');
+
+    std::string_view view(mp3);
+    // Set max size to 1 byte — any decoded output should exceed this.
+    SetEnvironmentVar("OVMS_AUDIO_MAX_FILE_SIZE_BYTES", "1");
+    EXPECT_THROW({ auto decoded = readMp3(view); }, std::runtime_error);
+    UnSetEnvironmentVar("OVMS_AUDIO_MAX_FILE_SIZE_BYTES");
+}
+
+TEST_F(AudioUtilsSampleRateTest, mp3WithoutXingTagAcceptedWhenLimitSufficient) {
+    // Same CBR frame as above, but with a generous limit.
+    std::string mp3;
+    mp3.push_back(static_cast<char>(0xFF));
+    mp3.push_back(static_cast<char>(0xFB));
+    mp3.push_back(static_cast<char>(0x90));
+    mp3.push_back(static_cast<char>(0x00));
+    mp3.append(413, '\0');
+
+    std::string_view view(mp3);
+    // 1MB limit — more than enough for a single decoded frame.
+    SetEnvironmentVar("OVMS_AUDIO_MAX_FILE_SIZE_BYTES", "1048576");
+    std::vector<float> decoded;
+    try {
+        decoded = readMp3(view);
+        // If decoding succeeds, output must be bounded.
+        EXPECT_LE(decoded.size(), 1152u * 2u * 2u);
+    } catch (const std::runtime_error&) {
+        // dr_mp3 may reject the synthetic all-zero payload. Acceptable.
+    }
     UnSetEnvironmentVar("OVMS_AUDIO_MAX_FILE_SIZE_BYTES");
 }
 }


### PR DESCRIPTION
- Add audio file size detection in validateAudioFileSize() for both multiplication and ceiling-division addition (prevents UINT64_MAX wrap-around bypass)
- Skip metadata-based validation when dr_mp3 sets totalPCMFrameCount to UINT64_MAX (no Xing/VBRI tag); rely on post-decode guard instead
- Add post-decode validateAudioFileSizeAgainstMaxValue() call after MP3 streaming decode (covers both early-return and resampling paths)
- Change debug SPDLOG_ERROR leftover to SPDLOG_DEBUG
- Remove unused DEFAULT_MIN_SAMPLE_RATE / DEFAULT_MAX_SAMPLE_RATE defines

