### PR TITLE
Fix python build for mp_on_py_off config

### DIFF
--- a/src/llm/BUILD
+++ b/src/llm/BUILD
@@ -362,6 +362,7 @@ ovms_cc_library(
         "//src:libovmsstatus",
     ],
     visibility = ["//visibility:public"],
+    additional_copts = COPTS_PYTHON
 )
 
 ovms_cc_library(

--- a/src/mediapipe_internal/graphqueue.cpp
+++ b/src/mediapipe_internal/graphqueue.cpp
@@ -28,7 +28,9 @@
 #include <vector>
 
 #include "../queue.hpp"
+#if (PYTHON_DISABLE == 0)
 #include "src/python/pythonnoderesources.hpp"
+#endif
 
 #pragma warning(push)
 #pragma warning(disable : 4324 6001 6385 6386 6326 6011 4309 4005 4456 6246)

--- a/src/test/pull_hf_model_test.cpp
+++ b/src/test/pull_hf_model_test.cpp
@@ -420,6 +420,9 @@ TEST_F(HfPullCache, Resume) {
 
 // ResumeAfterShutdownRequestAndRerun
 TEST_F(HfPull, ResumeShutdown) {
+#ifdef _WIN32
+    SKIP_AND_EXIT_IF_NOT_RUNNING_UNSTABLE();
+#endif
     std::string basePath = ovms::FileSystem::joinPath({this->directoryPath, "repository", "OpenVINO", "Phi-3-mini-FastDraft-50M-int8-ov"});
     std::string modelPath = ovms::FileSystem::appendSlash(basePath) + "openvino_model.bin";
     std::string model2Path = ovms::FileSystem::appendSlash(basePath) + "openvino_detokenizer.bin";
@@ -959,6 +962,9 @@ TEST(HfPullWindowsWorker, ResumeCtrlCChildProcess) {
 // partial-download artifacts remain on disk and that re-running --pull resumes the
 // download to completion.
 TEST_F(HfPull, ResumeCtrlC) {
+#ifdef _WIN32
+    SKIP_AND_EXIT_IF_NOT_RUNNING_UNSTABLE();
+#endif
     std::string basePath = ovms::FileSystem::joinPath({this->directoryPath, "repository", "OpenVINO", "Phi-3-mini-FastDraft-50M-int8-ov"});
     std::string modelPath = ovms::FileSystem::appendSlash(basePath) + "openvino_model.bin";
     std::string model2Path = ovms::FileSystem::appendSlash(basePath) + "openvino_detokenizer.bin";


### PR DESCRIPTION
Issue was that execution_context_utils while not including any python header pulled different header that required it.
This is temporary fix for RC, but we should switch in our buildsystem to use local_defines for propagation of PYTHON_DISABLE/MEDIAPIPE_DISABLE.
