### PR TITLE
introduce cache_interval_multiplier parameter (#4261)

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -131,16 +131,17 @@ Task specific parameters for different tasks (text generation/image generation/e
 | `--max_num_seqs`                      | `integer`    | The maximum number of sequences that can be processed together. Default: 256.                                              |
 | `--pipeline_type`                     | `string`     | Type of the pipeline to be used. Choices: `LM`, `LM_CB`, `VLM`, `VLM_CB`, `AUTO`. Default: `AUTO`.                         |
 | `--enable_prefix_caching`             | `bool`       | Enables algorithm to cache the prompt tokens. Default: true.                                                               |
-| `--max_num_batched_tokens`            | `integer`    | The maximum number of tokens that can be batched together.                                                                 |
+| `--max_num_batched_tokens`            | `integer`    | The maximum number of tokens that can be batched together. Default 256 is optimized for high concurrency. Increase the value to expected context length with single client to optimized for TTFT metric. |
 | `--cache_size`                        | `integer`    | KV Cache size in GB. Default: 0 which is a dynamic allocation.                              |
 | `--draft_source_model`                | `string`     | HF model name or path to the local folder with PyTorch or OpenVINO draft model.                                            |
 | `--dynamic_split_fuse`                | `bool`       | Enables dynamic split fuse algorithm. Default: true.                                                                       |
 | `--max_prompt_len`                    | `integer`    | Sets NPU specific property for maximum number of tokens in the prompt.                                                     |
-| `--kv_cache_precision`                | `string`     | Reduced kv cache precision to `u8` lowers the cache size consumption. Accepted values: `u8` or empty (default).            |
+| `--kv_cache_precision`                | `string`     | Reduced kv cache precision to `u8` lowers the cache size consumption. Accepted values: `u8`, `u4`, `f16`, `fp32` or empty (default).            |
 | `--model_distribution_policy`         | `string`     | TENSOR_PARALLEL distributes tensor to multiple sockets/devices and processes it in parallel. PIPELINE_PARALLEL distributes different tensors to process by each device. Accepted values: `TENSOR_PARALLEL`, `PIPELINE_PARALLEL` or empty (default). |
 | `--reasoning_parser`                  | `string`     | Type of parser to use for reasoning content extraction from model output. Currently supported: [qwen3, gptoss, gemma4]                     |
 | `--tool_parser`                       | `string`     | Type of parser to use for tool calls extraction from model output. Currently supported: [llama3, phi4, hermes3, mistral, qwen3coder, gptoss, devstral, lfm2, gemma4]            |
 | `--enable_tool_guided_generation`     | `bool`       | Enables enforcing tool schema during generation. Requires setting response parser. Default: false.                         |
+| `--cache_interval_multiplier`         | `integer`    | Applicable model models with linear attention and prefix caching enabled. Defines how to allocating one fixed state block per sequence. Default value 8 optimizes memory usage and performance for short prompts. For long prompts over 20k tokens, it is recommended to set value 64 to reduce kv cache usage.  |
 
 ### Image generation
 | option                            | Value format | Description                                                                                                         |

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -141,7 +141,7 @@ Task specific parameters for different tasks (text generation/image generation/e
 | `--reasoning_parser`                  | `string`     | Type of parser to use for reasoning content extraction from model output. Currently supported: [qwen3, gptoss, gemma4]                     |
 | `--tool_parser`                       | `string`     | Type of parser to use for tool calls extraction from model output. Currently supported: [llama3, phi4, hermes3, mistral, qwen3coder, gptoss, devstral, lfm2, gemma4]            |
 | `--enable_tool_guided_generation`     | `bool`       | Enables enforcing tool schema during generation. Requires setting response parser. Default: false.                         |
-| `--cache_interval_multiplier`         | `integer`    | Applicable model models with linear attention and prefix caching enabled. Defines how to allocating one fixed state block per sequence. Default value 8 optimizes memory usage and performance for short prompts. For long prompts over 20k tokens, it is recommended to set value 64 to reduce kv cache usage.  |
+| `--cache_interval_multiplier`         | `integer`    | Applicable to models with linear attention and prefix caching enabled. Defines how to allocate one fixed state block per sequence. Default value 8 optimizes memory usage and performance for short prompts. For long prompts over 20k tokens, it is recommended to set value 64 to reduce kv cache usage.  |
 
 ### Image generation
 | option                            | Value format | Description                                                                                                         |

--- a/src/capi_frontend/server_settings.hpp
+++ b/src/capi_frontend/server_settings.hpp
@@ -124,6 +124,7 @@ struct TextGenGraphSettingsImpl {
     std::optional<std::string> reasoningParser;
     std::optional<std::string> toolParser;
     std::string enableToolGuidedGeneration = "false";
+    std::optional<uint64_t> cacheIntervalMultiplier;
 };
 
 struct EmbeddingsGraphSettingsImpl {

--- a/src/graph_export/graph_cli_parser.cpp
+++ b/src/graph_export/graph_cli_parser.cpp
@@ -79,7 +79,11 @@ void GraphCLIParser::createOptions() {
         ("enable_tool_guided_generation",
             "Enables enforcing tool schema during generation. Requires setting tool parser. Default: false.",
             cxxopts::value<std::string>()->default_value("false"),
-            "ENABLE_TOOL_GUIDED_GENERATION");
+            "ENABLE_TOOL_GUIDED_GENERATION")
+        ("cache_interval_multiplier",
+            "Multiplier for the KV cache block interval. Controls the granularity of cache allocation. Default: unset.",
+            cxxopts::value<uint64_t>(),
+            "CACHE_INTERVAL_MULTIPLIER");
 
     options->add_options("plugin config")
         ("max_prompt_len",
@@ -157,6 +161,9 @@ void GraphCLIParser::prepare(OvmsServerMode serverMode, HFSettingsImpl& hfSettin
             graphSettings.toolParser = result->operator[]("tool_parser").as<std::string>();
         }
         graphSettings.enableToolGuidedGeneration = result->operator[]("enable_tool_guided_generation").as<std::string>();
+        if (result->count("cache_interval_multiplier")) {
+            graphSettings.cacheIntervalMultiplier = result->operator[]("cache_interval_multiplier").as<uint64_t>();
+        }
 
         // Plugin configuration
         if (result->count("max_prompt_len")) {

--- a/src/graph_export/graph_export.cpp
+++ b/src/graph_export/graph_export.cpp
@@ -201,6 +201,10 @@ static Status createTextGenerationGraphTemplate(const std::string& directoryPath
         oss << R"(
             enable_tool_guided_generation: true,)";
     }
+    if (graphSettings.cacheIntervalMultiplier.has_value()) {
+        oss << R"(
+            cache_interval_multiplier: )" << graphSettings.cacheIntervalMultiplier.value() << R"(,)";
+    }
     if (graphSettings.dynamicSplitFuse != "true") {
         oss << R"(
             dynamic_split_fuse: false,)";

--- a/src/llm/language_model/continuous_batching/servable_initializer.cpp
+++ b/src/llm/language_model/continuous_batching/servable_initializer.cpp
@@ -155,6 +155,9 @@ Status ContinuousBatchingServableInitializer::initialize(std::shared_ptr<GenAiSe
     properties->schedulerConfig.dynamic_split_fuse = nodeOptions.dynamic_split_fuse();
     properties->schedulerConfig.max_num_seqs = nodeOptions.max_num_seqs();
     properties->schedulerConfig.enable_prefix_caching = nodeOptions.enable_prefix_caching();
+    if (nodeOptions.has_cache_interval_multiplier()) {
+        properties->schedulerConfig.cache_interval_multiplier = nodeOptions.cache_interval_multiplier();
+    }
 
     if (nodeOptions.has_cache_eviction_config()) {
         properties->schedulerConfig.cache_eviction_config = prepareCacheEvictionConfig(nodeOptions);

--- a/src/llm/llm_calculator.proto
+++ b/src/llm/llm_calculator.proto
@@ -135,4 +135,6 @@ message LLMCalculatorOptions {
     optional bool enable_tool_guided_generation = 23 [default = false];
 
     optional SparseAttentionConfig sparse_attention_config = 24;
+
+    optional uint64 cache_interval_multiplier = 25;
 }


### PR DESCRIPTION
### 🛠 Summary

Add parameter cache_interval_multiplier for tuning prefix caching behavior for models with linear attention

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices. ``