### PR TITLE
change default cache_interal_miltiplier [test_doc_files_windows=demos…

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -137,6 +137,7 @@ Task specific parameters for different tasks (text generation/image generation/e
 | `--reasoning_parser`                  | `string`     | Type of parser to use for reasoning content extraction from model output. Currently supported: [qwen3, gptoss, gemma4]                     |
 | `--tool_parser`                       | `string`     | Type of parser to use for tool calls extraction from model output. Currently supported: [llama3, phi4, hermes3, mistral, qwen3coder, gptoss, devstral, lfm2, gemma4]            |
 | `--enable_tool_guided_generation`     | `bool`       | Enables enforcing tool schema during generation. Requires setting response parser. Default: false.                         |
+| `--cache_interval_multiplier`         | `integer`    | Multiplier for the KV cache block interval. Controls the granularity of cache allocation. Applicable only for models with linear attention. Default: 64. |
 
 ### Image generation
 | option                            | Value format | Description                                                                                                         |

--- a/src/graph_export/graph_cli_parser.cpp
+++ b/src/graph_export/graph_cli_parser.cpp
@@ -81,8 +81,8 @@ void GraphCLIParser::createOptions() {
             cxxopts::value<std::string>()->default_value("false"),
             "ENABLE_TOOL_GUIDED_GENERATION")
         ("cache_interval_multiplier",
-            "Multiplier for the KV cache block interval. Controls the granularity of cache allocation. Default: unset.",
-            cxxopts::value<uint64_t>(),
+            "Multiplier for the KV cache block interval. Controls the granularity of cache allocation. Applicable only for models with linear attention. Default: 64.",
+            cxxopts::value<uint64_t>()->default_value("64"),
             "CACHE_INTERVAL_MULTIPLIER");
 
     options->add_options("plugin config")

--- a/src/llm/language_model/continuous_batching/servable_initializer.cpp
+++ b/src/llm/language_model/continuous_batching/servable_initializer.cpp
@@ -155,9 +155,7 @@ Status ContinuousBatchingServableInitializer::initialize(std::shared_ptr<GenAiSe
     properties->schedulerConfig.dynamic_split_fuse = nodeOptions.dynamic_split_fuse();
     properties->schedulerConfig.max_num_seqs = nodeOptions.max_num_seqs();
     properties->schedulerConfig.enable_prefix_caching = nodeOptions.enable_prefix_caching();
-    if (nodeOptions.has_cache_interval_multiplier()) {
-        properties->schedulerConfig.cache_interval_multiplier = nodeOptions.cache_interval_multiplier();
-    }
+    properties->schedulerConfig.cache_interval_multiplier = nodeOptions.cache_interval_multiplier();
 
     if (nodeOptions.has_cache_eviction_config()) {
         properties->schedulerConfig.cache_eviction_config = prepareCacheEvictionConfig(nodeOptions);

--- a/src/llm/llm_calculator.proto
+++ b/src/llm/llm_calculator.proto
@@ -136,5 +136,6 @@ message LLMCalculatorOptions {
 
     optional SparseAttentionConfig sparse_attention_config = 24;
 
-    optional uint64 cache_interval_multiplier = 25;
+    // Applicable only for models with linear attention.
+    optional uint64 cache_interval_multiplier = 25 [default = 64];
 }

--- a/src/test/llm/llmnode_test.cpp
+++ b/src/test/llm/llmnode_test.cpp
@@ -4249,6 +4249,8 @@ void TestLLMNodeOptionsCheckDefault(std::string& modelsPath) {
     ASSERT_EQ(properties->schedulerConfig.dynamic_split_fuse, true);
     ASSERT_EQ(properties->schedulerConfig.max_num_seqs, 256);
     ASSERT_EQ(properties->schedulerConfig.enable_prefix_caching, false);
+    ASSERT_TRUE(properties->schedulerConfig.cache_interval_multiplier.has_value());
+    ASSERT_EQ(properties->schedulerConfig.cache_interval_multiplier.value(), 64);
     ASSERT_EQ(properties->device, "CPU");
     // CPU default properties (inference_num_threads, enable_cpu_pinning) are automatically
     // added to pluginConfig for CPU device; verify no user-specified entries are present.


### PR DESCRIPTION
…/continuous_batching/agentic_ai/README.md]

### 🛠 Summary

CVS-188061 - new default value for cache_interval_multiplier=64 is more tunned for long contexts which are expected to be typical for models with linear attention

### 🧪 Checklist

- [x] Unit tests added.
- [x] The documentation updated.
- [x] Change follows security best practices.
``

