### PR TITLE
swap_dir in test_framework fix for model reload

### DIFF
--- a/tests/functional/utils/test_framework.py
+++ b/tests/functional/utils/test_framework.py
@@ -294,14 +294,15 @@ def swap_directory(target_path, staging_path, backup_path=None):
     old_path = target_path + "_old"
     if os.path.exists(old_path):
         remove_dir_tree(old_path)
-    target_moved = False
+    parent_dir = os.path.dirname(target_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
     if os.path.exists(target_path):
         os.rename(target_path, old_path)
-        target_moved = True
     try:
         os.rename(staging_path, target_path)
     except OSError:
-        if target_moved and os.path.exists(old_path) and not os.path.exists(target_path):
+        if os.path.exists(old_path) and not os.path.exists(target_path):
             try:
                 os.rename(old_path, target_path)
             except OSError:


### PR DESCRIPTION
This PR adjusts the functional test framework’s swap_directory() helper to better support model reload scenarios by ensuring the target directory’s parent path exists before attempting a directory swap.
Fixes model-server.tests issues with new models export on clx6.

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

