### PR TITLE
Fix infer-request slot leak and deadlock on async start_async() error path (relates to #2871)

### DIFF
--- a/src/inference_executor.hpp
+++ b/src/inference_executor.hpp
@@ -48,6 +48,26 @@ enum : unsigned int {
     POSTPROCESS,
     TIMER_END
 };
+
+// Releases the infer-request slot acquired by modelInferAsync when start_async() throws.
+//
+// The stream-id guard that owns the slot was moved into the completion-callback lambda;
+// since start_async() failed, that callback will never fire to destroy the lambda, so the
+// slot would leak (#2871). Clearing the callback destroys the lambda and returns the slot.
+//
+// The callback lambda also holds a (copied) OutputKeeper. Clearing the callback runs while
+// OpenVINO holds the InferRequest's internal lock, so the lambda's OutputKeeper copy must not
+// reset output tensors there - doing so would reenter this InferRequest and deadlock
+// (std::terminate via an exception leaving the noexcept destructor). The caller retains the
+// original OutputKeeper handle (capture-by-copy), so we cancel it first: inference never ran,
+// so there is nothing to restore, and the retained handle's destructor then becomes a no-op.
+inline void releaseInferRequestSlotAfterStartAsyncFailure(ov::InferRequest& inferRequest, const std::shared_ptr<OutputKeeper>& outKeeper) {
+    if (outKeeper) {
+        outKeeper->cancel();
+    }
+    inferRequest.set_callback([](std::exception_ptr) {});
+}
+
 template <typename RequestType, typename ResponseType>
 Status modelInferAsync(ModelInstance& instance, const RequestType* request,
     std::unique_ptr<ModelInstanceUnloadGuard>& modelUnloadGuardPtr) {
@@ -136,7 +156,7 @@ Status modelInferAsync(ModelInstance& instance, const RequestType* request,
     {
         // order is important here - destructors are called in order from right to left
         inferRequest.set_callback(
-            [&instance, request, &inferRequest, userCallback, userCallbackData, modelUnloadGuardPtrMoved = std::shared_ptr<ModelInstanceUnloadGuard>(std::move(modelUnloadGuardPtr)), streamIdGuardMoved = std::move(executingStreamIdGuard), movedOutputKeeper = std::move(outKeeper)](std::exception_ptr exception) mutable {
+            [&instance, request, &inferRequest, userCallback, userCallbackData, modelUnloadGuardPtrMoved = std::shared_ptr<ModelInstanceUnloadGuard>(std::move(modelUnloadGuardPtr)), streamIdGuardMoved = std::move(executingStreamIdGuard), movedOutputKeeper = outKeeper](std::exception_ptr exception) mutable {
                 struct CallbackGuard {
                     OVMS_InferenceRequestCompletionCallback_t userCallback{nullptr};
                     void* userCallbackData{nullptr};
@@ -204,20 +224,14 @@ Status modelInferAsync(ModelInstance& instance, const RequestType* request,
 
     try {
         SPDLOG_DEBUG("ov::InferRequest: {}, inferRequest.start_async()", reinterpret_cast<void*>(&inferRequest));
-        inferRequest.start_async();
+        instance.startAsyncInference(inferRequest);
     } catch (std::exception& e) {
         SPDLOG_DEBUG("caught exception in ov::InferRequest.start_async: {}", e.what());
-        // start_async threw, so the completion callback will never fire to release the
-        // captured stream-id guard; clear the callback to destroy it and return the
-        // infer-request slot to the pool (otherwise the slot leaks -> #2871).
-        inferRequest.set_callback([](std::exception_ptr) {});
+        releaseInferRequestSlotAfterStartAsyncFailure(inferRequest, outKeeper);
         return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
     } catch (...) {
         SPDLOG_DEBUG("caught exception in ov::InferRequest.start_async");
-        // start_async threw, so the completion callback will never fire to release the
-        // captured stream-id guard; clear the callback to destroy it and return the
-        // infer-request slot to the pool (otherwise the slot leaks -> #2871).
-        inferRequest.set_callback([](std::exception_ptr) {});
+        releaseInferRequestSlotAfterStartAsyncFailure(inferRequest, outKeeper);
         return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
     }
     return StatusCode::OK;

--- a/src/inference_executor.hpp
+++ b/src/inference_executor.hpp
@@ -207,9 +207,17 @@ Status modelInferAsync(ModelInstance& instance, const RequestType* request,
         inferRequest.start_async();
     } catch (std::exception& e) {
         SPDLOG_DEBUG("caught exception in ov::InferRequest.start_async: {}", e.what());
+        // start_async threw, so the completion callback will never fire to release the
+        // captured stream-id guard; clear the callback to destroy it and return the
+        // infer-request slot to the pool (otherwise the slot leaks -> #2871).
+        inferRequest.set_callback([](std::exception_ptr) {});
         return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
     } catch (...) {
         SPDLOG_DEBUG("caught exception in ov::InferRequest.start_async");
+        // start_async threw, so the completion callback will never fire to release the
+        // captured stream-id guard; clear the callback to destroy it and return the
+        // infer-request slot to the pool (otherwise the slot leaks -> #2871).
+        inferRequest.set_callback([](std::exception_ptr) {});
         return StatusCode::OV_INTERNAL_INFERENCE_ERROR;
     }
     return StatusCode::OK;

--- a/src/modelinstance.cpp
+++ b/src/modelinstance.cpp
@@ -1604,6 +1604,10 @@ OVInferRequestsQueue& ModelInstance::getInferRequestsQueue() {
     return *inferRequestsQueue;
 }
 
+void ModelInstance::startAsyncInference(ov::InferRequest& inferRequest) {
+    inferRequest.start_async();
+}
+
 const size_t ModelInstance::getBatchSizeIndex() const {
     const auto& inputItr = this->inputsInfo.cbegin();
     if (inputItr == this->inputsInfo.cend()) {

--- a/src/modelinstance.hpp
+++ b/src/modelinstance.hpp
@@ -534,6 +534,16 @@ public:
     OVInferRequestsQueue& getInferRequestsQueue();
 
     /**
+         * @brief Starts asynchronous inference on the given infer request.
+         *
+         * Thin virtual wrapper over ov::InferRequest::start_async. In production it
+         * forwards unconditionally; it exists as a seam so tests can simulate
+         * start_async() throwing and verify the infer-request slot is released on
+         * that error path (see modelInferAsync and #2871).
+         */
+    virtual void startAsyncInference(ov::InferRequest& inferRequest);
+
+    /**
          * @brief Combines plugin config from user with default config calculated at runtime
          *
          * @return plugin config

--- a/src/outputkeeper.cpp
+++ b/src/outputkeeper.cpp
@@ -35,6 +35,9 @@ OutputKeeper::OutputKeeper(ov::InferRequest& request, const tensor_map_t& output
     }
 }
 OutputKeeper::~OutputKeeper() {
+    if (cancelled) {
+        return;
+    }
     for (auto [name, v] : outputs) {
         OV_LOGGER("ov::InferRequest: {}, request.set_tensor({}, {})", reinterpret_cast<void*>(&request), name, reinterpret_cast<void*>(&v));
         request.set_tensor(name, v);

--- a/src/outputkeeper.hpp
+++ b/src/outputkeeper.hpp
@@ -27,7 +27,12 @@ namespace ovms {
 struct OutputKeeper {
     std::unordered_map<std::string, ov::Tensor> outputs;
     ov::InferRequest& request;
+    bool cancelled{false};
     OutputKeeper(ov::InferRequest& request, const tensor_map_t& outputsInfo);
     ~OutputKeeper();
+    // Disable the output-tensor restore performed by the destructor. Used on the async
+    // start_async() error path, where inference never ran (so there is nothing to restore)
+    // and reentering the InferRequest from the destructor would deadlock (#2871).
+    void cancel() { this->cancelled = true; }
 };
 }  // namespace ovms

--- a/src/test/c_api_tests.cpp
+++ b/src/test/c_api_tests.cpp
@@ -29,6 +29,7 @@
 #include "../capi_frontend/capi_request_utils.hpp"
 #include "../deserialization_main.hpp"
 #include "../inference_executor.hpp"
+#include "../ovinferrequestsqueue.hpp"
 #include "../capi_frontend/capi_utils.hpp"
 #include "../capi_frontend/serialization.hpp"
 #include "../capi_frontend/deserialization.hpp"
@@ -2043,6 +2044,62 @@ TEST_F(CAPIInference, AsyncErrorHandling) {
     EXPECT_EQ(status, ovms::StatusCode::OK) << status.string();
     unblockSignal.get();
     std::this_thread::sleep_for(std::chrono::seconds(1));
+    unloadGuard.reset();
+    instance.retireModel();
+}
+
+// Model instance whose async inference start deterministically throws, to exercise the
+// modelInferAsync start_async() error path (see #2871). Production ModelInstance forwards
+// startAsyncInference() to ov::InferRequest::start_async(); here we override it to throw.
+class MockModelInstanceThrowingOnStartAsync : public ovms::ModelInstance {
+public:
+    MockModelInstanceThrowingOnStartAsync(ov::Core& ieCore) :
+        ModelInstance(std::string("UNUSED_NAME"), 0, ieCore, nullptr, nullptr) {
+        status = ovms::ModelVersionStatus("UNUSED_NAME", UNUSED_MODEL_VERSION, ovms::ModelVersionState::START);
+    }
+    virtual ~MockModelInstanceThrowingOnStartAsync() {}
+    ovms::Status loadModel(const ovms::ModelConfig& config) override {
+        return ModelInstance::loadModel(config);
+    }
+    void startAsyncInference(ov::InferRequest& inferRequest) override {
+        throw std::runtime_error("simulated start_async failure");
+    }
+};
+
+// Regression test for #2871: when start_async() throws, modelInferAsync must release the
+// infer-request slot it acquired. With a single-stream pool, a leak makes the slot
+// permanently unavailable; we assert it is returned by querying the queue afterwards.
+TEST_F(CAPIInference, AsyncStartAsyncThrowReleasesInferRequestSlot) {
+    ov::Core core;
+    MockModelInstanceThrowingOnStartAsync instance(core);
+    ovms::ModelConfig config = DUMMY_MODEL_CONFIG;
+    config.setNireq(1);  // single slot -> a leaked slot is observable
+    ASSERT_EQ(instance.loadModel(config), ovms::StatusCode::OK);
+    std::unique_ptr<ModelInstanceUnloadGuard> unloadGuard;
+    instance.waitForLoaded(0, unloadGuard);
+
+    // Sanity: the single slot is idle before inference.
+    {
+        auto idle = instance.getInferRequestsQueue().tryToGetIdleStream();
+        ASSERT_TRUE(idle.has_value());
+        instance.getInferRequestsQueue().returnStream(idle.value());
+    }
+
+    ovms::InferenceRequest request("dummy", 0);
+    std::vector<float> in(DUMMY_MODEL_INPUT_SIZE, INITIAL_VALUE);
+    request.addInput(DUMMY_MODEL_INPUT_NAME, OVMS_DATATYPE_FP32, DUMMY_MODEL_SHAPE.data(), DUMMY_MODEL_SHAPE.size());
+    request.setInputBuffer(DUMMY_MODEL_INPUT_NAME, in.data(), DUMMY_MODEL_INPUT_SIZE * sizeof(float), OVMS_BUFFERTYPE_CPU, 0);
+    CallbackUnblockingAndCheckingStruct callbackStruct;
+    request.setCompletionCallback(callbackCheckingIfErrorReported, &callbackStruct);
+
+    auto status = ovms::modelInferAsync<ovms::InferenceRequest, ovms::InferenceResponse>(instance, &request, unloadGuard);
+    EXPECT_EQ(status, ovms::StatusCode::OV_INTERNAL_INFERENCE_ERROR) << status.string();
+
+    // The slot acquired by modelInferAsync must have been returned to the pool despite the
+    // start_async() failure. Without the fix it leaks and tryToGetIdleStream() returns nullopt.
+    auto idleAfter = instance.getInferRequestsQueue().tryToGetIdleStream();
+    EXPECT_TRUE(idleAfter.has_value()) << "infer-request slot leaked after start_async() threw (#2871)";
+
     unloadGuard.reset();
     instance.retireModel();
 }


### PR DESCRIPTION
### 🛠 Summary

Fixes an infer-request pool-slot **leak** on the async inference error path that can, over long-running concurrent load, drain the infer-request pool and surface as gRPC `ResourceExhausted` despite low CPU/GPU/RAM. Relates to #2871 (a plausible contributor — see "Scope" below).

This PR has two commits:
1. Release the slot when `start_async()` throws.
2. **Fix a deadlock/crash that commit 1 introduced**, and add a regression test that reproduces both the leak and the crash.

### Root cause (leak)

In `modelInferAsync` (`src/inference_executor.hpp`, used by the **KServe gRPC** path and the **C-API async** endpoint):

1. An `ExecutingStreamIdGuard` — which holds an infer-request **pool slot** and returns it to `OVInferRequestsQueue` on destruction — is `std::move`-d into the OV completion-callback lambda passed to `inferRequest.set_callback(...)`. After the move, that lambda is the **sole owner** of the guard, so the slot is returned only when the lambda is destroyed (normally when the async completion callback fires).
2. `inferRequest.start_async()` is then called inside a `try`. If it **throws**, the function returns immediately. The async op never started, the completion callback never fires, the lambda is never destroyed, and **the slot is never returned to the pool**.

Under sustained load, each `start_async()` failure permanently loses one slot until the pool drains and gRPC reports `ResourceExhausted` despite low hardware utilization.

### The subtlety (deadlock) — why the naive fix is unsafe

The obvious fix is to clear the callback in the `catch` so the captured guard is destroyed and the slot is returned:

```cpp
inferRequest.set_callback([](std::exception_ptr) {});  // unsafe on its own
```

This **introduces a crash**. Clearing the callback destroys the completion lambda *synchronously while OpenVINO holds the InferRequest's internal lock*. That lambda also owns an `OutputKeeper`, whose destructor calls `request.set_tensor(...)` back into the **same** InferRequest. For models that support output-tensor reset (the common case), this reenters the locked request and throws `resource deadlock would occur` out of a `noexcept` destructor → **`std::terminate`** — crashing the server on the very error path the fix targets.

(The normal completion path doesn't hit this: there, `set_callback` is called from *inside* the executing callback, so OpenVINO defers the lambda's destruction until after it returns — i.e. outside the lock.)

### Fix

Release the slot **without** destroying the `OutputKeeper` under the lock:

- `OutputKeeper::cancel()` disables the destructor's tensor-restore.
- `modelInferAsync` captures the `OutputKeeper` into the callback **by copy** and retains the original handle in function scope, so clearing the callback no longer triggers `~OutputKeeper` under the lock.
- The error path cancels the keeper (inference never ran, so there is nothing to restore), then clears the callback to return the slot. Both `catch` blocks share `releaseInferRequestSlotAfterStartAsyncFailure()`.

The synchronous `infer()` path is unaffected (stack-allocated guard, RAII release).

### Regression test

`CAPIInference.AsyncStartAsyncThrowReleasesInferRequestSlot` forces `start_async()` to throw — via a thin virtual seam `ModelInstance::startAsyncInference()` (production forwards unconditionally to `start_async`) — on a single-stream pool (`setNireq(1)`), then asserts the slot is returned via `OVInferRequestsQueue::tryToGetIdleStream()`.

This test reproduces **both** failure modes: without the release it observes the leaked slot (nullopt), and with the naive release it crashes via the deadlock described above. It passes only with the corrected fix.

### Validation

- Builds clean from source on Windows (`//src:ovms //src:ovms_test`, `Build completed successfully`).
- **Full `CAPIInference` gtest suite passes (17/17)**, including `AsyncWithCallbackDummy` (async success), `AsyncErrorHandling` (async error via callback), and the new test — confirming the capture-by-copy change does not regress the normal path.

### Scope / honesty note

This is a genuine, gRPC-reachable resource leak, but it only triggers when `start_async()` actually throws (transient OV/device errors), so I can't claim it is definitively the cause of #2871 (reporter's logs are limited, and the synchronous predict path is already leak-safe). It is a correct, low-risk hardening regardless — and the regression test demonstrates the error path is now both leak-free and crash-free.
