### PR TITLE
Support BOOL tensor inputs in TFS REST API parser

### DIFF
--- a/src/rest_parser.cpp
+++ b/src/rest_parser.cpp
@@ -361,6 +361,30 @@ static bool addToIntVal(tensorflow::TensorProto& proto, const rapidjson::Value& 
     return false;
 }
 
+static bool addToBoolVal(tensorflow::TensorProto& proto, const rapidjson::Value& value) {
+    if (value.IsBool()) {
+        proto.add_bool_val(value.GetBool());
+        return true;
+    }
+    if (value.IsInt()) {
+        proto.add_bool_val(value.GetInt() != 0);
+        return true;
+    }
+    if (value.IsUint()) {
+        proto.add_bool_val(value.GetUint() != 0);
+        return true;
+    }
+    if (value.IsInt64()) {
+        proto.add_bool_val(value.GetInt64() != 0);
+        return true;
+    }
+    if (value.IsUint64()) {
+        proto.add_bool_val(value.GetUint64() != 0);
+        return true;
+    }
+    return false;
+}
+
 static bool addNumber(tensorflow::TensorProto& proto, const rapidjson::Value& value) {
     switch (proto.dtype()) {
     case tensorflow::DataType::DT_FLOAT:
@@ -385,6 +409,8 @@ static bool addNumber(tensorflow::TensorProto& proto, const rapidjson::Value& va
         return addToTensorContent<uint32_t>(proto, value);
     case tensorflow::DataType::DT_UINT64:
         return addToTensorContent<uint64_t>(proto, value);
+    case tensorflow::DataType::DT_BOOL:
+        return addToBoolVal(proto, value);
     default:
         return false;
     }
@@ -513,7 +539,7 @@ bool TFSRestParser::addValue(tensorflow::TensorProto& proto, const rapidjson::Va
         return true;
     }
 
-    if (!value.IsNumber()) {
+    if (!value.IsNumber() && !value.IsBool()) {
         return false;
     }
 
@@ -526,7 +552,9 @@ bool TFSRestParser::setDTypeIfNotSet(const rapidjson::Value& value, tensorflow::
     if (tensorPrecisionMap.count(tensorName))
         return true;
 
-    if (value.IsInt())
+    if (value.IsBool())
+        tensorPrecisionMap[tensorName] = ovms::Precision::BOOL;
+    else if (value.IsInt())
         tensorPrecisionMap[tensorName] = ovms::Precision::I32;
     else if (value.IsDouble())
         tensorPrecisionMap[tensorName] = ovms::Precision::FP32;

--- a/src/test/tfs_rest_parser_column_test.cpp
+++ b/src/test/tfs_rest_parser_column_test.cpp
@@ -487,6 +487,23 @@ TEST(TFSRestParserColumn, ParseFloat) {
     EXPECT_THAT(asVector<float>(parser.getProto().inputs().at("i").tensor_content()), ElementsAre(-5.12, 0.4344, -4.521, 155234.221));
 }
 
+TEST(TFSRestParserColumn, ParseBool) {
+    TFSRestParser parser(prepareTensors({{"i", {1, 1, 4}}}, ovms::Precision::BOOL));
+
+    ASSERT_EQ(parser.parse(R"({"signature_name":"","inputs":{"i":[[[true, false, true, false]]]}})"), StatusCode::OK);
+    EXPECT_EQ(parser.getProto().inputs().at("i").dtype(), tensorflow::DataType::DT_BOOL);
+    EXPECT_THAT(parser.getProto().inputs().at("i").bool_val(), ElementsAre(true, false, true, false));
+}
+
+TEST(TFSRestParserColumn, ParseBoolFromIntegers) {
+    // 1/0 are also accepted for a BOOL tensor (the historic workaround) and yield a BOOL tensor.
+    TFSRestParser parser(prepareTensors({{"i", {1, 1, 4}}}, ovms::Precision::BOOL));
+
+    ASSERT_EQ(parser.parse(R"({"signature_name":"","inputs":{"i":[[[1, 0, 1, 0]]]}})"), StatusCode::OK);
+    EXPECT_EQ(parser.getProto().inputs().at("i").dtype(), tensorflow::DataType::DT_BOOL);
+    EXPECT_THAT(parser.getProto().inputs().at("i").bool_val(), ElementsAre(true, false, true, false));
+}
+
 TEST(TFSRestParserColumn, ParseHalf) {
     std::vector<TFSRestParser> parsers{TFSRestParser(prepareTensors({{"i", {1, 1, 4}}}, ovms::Precision::FP16))};
     for (TFSRestParser& parser : parsers) {

--- a/src/test/tfs_rest_parser_row_test.cpp
+++ b/src/test/tfs_rest_parser_row_test.cpp
@@ -176,6 +176,19 @@ TEST(TFSRestParserRow, ValidShape_1x1) {
     EXPECT_THAT(asVector<float>(parser.getProto().inputs().at("i").tensor_content()), ElementsAre(155.0));
 }
 
+TEST(TFSRestParserRow, ParseBool) {
+    TFSRestParser parser(prepareTensors({{"i", {2, 2}}}, ovms::Precision::BOOL));
+
+    ASSERT_EQ(parser.parse(R"({"signature_name":"","instances":[
+        {"i":[true, false]},
+        {"i":[false, true]}
+    ]})"),
+        StatusCode::OK);
+    EXPECT_EQ(parser.getProto().inputs().at("i").dtype(), tensorflow::DataType::DT_BOOL);
+    EXPECT_THAT(asVector(parser.getProto().inputs().at("i").tensor_shape()), ElementsAre(2, 2));
+    EXPECT_THAT(parser.getProto().inputs().at("i").bool_val(), ElementsAre(true, false, false, true));
+}
+
 TEST(TFSRestParserRow, ValidShape_1x2) {
     TFSRestParser parser(prepareTensors({{"i", {1, 2}}}));
 


### PR DESCRIPTION
### Summary
The **TFS REST predict API** parser cannot handle boolean tensor inputs. A request with a `DT_BOOL` input (sent as JSON `true`/`false`) fails with:

```
Could not parse input content. Not valid ndarray detected
```

even though the model declares the input as `BOOL` and the **KServe (KFS) REST** parser already supports it. This was reported in #2858 (serving GLiNER, which has a `DT_BOOL` `span_mask` input).

### Root cause
In `src/rest_parser.cpp`, the `TFSRestParser` path has three gaps, all on boolean values:
- `setDTypeIfNotSet` only infers a precision from `IsInt()`/`IsDouble()`, so a JSON bool falls through to `return false`.
- `addValue` rejects anything that is not `IsNumber()` (rapidjson treats `bool` as *not* a number).
- `addNumber`'s `switch (proto.dtype())` has no `DT_BOOL` case (hits `default: return false`).

Any one of these makes `parseArray` fail → `REST_COULD_NOT_PARSE_INPUT`.

### Change
Bring the TFS parser to parity with the KFS parser:
- `setDTypeIfNotSet` infers `Precision::BOOL` from a JSON bool (`Precision::BOOL` → `DT_BOOL` via `getPrecisionAsDataType`).
- `addValue` lets boolean values through to `addNumber`.
- `addNumber` gains a `DT_BOOL` case backed by a new `addToBoolVal` helper that accepts JSON `true`/`false` **and** numeric `0`/`1` (the latter is the workaround users were told to use; it now correctly produces a BOOL tensor rather than INT32).

Applies to both TFS request shapes — row (`"instances"`) and column (`"inputs"`).

### Tests
Added unit tests in `tfs_rest_parser_column_test.cpp` (`ParseBool`, `ParseBoolFromIntegers`) and `tfs_rest_parser_row_test.cpp` (`ParseBool`), asserting `dtype() == DT_BOOL` and the parsed `bool_val` contents.

### Validation
Built `ovms_test` and ran the TFS REST parser suites — **123/123 pass**, including the 3 new tests; no regression.

Fixes #2858.
