### PR TITLE
Bundle libxml2 + ICU in the baremetal package so it runs on newer distros (fixes #4362)

### DIFF
--- a/create_package.sh
+++ b/create_package.sh
@@ -115,6 +115,23 @@ fi
 if [ "$BASE_OS" == "redhat" ] ; then cp -P /usr/lib64/libOpenCL.so* /ovms_release/lib/ ; fi
 if [[ "$BASE_OS" =~ "ubuntu" ]] ; then cp -P /usr/lib/x86_64-linux-gnu/libOpenCL.so* /ovms_release/lib/ ; fi
 
+# libxml2 is a runtime dependency of the ovms binary (Dockerfile.ubuntu apt-installs
+# it into the runtime image), but it is provided by the base image rather than by
+# bazel-out, so the portable tarball never bundled it. The Docker image is therefore
+# fine while the baremetal package fails to start on any host whose system libxml2 /
+# ICU soname differs from the ubuntu build base -- e.g. Ubuntu 26.04 ships
+# libxml2.so.16 + ICU 78, not the libxml2.so.2 + ICU 74 this build links against:
+#   ovms: error while loading shared libraries: libxml2.so.2: cannot open shared object file
+# Bundle libxml2 and its ICU dependency chain (ovms -> libxml2.so.2 -> libicuuc ->
+# libicudata) so the tarball is self-contained. The copies land before the patchelf
+# rpath pass below, so they get '$ORIGIN/../lib' and resolve one another in the bundle.
+# See https://github.com/openvinotoolkit/model_server/issues/4362
+if [[ "$BASE_OS" =~ "ubuntu" ]] ; then
+	cp -P /usr/lib/x86_64-linux-gnu/libxml2.so.2* /ovms_release/lib/
+	cp -P /usr/lib/x86_64-linux-gnu/libicuuc.so.* /ovms_release/lib/
+	cp -P /usr/lib/x86_64-linux-gnu/libicudata.so.* /ovms_release/lib/
+fi
+
 if [ "$FUZZER_BUILD" == "0" ]; then find /ovms/bazel-bin/src -name 'ovms' -type f -exec cp -v {} /ovms_release/bin \; ; fi;
 cd /ovms_release/bin
 if [ "$FUZZER_BUILD" == "0" ]; then patchelf --remove-rpath ./ovms && patchelf --set-rpath '$ORIGIN/../lib/' ./ovms; fi;


### PR DESCRIPTION
## Problem
The baremetal Linux release tarball fails to start on distros newer than the build base, because it does not bundle `libxml2` — a runtime dependency of the `ovms` binary.

`ldd /opt/ovms/bin/ovms` reports `libxml2.so.2 => not found`. `create_package.sh` bundles the bazel-out artifacts plus the OpenVINO/OpenCV/TBB/OpenCL libraries, but `libxml2` is pulled in from the base image (`Dockerfile.ubuntu` `apt-get install ... libxml2`), so the portable tarball never included it. On Ubuntu 22.04/24.04 the host provides `libxml2.so.2`, masking the gap. On a host whose `libxml2`/ICU soname differs it breaks — e.g. **Ubuntu 26.04** ships `libxml2.so.16` + ICU 78 (no `libxml2.so.2`, no ICU 74):

```
ovms: error while loading shared libraries: libxml2.so.2: cannot open shared object file: No such file or directory
```

The full unmet chain (via `readelf -d`) is `ovms → libxml2.so.2 → libicuuc.so.74 → libicudata.so.74`.

Reported in #4362.

## Fix
Bundle `libxml2` and its ICU dependency chain into `/ovms_release/lib/` in `create_package.sh`, alongside the existing `libOpenCL` copy and **before** the `patchelf --set-rpath '$ORIGIN/../lib'` pass, so the copied libraries get an rpath that resolves them within the package.

```sh
if [[ "$BASE_OS" =~ "ubuntu" ]] ; then
	cp -P /usr/lib/x86_64-linux-gnu/libxml2.so.2* /ovms_release/lib/
	cp -P /usr/lib/x86_64-linux-gnu/libicuuc.so.* /ovms_release/lib/
	cp -P /usr/lib/x86_64-linux-gnu/libicudata.so.* /ovms_release/lib/
fi
```

Only the minimal chain is bundled — `libz`, `liblzma`, `libstdc++`, `libm`, `libc` have stable sonames present on every target and are intentionally left to the host.

## Verification
On **Ubuntu 26.04** (glibc 2.43), with the current `v2026.2.1` `ovms_ubuntu24` tarball the binary won't start (`libxml2.so.2: cannot open shared object file`). After adding these three libraries to `ovms/lib/`, `ldd ovms` is fully resolved and OVMS starts and serves an LLM on the GPU (Intel Arc Pro B60) end-to-end via `/v3/chat/completions`. This PR makes `create_package.sh` produce that self-contained tarball directly.

## Notes / scope
- **ubuntu x86_64 only.** This is the reported and verified case. The `redhat` package (and aarch64) likely need the analogous copy from their own libdirs, but I could only verify ubuntu x86_64, so I left them untouched rather than ship unverified paths.
- **Size:** adds ~30 MB, almost entirely `libicudata` (the ICU data blob `libxml2` requires). If that's a concern, an alternative is to link a libxml2 built `--without-icu` (or statically), which would avoid bundling ICU — happy to pursue that direction instead if maintainers prefer.
- **Licenses:** `libxml2` (MIT) and ICU (Unicode license) are now shipped in the tarball; `thirdparty-licenses/` may want their texts added.
