### PR TITLE
Fix: add `ffmpeg_output_width` and `ffmpeg_output_height` parameters to client.py

### DIFF
--- a/demos/real_time_stream_analysis/python/client.py
+++ b/demos/real_time_stream_analysis/python/client.py
@@ -23,8 +23,8 @@ from stream_client import StreamClient
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--grpc_address', required=False, default='localhost:9022', help='Specify url to grpc service')
-parser.add_argument('--ffmpeg_output_width', required=False, default=None, type=int, help='Width of the output video')
-parser.add_argument('--ffmpeg_output_height', required=False, default=None, type=int, help='Height of the output video')
+parser.add_argument('--ffmpeg_output_width', required=False, default=None, type=int, help='Width of the rtsp output channel window')
+parser.add_argument('--ffmpeg_output_height', required=False, default=None, type=int, help='Height of the rtsp output channel window')
 parser.add_argument('--input_stream', required=False, default="rtsp://localhost:8080/channel1", type=str, help='Url of input rtsp stream')
 parser.add_argument('--output_stream', required=False, default="rtsp://localhost:8080/channel2", type=str, help='Url of output rtsp stream')
 parser.add_argument('--model_name', required=False, default="holisticTracking", type=str, help='Name of the model')

--- a/demos/real_time_stream_analysis/python/client.py
+++ b/demos/real_time_stream_analysis/python/client.py
@@ -56,12 +56,6 @@ else:
     backend = StreamClient.OutputBackends.cv2
     exact = True
 
-if args.output_stream[:4] == "rtsp":
-    if(args.ffmpeg_output_width is None or args.ffmpeg_output_height is None):
-        print("Please specify output width (--ffmpeg_output_width) and height (--ffmpeg_output_height) for ffmpeg output")
-        sys.exit(-1)
-    client = StreamClient(postprocess_callback = postprocess, preprocess_callback=preprocess, output_backend=backend, source=args.input_stream, sink=args.output_stream, exact=exact, benchmark=args.benchmark, verbose=args.verbose,ffmpeg_output_width=args.ffmpeg_output_width, ffmpeg_output_height=args.ffmpeg_output_height)
-else:
-    client = StreamClient(postprocess_callback = postprocess, preprocess_callback=preprocess, output_backend=backend, source=args.input_stream, sink=args.output_stream, exact=exact, benchmark=args.benchmark, verbose=args.verbose)
+client = StreamClient(postprocess_callback = postprocess, preprocess_callback=preprocess, output_backend=backend, source=args.input_stream, sink=args.output_stream, exact=exact, benchmark=args.benchmark, verbose=args.verbose,ffmpeg_output_width=args.ffmpeg_output_width, ffmpeg_output_height=args.ffmpeg_output_height)
 client.start(ovms_address=args.grpc_address, input_name=args.input_name, model_name=args.model_name, datatype = StreamClient.Datatypes.uint8, batch = False, limit_stream_duration = args.limit_stream_duration, limit_frames = args.limit_frames, streaming_api=True)
 

--- a/demos/real_time_stream_analysis/python/client.py
+++ b/demos/real_time_stream_analysis/python/client.py
@@ -23,6 +23,8 @@ from stream_client import StreamClient
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--grpc_address', required=False, default='localhost:9022', help='Specify url to grpc service')
+parser.add_argument('--ffmpeg_output_width', required=False, default=None, type=int, help='Width of the output video')
+parser.add_argument('--ffmpeg_output_height', required=False, default=None, type=int, help='Height of the output video')
 parser.add_argument('--input_stream', required=False, default="rtsp://localhost:8080/channel1", type=str, help='Url of input rtsp stream')
 parser.add_argument('--output_stream', required=False, default="rtsp://localhost:8080/channel2", type=str, help='Url of output rtsp stream')
 parser.add_argument('--model_name', required=False, default="holisticTracking", type=str, help='Name of the model')
@@ -54,6 +56,12 @@ else:
     backend = StreamClient.OutputBackends.cv2
     exact = True
 
-client = StreamClient(postprocess_callback = postprocess, preprocess_callback=preprocess, output_backend=backend, source=args.input_stream, sink=args.output_stream, exact=exact, benchmark=args.benchmark, verbose=args.verbose)
+if args.output_stream[:4] == "rtsp":
+    if(args.ffmpeg_output_width is None or args.ffmpeg_output_height is None):
+        print("Please specify output width (--ffmpeg_output_width) and height (--ffmpeg_output_height) for ffmpeg output")
+        sys.exit(-1)
+    client = StreamClient(postprocess_callback = postprocess, preprocess_callback=preprocess, output_backend=backend, source=args.input_stream, sink=args.output_stream, exact=exact, benchmark=args.benchmark, verbose=args.verbose,ffmpeg_output_width=args.ffmpeg_output_width, ffmpeg_output_height=args.ffmpeg_output_height)
+else:
+    client = StreamClient(postprocess_callback = postprocess, preprocess_callback=preprocess, output_backend=backend, source=args.input_stream, sink=args.output_stream, exact=exact, benchmark=args.benchmark, verbose=args.verbose)
 client.start(ovms_address=args.grpc_address, input_name=args.input_name, model_name=args.model_name, datatype = StreamClient.Datatypes.uint8, batch = False, limit_stream_duration = args.limit_stream_duration, limit_frames = args.limit_frames, streaming_api=True)
 

--- a/demos/real_time_stream_analysis/python/client.py
+++ b/demos/real_time_stream_analysis/python/client.py
@@ -56,6 +56,17 @@ else:
     backend = StreamClient.OutputBackends.cv2
     exact = True
 
-client = StreamClient(postprocess_callback = postprocess, preprocess_callback=preprocess, output_backend=backend, source=args.input_stream, sink=args.output_stream, exact=exact, benchmark=args.benchmark, verbose=args.verbose,ffmpeg_output_width=args.ffmpeg_output_width, ffmpeg_output_height=args.ffmpeg_output_height)
+client = StreamClient(
+    postprocess_callback=postprocess,
+    preprocess_callback=preprocess,
+    output_backend=backend,
+    source=args.input_stream,
+    sink=args.output_stream,
+    exact=exact,
+    benchmark=args.benchmark,
+    verbose=args.verbose,
+    ffmpeg_output_width=args.ffmpeg_output_width,
+    ffmpeg_output_height=args.ffmpeg_output_height,
+)
 client.start(ovms_address=args.grpc_address, input_name=args.input_name, model_name=args.model_name, datatype = StreamClient.Datatypes.uint8, batch = False, limit_stream_duration = args.limit_stream_duration, limit_frames = args.limit_frames, streaming_api=True)
 


### PR DESCRIPTION
### 🛠 Summary

@atobiszei , @dtrawins 

This PR adds ffmpeg_output_width and ffmpeg_output_height parameters to the RTSP output backend in client.py.

Previously, the FFmpeg output sink assumed that the output frame dimensions matched the input stream. MediaPipe graphs that resize or transform frames (for example, object detection graphs) can produce annotated frames whose dimensions differ from those assumed by the FFmpeg writer. This mismatch results in corrupted RTSP output (tearing, repeated tiles, or distorted frames).

By exposing the output dimensions as configurable parameters, the FFmpeg sink can be initialized with the correct frame size for each graph, avoiding these artifacts.

