### PR TITLE
Fix non-mediapipe build

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -2403,6 +2403,9 @@ cc_test(
                 ":text2image_test",
                 "//src/rerank:rerank_api_handler",
                 ":embeddings_handler_tests",
+                "libovms_mediapipe_kfs_executor",
+                "//src/mediapipe_internal:mediapipe_utils",
+                "tensorflow_type_utils",
             ],
             "//:disable_mediapipe" :
             [

--- a/src/test/ensemble_config_change_stress.cpp
+++ b/src/test/ensemble_config_change_stress.cpp
@@ -22,7 +22,9 @@
 #include "../dags/pipeline.hpp"
 #include "../dags/pipeline_factory.hpp"
 #include "../dags/pipelinedefinition.hpp"
-#include "../kfs_frontend/kfs_graph_executor_impl.hpp"
+#if (MEDIAPIPE_DISABLE == 0)
+#include "src/kfs_frontend/kfs_graph_executor_impl.hpp"
+#endif
 #include "../kfs_frontend/kfs_utils.hpp"
 #include "src/filesystem/localfilesystem.hpp"
 #include "../logging.hpp"

--- a/src/test/stress_test_utils.hpp
+++ b/src/test/stress_test_utils.hpp
@@ -50,14 +50,14 @@
 #include "../status.hpp"
 #include "../stringutils.hpp"
 #include "src/timer.hpp"
-#include "../tensorflow_type_utils.hpp"
 #include "c_api_test_utils.hpp"
 #include "test_utils.hpp"
 #include "light_test_utils.hpp"
 #include "platform_utils.hpp"
 #include "test_with_temp_dir.hpp"
 #if (MEDIAPIPE_DISABLE == 0)
-#include "../mediapipe_internal/mediapipegraphexecutor.hpp"
+#include "src/mediapipe_internal/mediapipegraphexecutor.hpp"
+#include "src/tensorflow_type_utils.hpp"
 #endif
 
 using namespace ovms;


### PR DESCRIPTION
Regression introduced with:
https://github.com/openvinotoolkit/model_server/pull/4349

Include of kfs_graph_executor_impl.hpp  in src/test/ensemble_config_change_stress.cpp was not done behind ifdef.

Ticket:CVS-191156
