### PR TITLE
Fix configure

### DIFF
--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -473,6 +473,10 @@ std::variant<bool, std::pair<int, std::string>> CLIParser::parse(int argc, char*
             ss << "error parsing options - --configure cannot be used with --pull" << std::endl;
             return std::make_pair(OVMS_EX_USAGE, ss.str());
         }
+        if (result->count("configure") && result->count("model_name")) {
+            ss << "error parsing options - --model_name cannot be used with --configure" << std::endl;
+            return std::make_pair(OVMS_EX_USAGE, ss.str());
+        }
         if (result->count("add_to_config") && result->count("list_models")) {
             ss << "error parsing options - --list_models cannot be used with --add_to_config" << std::endl;
             return std::make_pair(OVMS_EX_USAGE, ss.str());

--- a/src/graph_export/graph_export.cpp
+++ b/src/graph_export/graph_export.cpp
@@ -259,8 +259,7 @@ static Status createRerankGraphTemplate(const std::string& directoryPath, const 
 input_stream: "REQUEST_PAYLOAD:input"
 output_stream: "RESPONSE_PAYLOAD:output"
 node {
-    name: ")"
-    << exportSettings.modelName << R"(",
+    name: "RerankExecutor"
     calculator: "RerankCalculatorOV"
     input_side_packet: "RERANK_NODE_RESOURCES:rerank_servable"
     input_stream: "REQUEST_PAYLOAD:input"
@@ -306,8 +305,7 @@ static Status createEmbeddingsGraphTemplate(const std::string& directoryPath, co
 input_stream: "REQUEST_PAYLOAD:input"
 output_stream: "RESPONSE_PAYLOAD:output"
 node {
-    name: ")"
-    << exportSettings.modelName << R"(",
+    name: "EmbeddingsExecutor"
     calculator: "EmbeddingsCalculatorOV"
     input_side_packet: "EMBEDDINGS_NODE_RESOURCES:embeddings_servable"
     input_stream: "REQUEST_PAYLOAD:input"
@@ -359,8 +357,7 @@ static Status createTextToSpeechGraphTemplate(const std::string& directoryPath, 
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 node {
-    name: ")"
-    << exportSettings.modelName << R"("
+    name: "T2sExecutor"
     calculator: "T2sCalculator"
     input_side_packet: "TTS_NODE_RESOURCES:t2s_servable"
     input_stream: "HTTP_REQUEST_PAYLOAD:input"
@@ -417,8 +414,7 @@ static Status createSpeechToTextGraphTemplate(const std::string& directoryPath, 
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 node {
-    name: ")"
-    << exportSettings.modelName << R"("
+    name: "S2tExecutor"
     calculator: "S2tCalculator"
     input_side_packet: "STT_NODE_RESOURCES:s2t_servable"
     input_stream: "LOOPBACK:loopback"

--- a/src/test/graph_export_test.cpp
+++ b/src/test/graph_export_test.cpp
@@ -294,7 +294,7 @@ const std::string expectedRerankGraphContentsNonDefault = R"(
 input_stream: "REQUEST_PAYLOAD:input"
 output_stream: "RESPONSE_PAYLOAD:output"
 node {
-    name: "myModel",
+    name: "RerankExecutor"
     calculator: "RerankCalculatorOV"
     input_side_packet: "RERANK_NODE_RESOURCES:rerank_servable"
     input_stream: "REQUEST_PAYLOAD:input"
@@ -314,7 +314,7 @@ const std::string expectedRerankGraphContentsDefault = R"(
 input_stream: "REQUEST_PAYLOAD:input"
 output_stream: "RESPONSE_PAYLOAD:output"
 node {
-    name: "",
+    name: "RerankExecutor"
     calculator: "RerankCalculatorOV"
     input_side_packet: "RERANK_NODE_RESOURCES:rerank_servable"
     input_stream: "REQUEST_PAYLOAD:input"
@@ -333,7 +333,7 @@ const std::string expectedEmbeddingsGraphContents = R"(
 input_stream: "REQUEST_PAYLOAD:input"
 output_stream: "RESPONSE_PAYLOAD:output"
 node {
-    name: "myModel",
+    name: "EmbeddingsExecutor"
     calculator: "EmbeddingsCalculatorOV"
     input_side_packet: "EMBEDDINGS_NODE_RESOURCES:embeddings_servable"
     input_stream: "REQUEST_PAYLOAD:input"
@@ -355,7 +355,7 @@ const std::string expectedEmbeddingsGraphContentsDefault = R"(
 input_stream: "REQUEST_PAYLOAD:input"
 output_stream: "RESPONSE_PAYLOAD:output"
 node {
-    name: "",
+    name: "EmbeddingsExecutor"
     calculator: "EmbeddingsCalculatorOV"
     input_side_packet: "EMBEDDINGS_NODE_RESOURCES:embeddings_servable"
     input_stream: "REQUEST_PAYLOAD:input"
@@ -375,7 +375,7 @@ const std::string expectedTextToSpeechGraphContents = R"(
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 node {
-    name: "myModel"
+    name: "T2sExecutor"
     calculator: "T2sCalculator"
     input_side_packet: "TTS_NODE_RESOURCES:t2s_servable"
     input_stream: "HTTP_REQUEST_PAYLOAD:input"
@@ -394,7 +394,7 @@ const std::string expectedTextToSpeechGraphContentsDefault = R"(
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 node {
-    name: ""
+    name: "T2sExecutor"
     calculator: "T2sCalculator"
     input_side_packet: "TTS_NODE_RESOURCES:t2s_servable"
     input_stream: "HTTP_REQUEST_PAYLOAD:input"
@@ -411,7 +411,7 @@ const std::string expectedTextToSpeechGraphContentsKokoro = R"(
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 node {
-    name: "myModel"
+    name: "T2sExecutor"
     calculator: "T2sCalculator"
     input_side_packet: "TTS_NODE_RESOURCES:t2s_servable"
     input_stream: "HTTP_REQUEST_PAYLOAD:input"
@@ -428,7 +428,7 @@ const std::string expectedSpeechToTextGraphContents = R"(
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 node {
-    name: "myModel"
+    name: "S2tExecutor"
     calculator: "S2tCalculator"
     input_side_packet: "STT_NODE_RESOURCES:s2t_servable"
     input_stream: "LOOPBACK:loopback"
@@ -463,7 +463,7 @@ const std::string expectedSpeechToTextGraphContentsDefault = R"(
 input_stream: "HTTP_REQUEST_PAYLOAD:input"
 output_stream: "HTTP_RESPONSE_PAYLOAD:output"
 node {
-    name: ""
+    name: "S2tExecutor"
     calculator: "S2tCalculator"
     input_side_packet: "STT_NODE_RESOURCES:s2t_servable"
     input_stream: "LOOPBACK:loopback"
@@ -704,7 +704,7 @@ TEST_F(GraphCreationTest, rerankCreatedPbtxtInvalid) {
     hfSettings.task = ovms::RERANK_GRAPH;
     ovms::RerankGraphSettingsImpl rerankGraphSettings;
     exportSettings.targetDevice = "GPU";
-    exportSettings.modelName = "myModel\"";
+    exportSettings.modelPath = "/model/path\"";
     exportSettings.pluginConfig.numStreams = 2;
     hfSettings.graphSettings = std::move(rerankGraphSettings);
     std::string graphPath = ovms::FileSystem::appendSlash(this->directoryPath) + "graph.pbtxt";
@@ -746,7 +746,7 @@ TEST_F(GraphCreationTest, embeddingsCreatedPbtxtInvalid) {
     hfSettings.task = ovms::EMBEDDINGS_GRAPH;
     ovms::EmbeddingsGraphSettingsImpl embeddingsGraphSettings;
     hfSettings.exportSettings.targetDevice = "GPU";
-    hfSettings.exportSettings.modelName = "myModel\"";
+    hfSettings.exportSettings.modelPath = "/model/path\"";
     hfSettings.exportSettings.pluginConfig.numStreams = 2;
     embeddingsGraphSettings.normalize = "true";
     embeddingsGraphSettings.pooling = "CLS";
@@ -824,7 +824,7 @@ TEST_F(GraphCreationTest, textToSpeechCreatedPbtxtInvalid) {
     hfSettings.task = ovms::TEXT_TO_SPEECH_GRAPH;
     ovms::TextToSpeechGraphSettingsImpl textToSpeechGraphSettings;
     hfSettings.exportSettings.targetDevice = "GPU";
-    hfSettings.exportSettings.modelName = "myModel\"";
+    hfSettings.exportSettings.modelPath = "/model/path\"";
     hfSettings.exportSettings.pluginConfig.numStreams = 2;
     hfSettings.graphSettings = std::move(textToSpeechGraphSettings);
     std::unique_ptr<ovms::GraphExport> graphExporter = std::make_unique<ovms::GraphExport>();
@@ -861,7 +861,7 @@ TEST_F(GraphCreationTest, speechToTextCreatedPbtxtInvalid) {
     hfSettings.task = ovms::SPEECH_TO_TEXT_GRAPH;
     ovms::SpeechToTextGraphSettingsImpl speechToTextGraphSettings;
     hfSettings.exportSettings.targetDevice = "GPU";
-    hfSettings.exportSettings.modelName = "myModel\"";
+    hfSettings.exportSettings.modelPath = "/model/path\"";
     hfSettings.exportSettings.pluginConfig.numStreams = 2;
     hfSettings.graphSettings = std::move(speechToTextGraphSettings);
     std::unique_ptr<ovms::GraphExport> graphExporter = std::make_unique<ovms::GraphExport>();

--- a/src/test/ovmsconfig_test.cpp
+++ b/src/test/ovmsconfig_test.cpp
@@ -3189,4 +3189,21 @@ TEST_F(OvmsConfigDeathTest, negativeConfigureModeRequiresTaskWhenCannotInfer) {
         "Could not infer model task");
 }
 
+TEST_F(OvmsConfigDeathTest, negativeConfigureModeCannotBeUsedWithModelName) {
+    char* n_argv[] = {
+        (char*)"ovms",
+        (char*)"--configure",
+        (char*)"--model_path",
+        (char*)"/non/existing/model/path",
+        (char*)"--task",
+        (char*)"embeddings",
+        (char*)"--model_name",
+        (char*)"some_name",
+    };
+    int arg_count = 8;
+    EXPECT_EXIT(ovms::Config::instance().parse(arg_count, n_argv),
+        ::testing::ExitedWithCode(OVMS_EX_USAGE),
+        "--model_name cannot be used with --configure");
+}
+
 #pragma GCC diagnostic pop


### PR DESCRIPTION
### 🛠 Summary

correct command configure to be used without model_name

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

