### PR TITLE
make OVMSTextStreamer delay_n_tokens configurable via OVMS_LLM_DELAY_…

### DIFF
--- a/docs/llm/reference.md
+++ b/docs/llm/reference.md
@@ -110,6 +110,9 @@ The calculator supports the following `node_options` for tuning the pipeline con
 -    `optional bool enable_tool_guided_generation` - enable enforcing tool schema during generation. Requires setting response parser. [default = false];
 -    `optional SparseAttentionConfig sparse_attention_config` - Sparse attention configuration. Disabled if not specified.
 
+### Streaming settings
+The number of tokens the streaming response withholds before flushing a decoded chunk to the client can be tuned with the `OVMS_LLM_DELAY_N_TOKENS` environment variable (default: 3). This lookahead buffer lets the tokenizer resolve multi-token sequences (e.g. incomplete UTF-8 characters or parser markers) correctly before emitting a chunk. Increasing the value can improve output correctness for some models/parsers, but increases time to first token (TTFT) and inter-token latency. The value must be a positive integer; invalid, empty, or zero values fall back to the default.
+
 ### Caching settings
 The value of `cache_size` might have performance and stability implications. It is used for storing LLM model KV cache data. Adjust it based on your environment capabilities, model size and expected level of concurrency.
 You can track the actual usage of the cache in the server logs. You can observe in the logs output like below:

--- a/src/llm/ovms_text_streamer.cpp
+++ b/src/llm/ovms_text_streamer.cpp
@@ -16,10 +16,15 @@
 #include "ovms_text_streamer.hpp"
 
 #include <algorithm>
+#include <cstdlib>
+#include <limits>
 #include <string>
 #include <utility>
 
 #include <rapidjson/document.h>
+
+#include "../logging.hpp"
+#include "../stringutils.hpp"
 
 namespace {
 // Matches GenAI's is_incomplete() in text_streamer.cpp.
@@ -28,6 +33,24 @@ namespace {
 bool is_incomplete(const std::string& text) {
     constexpr char replacement[] = "\xef\xbf\xbd";
     return text.size() >= 3 && text.compare(text.size() - 3, 3, replacement) == 0;
+}
+
+// Resolves the token lookahead delay from the OVMS_LLM_DELAY_N_TOKENS environment
+// variable. Falls back to ovms::OVMSTextStreamer::kDefaultDelayNTokens when the
+// variable is unset, empty, not a valid number, or zero (zero would cause an
+// out-of-bounds access in the delay-buffer logic).
+size_t getDelayNTokensFromEnv() {
+    const char* env = std::getenv("OVMS_LLM_DELAY_N_TOKENS");
+    if (env && *env) {
+        auto parsed = ovms::stou64(env);
+        if (parsed.has_value() &&
+            parsed.value() > 0 &&
+            parsed.value() <= static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+            return static_cast<size_t>(parsed.value());
+        }
+        SPDLOG_LOGGER_WARN(ovms::llm_calculator_logger, "Invalid OVMS_LLM_DELAY_N_TOKENS value: '{}'. Using default: {}", env, ovms::OVMSTextStreamer::kDefaultDelayNTokens);
+    }
+    return ovms::OVMSTextStreamer::kDefaultDelayNTokens;
 }
 }  // namespace
 
@@ -49,7 +72,8 @@ OVMSTextStreamer::OVMSTextStreamer(
     ov::genai::TextStreamer(tokenizer, noop_string_callback, decode_params),
     m_output_parser(output_parser),
     m_tools_available(tools_available),
-    m_callback(std::move(callback)) {}
+    m_callback(std::move(callback)),
+    m_delay_n_tokens(getDelayNTokensFromEnv()) {}
 
 // -----------------------------------------------------------------------------
 // write(int64_t) — owned decode loop (does NOT delegate to TextStreamer::write)
@@ -57,7 +81,7 @@ OVMSTextStreamer::OVMSTextStreamer(
 // Replicates TextStreamer's flush heuristics:
 //   1. Newline flush: emit immediately when text ends with '\n'.
 //   2. Incomplete UTF-8 guard: if text ends with U+FFFD replacement char, mark as -1.
-//   3. Delay buffer: hold back the last DELAY_N_TOKENS positions before flushing.
+//   3. Delay buffer: hold back the last m_delay_n_tokens positions before flushing.
 //
 // Operates directly on the protected members inherited from TextStreamer:
 //   m_tokens_cache, m_decoded_lengths, m_printed_len,
@@ -85,14 +109,14 @@ ov::genai::StreamingStatus OVMSTextStreamer::write(int64_t token) {
         return ov::genai::StreamingStatus::RUNNING;
     }
 
-    // 3. Delay buffer: need at least DELAY_N_TOKENS entries before flushing.
+    // 3. Delay buffer: need at least m_delay_n_tokens entries before flushing.
     const size_t n = m_decoded_lengths.size();
-    if (n < DELAY_N_TOKENS) {
+    if (n < m_delay_n_tokens) {
         return ov::genai::StreamingStatus::RUNNING;
     }
 
-    // Flush up to the decoded length DELAY_N_TOKENS positions from the end.
-    const int64_t print_until_len = m_decoded_lengths[n - DELAY_N_TOKENS];
+    // Flush up to the decoded length m_delay_n_tokens positions from the end.
+    const int64_t print_until_len = m_decoded_lengths[n - m_delay_n_tokens];
     if (print_until_len <= 0 || static_cast<size_t>(print_until_len) <= m_printed_len) {
         return ov::genai::StreamingStatus::RUNNING;
     }
@@ -114,7 +138,7 @@ ov::genai::StreamingStatus OVMSTextStreamer::write(const std::vector<int64_t>& t
 
 // -----------------------------------------------------------------------------
 //
-// Decodes the remaining token cache (up to DELAY_N_TOKENS - 1 tokens that
+// Decodes the remaining token cache (up to m_delay_n_tokens - 1 tokens that
 // write() deliberately held back) and flushes with GenerationFinishReason::STOP.
 //
 // Does NOT call TextStreamer::end() — the base would fire its no-op callback

--- a/src/llm/ovms_text_streamer.hpp
+++ b/src/llm/ovms_text_streamer.hpp
@@ -58,6 +58,14 @@ public:
     // completion signal are observed atomically (no separate signalComplete() needed).
     using Callback = std::function<ov::genai::StreamingStatus(rapidjson::Document, bool /*isLast*/)>;
 
+    // Default number of tokens the streamer withholds before flushing a decoded chunk.
+    // Matches the file-scope constexpr in openvino/genai text_streamer.cpp. Overridable
+    // at runtime via the OVMS_LLM_DELAY_N_TOKENS environment variable (see
+    // getDelayNTokensFromEnv() in ovms_text_streamer.cpp). Larger values give the
+    // tokenizer more lookahead before a chunk is flushed, at the cost of higher
+    // time-to-first-token (TTFT) and inter-token latency.
+    static constexpr size_t kDefaultDelayNTokens = 3;
+
     // outputParser may be nullptr (e.g. for the unary VLM path).
     // TODO(phase3): rework ownership — OVMSTextStreamer should not need to keep
     // the parser alive; it will be restructured in the next refactor phase.
@@ -83,10 +91,7 @@ private:
     std::shared_ptr<OutputParser> m_output_parser;
     bool m_tools_available;
     Callback m_callback;
-
-    // Must match the file-scope constexpr in openvino/genai text_streamer.cpp.
-    // Named here so a future GenAI change is a single update point.
-    static constexpr size_t DELAY_N_TOKENS = 3;
+    const size_t m_delay_n_tokens;
 
     // Flush text[m_printed_len : print_until] with the corresponding token slice.
     ov::genai::StreamingStatus flush_chunk(


### PR DESCRIPTION
…N_TOKENS env var

OVMSTextStreamer previously hardcoded a 3-token lookahead buffer (DELAY_N_TOKENS) before flushing a decoded chunk to the client. This delay trades off time-to-first-token (TTFT) and inter-token latency for more reliable multi-token resolution (e.g. incomplete UTF-8 sequences, parser markers).

Make this tunable at runtime via the OVMS_LLM_DELAY_N_TOKENS environment variable, following the existing convention used by OVMS_AUDIO_MAX_FILE_SIZE_BYTES:
- kDefaultDelayNTokens (3) is now a public static constexpr on OVMSTextStreamer, used as the fallback default.
- getDelayNTokensFromEnv() reads and parses the env var via stou64(), falling back to the default (with a warning) when unset, empty, invalid, or zero.
- m_delay_n_tokens replaces the previous static DELAY_N_TOKENS constant and is resolved once at streamer construction time.

This applies uniformly across all pipeline types (LM, LM_CB, VLM, VLM_CB, OMNI) since they all construct OVMSTextStreamer the same way, with no graph.pbtxt / node_options changes required.

Documented the new env var in docs/llm/reference.md.

### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

