### PR TITLE
docs: remove obsolete Eagle3 prefix caching limitation

### DIFF
--- a/demos/continuous_batching/speculative_decoding/README.md
+++ b/demos/continuous_batching/speculative_decoding/README.md
@@ -172,7 +172,6 @@ The built-in fallback is `5`. The same applies to `assistant_confidence_threshol
 Eagle3 deployments currently have following known limitations:
 - stateful mode (pipeline_type: LM) not supported,
 - concurrency not supported - max 1 request can be processed at a time (**ALWAYS** use rest_workers=2 when deploying Eagle3 pipeline),
-- prefix caching not supported,
 - only greedy sampling is supported (enforced by OVMS if pipeline configured properly),
 - MoE models not supported
 


### PR DESCRIPTION
### 🛠 Summary
Correcting inaccurate claim in documentation. Based on [CVS-186806](https://jira.devtools.intel.com/browse/CVS-186806) and information from Ilia. Prefix caching is supported now, so the change is to remove the bullet that claimed it wasn't.

