### PR TITLE
Fixing content parsing for onyx

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,7 @@ http_archive(
     build_file = "@mediapipe//third_party:zlib.BUILD",
     sha256 = "bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16",
     strip_prefix = "zlib-1.3.2",
-    url = "http://zlib.net/fossils/zlib-1.3.2.tar.gz",
+    url = "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz",
 )
 
 # RapidJSON

--- a/src/llm/io_processing/onyx/onyx_tool_parser.cpp
+++ b/src/llm/io_processing/onyx/onyx_tool_parser.cpp
@@ -40,7 +40,8 @@ const std::string OnyxToolParser::PARAMETER_NAME_TAG = "<atem:parameter name=\""
 const std::string OnyxToolParser::PARAMETER_END_TAG = "</atem:parameter>";
 const std::string OnyxToolParser::NAME_ATTR_END_TAG = "\">";
 const std::string OnyxToolParser::ASSISTANT_PREFIX = "<|start|>assistant ";
-const std::string OnyxToolParser::CONTENT_START_INDICATOR = "to=user<|message|>";
+const std::string OnyxToolParser::CONTENT_START_INDICATOR = "to=user";
+const std::string OnyxToolParser::MESSAGE_TAG = "<|message|>";
 const std::string OnyxToolParser::END_OF_TURN_TAG = "<|eot|>";
 
 // Static empty map the default-constructed impl binds its const-ref member to (used by the

--- a/src/llm/io_processing/onyx/onyx_tool_parser.hpp
+++ b/src/llm/io_processing/onyx/onyx_tool_parser.hpp
@@ -133,7 +133,8 @@ public:
     static const std::string PARAMETER_END_TAG;        // "</atem:parameter>"
     static const std::string NAME_ATTR_END_TAG;        // "\">" -- closes an invoke/parameter name
     static const std::string ASSISTANT_PREFIX;         // "<|start|>assistant "
-    static const std::string CONTENT_START_INDICATOR;  // "to=...<|message|>"
+    static const std::string CONTENT_START_INDICATOR;  // "to=user"
+    static const std::string MESSAGE_TAG;              // "<|message|>"
     static const std::string END_OF_TURN_TAG;          // "<|eot|>"
 
 private:
@@ -178,7 +179,7 @@ public:
         return true;
     }
     const std::vector<std::string>& getSpecialTagsToErase() const override {
-        static const std::vector<std::string> specialTagsToErase{ASSISTANT_PREFIX, CONTENT_START_INDICATOR, END_OF_TURN_TAG};
+        static const std::vector<std::string> specialTagsToErase{ASSISTANT_PREFIX, CONTENT_START_INDICATOR, MESSAGE_TAG, END_OF_TURN_TAG};
         return specialTagsToErase;
     }
 };

--- a/src/test/llm/output_parsers/onyx_output_parser_test.cpp
+++ b/src/test/llm/output_parsers/onyx_output_parser_test.cpp
@@ -673,6 +673,8 @@ TEST_F(OnyxOutputParserTest, StreamingReasoningThenContent) {
 TEST_F(OnyxOutputParserTest, StreamingContentOnly) {
     int i = -1;
     std::vector<std::tuple<std::string, ov::genai::GenerationFinishReason, std::optional<std::string>>> chunkToDeltaVec{
+        {"<|start|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"assistant ", ov::genai::GenerationFinishReason::NONE, std::nullopt},
         {"to=user", ov::genai::GenerationFinishReason::NONE, std::nullopt},
         {"<|message|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
         {"Your ", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"content":"Your "}})"},


### PR DESCRIPTION
### 🛠 Summary

Removing `to=user<|message|>` from content with new version of model

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

