### PR TITLE
Backport Gemma4 tool parser fixes to 2026.4

### DIFF
--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
@@ -373,7 +373,9 @@ std::optional<rapidjson::Document> Gemma4ToolParser::parseChunk(const std::strin
             return BaseOutputParser::wrapFirstDelta(this->toolCall.name, toolCallIndex);
         }
         if (this->currentState == State::ToolCallEnded) {
-            return wrapDeltaArgs(this->toolCall.arguments, toolCallIndex);
+            auto delta = wrapDeltaArgs(this->toolCall.arguments, toolCallIndex);
+            this->toolCall = ToolCall{};
+            return delta;
         }
         if (this->currentState == State::Content) {
             size_t contentEnd = this->streamingContent.find(TOOL_CALL_START_TAG, this->streamingPosition);

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
@@ -210,13 +210,48 @@ std::pair<std::string, std::string> Gemma4ToolParser::parseSingleArgument(const 
     return argument;
 }
 
+std::string Gemma4ToolParser::maskStringValues(const std::string& text) {
+    std::string masked = text;
+    size_t pos = 0;
+    while (true) {
+        const size_t openPos = text.find(TOOL_ARGS_STRING_INDICATOR, pos);
+        if (openPos == std::string::npos)
+            break;
+        const size_t valueStart = openPos + TOOL_ARGS_STRING_INDICATOR.size();
+        const size_t closePos = text.find(TOOL_ARGS_STRING_INDICATOR, valueStart);
+        // Value not closed yet (still streaming): mask through the current buffer end too,
+        // otherwise its already-received tail would desync quote/brace tracking; a later
+        // call re-masks from scratch once the closing delimiter has arrived.
+        const size_t maskEnd = (closePos == std::string::npos) ? text.size() : closePos;
+        for (size_t i = valueStart; i < maskEnd; i++) {
+            switch (masked[i]) {
+            case '"':
+            case '\'':
+            case '{':
+            case '}':
+            case '[':
+            case ']':
+                masked[i] = '\x01';
+                break;
+            default:
+                break;
+            }
+        }
+        if (closePos == std::string::npos)
+            break;
+        pos = closePos + TOOL_ARGS_STRING_INDICATOR.size();
+    }
+    return masked;
+}
+
 std::vector<std::pair<std::string, std::string>> Gemma4ToolParser::parseArguments(const std::string& argumentsStr) {
     std::vector<std::string> args;
     std::vector<std::pair<std::string, std::string>> parsedArgs;
 
+    const std::string maskedArgumentsStr = maskStringValues(argumentsStr);
     size_t argPos = 0;
     while (argPos < argumentsStr.length()) {
-        size_t commaPos = findInStringRespectingSpecialChars(argumentsStr, TOOL_ARGS_SEPARATOR_STR, argPos);
+        size_t commaPos = findInStringRespectingSpecialChars(maskedArgumentsStr, TOOL_ARGS_SEPARATOR_STR, argPos);
         if (commaPos == std::string::npos) {
             auto remainingStr = argumentsStr.substr(argPos);
             args.push_back(remainingStr);
@@ -278,7 +313,8 @@ bool Gemma4ToolParser::parseToolCallParametersState() {
     if (this->streamingContent.back() == TOOL_ARGS_END_INDICATOR.back()) {
         SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool arguments end indicator found at the end of streaming content, attempting to parse arguments: {}", this->streamingContent.substr(this->streamingPosition));
     }
-    size_t pos = findInStringRespectingSpecialChars(this->streamingContent, TOOL_ARGS_END_INDICATOR, this->streamingPosition);
+    const std::string maskedStreamingContent = maskStringValues(this->streamingContent);
+    size_t pos = findInStringRespectingSpecialChars(maskedStreamingContent, TOOL_ARGS_END_INDICATOR, this->streamingPosition);
     if (pos == std::string::npos) {
         SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool arguments end indicator not found in streaming content starting from position: {}", this->streamingPosition);
         return false;
@@ -386,6 +422,16 @@ std::optional<rapidjson::Document> Gemma4ToolParser::parseChunk(const std::strin
                 content = this->streamingContent.substr(this->streamingPosition);
             }
             this->streamingPosition += content.size();
+
+            // Structural/stop markers must never reach the client, on any chunk, not just the final flush.
+            for (const std::string& tagToErase : {TURN_END_TAG, TOOL_RESPONSE_START_TAG}) {
+                size_t tagPos = content.find(tagToErase);
+                while (tagPos != std::string::npos) {
+                    content.erase(tagPos, tagToErase.length());
+                    tagPos = content.find(tagToErase, tagPos);
+                }
+            }
+
             return wrapDeltaContent(content);
         }
         if (this->currentState == State::AfterToolCall) {

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
@@ -83,6 +83,14 @@ public:
 private:
     void writeArgumentToWriter(const std::string& arg, rapidjson::Writer<rapidjson::StringBuffer>& writer);
 
+    // Masks '"', '\'', '{', '}', '[', ']' found inside <|"|>...<|"|> pairs (same length,
+    // delimiter's own quotes left intact) so a Gemma4 string value's own payload (e.g. code
+    // containing commas/braces/quotes) can't be mistaken for structural tokens by
+    // findInStringRespectingSpecialChars. An unclosed trailing value (still streaming) is
+    // masked through the current buffer end too; a later call re-masks from scratch once
+    // its closing delimiter has arrived.
+    static std::string maskStringValues(const std::string& text);
+
     std::pair<std::string, std::string> parseSingleArgument(const std::string& argumentStr);
     std::vector<std::pair<std::string, std::string>> parseArguments(const std::string& argumentsStr);
 

--- a/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
@@ -441,6 +441,58 @@ TEST_F(Gemma4OutputParserTest, ParseToolCallWithMultipleUtfCharsStreaming) {
     assertStreamingVec(chunkToDeltaVec);
 }
 
+TEST_F(Gemma4OutputParserTest, ParseToolCallArgumentValueContainingComma) {
+    // Comma embedded inside a string value (e.g. generated code) must
+    // not be mistaken for the separator between arguments.
+    std::string input =
+        "<|tool_call>call:editor{new_text:<|\"|>print(\"Hello, World!\")\n"
+        "<|\"|>,path:<|\"|>/home/user/demos/hello_world_python/hello.py<|\"|>}<tool_call|>";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "editor");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments,
+        "{\"new_text\":\"print(\\\"Hello, World!\\\")\\n\",\"path\":\"/home/user/demos/hello_world_python/hello.py\"}");
+}
+
+TEST_F(Gemma4OutputParserTest, ParseToolCallArgumentValueContainingBracesAndBrackets) {
+    // Literal '{', '}', '[', ']' inside a string value must not be mistaken
+    // for nested object/array structure or for the tool call's own top-level closing brace.
+    std::string input =
+        "<|tool_call>call:editor{new_text:<|\"|>numbers = [1, 2, 3] and config = {a: 1, b: 2}<|\"|>,"
+        "path:<|\"|>file.txt<|\"|>}<tool_call|>";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "editor");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments,
+        "{\"new_text\":\"numbers = [1, 2, 3] and config = {a: 1, b: 2}\",\"path\":\"file.txt\"}");
+}
+
+TEST_F(Gemma4OutputParserTest, ParseToolCallArgumentValueWithUnclosedQuoteAndBraceMidStream) {
+    // While a string value is still streaming (its closing <|"|> hasn't
+    // arrived yet), an internal '"' followed by a '}' inside the already-received partial
+    // value must not be mistaken for the tool call's own closing brace.
+    std::vector<std::tuple<std::string, ov::genai::GenerationFinishReason, std::optional<std::string>>> chunkToDeltaVec{
+        {"<|tool_call>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"call:", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"editor", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"{new_text", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"tool_calls":[{"id":"XXXXXXXXX","type":"function","index":0,"function":{"name":"editor"}}]}})"},
+        {":<|\"|>say ", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"\"hi}", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {" keep going", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"<|\"|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"}", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"new_text\":\"say \\\"hi} keep going\"}"}}]}})"},
+        {"<tool_call|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+    };
+
+    assertStreamingVec(chunkToDeltaVec);
+}
+
 TEST_F(Gemma4OutputParserTest, ParseToolCallOutputWithContentAndNoToolCalls) {
     std::string input = "This is a regular model response without tool calls.";
     auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;

--- a/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
@@ -609,6 +609,23 @@ TEST_F(Gemma4OutputParserTest, StreamingWithToolResponseTokenAtTheEndOfGeneratio
     assertStreamingVec(chunkToDeltaVec);
 }
 
+// Model omits the "<tool_call|>" end tag entirely and jumps straight to a stray
+// "<|tool_response>" before stopping. Arguments must be emitted exactly once
+// (regression test: the finish-flush fallback used to blindly re-emit them).
+TEST_F(Gemma4OutputParserTest, StreamingWithMissingEndTagBeforeStop) {
+    std::vector<std::tuple<std::string, ov::genai::GenerationFinishReason, std::optional<std::string>>> chunkToDeltaVec{
+        {"<|tool_call>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"call:", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"ls", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"{a:", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"tool_calls":[{"id":"XXXXXXXXX","type":"function","index":0,"function":{"name":"ls"}}]}})"},
+        {"true}", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"a\":true}"}}]}})"},
+        {"<|tool_response>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"", ov::genai::GenerationFinishReason::STOP, std::nullopt},
+    };
+
+    assertStreamingVec(chunkToDeltaVec);
+}
+
 TEST_F(Gemma4OutputParserTest, StreamingContentWithTurnTokenAtTheEndOfGeneration) {
     std::vector<std::tuple<std::string, ov::genai::GenerationFinishReason, std::optional<std::string>>> chunkToDeltaVec{
         {"This is", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"content":"This is"}})"},


### PR DESCRIPTION
## Summary
- Backport the **Gemma4-only** portions of #4493 and #4508 onto `main-2026.4`.
- On this branch, sibling parsers from #4493 (lfm2 / minicpm5 / qwen3coder / onyx) are absent or conflict, so they are not included.
- `DefaultContentParser` / `contentParser` from #4508 do not exist on the 2026.4 `OutputParser`. `output_parser.cpp` is left at `main-2026.4` HEAD; the Gemma4 `parseChunk` tag-erase loop is the compatible content-leak fix.

This matches what is already on `main`:
- #4493 `503ff866278e9236d08bc9b6ddd18ec879660f72`
- #4508 `95628b45a082bd3d9562a3ad2f3d0762d5883ca4`

Without this backport, Gemma4 native tool markup can leak into OpenAI `message.content` instead of `message.tool_calls`.

## Test plan
- [x] Windows OVMS 2026.4 RC1 (`530dc63f`) with this parser: `Gemma4OutputParserTest.*` — 43 tests PASSED
- [x] Live serve of Gemma4 26B INT4 + OpenAI `/v1/chat/completions` with `tool_choice=auto`: tool call exposed as `message.tool_calls` (`get_weather`, arguments `{"city":"Berlin"}`), not raw tool markup in `content`
- [ ] Linux CI `Gemma4OutputParserTest.*`
