### PR TITLE
Gemma4 native tool calling: parser, lazy generation and chat-template hardening

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -2433,6 +2433,9 @@ cc_library(
     name = "test_platform_utils",
     hdrs = ["test/platform_utils.hpp",],
     srcs = ["test/platform_utils.cpp",],
+    visibility = [
+        "//src/test/llm/generation_config:__pkg__",
+    ],
     deps = [
         "@com_google_googletest//:gtest",
     ],
@@ -2845,6 +2848,21 @@ cc_library(
     local_defines = COMMON_LOCAL_DEFINES,
 )
 
+cc_test(
+    name = "llm_output_parser_tests",
+    env_inherit = ["PATH"],
+    deps = [
+        ":test_llm_output_parser_tests",
+        "@com_google_googletest//:gtest_main",
+        "//third_party:genai",
+        "//third_party:openvino",
+    ],
+    copts = COPTS_TESTS,
+    local_defines = COMMON_LOCAL_DEFINES,
+    linkopts = COMMON_STATIC_LIBS_LINKOPTS,
+    linkstatic = 1,
+)
+
 cc_library(
     name = "test_chat_template_workarounds",
     linkstatic = 1,
@@ -2870,6 +2888,19 @@ cc_library(
     ],
     copts = COPTS_TESTS,
     local_defines = COMMON_LOCAL_DEFINES,
+)
+
+cc_test(
+    name = "chat_template_workarounds_tests",
+    env_inherit = ["PATH"],
+    deps = [
+        ":test_chat_template_workarounds",
+        "@com_google_googletest//:gtest_main",
+    ],
+    copts = COPTS_TESTS,
+    local_defines = COMMON_LOCAL_DEFINES,
+    linkopts = COMMON_STATIC_LIBS_LINKOPTS,
+    linkstatic = 1,
 )
 
 cc_library(

--- a/src/llm/apis/openai_request.hpp
+++ b/src/llm/apis/openai_request.hpp
@@ -81,6 +81,9 @@ struct OpenAIRequest {
     ToolsSchemas_t toolNameSchemaMap;
     // Holds value for tool_choice field as described in https://platform.openai.com/docs/api-reference/chat/create#chat_create-tool_choice
     std::string toolChoice;
+    // Whether the assistant may emit more than one tool call in the same turn.
+    // OpenAI-compatible servers default this field to true when it is omitted.
+    bool parallelToolCalls{true};
 
     bool skipSpecialTokens{true};
 

--- a/src/llm/io_processing/base_generation_config_builder.hpp
+++ b/src/llm/io_processing/base_generation_config_builder.hpp
@@ -97,6 +97,13 @@ public:
     void unsetStructuredOutputConfig();
 
     /*
+     * Model-specific policy for structured-output validation failures. The generic
+     * serving path falls back to unguided generation; builders representing a hard
+     * API contract may override this to keep the grammar fail-closed.
+     */
+    virtual bool shouldPreserveStructuredOutputOnValidationFailure() const { return false; }
+
+    /*
      * Fills generation config with values read from OpenAI request.
      * If extended, model specific implementation should call base class method first to fill in common configuration
      * and then set model specific parameters.

--- a/src/llm/io_processing/chat_template/analyzer.cpp
+++ b/src/llm/io_processing/chat_template/analyzer.cpp
@@ -51,6 +51,14 @@ ChatTemplateAnalysisResult ChatTemplateAnalyzer::analyze(const std::string& temp
         result.detectedReasoningParser = "gemma4";  // gemma is always tied to its own parser for reasoning
         result.caps.supportsToolCalls = true;
         result.caps.supportsResponseFieldInToolDefinition = true;
+
+        // A mapping branch alone is insufficient to opt role:tool JSON content into
+        // object conversion. Jinja treats mappings as sequences too; templates that
+        // later iterate content parts and call part.get() would then iterate string
+        // keys and fail with `'str object' has no attribute 'get'`.
+        const bool mapsResponse = contains(templateSource, "response is mapping");
+        const bool iteratesPartsWithGet = contains(templateSource, "part.get('type')");
+        result.caps.parseToolResponseJsonContent = mapsResponse && !iteratesPartsWithGet;
         return result;
     }
 

--- a/src/llm/io_processing/chat_template/caps.hpp
+++ b/src/llm/io_processing/chat_template/caps.hpp
@@ -25,17 +25,22 @@ struct ChatTemplateCaps {
     // Some templates require tool_call arguments to be a dict/object rather than a stringified JSON.
     bool requiresObjectArguments = false;
 
+    // Some templates render role:tool JSON object strings as mappings. This is a
+    // template capability, not a general OpenAI-history conversion rule.
+    bool parseToolResponseJsonContent = false;
+
     std::string missnamedReasoningField = "";
 
     bool supportsResponseFieldInToolDefinition = false;
 
     bool needsWorkarounds() const {
-        return requiresObjectArguments || !missnamedReasoningField.empty() || supportsResponseFieldInToolDefinition;
+        return requiresObjectArguments || parseToolResponseJsonContent || !missnamedReasoningField.empty() || supportsResponseFieldInToolDefinition;
     }
 
     std::string toString() const {
         return std::string("supportsToolCalls=") + (supportsToolCalls ? "true" : "false") +
                ", requiresObjectArguments=" + (requiresObjectArguments ? "true" : "false") +
+               ", parseToolResponseJsonContent=" + (parseToolResponseJsonContent ? "true" : "false") +
                ", missnamedReasoningField=" + missnamedReasoningField +
                ", supportsResponseFieldInToolDefinition=" + (supportsResponseFieldInToolDefinition ? "true" : "false");
     }

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
@@ -6,376 +6,546 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //*****************************************************************************
+
 #include "gemma4_tool_parser.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "../utils.hpp"
 #include "../../../logging.hpp"
 #include "../../../stringutils.hpp"
-#include "rapidjson/error/en.h"
-#include <algorithm>
-#include <cctype>
-#include <utility>
+#include "src/port/rapidjson_document.hpp"
+#include "src/port/rapidjson_stringbuffer.hpp"
+#include "src/port/rapidjson_writer.hpp"
 
 namespace ovms {
 
 const std::string Gemma4ToolParser::TOOL_CALL_START_TAG = "<|tool_call>";
 const std::string Gemma4ToolParser::TOOL_CALL_END_TAG = "<tool_call|>";
 const std::string Gemma4ToolParser::TOOL_CALL_NAME_PREFIX = "call:";
-
-const std::string Gemma4ToolParser::TOOL_ARGS_START_INDICATOR = "{";
-const std::string Gemma4ToolParser::TOOL_ARGS_END_INDICATOR = "}";
 const std::string Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR = "<|\"|>";
-const std::string Gemma4ToolParser::TOOL_ARGS_SEPARATOR_STR = ",";
-
 const std::string Gemma4ToolParser::TURN_END_TAG = "<turn|>";
 const std::string Gemma4ToolParser::TOOL_RESPONSE_START_TAG = "<|tool_response>";
 
-const int64_t Gemma4ToolParser::botTokenId = 48;  // <|tool_call>
-const int64_t Gemma4ToolParser::eotTokenId = 49;  // <tool_call|>
+namespace {
 
-const int64_t Gemma4ToolParser::reasoningTokenId = 100;     // <|channel>
-const int64_t Gemma4ToolParser::reasoningEndTokenId = 101;  // <channel|>
+using JsonWriter = rapidjson::Writer<rapidjson::StringBuffer>;
 
-std::string Gemma4ToolParser::parseArrayParameter(const std::string& argumentStr) {
-    size_t pos = 1;
-    std::string parsedArguments = "[";
-
-    while (pos != std::string::npos) {
-        size_t stringStartPos = argumentStr.find(TOOL_ARGS_STRING_INDICATOR, pos);
-        if (stringStartPos == std::string::npos) {
-            break;
-        }
-        stringStartPos += TOOL_ARGS_STRING_INDICATOR.size();
-        size_t stringEndPos = argumentStr.find(TOOL_ARGS_STRING_INDICATOR, stringStartPos);
-        if (stringEndPos == std::string::npos) {
-            break;
-        }
-
-        std::string originalStr = argumentStr.substr(stringStartPos, stringEndPos - stringStartPos);
-        size_t quotePos = 0;
-        while ((quotePos = originalStr.find('\"', quotePos)) != std::string::npos) {
-            originalStr.insert(quotePos, "\\");
-            quotePos += 2;
-        }
-        parsedArguments += "\"" + originalStr + "\",";
-
-        pos = stringEndPos + TOOL_ARGS_STRING_INDICATOR.size() + 1;
-    }
-
-    parsedArguments.back() = ']';
-
-    return parsedArguments;
+void trimLocal(std::string& value) {
+    auto notSpace = [](unsigned char c) { return !std::isspace(c); };
+    value.erase(value.begin(), std::find_if(value.begin(), value.end(), notSpace));
+    value.erase(std::find_if(value.rbegin(), value.rend(), notSpace).base(), value.end());
 }
 
-std::string Gemma4ToolParser::parseObjectParameter(const std::string& argumentStr) {
-    size_t pos = 1;
-    std::vector<std::pair<std::string, std::string>> keyValuePairs;
-
-    while (pos != std::string::npos) {
-        std::string key, value;
-        bool isStringValue = false;
-        size_t keyEndPos = argumentStr.find(':', pos);
-        if (keyEndPos == std::string::npos) {
-            break;
-        }
-        key = argumentStr.substr(pos, keyEndPos - pos);
-        size_t valueStartPos = keyEndPos + 1;
-        size_t valueEndPos = std::string::npos;
-        if (argumentStr.substr(valueStartPos, TOOL_ARGS_STRING_INDICATOR.size()) == TOOL_ARGS_STRING_INDICATOR) {
-            valueStartPos = valueStartPos + TOOL_ARGS_STRING_INDICATOR.size();
-            valueEndPos = argumentStr.find(TOOL_ARGS_STRING_INDICATOR, valueStartPos);
-            isStringValue = true;
-        } else {
-            valueEndPos = argumentStr.find(',', valueStartPos);
-        }
-
-        if (valueEndPos == std::string::npos) {
-            valueEndPos = argumentStr.size() - 1;
-        }
-        value = argumentStr.substr(valueStartPos, valueEndPos - valueStartPos);
-        if (isStringValue) {
-            value = "\"" + value + "\"";
-        }
-        keyValuePairs.emplace_back(key, value);
-        if (valueEndPos == argumentStr.size() - 1) {
-            break;
-        } else if (isStringValue) {
-            pos = valueEndPos + TOOL_ARGS_STRING_INDICATOR.size() + 1;
-        } else {
-            pos = valueEndPos + 1;
-        }
-    }
-
-    if (keyValuePairs.empty()) {
-        return argumentStr;
-    }
-
-    std::string parsedObject = "{";
-    for (const auto& [key, value] : keyValuePairs) {
-        parsedObject += "\"" + key + "\":" + value + ",";
-    }
-    parsedObject.back() = '}';
-    return parsedObject;
+bool saneToolName(const std::string& name) {
+    if (name.empty())
+        return false;
+    return std::all_of(name.begin(), name.end(), [](unsigned char c) {
+        return std::isalnum(c) || c == '_' || c == '-' || c == '.';
+    });
 }
 
-std::string Gemma4ToolParser::normalizeArgStr(const std::string& arg) {
-    if (arg.empty()) {
-        return arg;
+class NativeValueParser {
+    const std::string& input;
+    size_t pos{0};
+    JsonWriter& writer;
+
+    bool startsWith(const std::string& marker) const {
+        return pos + marker.size() <= input.size() && input.compare(pos, marker.size(), marker) == 0;
     }
 
-    std::string normalized = arg;
-    trim(normalized);
-    std::string lower = normalized;
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-
-    if (lower == "true" || lower == "false" || lower == "null") {
-        return lower;
+    void skipWs() {
+        while (pos < input.size() && std::isspace(static_cast<unsigned char>(input[pos])))
+            ++pos;
     }
 
-    const char first = normalized.front();
-    const char last = normalized.back();
-    if (first == '{' && last == '}') {
-        normalized = parseObjectParameter(normalized);
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument contains is an object, changed it to correct JSON format. Modified string: {}", normalized);
+    bool writeJsonToken(const std::string& token) {
+        rapidjson::Document doc;
+        doc.Parse(token.c_str());
+        if (doc.HasParseError())
+            return false;
+        return doc.Accept(writer);
     }
 
-    if (first == '[' && last == ']' && normalized.find(TOOL_ARGS_STRING_INDICATOR) != std::string::npos) {
-        normalized = parseArrayParameter(normalized);
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument is an array, normalized quotes for JSON parsing. Modified string: {}", normalized);
+    bool parseDelimitedString() {
+        if (!startsWith(Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR))
+            return false;
+        pos += Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR.size();
+        const size_t end = input.find(Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR, pos);
+        if (end == std::string::npos)
+            return false;
+        writer.String(input.data() + pos, static_cast<rapidjson::SizeType>(end - pos));
+        pos = end + Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR.size();
+        return true;
     }
 
-    if (normalized.substr(0, TOOL_ARGS_STRING_INDICATOR.size()) == TOOL_ARGS_STRING_INDICATOR &&
-        normalized.substr(normalized.size() - TOOL_ARGS_STRING_INDICATOR.size(), TOOL_ARGS_STRING_INDICATOR.size()) == TOOL_ARGS_STRING_INDICATOR) {
-        normalized = "\"" + normalized.substr(TOOL_ARGS_STRING_INDICATOR.size(), normalized.size() - 2 * TOOL_ARGS_STRING_INDICATOR.size()) + "\"";
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument is enclosed in string indicators, removed them for JSON parsing. Modified string: {}", normalized);
-    }
-
-    rapidjson::Document tempDoc;
-    rapidjson::Value finalValue;
-    tempDoc.Parse(normalized.c_str());
-    if (tempDoc.HasParseError()) {
-        auto errorCode = tempDoc.GetParseError();
-        auto errorMessage = rapidjson::GetParseError_En(errorCode);
-        size_t errorOffset = tempDoc.GetErrorOffset();
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Failed to parse argument string as JSON. Argument string: {}, Error: {} Offset: {}", normalized, errorMessage, errorOffset);
-
-        if (normalized.front() == '\"' && normalized.back() == '\"') {
-            normalized = normalized.substr(1, normalized.size() - 2);
-        }
-        finalValue.SetString(normalized.c_str(), static_cast<rapidjson::SizeType>(normalized.size()), tempDoc.GetAllocator());
-    } else {
-        finalValue.CopyFrom(tempDoc, tempDoc.GetAllocator());
-    }
-
-    {
-        rapidjson::StringBuffer buffer;
-        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-        finalValue.Accept(writer);
-        normalized = buffer.GetString();
-    }
-
-    return normalized;
-}
-
-void Gemma4ToolParser::writeArgumentToWriter(const std::string& arg, rapidjson::Writer<rapidjson::StringBuffer>& writer) {
-    std::string normalized = normalizeArgStr(arg);
-
-    rapidjson::Document doc;
-    doc.Parse(normalized.c_str());
-
-    rapidjson::Value& argumentDoc = doc;
-    writeArgumentOfAnyType(argumentDoc, writer);
-}
-
-std::pair<std::string, std::string> Gemma4ToolParser::parseSingleArgument(const std::string& argumentStr) {
-    std::pair<std::string, std::string> argument;
-
-    size_t colonPos = argumentStr.find(':');
-    if (colonPos != std::string::npos) {
-        argument.first = argumentStr.substr(0, colonPos);
-        std::string value = argumentStr.substr(colonPos + 1);
-        argument.second = value;
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Parsed argument - name: {}, value: {}", argument.first, argument.second);
-    } else {
-        argument.first = argumentStr;
-        argument.second = "";
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument string: {} does not contain ':', setting name as entire string and value as empty", argumentStr);
-    }
-    return argument;
-}
-
-std::string Gemma4ToolParser::maskStringValues(const std::string& text) {
-    std::string masked = text;
-    size_t pos = 0;
-    while (true) {
-        const size_t openPos = text.find(TOOL_ARGS_STRING_INDICATOR, pos);
-        if (openPos == std::string::npos)
-            break;
-        const size_t valueStart = openPos + TOOL_ARGS_STRING_INDICATOR.size();
-        const size_t closePos = text.find(TOOL_ARGS_STRING_INDICATOR, valueStart);
-        // Value not closed yet (still streaming): mask through the current buffer end too,
-        // otherwise its already-received tail would desync quote/brace tracking; a later
-        // call re-masks from scratch once the closing delimiter has arrived.
-        const size_t maskEnd = (closePos == std::string::npos) ? text.size() : closePos;
-        for (size_t i = valueStart; i < maskEnd; i++) {
-            switch (masked[i]) {
-            case '"':
-            case '\'':
-            case '{':
-            case '}':
-            case '[':
-            case ']':
-                masked[i] = '\x01';
-                break;
-            default:
-                break;
+    bool parseJsonString() {
+        if (pos >= input.size() || input[pos] != '"')
+            return false;
+        const size_t start = pos++;
+        bool escaped = false;
+        while (pos < input.size()) {
+            const char c = input[pos++];
+            if (escaped) {
+                escaped = false;
+                continue;
             }
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (c == '"')
+                return writeJsonToken(input.substr(start, pos - start));
         }
-        if (closePos == std::string::npos)
-            break;
-        pos = closePos + TOOL_ARGS_STRING_INDICATOR.size();
-    }
-    return masked;
-}
-
-std::vector<std::pair<std::string, std::string>> Gemma4ToolParser::parseArguments(const std::string& argumentsStr) {
-    std::vector<std::string> args;
-    std::vector<std::pair<std::string, std::string>> parsedArgs;
-
-    const std::string maskedArgumentsStr = maskStringValues(argumentsStr);
-    size_t argPos = 0;
-    while (argPos < argumentsStr.length()) {
-        size_t commaPos = findInStringRespectingSpecialChars(maskedArgumentsStr, TOOL_ARGS_SEPARATOR_STR, argPos);
-        if (commaPos == std::string::npos) {
-            auto remainingStr = argumentsStr.substr(argPos);
-            args.push_back(remainingStr);
-            SPDLOG_LOGGER_TRACE(llm_calculator_logger, "No more commas found, adding remaining argument string: {}", remainingStr);
-            break;
-        }
-        std::string argStr = argumentsStr.substr(argPos, commaPos - argPos);
-        args.push_back(argStr);
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Parsed argument string: {}", argStr);
-        argPos = commaPos + TOOL_ARGS_SEPARATOR_STR.length();
-    }
-
-    for (const std::string& arg : args) {
-        parsedArgs.push_back(parseSingleArgument(arg));
-    }
-    return parsedArgs;
-}
-
-bool Gemma4ToolParser::parseInContentState() {
-    size_t toolCallStartTagPos = this->streamingContent.find(TOOL_CALL_START_TAG, this->streamingPosition);
-    if (toolCallStartTagPos != std::string::npos) {
-        if (toolCallStartTagPos > this->streamingPosition) {
-            SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Content found before tool call start tag at position: {}", toolCallStartTagPos);
-            return true;
-        }
-        this->streamingPosition = toolCallStartTagPos + TOOL_CALL_START_TAG.length();
-        this->currentState = State::ToolCallStarted;
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Detected start of tool call at position: {}", toolCallStartTagPos);
         return false;
     }
 
+    bool parseKey(std::string& key) {
+        skipWs();
+        if (startsWith(Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR)) {
+            pos += Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR.size();
+            const size_t end = input.find(Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR, pos);
+            if (end == std::string::npos)
+                return false;
+            key = input.substr(pos, end - pos);
+            pos = end + Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR.size();
+            return true;
+        }
+        if (pos < input.size() && input[pos] == '"') {
+            const size_t start = pos++;
+            bool escaped = false;
+            while (pos < input.size()) {
+                const char c = input[pos++];
+                if (escaped) {
+                    escaped = false;
+                    continue;
+                }
+                if (c == '\\') {
+                    escaped = true;
+                    continue;
+                }
+                if (c == '"') {
+                    rapidjson::Document keyDoc;
+                    const std::string token = input.substr(start, pos - start);
+                    keyDoc.Parse(token.c_str());
+                    if (keyDoc.HasParseError() || !keyDoc.IsString())
+                        return false;
+                    key.assign(keyDoc.GetString(), keyDoc.GetStringLength());
+                    return true;
+                }
+            }
+            return false;
+        }
+        const size_t start = pos;
+        while (pos < input.size() && input[pos] != ':')
+            ++pos;
+        if (pos == input.size())
+            return false;
+        key = input.substr(start, pos - start);
+        trimLocal(key);
+        return !key.empty();
+    }
+
+    bool parseObject() {
+        if (pos >= input.size() || input[pos] != '{')
+            return false;
+        ++pos;
+        writer.StartObject();
+        skipWs();
+        if (pos < input.size() && input[pos] == '}') {
+            ++pos;
+            writer.EndObject();
+            return true;
+        }
+        while (pos < input.size()) {
+            std::string key;
+            if (!parseKey(key))
+                return false;
+            skipWs();
+            if (pos >= input.size() || input[pos] != ':')
+                return false;
+            ++pos;
+            writer.Key(key.c_str(), static_cast<rapidjson::SizeType>(key.size()));
+            if (!parseValue())
+                return false;
+            skipWs();
+            if (pos < input.size() && input[pos] == ',') {
+                ++pos;
+                skipWs();
+                continue;
+            }
+            if (pos < input.size() && input[pos] == '}') {
+                ++pos;
+                writer.EndObject();
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    bool parseArray() {
+        if (pos >= input.size() || input[pos] != '[')
+            return false;
+        ++pos;
+        writer.StartArray();
+        skipWs();
+        if (pos < input.size() && input[pos] == ']') {
+            ++pos;
+            writer.EndArray();
+            return true;
+        }
+        while (pos < input.size()) {
+            if (!parseValue())
+                return false;
+            skipWs();
+            if (pos < input.size() && input[pos] == ',') {
+                ++pos;
+                skipWs();
+                continue;
+            }
+            if (pos < input.size() && input[pos] == ']') {
+                ++pos;
+                writer.EndArray();
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    bool parseBareScalar() {
+        const size_t start = pos;
+        while (pos < input.size()) {
+            const char c = input[pos];
+            if (c == ',' || c == '}' || c == ']' || c == ')')
+                break;
+            ++pos;
+        }
+        std::string token = input.substr(start, pos - start);
+        trimLocal(token);
+        if (token.empty())
+            return false;
+        if (writeJsonToken(token))
+            return true;
+        writer.String(token.c_str(), static_cast<rapidjson::SizeType>(token.size()));
+        return true;
+    }
+
+public:
+    NativeValueParser(const std::string& input, JsonWriter& writer) : input(input), writer(writer) {}
+
+    bool parseValue() {
+        skipWs();
+        if (pos >= input.size())
+            return false;
+        if (startsWith(Gemma4ToolParser::TOOL_ARGS_STRING_INDICATOR))
+            return parseDelimitedString();
+        if (input[pos] == '"')
+            return parseJsonString();
+        if (input[pos] == '{')
+            return parseObject();
+        if (input[pos] == '[')
+            return parseArray();
+        return parseBareScalar();
+    }
+
+    bool parseArgumentsBody() {
+        writer.StartObject();
+        skipWs();
+        if (pos == input.size()) {
+            writer.EndObject();
+            return true;
+        }
+        while (pos < input.size()) {
+            std::string key;
+            if (!parseKey(key))
+                return false;
+            skipWs();
+            if (pos >= input.size() || input[pos] != ':')
+                return false;
+            ++pos;
+            writer.Key(key.c_str(), static_cast<rapidjson::SizeType>(key.size()));
+            if (!parseValue())
+                return false;
+            skipWs();
+            if (pos == input.size()) {
+                writer.EndObject();
+                return true;
+            }
+            if (input[pos] != ',')
+                return false;
+            ++pos;
+            skipWs();
+            if (pos == input.size())
+                return false;
+        }
+        return false;
+    }
+
+    bool parseSingleValueFully() {
+        if (!parseValue())
+            return false;
+        skipWs();
+        return pos == input.size();
+    }
+};
+
+std::optional<std::string> normalizeSingleNativeValue(const std::string& arg) {
+    std::string value = arg;
+    trimLocal(value);
+    if (value.empty())
+        return std::nullopt;
+
+    rapidjson::Document doc;
+    doc.Parse(value.c_str());
+    if (!doc.HasParseError()) {
+        rapidjson::StringBuffer buffer;
+        JsonWriter writer(buffer);
+        doc.Accept(writer);
+        return std::string(buffer.GetString(), buffer.GetSize());
+    }
+
+    rapidjson::StringBuffer buffer;
+    JsonWriter writer(buffer);
+    NativeValueParser parser(value, writer);
+    if (!parser.parseSingleValueFully())
+        return std::nullopt;
+    return std::string(buffer.GetString(), buffer.GetSize());
+}
+
+}  // namespace
+
+std::optional<std::string> Gemma4ToolParser::parseNativeArgumentsBody(const std::string& argumentsBody) {
+    const std::string jsonCandidate = "{" + argumentsBody + "}";
+    rapidjson::Document doc;
+    doc.Parse(jsonCandidate.c_str());
+    if (!doc.HasParseError() && doc.IsObject()) {
+        rapidjson::StringBuffer buffer;
+        JsonWriter writer(buffer);
+        doc.Accept(writer);
+        return std::string(buffer.GetString(), buffer.GetSize());
+    }
+
+    rapidjson::StringBuffer buffer;
+    JsonWriter writer(buffer);
+    NativeValueParser parser(argumentsBody, writer);
+    if (!parser.parseArgumentsBody())
+        return std::nullopt;
+    return std::string(buffer.GetString(), buffer.GetSize());
+}
+
+std::optional<size_t> Gemma4ToolParser::findMatchingContainerEnd(const std::string& text, size_t openPos, char openChar, char closeChar) {
+    if (openPos >= text.size() || text[openPos] != openChar)
+        return std::nullopt;
+
+    std::vector<char> expectedClosers{closeChar};
+    size_t i = openPos + 1;
+    while (i < text.size()) {
+        if (text.compare(i, TOOL_CALL_END_TAG.size(), TOOL_CALL_END_TAG) == 0)
+            return std::nullopt;
+
+        if (text.compare(i, TOOL_ARGS_STRING_INDICATOR.size(), TOOL_ARGS_STRING_INDICATOR) == 0) {
+            const size_t valueStart = i + TOOL_ARGS_STRING_INDICATOR.size();
+            const size_t valueEnd = text.find(TOOL_ARGS_STRING_INDICATOR, valueStart);
+            if (valueEnd == std::string::npos)
+                return std::nullopt;
+            i = valueEnd + TOOL_ARGS_STRING_INDICATOR.size();
+            continue;
+        }
+
+        if (text[i] == '"') {
+            ++i;
+            bool escaped = false;
+            while (i < text.size()) {
+                const char c = text[i++];
+                if (escaped) {
+                    escaped = false;
+                    continue;
+                }
+                if (c == '\\') {
+                    escaped = true;
+                    continue;
+                }
+                if (c == '"')
+                    break;
+            }
+            continue;
+        }
+
+        switch (text[i]) {
+        case '{': expectedClosers.push_back('}'); break;
+        case '[': expectedClosers.push_back(']'); break;
+        case '(': expectedClosers.push_back(')'); break;
+        case '}':
+        case ']':
+        case ')':
+            if (expectedClosers.empty() || expectedClosers.back() != text[i])
+                return std::nullopt;
+            expectedClosers.pop_back();
+            if (expectedClosers.empty())
+                return i;
+            break;
+        default: break;
+        }
+        ++i;
+    }
+    return std::nullopt;
+}
+
+std::string Gemma4ToolParser::normalizeToolName(std::string rawName) {
+    trim(rawName);
+    if (rawName.rfind(TOOL_CALL_NAME_PREFIX, 0) == 0)
+        rawName.erase(0, TOOL_CALL_NAME_PREFIX.size());
+    trim(rawName);
+    if (!rawName.empty() && rawName.front() == ':')
+        rawName.erase(rawName.begin());
+    trim(rawName);
+    return rawName;
+}
+
+std::string Gemma4ToolParser::normalizeArgStr(const std::string& arg) {
+    auto normalized = normalizeSingleNativeValue(arg);
+    return normalized.value_or(arg);
+}
+
+std::string Gemma4ToolParser::parseArrayParameter(const std::string& argumentStr) {
+    return normalizeArgStr(argumentStr);
+}
+
+std::string Gemma4ToolParser::parseObjectParameter(const std::string& argumentStr) {
+    return normalizeArgStr(argumentStr);
+}
+
+bool Gemma4ToolParser::parseInContentState() {
+    const size_t toolCallStartTagPos = streamingContent.find(TOOL_CALL_START_TAG, streamingPosition);
+    if (toolCallStartTagPos != std::string::npos) {
+        if (toolCallStartTagPos > streamingPosition)
+            return true;
+        streamingPosition = toolCallStartTagPos + TOOL_CALL_START_TAG.length();
+        currentState = State::ToolCallStarted;
+        currentCallValid = true;
+        return false;
+    }
+
+    // The generic OutputParser may route the preamble-only `call:` variant here
+    // after a reasoning end boundary. Do not search for it later in arbitrary
+    // content: accept it only exactly at the current phase entry position.
+    if (streamingContent.compare(streamingPosition, TOOL_CALL_NAME_PREFIX.size(), TOOL_CALL_NAME_PREFIX) == 0) {
+        currentState = State::ToolCallStarted;
+        currentCallValid = true;
+        return false;
+    }
     return true;
 }
 
 bool Gemma4ToolParser::parseInToolCallState() {
-    size_t argsPos = this->streamingContent.find(TOOL_ARGS_START_INDICATOR, this->streamingPosition);
-    if (argsPos == std::string::npos) {
+    const size_t endTagPos = streamingContent.find(TOOL_CALL_END_TAG, streamingPosition);
+    const size_t bracePos = streamingContent.find('{', streamingPosition);
+    const size_t parenPos = streamingContent.find('(', streamingPosition);
+
+    size_t argsPos = std::string::npos;
+    if (bracePos != std::string::npos)
+        argsPos = bracePos;
+    if (parenPos != std::string::npos && (argsPos == std::string::npos || parenPos < argsPos))
+        argsPos = parenPos;
+
+    if (endTagPos != std::string::npos && (argsPos == std::string::npos || endTagPos < argsPos)) {
+        SPDLOG_LOGGER_DEBUG(llm_calculator_logger, "Gemma4 tool call ended before an argument container; dropping malformed call");
+        streamingPosition = endTagPos + TOOL_CALL_END_TAG.size();
+        currentState = State::AfterToolCall;
+        currentCallValid = false;
+        toolCall = {};
+        return true;
+    }
+    if (argsPos == std::string::npos)
         return false;
-    }
 
-    size_t toolNameStart = this->streamingContent.find(TOOL_CALL_NAME_PREFIX, this->streamingPosition);
-    if (toolNameStart != std::string::npos && toolNameStart < argsPos) {
-        toolNameStart += TOOL_CALL_NAME_PREFIX.length();
+    std::string toolName = normalizeToolName(streamingContent.substr(streamingPosition, argsPos - streamingPosition));
+    currentCallValid = saneToolName(toolName) && toolNameAllowed(toolName);
+    if (!currentCallValid)
+        SPDLOG_LOGGER_WARN(llm_calculator_logger, "Gemma4 parser refusing malformed or unavailable tool name: '{}'", toolName);
+
+    currentArgsOpen = streamingContent[argsPos];
+    currentArgsClose = currentArgsOpen == '(' ? ')' : '}';
+    streamingPosition = argsPos + 1;
+    currentState = State::ToolCallParameters;
+
+    if (currentCallValid) {
+        toolCall = ToolCall{generateRandomId(), toolName, ""};
+        ++toolCallIndex;
     } else {
-        toolNameStart = this->streamingPosition;
+        toolCall = {};
     }
-
-    std::string toolName = this->streamingContent.substr(toolNameStart, argsPos - toolNameStart);
-    trim(toolName);
-    this->toolCall = ToolCall{generateRandomId(), toolName, ""};
-    SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Parsed tool name: {}", toolName);
-    this->streamingPosition = argsPos + TOOL_ARGS_START_INDICATOR.length();
-    this->currentState = State::ToolCallParameters;
-    this->toolCallIndex++;
     return true;
 }
 
 bool Gemma4ToolParser::parseToolCallParametersState() {
-    if (this->streamingContent.back() == TOOL_ARGS_END_INDICATOR.back()) {
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool arguments end indicator found at the end of streaming content, attempting to parse arguments: {}", this->streamingContent.substr(this->streamingPosition));
-    }
-    const std::string maskedStreamingContent = maskStringValues(this->streamingContent);
-    size_t pos = findInStringRespectingSpecialChars(maskedStreamingContent, TOOL_ARGS_END_INDICATOR, this->streamingPosition);
-    if (pos == std::string::npos) {
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool arguments end indicator not found in streaming content starting from position: {}", this->streamingPosition);
+    if (streamingPosition == 0)
+        return false;
+    const size_t openPos = streamingPosition - 1;
+    auto closePos = findMatchingContainerEnd(streamingContent, openPos, currentArgsOpen, currentArgsClose);
+    if (!closePos.has_value()) {
+        const size_t endTagPos = streamingContent.find(TOOL_CALL_END_TAG, streamingPosition);
+        if (endTagPos != std::string::npos) {
+            SPDLOG_LOGGER_WARN(llm_calculator_logger, "Gemma4 malformed tool arguments bounded by <tool_call|>; dropping current call");
+            streamingPosition = endTagPos + TOOL_CALL_END_TAG.size();
+            currentState = State::AfterToolCall;
+            currentCallValid = false;
+            toolCall = {};
+            return true;
+        }
         return false;
     }
-    std::string argumentsStr = this->streamingContent.substr(this->streamingPosition, pos - this->streamingPosition);
-    SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Parsed arguments string: {}", argumentsStr);
-    std::vector<std::pair<std::string, std::string>> arguments = parseArguments(argumentsStr);
 
-    rapidjson::Document argsDoc(rapidjson::kObjectType);
-    rapidjson::StringBuffer sb;
-    rapidjson::Writer<rapidjson::StringBuffer> argsWriter(sb);
-    argsWriter.StartObject();
-
-    for (const std::pair<std::string, std::string>& argument : arguments) {
-        argsWriter.Key(argument.first.c_str());
-        writeArgumentToWriter(argument.second, argsWriter);
+    const std::string argumentsBody = streamingContent.substr(streamingPosition, closePos.value() - streamingPosition);
+    if (currentCallValid) {
+        auto parsedArguments = parseNativeArgumentsBody(argumentsBody);
+        if (parsedArguments.has_value()) {
+            toolCall.arguments = std::move(parsedArguments.value());
+        } else {
+            SPDLOG_LOGGER_WARN(llm_calculator_logger, "Gemma4 native argument parse failed; refusing executable tool call '{}'.", toolCall.name);
+            currentCallValid = false;
+            toolCall = {};
+        }
     }
 
-    argsWriter.EndObject();
-    this->toolCall.arguments = sb.GetString();
-    this->currentState = State::ToolCallEnded;
-    this->streamingPosition = pos + TOOL_ARGS_END_INDICATOR.length();
-
+    streamingPosition = closePos.value() + 1;
+    currentState = State::ToolCallEnded;
     return true;
 }
 
 bool Gemma4ToolParser::parseInToolCallEndedState() {
-    size_t nextToolCallPos = this->streamingContent.find(TOOL_CALL_NAME_PREFIX, this->streamingPosition);
-    size_t toolCallEndTagPos = this->streamingContent.find(TOOL_CALL_END_TAG, this->streamingPosition);
-    SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Current state: ToolCallEnded. Streaming content from current position: {}", this->streamingContent.substr(this->streamingPosition));
-    if (nextToolCallPos != std::string::npos && nextToolCallPos < toolCallEndTagPos) {
-        this->streamingPosition = nextToolCallPos;
-        this->currentState = State::ToolCallStarted;
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Detected next tool call at position: {}", nextToolCallPos);
-    } else if (toolCallEndTagPos != std::string::npos) {
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Detected end of tool call at position: {}", toolCallEndTagPos);
-        this->streamingPosition = toolCallEndTagPos + TOOL_CALL_END_TAG.length();
-        this->currentState = State::AfterToolCall;
-    } else {
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Waiting for more data in ToolCallEnded state; no complete next tool call prefix or end tag found from position: {}", this->streamingPosition);
-        return false;
+    const size_t endTagPos = streamingContent.find(TOOL_CALL_END_TAG, streamingPosition);
+    const size_t nextCallPos = streamingContent.find(TOOL_CALL_NAME_PREFIX, streamingPosition);
+
+    if (nextCallPos != std::string::npos && (endTagPos == std::string::npos || nextCallPos < endTagPos)) {
+        streamingPosition = nextCallPos;
+        currentState = State::ToolCallStarted;
+        currentCallValid = true;
+        return true;
     }
-    return true;
+    if (endTagPos != std::string::npos) {
+        streamingPosition = endTagPos + TOOL_CALL_END_TAG.length();
+        currentState = State::AfterToolCall;
+        return true;
+    }
+    return false;
 }
 
 bool Gemma4ToolParser::parseNewContent() {
-    switch (this->currentState) {
-    case State::Content: {
-        return parseInContentState();
-    }
-    case State::ToolCallStarted: {
-        return parseInToolCallState();
-    }
-    case State::ToolCallParameters: {
-        return parseToolCallParametersState();
-    }
-    case State::ToolCallEnded: {
-        return parseInToolCallEndedState();
-    }
-    case State::AfterToolCall:
-        break;
+    switch (currentState) {
+    case State::Content: return parseInContentState();
+    case State::ToolCallStarted: return parseInToolCallState();
+    case State::ToolCallParameters: return parseToolCallParametersState();
+    case State::ToolCallEnded: return parseInToolCallEndedState();
+    case State::AfterToolCall: break;
     }
     return false;
 }
@@ -386,35 +556,32 @@ std::optional<Delta> Gemma4ToolParser::wrapDeltaContent(const std::string& conte
     return ContentDelta{content};
 }
 
-ToolCallDelta Gemma4ToolParser::wrapDeltaArgs(const std::string& argsStr, int toolCallIndex) {
-    return ToolCallDelta{toolCallIndex, std::nullopt, std::nullopt, argsStr};
+ToolCallDelta Gemma4ToolParser::wrapDeltaArgs(const std::string& argsStr, int index) {
+    return ToolCallDelta{index, std::nullopt, std::nullopt, argsStr};
 }
 
 std::optional<Delta> Gemma4ToolParser::parseChunk(const std::string& chunk, const std::vector<int64_t>& /*tokens*/, ov::genai::GenerationFinishReason finishReason) {
-    if (!chunk.empty()) {
-        this->streamingContent += chunk;
-    }
+    if (!chunk.empty())
+        streamingContent += chunk;
 
     if (parseNewContent()) {
-        if (this->currentState == State::ToolCallParameters) {
-            return ToolCallDelta{toolCallIndex, generateRandomId(), this->toolCall.name, ""};
-        }
-        if (this->currentState == State::ToolCallEnded) {
-            auto delta = wrapDeltaArgs(this->toolCall.arguments, toolCallIndex);
-            this->toolCall = ToolCall{};
-            return delta;
-        }
-        if (this->currentState == State::Content) {
-            size_t contentEnd = this->streamingContent.find(TOOL_CALL_START_TAG, this->streamingPosition);
-            std::string content;
-            if (contentEnd != std::string::npos) {
-                content = this->streamingContent.substr(this->streamingPosition, contentEnd - this->streamingPosition);
-            } else {
-                content = this->streamingContent.substr(this->streamingPosition);
+        if (currentState == State::ToolCallParameters && currentCallValid)
+            return ToolCallDelta{toolCallIndex, toolCall.id, toolCall.name, ""};
+        if (currentState == State::ToolCallEnded) {
+            if (currentCallValid && !toolCall.arguments.empty()) {
+                auto delta = wrapDeltaArgs(toolCall.arguments, toolCallIndex);
+                toolCall = {};
+                return delta;
             }
-            this->streamingPosition += content.size();
-
-            // Structural/stop markers must never reach the client, on any chunk, not just the final flush.
+            toolCall = {};
+            return std::nullopt;
+        }
+        if (currentState == State::Content) {
+            const size_t contentEnd = streamingContent.find(TOOL_CALL_START_TAG, streamingPosition);
+            std::string content = contentEnd == std::string::npos
+                ? streamingContent.substr(streamingPosition)
+                : streamingContent.substr(streamingPosition, contentEnd - streamingPosition);
+            streamingPosition += content.size();
             for (const std::string& tagToErase : {TURN_END_TAG, TOOL_RESPONSE_START_TAG}) {
                 size_t tagPos = content.find(tagToErase);
                 while (tagPos != std::string::npos) {
@@ -422,31 +589,23 @@ std::optional<Delta> Gemma4ToolParser::parseChunk(const std::string& chunk, cons
                     tagPos = content.find(tagToErase, tagPos);
                 }
             }
-
             return wrapDeltaContent(content);
         }
-        if (this->currentState == State::AfterToolCall) {
-            this->currentState = State::Content;
-        }
+        if (currentState == State::AfterToolCall)
+            currentState = State::Content;
     }
 
     if (finishReason != ov::genai::GenerationFinishReason::NONE) {
-        // Unary/STOP flush can arrive after a chunk that only advanced one state
-        // (e.g. parsed the tool name but not yet the immediately following "}").
-        // Give the state machine one last chance to consume already-buffered data
-        // before deciding whether an arguments delta exists.
-        if (this->currentState == State::ToolCallParameters) {
+        if (currentState == State::ToolCallParameters)
             parseToolCallParametersState();
+        if (currentState == State::ToolCallEnded && currentCallValid && !toolCall.arguments.empty()) {
+            auto delta = wrapDeltaArgs(toolCall.arguments, toolCallIndex);
+            toolCall = {};
+            return delta;
         }
-
-        if ((this->currentState == State::ToolCallParameters || this->currentState == State::ToolCallEnded) && !this->toolCall.arguments.empty()) {
-            return wrapDeltaArgs(this->toolCall.arguments, toolCallIndex);
-        }
-
-        if (this->currentState == State::Content && this->streamingPosition < this->streamingContent.size()) {
-            auto content = this->streamingContent.substr(this->streamingPosition);
-            this->streamingPosition += content.size();
-
+        if (currentState == State::Content && streamingPosition < streamingContent.size()) {
+            auto content = streamingContent.substr(streamingPosition);
+            streamingPosition += content.size();
             for (const std::string& tagToErase : {TURN_END_TAG, TOOL_RESPONSE_START_TAG}) {
                 size_t tagPos = content.find(tagToErase);
                 while (tagPos != std::string::npos) {
@@ -454,46 +613,11 @@ std::optional<Delta> Gemma4ToolParser::parseChunk(const std::string& chunk, cons
                     tagPos = content.find(tagToErase, tagPos);
                 }
             }
-
             return wrapDeltaContent(content);
         }
     }
 
     return std::nullopt;
-}
-
-bool Gemma4ToolParser::parseSingleToolCall(const std::string& toolStr, ToolCall& toolCall) {
-    size_t argsPos = toolStr.find(TOOL_ARGS_START_INDICATOR);
-    if (argsPos != std::string::npos) {
-        std::string toolNameWithPrefix = toolStr.substr(0, argsPos);
-        if (toolNameWithPrefix.find(TOOL_CALL_NAME_PREFIX) != 0) {
-            SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool name does not start with expected prefix '{}'. Tool string: {}", TOOL_CALL_NAME_PREFIX, toolStr);
-            return false;
-        }
-        std::string toolName = toolNameWithPrefix.substr(TOOL_CALL_NAME_PREFIX.length());
-        trim(toolName);
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Parsed tool name: {}", toolName);
-
-        int argsStrLen = toolStr.length() - argsPos - TOOL_ARGS_START_INDICATOR.length() - TOOL_ARGS_END_INDICATOR.length();
-        std::string argsStr = toolStr.substr(argsPos + TOOL_ARGS_START_INDICATOR.length(), argsStrLen);
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Parsed args string: {}", argsStr);
-        std::vector<std::pair<std::string, std::string>> arguments = parseArguments(argsStr);
-
-        toolCall.name = toolName;
-        rapidjson::Document argsDoc(rapidjson::kObjectType);
-        rapidjson::StringBuffer sb;
-        rapidjson::Writer<rapidjson::StringBuffer> argsWriter(sb);
-        argsWriter.StartObject();
-        for (const std::pair<std::string, std::string>& argument : arguments) {
-            argsWriter.Key(argument.first.c_str());
-            writeArgumentToWriter(argument.second, argsWriter);
-        }
-        argsWriter.EndObject();
-        toolCall.arguments = sb.GetString();
-        toolCall.id = generateRandomId();
-        return true;
-    }
-    return false;
 }
 
 }  // namespace ovms

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -37,6 +38,26 @@ namespace {
 
 using JsonWriter = rapidjson::Writer<rapidjson::StringBuffer>;
 
+// Tool arguments are JSON text, not machine arithmetic. Preserve number tokens
+// without routing large integers/decimals through uint64_t or double.
+class NumberPreservingWriter : public JsonWriter {
+public:
+    explicit NumberPreservingWriter(rapidjson::StringBuffer& buffer) : JsonWriter(buffer) {}
+    bool RawNumber(const char* value, rapidjson::SizeType length, bool) {
+        return RawValue(value, length, rapidjson::kNumberType);
+    }
+};
+
+std::optional<std::string> normalizeJsonLosslessly(const std::string& input) {
+    rapidjson::StringStream stream(input.c_str());
+    rapidjson::Reader reader;
+    rapidjson::StringBuffer buffer;
+    NumberPreservingWriter writer(buffer);
+    if (!reader.Parse<rapidjson::kParseNumbersAsStringsFlag>(stream, writer) || stream.Tell() != input.size())
+        return std::nullopt;
+    return std::string(buffer.GetString(), buffer.GetSize());
+}
+
 void trimLocal(std::string& value) {
     auto notSpace = [](unsigned char c) { return !std::isspace(c); };
     value.erase(value.begin(), std::find_if(value.begin(), value.end(), notSpace));
@@ -49,6 +70,55 @@ bool saneToolName(const std::string& name) {
     return std::all_of(name.begin(), name.end(), [](unsigned char c) {
         return std::isalnum(c) || c == '_' || c == '-' || c == '.';
     });
+}
+
+// Recover only the observed native leak shape where `call:` starts a logical line
+// (optionally indented). This deliberately rejects prose such as
+// `Documentation example: call:foo{...}` and quoted examples. The candidate is
+// still validated again by the normal argument parser before it becomes executable.
+std::optional<size_t> findRecoverableBareCall(
+    const std::string& content,
+    size_t from,
+    const std::unordered_set<std::string>& allowedToolNames,
+    bool enforceToolRegistry) {
+    size_t candidate = content.find(Gemma4ToolParser::TOOL_CALL_NAME_PREFIX, from);
+    while (candidate != std::string::npos) {
+        bool lineBoundary = candidate == from;
+        if (!lineBoundary) {
+            const size_t lineStartPos = content.rfind('\n', candidate - 1);
+            const size_t lineStart = lineStartPos == std::string::npos ? from : lineStartPos + 1;
+            lineBoundary = lineStart >= from;
+            for (size_t i = lineStart; lineBoundary && i < candidate; ++i) {
+                const char c = content[i];
+                if (c != ' ' && c != '\t' && c != '\r')
+                    lineBoundary = false;
+            }
+        }
+        if (!lineBoundary) {
+            candidate = content.find(Gemma4ToolParser::TOOL_CALL_NAME_PREFIX, candidate + Gemma4ToolParser::TOOL_CALL_NAME_PREFIX.size());
+            continue;
+        }
+
+        const size_t nameStart = candidate + Gemma4ToolParser::TOOL_CALL_NAME_PREFIX.size();
+        const size_t bracePos = content.find('{', nameStart);
+        const size_t parenPos = content.find('(', nameStart);
+        size_t argsPos = std::string::npos;
+        if (bracePos != std::string::npos)
+            argsPos = bracePos;
+        if (parenPos != std::string::npos && (argsPos == std::string::npos || parenPos < argsPos))
+            argsPos = parenPos;
+        if (argsPos == std::string::npos)
+            return candidate;  // hold a streaming prefix until the argument opener arrives
+
+        std::string name = content.substr(nameStart, argsPos - nameStart);
+        trimLocal(name);
+        const bool allowed = saneToolName(name) && (!enforceToolRegistry || allowedToolNames.count(name) != 0);
+        if (allowed)
+            return candidate;
+
+        candidate = content.find(Gemma4ToolParser::TOOL_CALL_NAME_PREFIX, candidate + Gemma4ToolParser::TOOL_CALL_NAME_PREFIX.size());
+    }
+    return std::nullopt;
 }
 
 class NativeValueParser {
@@ -66,11 +136,20 @@ class NativeValueParser {
     }
 
     bool writeJsonToken(const std::string& token) {
-        rapidjson::Document doc;
-        doc.Parse(token.c_str());
-        if (doc.HasParseError())
+        if (!token.empty() && (std::isdigit(static_cast<unsigned char>(token.front())) || token.front() == '-')) {
+            // The native grammar already delimits this scalar. Keep its lexical
+            // spelling; parsing it through a DOM would round large values.
+            return writer.RawValue(token.data(), static_cast<rapidjson::SizeType>(token.size()), rapidjson::kNumberType);
+        }
+        auto normalized = normalizeJsonLosslessly(token);
+        if (!normalized)
             return false;
-        return doc.Accept(writer);
+        // This path accepts a quoted string or a bare scalar only.
+        const auto type = normalized->front() == '"' ? rapidjson::kStringType :
+            normalized->front() == 't' ? rapidjson::kTrueType :
+            normalized->front() == 'f' ? rapidjson::kFalseType :
+            normalized->front() == 'n' ? rapidjson::kNullType : rapidjson::kNumberType;
+        return writer.RawValue(normalized->data(), normalized->size(), type);
     }
 
     bool parseDelimitedString() {
@@ -303,15 +382,6 @@ std::optional<std::string> normalizeSingleNativeValue(const std::string& arg) {
     if (value.empty())
         return std::nullopt;
 
-    rapidjson::Document doc;
-    doc.Parse(value.c_str());
-    if (!doc.HasParseError()) {
-        rapidjson::StringBuffer buffer;
-        JsonWriter writer(buffer);
-        doc.Accept(writer);
-        return std::string(buffer.GetString(), buffer.GetSize());
-    }
-
     rapidjson::StringBuffer buffer;
     JsonWriter writer(buffer);
     NativeValueParser parser(value, writer);
@@ -324,15 +394,6 @@ std::optional<std::string> normalizeSingleNativeValue(const std::string& arg) {
 
 std::optional<std::string> Gemma4ToolParser::parseNativeArgumentsBody(const std::string& argumentsBody) {
     const std::string jsonCandidate = "{" + argumentsBody + "}";
-    rapidjson::Document doc;
-    doc.Parse(jsonCandidate.c_str());
-    if (!doc.HasParseError() && doc.IsObject()) {
-        rapidjson::StringBuffer buffer;
-        JsonWriter writer(buffer);
-        doc.Accept(writer);
-        return std::string(buffer.GetString(), buffer.GetSize());
-    }
-
     rapidjson::StringBuffer buffer;
     JsonWriter writer(buffer);
     NativeValueParser parser(argumentsBody, writer);
@@ -341,16 +402,15 @@ std::optional<std::string> Gemma4ToolParser::parseNativeArgumentsBody(const std:
     return std::string(buffer.GetString(), buffer.GetSize());
 }
 
-std::optional<size_t> Gemma4ToolParser::findMatchingContainerEnd(const std::string& text, size_t openPos, char openChar, char closeChar) {
+std::optional<size_t> Gemma4ToolParser::findMatchingContainerEnd(const std::string& text, size_t openPos, char openChar, char closeChar, size_t& malformedEndTag) {
+    malformedEndTag = std::string::npos;
     if (openPos >= text.size() || text[openPos] != openChar)
         return std::nullopt;
 
     std::vector<char> expectedClosers{closeChar};
+    bool malformed = false;
     size_t i = openPos + 1;
     while (i < text.size()) {
-        if (text.compare(i, TOOL_CALL_END_TAG.size(), TOOL_CALL_END_TAG) == 0)
-            return std::nullopt;
-
         if (text.compare(i, TOOL_ARGS_STRING_INDICATOR.size(), TOOL_ARGS_STRING_INDICATOR) == 0) {
             const size_t valueStart = i + TOOL_ARGS_STRING_INDICATOR.size();
             const size_t valueEnd = text.find(TOOL_ARGS_STRING_INDICATOR, valueStart);
@@ -379,6 +439,11 @@ std::optional<size_t> Gemma4ToolParser::findMatchingContainerEnd(const std::stri
             continue;
         }
 
+        if (text.compare(i, TOOL_CALL_END_TAG.size(), TOOL_CALL_END_TAG) == 0) {
+            malformedEndTag = i;
+            return std::nullopt;
+        }
+
         switch (text[i]) {
         case '{': expectedClosers.push_back('}'); break;
         case '[': expectedClosers.push_back(']'); break;
@@ -386,10 +451,12 @@ std::optional<size_t> Gemma4ToolParser::findMatchingContainerEnd(const std::stri
         case '}':
         case ']':
         case ')':
-            if (expectedClosers.empty() || expectedClosers.back() != text[i])
-                return std::nullopt;
+            if (expectedClosers.empty() || expectedClosers.back() != text[i]) {
+                malformed = true;
+                break;
+            }
             expectedClosers.pop_back();
-            if (expectedClosers.empty())
+            if (expectedClosers.empty() && !malformed)
                 return i;
             break;
         default: break;
@@ -434,10 +501,11 @@ bool Gemma4ToolParser::parseInContentState() {
         return false;
     }
 
-    // The generic OutputParser may route the preamble-only `call:` variant here
-    // after a reasoning end boundary. Do not search for it later in arbitrary
-    // content: accept it only exactly at the current phase entry position.
-    if (streamingContent.compare(streamingPosition, TOOL_CALL_NAME_PREFIX.size(), TOOL_CALL_NAME_PREFIX) == 0) {
+    const auto bareCallPos = findRecoverableBareCall(streamingContent, streamingPosition, allowedToolNames, enforceToolRegistry);
+    if (bareCallPos.has_value()) {
+        if (bareCallPos.value() > streamingPosition)
+            return true;
+        streamingPosition += TOOL_CALL_NAME_PREFIX.size();
         currentState = State::ToolCallStarted;
         currentCallValid = true;
         return false;
@@ -479,7 +547,6 @@ bool Gemma4ToolParser::parseInToolCallState() {
 
     if (currentCallValid) {
         toolCall = ToolCall{generateRandomId(), toolName, ""};
-        ++toolCallIndex;
     } else {
         toolCall = {};
     }
@@ -490,9 +557,9 @@ bool Gemma4ToolParser::parseToolCallParametersState() {
     if (streamingPosition == 0)
         return false;
     const size_t openPos = streamingPosition - 1;
-    auto closePos = findMatchingContainerEnd(streamingContent, openPos, currentArgsOpen, currentArgsClose);
+    size_t endTagPos = std::string::npos;
+    auto closePos = findMatchingContainerEnd(streamingContent, openPos, currentArgsOpen, currentArgsClose, endTagPos);
     if (!closePos.has_value()) {
-        const size_t endTagPos = streamingContent.find(TOOL_CALL_END_TAG, streamingPosition);
         if (endTagPos != std::string::npos) {
             SPDLOG_LOGGER_WARN(llm_calculator_logger, "Gemma4 malformed tool arguments bounded by <tool_call|>; dropping current call");
             streamingPosition = endTagPos + TOOL_CALL_END_TAG.size();
@@ -526,7 +593,7 @@ bool Gemma4ToolParser::parseInToolCallEndedState() {
     const size_t nextCallPos = streamingContent.find(TOOL_CALL_NAME_PREFIX, streamingPosition);
 
     if (nextCallPos != std::string::npos && (endTagPos == std::string::npos || nextCallPos < endTagPos)) {
-        streamingPosition = nextCallPos;
+        streamingPosition = nextCallPos + TOOL_CALL_NAME_PREFIX.size();
         currentState = State::ToolCallStarted;
         currentCallValid = true;
         return true;
@@ -561,15 +628,23 @@ ToolCallDelta Gemma4ToolParser::wrapDeltaArgs(const std::string& argsStr, int in
 }
 
 std::optional<Delta> Gemma4ToolParser::parseChunk(const std::string& chunk, const std::vector<int64_t>& /*tokens*/, ov::genai::GenerationFinishReason finishReason) {
+    // Emitted deltas own their strings. Only the unconsumed suffix belongs to
+    // this parser; it is not conversation memory. Preserve the argument opener
+    // while its container is incomplete (the scanner starts one byte before pos).
+    if (streamingPosition >= 4096) {
+        const size_t keep = currentState == State::ToolCallParameters ? 1 : 0;
+        streamingContent.erase(0, streamingPosition - keep);
+        streamingPosition = keep;
+    }
     if (!chunk.empty())
         streamingContent += chunk;
 
     if (parseNewContent()) {
-        if (currentState == State::ToolCallParameters && currentCallValid)
-            return ToolCallDelta{toolCallIndex, toolCall.id, toolCall.name, ""};
         if (currentState == State::ToolCallEnded) {
             if (currentCallValid && !toolCall.arguments.empty()) {
-                auto delta = wrapDeltaArgs(toolCall.arguments, toolCallIndex);
+                // An emitted header cannot be retracted from SSE or the unary
+                // accumulator. Publish the complete call only after validation.
+                auto delta = ToolCallDelta{++toolCallIndex, toolCall.id, toolCall.name, toolCall.arguments};
                 toolCall = {};
                 return delta;
             }
@@ -577,7 +652,10 @@ std::optional<Delta> Gemma4ToolParser::parseChunk(const std::string& chunk, cons
             return std::nullopt;
         }
         if (currentState == State::Content) {
-            const size_t contentEnd = streamingContent.find(TOOL_CALL_START_TAG, streamingPosition);
+            size_t contentEnd = streamingContent.find(TOOL_CALL_START_TAG, streamingPosition);
+            const auto bareCallPos = findRecoverableBareCall(streamingContent, streamingPosition, allowedToolNames, enforceToolRegistry);
+            if (bareCallPos.has_value() && (contentEnd == std::string::npos || bareCallPos.value() < contentEnd))
+                contentEnd = bareCallPos.value();
             std::string content = contentEnd == std::string::npos
                 ? streamingContent.substr(streamingPosition)
                 : streamingContent.substr(streamingPosition, contentEnd - streamingPosition);
@@ -599,7 +677,7 @@ std::optional<Delta> Gemma4ToolParser::parseChunk(const std::string& chunk, cons
         if (currentState == State::ToolCallParameters)
             parseToolCallParametersState();
         if (currentState == State::ToolCallEnded && currentCallValid && !toolCall.arguments.empty()) {
-            auto delta = wrapDeltaArgs(toolCall.arguments, toolCallIndex);
+            auto delta = ToolCallDelta{++toolCallIndex, toolCall.id, toolCall.name, toolCall.arguments};
             toolCall = {};
             return delta;
         }

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
@@ -6,47 +6,39 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //*****************************************************************************
 #pragma once
+
+#include <optional>
 #include <string>
-#include <vector>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "src/llm/io_processing/base_output_parser.hpp"
 #include "src/port/rapidjson_stringbuffer.hpp"
 #include "src/port/rapidjson_writer.hpp"
 
 namespace ovms {
+
 class Gemma4ToolParser : public BaseOutputParser {
-protected:
+public:
+    // Public protocol constants are also used by the private recursive parser
+    // implementation and conformance tests. They are semantic markers, not state.
     static const std::string TOOL_CALL_START_TAG;
     static const std::string TOOL_CALL_END_TAG;
     static const std::string TOOL_CALL_NAME_PREFIX;
-
-    static const std::string TOOL_ARGS_START_INDICATOR;
-    static const std::string TOOL_ARGS_END_INDICATOR;
     static const std::string TOOL_ARGS_STRING_INDICATOR;
-    static const std::string TOOL_ARGS_SEPARATOR_STR;
     static const std::string TURN_END_TAG;
     static const std::string TOOL_RESPONSE_START_TAG;
 
-    static const int64_t botTokenId;
-    static const int64_t eotTokenId;
-    static const int64_t reasoningTokenId;
-    static const int64_t reasoningEndTokenId;
-
+protected:
     enum class State {
-        Content,             // Content -> ToolCallStarted (on TOOL_CALL_START_TAG)
-        ToolCallStarted,     // ToolCallStarted -> ToolCallParameters (on TOOL_ARGS_START_INDICATOR, emits name)
-        ToolCallParameters,  // ToolCallParameters -> ToolCallEnded (on TOOL_ARGS_END_INDICATOR, emits args)
-        ToolCallEnded,       // ToolCallEnded -> ToolCallStarted (on TOOL_CALL_NAME_PREFIX) | AfterToolCall (on end tag)
-        AfterToolCall        // AfterToolCall -> Content
+        Content,
+        ToolCallStarted,
+        ToolCallParameters,
+        ToolCallEnded,
+        AfterToolCall
     };
 
 public:
@@ -56,6 +48,11 @@ public:
         OutputParsingConfig cfg;
         cfg.startTags = {"<|tool_call>"};
         cfg.tokenIdStartTags = {"<|tool_call>"};
+        // Real Gemma4 traces occasionally omit the repeated tool marker after a
+        // reasoning channel and continue directly with call:name{...}. The generic
+        // OutputParser returns to UNKNOWN after reasoning; preambleStartTags is the
+        // deliberately narrow hook for this variant and is not matched mid-content.
+        cfg.preambleStartTags = {"call:"};
         cfg.endTag = "<tool_call|>";
         cfg.needsSpecialTokens = true;
         return cfg;
@@ -66,35 +63,49 @@ public:
         BaseOutputParser(tokenizer,
             configOverride.has_value() ? std::move(*configOverride) : defaultParsingConfig()) {}
 
+    // Registry-aware overload. Empty registry deliberately means "syntax-only" for
+    // backwards compatibility; OutputParser wiring can pass request tool names to
+    // enable executable-call validation without changing parser grammar.
+    Gemma4ToolParser(ov::genai::Tokenizer& tokenizer,
+        const ToolsSchemas_t& toolsSchemas,
+        std::optional<OutputParsingConfig> configOverride = std::nullopt) :
+        BaseOutputParser(tokenizer,
+            configOverride.has_value() ? std::move(*configOverride) : defaultParsingConfig()) {
+        for (const auto& [name, schema] : toolsSchemas) {
+            (void)schema;
+            allowedToolNames.insert(name);
+        }
+        enforceToolRegistry = !allowedToolNames.empty();
+    }
+
     void resetState() override {
         streamingContent.clear();
         streamingPosition = 0;
         currentState = State::Content;
         toolCall = {};
         toolCallIndex = -1;
+        currentArgsOpen = '{';
+        currentArgsClose = '}';
+        currentCallValid = true;
     }
 
     std::optional<Delta> parseChunk(const std::string& chunk, const std::vector<int64_t>& tokens, ov::genai::GenerationFinishReason finishReason) override;
 
+    // Compatibility helpers retained for existing unit tests/callers. They now use
+    // the same recursive native-value parser as the streaming path.
     static std::string normalizeArgStr(const std::string& arg);
     static std::string parseArrayParameter(const std::string& argumentStr);
     static std::string parseObjectParameter(const std::string& argumentStr);
 
 private:
-    void writeArgumentToWriter(const std::string& arg, rapidjson::Writer<rapidjson::StringBuffer>& writer);
+    static std::optional<std::string> parseNativeArgumentsBody(const std::string& argumentsBody);
+    static std::optional<size_t> findMatchingContainerEnd(const std::string& text, size_t openPos, char openChar, char closeChar);
+    static std::string normalizeToolName(std::string rawName);
 
-    // Masks '"', '\'', '{', '}', '[', ']' found inside <|"|>...<|"|> pairs (same length,
-    // delimiter's own quotes left intact) so a Gemma4 string value's own payload (e.g. code
-    // containing commas/braces/quotes) can't be mistaken for structural tokens by
-    // findInStringRespectingSpecialChars. An unclosed trailing value (still streaming) is
-    // masked through the current buffer end too; a later call re-masks from scratch once
-    // its closing delimiter has arrived.
-    static std::string maskStringValues(const std::string& text);
+    bool toolNameAllowed(const std::string& name) const {
+        return !enforceToolRegistry || allowedToolNames.count(name) != 0;
+    }
 
-    std::pair<std::string, std::string> parseSingleArgument(const std::string& argumentStr);
-    std::vector<std::pair<std::string, std::string>> parseArguments(const std::string& argumentsStr);
-
-    bool parseSingleToolCall(const std::string& toolStr, ToolCall& toolCall);
     bool parseNewContent();
     bool parseInContentState();
     bool parseInToolCallState();
@@ -109,5 +120,10 @@ private:
     State currentState{State::Content};
     ToolCall toolCall;
     int toolCallIndex{-1};
+    char currentArgsOpen{'{'};
+    char currentArgsClose{'}'};
+    bool currentCallValid{true};
+    bool enforceToolRegistry{false};
+    std::unordered_set<std::string> allowedToolNames;
 };
 }  // namespace ovms

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
@@ -55,6 +55,7 @@ public:
         cfg.preambleStartTags = {"call:"};
         cfg.endTag = "<tool_call|>";
         cfg.needsSpecialTokens = true;
+        cfg.ownsToolCallBoundaries = true;
         return cfg;
     }
 
@@ -98,8 +99,9 @@ public:
     static std::string parseObjectParameter(const std::string& argumentStr);
 
 private:
+    friend struct Gemma4ToolParserTestAccess;
     static std::optional<std::string> parseNativeArgumentsBody(const std::string& argumentsBody);
-    static std::optional<size_t> findMatchingContainerEnd(const std::string& text, size_t openPos, char openChar, char closeChar);
+    static std::optional<size_t> findMatchingContainerEnd(const std::string& text, size_t openPos, char openChar, char closeChar, size_t& malformedEndTag);
     static std::string normalizeToolName(std::string rawName);
 
     bool toolNameAllowed(const std::string& name) const {

--- a/src/llm/io_processing/generation_config_builder.hpp
+++ b/src/llm/io_processing/generation_config_builder.hpp
@@ -15,14 +15,18 @@
 //*****************************************************************************
 
 #pragma once
-#include <memory>
+#include <algorithm>
+#include <cctype>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
+
 #include <openvino/genai/generation_config.hpp>
 #include <openvino/genai/tokenizer.hpp>
+
 #include "base_generation_config_builder.hpp"
 #include "phi4/generation_config_builder.hpp"
 #include "llama3/generation_config_builder.hpp"
@@ -32,15 +36,38 @@
 #include "../../logging.hpp"
 
 namespace ovms {
+
 class Gemma4GenerationConfigBuilder : public BaseGenerationConfigBuilder {
+    enum class ToolConstraintMode {
+        Disabled,
+        Auto,
+        Hard,
+    };
+
     bool hardToolChoice{false};
+
+    static bool isValidToolName(const std::string& name) {
+        return !name.empty() && std::all_of(name.begin(), name.end(), [](unsigned char c) {
+            return std::isalnum(c) || c == '_' || c == '-' || c == '.';
+        });
+    }
 
     static bool isNamedToolChoice(const std::string& toolChoice) {
         return !toolChoice.empty() && toolChoice != "auto" && toolChoice != "none" && toolChoice != "required";
     }
 
-    static bool isHardToolChoice(const std::string& toolChoice) {
+    static bool isHardToolChoiceImpl(const std::string& toolChoice) {
         return toolChoice == "required" || isNamedToolChoice(toolChoice);
+    }
+
+    static ToolConstraintMode getToolConstraintMode(const OpenAIRequest& request) {
+        if (request.toolNameSchemaMap.empty() || request.toolChoice == "none") {
+            return ToolConstraintMode::Disabled;
+        }
+        if (request.toolChoice.empty() || request.toolChoice == "auto") {
+            return ToolConstraintMode::Auto;
+        }
+        return ToolConstraintMode::Hard;
     }
 
     static ov::genai::StructuredOutputConfig::Tag buildToolTag(const std::string& toolName, const ToolSchemaWrapper& toolSchemaWrapper) {
@@ -61,14 +88,65 @@ class Gemma4GenerationConfigBuilder : public BaseGenerationConfigBuilder {
             if (it == request.toolNameSchemaMap.end()) {
                 throw std::invalid_argument("Gemma4 named tool_choice references an unavailable tool: " + request.toolChoice);
             }
+            if (!isValidToolName(it->first)) {
+                throw std::invalid_argument("Gemma4 tool name contains unsupported characters: " + it->first);
+            }
             tags.push_back(buildToolTag(it->first, it->second));
             return tags;
         }
         tags.reserve(request.toolNameSchemaMap.size());
         for (const auto& [toolName, toolSchemaWrapper] : request.toolNameSchemaMap) {
+            if (!isValidToolName(toolName)) {
+                throw std::invalid_argument("Gemma4 tool name contains unsupported characters: " + toolName);
+            }
             tags.push_back(buildToolTag(toolName, toolSchemaWrapper));
         }
         return tags;
+    }
+
+    static ov::genai::StructuredOutputConfig::StructuralTag buildAutoToolGrammar(
+        std::vector<ov::genai::StructuredOutputConfig::Tag> toolTags,
+        bool parallelToolCalls) {
+        using Structured = ov::genai::StructuredOutputConfig;
+        auto triggeredTags = std::make_shared<Structured::TriggeredTags>();
+        triggeredTags->triggers = {"<|tool_call>"};
+        triggeredTags->tags = std::move(toolTags);
+        // TriggeredTags itself supplies the free-text prefix. Setting at_least_one
+        // would prohibit ordinary prose and turn OpenAI `auto` into `required`.
+        triggeredTags->at_least_one = false;
+        // xgrammar's structural-tag contract maps parallel_tool_calls=false to
+        // stop_after_first=true. With the default true, later triggers remain legal.
+        triggeredTags->stop_after_first = !parallelToolCalls;
+        return triggeredTags;
+    }
+
+    static ov::genai::StructuredOutputConfig::StructuralTag buildMandatoryToolGrammar(
+        std::vector<ov::genai::StructuredOutputConfig::Tag> toolTags,
+        bool parallelToolCalls) {
+        using Structured = ov::genai::StructuredOutputConfig;
+
+        auto requiredTags = std::make_shared<Structured::TagsWithSeparator>();
+        requiredTags->tags = std::move(toolTags);
+        requiredTags->separator = "";
+        requiredTags->at_least_one = true;
+        requiredTags->stop_after_first = !parallelToolCalls;
+
+        // Google Gemma4 may open/close its thought channel before choosing a
+        // tool after a tool response, including for a named choice. Selecting
+        // a name restricts the available tags, not the model's thought phase.
+        // xgrammar rejects empty ConstString, so optional thought is a Union of
+        // tools-only versus thought-then-tools rather than Concat("", thought).
+        auto thought = std::make_shared<Structured::Tag>();
+        thought->begin = "<|channel>thought\n";
+        thought->content = Structured::AnyText();
+        thought->end = "<channel|>";
+
+        auto thoughtThenTools = std::make_shared<Structured::Concat>();
+        thoughtThenTools->elements = {thought, requiredTags};
+
+        auto alternatives = std::make_shared<Structured::Union>();
+        alternatives->elements = {requiredTags, thoughtThenTools};
+        return alternatives;
     }
 
 public:
@@ -82,34 +160,38 @@ public:
 
     void parseConfigFromRequest(const OpenAIRequest& request) override {
         BaseGenerationConfigBuilder::parseConfigFromRequest(request);
+        hardToolChoice = isHardToolChoiceImpl(request.toolChoice);
 
-        hardToolChoice = isHardToolChoice(request.toolChoice);
         if (hardToolChoice && request.toolNameSchemaMap.empty()) {
             throw std::invalid_argument("Gemma4 hard tool_choice requires at least one available tool schema");
         }
         if (request.responseFormat.has_value() && request.toolChoice != "none" && !request.toolNameSchemaMap.empty()) {
             throw std::invalid_argument("Gemma4 response_format cannot be combined with active tool generation constraints");
         }
-        if (request.toolNameSchemaMap.empty() || request.toolChoice == "none") {
-            return;
-        }
 
-        if (!hardToolChoice) {
-            config.structured_output_config.reset();
+        const ToolConstraintMode mode = getToolConstraintMode(request);
+        if (mode == ToolConstraintMode::Disabled) {
             return;
         }
 
         auto toolTags = buildToolTags(request);
         if (toolTags.empty()) {
-            throw std::invalid_argument("Gemma4 hard tool_choice did not produce an enforceable tool tag");
+            throw std::invalid_argument("Gemma4 active tool_choice did not produce an enforceable tool tag");
         }
-        auto requiredTags = std::make_shared<ov::genai::StructuredOutputConfig::TagsWithSeparator>();
-        requiredTags->tags = std::move(toolTags);
-        requiredTags->separator = "";
-        requiredTags->at_least_one = true;
-        requiredTags->stop_after_first = false;
-        ov::genai::StructuredOutputConfig::StructuralTag structuralTag = requiredTags;
-        setStructuralTagsConfig(structuralTag);
+
+        switch (mode) {
+        case ToolConstraintMode::Auto:
+            // OpenVINO GenAI TriggeredTags maps to xgrammar's lazy structural-tag
+            // dispatch: normal text is unconstrained until the tool marker appears,
+            // then the selected request tool name and JSON schema become authoritative.
+            setStructuralTagsConfig(buildAutoToolGrammar(std::move(toolTags), request.parallelToolCalls));
+            return;
+        case ToolConstraintMode::Hard:
+            setStructuralTagsConfig(buildMandatoryToolGrammar(std::move(toolTags), request.parallelToolCalls));
+            return;
+        case ToolConstraintMode::Disabled:
+            return;
+        }
     }
 };
 
@@ -118,12 +200,10 @@ class GenerationConfigBuilder {
 
 public:
     GenerationConfigBuilder() = delete;
-    // Using tool parser name to select appropriate builder implementation to avoid introducing additional parameters. Might be insufficient in the future.
     explicit GenerationConfigBuilder(const ov::genai::GenerationConfig& baseConfig, std::string toolParserName, bool enableToolGuidedGeneration, DecodingMethod decodingMethod) {
         if (toolParserName == "llama3") {
             builder_impl = std::make_unique<Llama3GenerationConfigBuilder>(baseConfig, enableToolGuidedGeneration, decodingMethod);
         } else if (toolParserName == "qwen3") {
-            // Qwen3 and Hermes3 share the same mechanism for generating tool calls, so we can use Hermes3GenerationConfigBuilder
             builder_impl = std::make_unique<Hermes3GenerationConfigBuilder>(baseConfig, enableToolGuidedGeneration, decodingMethod);
         } else if (toolParserName == "hermes3") {
             builder_impl = std::make_unique<Hermes3GenerationConfigBuilder>(baseConfig, enableToolGuidedGeneration, decodingMethod);
@@ -141,17 +221,9 @@ public:
         }
     }
 
-    ov::genai::GenerationConfig& getConfig() {
-        return builder_impl->getConfig();
-    }
-
-    void adjustConfigForDecodingMethod() {
-        builder_impl->adjustConfigForDecodingMethod();
-    }
-
-    void validateStructuredOutputConfig(ov::genai::Tokenizer& tokenizer) {
-        builder_impl->validateStructuredOutputConfig(tokenizer);
-    }
+    ov::genai::GenerationConfig& getConfig() { return builder_impl->getConfig(); }
+    void adjustConfigForDecodingMethod() { builder_impl->adjustConfigForDecodingMethod(); }
+    void validateStructuredOutputConfig(ov::genai::Tokenizer& tokenizer) { builder_impl->validateStructuredOutputConfig(tokenizer); }
 
     void unsetStructuredOutputConfig() {
         if (builder_impl->shouldPreserveStructuredOutputOnValidationFailure()) {
@@ -166,8 +238,7 @@ public:
         builder_impl->parseConfigFromRequest(request);
     }
 
-    void addStopString(const std::string& decodedStopString) {
-        builder_impl->addStopString(decodedStopString);
-    }
+    bool hasHardToolChoice() const { return builder_impl->shouldPreserveStructuredOutputOnValidationFailure(); }
+    void addStopString(const std::string& decodedStopString) { builder_impl->addStopString(decodedStopString); }
 };
 }  // namespace ovms

--- a/src/llm/io_processing/generation_config_builder.hpp
+++ b/src/llm/io_processing/generation_config_builder.hpp
@@ -17,7 +17,10 @@
 #pragma once
 #include <memory>
 #include <iostream>
+#include <stdexcept>
 #include <string>
+#include <utility>
+#include <vector>
 #include <openvino/genai/generation_config.hpp>
 #include <openvino/genai/tokenizer.hpp>
 #include "base_generation_config_builder.hpp"
@@ -29,6 +32,87 @@
 #include "../../logging.hpp"
 
 namespace ovms {
+class Gemma4GenerationConfigBuilder : public BaseGenerationConfigBuilder {
+    bool hardToolChoice{false};
+
+    static bool isNamedToolChoice(const std::string& toolChoice) {
+        return !toolChoice.empty() && toolChoice != "auto" && toolChoice != "none" && toolChoice != "required";
+    }
+
+    static bool isHardToolChoice(const std::string& toolChoice) {
+        return toolChoice == "required" || isNamedToolChoice(toolChoice);
+    }
+
+    static ov::genai::StructuredOutputConfig::Tag buildToolTag(const std::string& toolName, const ToolSchemaWrapper& toolSchemaWrapper) {
+        if (toolSchemaWrapper.stringRepr.empty()) {
+            throw std::invalid_argument("Gemma4 guided tool schema for '" + toolName + "' is empty");
+        }
+        ov::genai::StructuredOutputConfig::Tag tag;
+        tag.begin = "<|tool_call>call:" + toolName;
+        tag.content = ov::genai::StructuredOutputConfig::JSONSchema(toolSchemaWrapper.stringRepr);
+        tag.end = "<tool_call|>";
+        return tag;
+    }
+
+    static std::vector<ov::genai::StructuredOutputConfig::Tag> buildToolTags(const OpenAIRequest& request) {
+        std::vector<ov::genai::StructuredOutputConfig::Tag> tags;
+        if (isNamedToolChoice(request.toolChoice)) {
+            const auto it = request.toolNameSchemaMap.find(request.toolChoice);
+            if (it == request.toolNameSchemaMap.end()) {
+                throw std::invalid_argument("Gemma4 named tool_choice references an unavailable tool: " + request.toolChoice);
+            }
+            tags.push_back(buildToolTag(it->first, it->second));
+            return tags;
+        }
+        tags.reserve(request.toolNameSchemaMap.size());
+        for (const auto& [toolName, toolSchemaWrapper] : request.toolNameSchemaMap) {
+            tags.push_back(buildToolTag(toolName, toolSchemaWrapper));
+        }
+        return tags;
+    }
+
+public:
+    Gemma4GenerationConfigBuilder() = delete;
+    explicit Gemma4GenerationConfigBuilder(const ov::genai::GenerationConfig& baseConfig, bool enableToolGuidedGeneration, DecodingMethod decodingMethod) :
+        BaseGenerationConfigBuilder(baseConfig, enableToolGuidedGeneration, decodingMethod) {}
+
+    bool shouldPreserveStructuredOutputOnValidationFailure() const override {
+        return hardToolChoice;
+    }
+
+    void parseConfigFromRequest(const OpenAIRequest& request) override {
+        BaseGenerationConfigBuilder::parseConfigFromRequest(request);
+
+        hardToolChoice = isHardToolChoice(request.toolChoice);
+        if (hardToolChoice && request.toolNameSchemaMap.empty()) {
+            throw std::invalid_argument("Gemma4 hard tool_choice requires at least one available tool schema");
+        }
+        if (request.responseFormat.has_value() && request.toolChoice != "none" && !request.toolNameSchemaMap.empty()) {
+            throw std::invalid_argument("Gemma4 response_format cannot be combined with active tool generation constraints");
+        }
+        if (request.toolNameSchemaMap.empty() || request.toolChoice == "none") {
+            return;
+        }
+
+        if (!hardToolChoice) {
+            config.structured_output_config.reset();
+            return;
+        }
+
+        auto toolTags = buildToolTags(request);
+        if (toolTags.empty()) {
+            throw std::invalid_argument("Gemma4 hard tool_choice did not produce an enforceable tool tag");
+        }
+        auto requiredTags = std::make_shared<ov::genai::StructuredOutputConfig::TagsWithSeparator>();
+        requiredTags->tags = std::move(toolTags);
+        requiredTags->separator = "";
+        requiredTags->at_least_one = true;
+        requiredTags->stop_after_first = false;
+        ov::genai::StructuredOutputConfig::StructuralTag structuralTag = requiredTags;
+        setStructuralTagsConfig(structuralTag);
+    }
+};
+
 class GenerationConfigBuilder {
     std::unique_ptr<BaseGenerationConfigBuilder> builder_impl;
 
@@ -43,6 +127,8 @@ public:
             builder_impl = std::make_unique<Hermes3GenerationConfigBuilder>(baseConfig, enableToolGuidedGeneration, decodingMethod);
         } else if (toolParserName == "hermes3") {
             builder_impl = std::make_unique<Hermes3GenerationConfigBuilder>(baseConfig, enableToolGuidedGeneration, decodingMethod);
+        } else if (toolParserName == "gemma4") {
+            builder_impl = std::make_unique<Gemma4GenerationConfigBuilder>(baseConfig, enableToolGuidedGeneration, decodingMethod);
         } else if (toolParserName == "phi4") {
             builder_impl = std::make_unique<Phi4GenerationConfigBuilder>(baseConfig, enableToolGuidedGeneration, decodingMethod);
         } else if (toolParserName == "devstral") {
@@ -68,6 +154,11 @@ public:
     }
 
     void unsetStructuredOutputConfig() {
+        if (builder_impl->shouldPreserveStructuredOutputOnValidationFailure()) {
+            SPDLOG_LOGGER_WARN(llm_calculator_logger,
+                "Refusing to clear structured output after validation failure for Gemma4 required/named tool_choice; keeping generation fail-closed.");
+            return;
+        }
         builder_impl->unsetStructuredOutputConfig();
     }
 

--- a/src/llm/io_processing/input_processors/chat_template_adapter.cpp
+++ b/src/llm/io_processing/input_processors/chat_template_adapter.cpp
@@ -60,6 +60,29 @@ void funcArgsToObjectHistory(ov::genai::ChatHistory& chatHistory) {
     }
 }
 
+void toolResponseJsonContentToObjectHistory(ov::genai::ChatHistory& chatHistory) {
+    for (size_t msgIdx = 0; msgIdx < chatHistory.size(); ++msgIdx) {
+        auto message = chatHistory[msgIdx];
+        if (!message.contains("role") || !message["role"].is_string() || message["role"].get_string() != "tool") {
+            continue;
+        }
+        if (!message.contains("content") || !message["content"].is_string()) {
+            continue;
+        }
+
+        const std::string content = message["content"].get_string();
+        try {
+            auto parsed = ov::genai::JsonContainer::from_json_string(content);
+            if (!parsed.is_object()) {
+                continue;
+            }
+            message["content"] = parsed;
+        } catch (...) {
+            SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool response content is not a JSON object; keeping string content");
+        }
+    }
+}
+
 void injectReasoningIntoMissnamedSection(ov::genai::ChatHistory& chatHistory, const std::string& templateReasoningFieldName) {
     for (size_t msgIdx = 0; msgIdx < chatHistory.size(); ++msgIdx) {
         auto message = chatHistory[msgIdx];
@@ -95,6 +118,9 @@ void applyToHistory(const ChatTemplateCaps& caps, ov::genai::ChatHistory& chatHi
     SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Applying chat template adaptations: {}", caps.toString());
     if (caps.requiresObjectArguments) {
         funcArgsToObjectHistory(chatHistory);
+    }
+    if (caps.parseToolResponseJsonContent) {
+        toolResponseJsonContentToObjectHistory(chatHistory);
     }
     if (!caps.missnamedReasoningField.empty()) {
         injectReasoningIntoMissnamedSection(chatHistory, caps.missnamedReasoningField);

--- a/src/llm/io_processing/input_processors/chat_template_adapter.hpp
+++ b/src/llm/io_processing/input_processors/chat_template_adapter.hpp
@@ -29,6 +29,10 @@ namespace chat_template_adapter {
 // Models like Gemma require arguments as a dict/object, not a stringified JSON.
 void funcArgsToObjectHistory(ov::genai::ChatHistory& chatHistory);
 
+// Converts JSON-object strings in role:tool content to objects. This is deliberately
+// limited to objects: arrays/scalars keep their original OpenAI content semantics.
+void toolResponseJsonContentToObjectHistory(ov::genai::ChatHistory& chatHistory);
+
 // Apply all relevant adaptations to the ChatHistory based on detected capabilities.
 void applyToHistory(const ChatTemplateCaps& caps, ov::genai::ChatHistory& chatHistory);
 

--- a/src/llm/io_processing/output_parser.cpp
+++ b/src/llm/io_processing/output_parser.cpp
@@ -204,7 +204,7 @@ OutputParser::OutputParser(ov::genai::Tokenizer& tokenizer, const std::string to
     } else if (toolParserName == "lfm2") {
         toolParser = std::make_unique<Lfm2ToolParser>(tokenizer);
     } else if (toolParserName == "gemma4") {
-        toolParser = std::make_unique<Gemma4ToolParser>(tokenizer);
+        toolParser = std::make_unique<Gemma4ToolParser>(tokenizer, toolNameSchemaMap);
     } else if (toolParserName == "onyx") {
         toolParser = std::make_unique<OnyxToolParser>(tokenizer, toolNameSchemaMap);
     } else if (toolParserName == "minicpm5") {

--- a/src/llm/io_processing/output_parser.cpp
+++ b/src/llm/io_processing/output_parser.cpp
@@ -135,6 +135,12 @@ std::optional<Delta> OutputParser::parseToolCallChunk(const std::vector<int64_t>
     if (!toolParser) {
         throw std::runtime_error("Tool parser is not available, cannot parse tool call chunk");
     }
+    if (toolParser->getParsingConfig().ownsToolCallBoundaries) {
+        auto result = toolParser->parseChunk(streamOutputCache.getBuffer(), tokens, finishReason);
+        streamOutputCache.clear();
+        processingPhase = TOOL_CALLS_PROCESSING_TOOL;
+        return result;
+    }
     // Bytes after the end tag belong to the next phase — preserve them before clearing.
     std::string remainder;
     const std::string& endTag = toolParser->getParsingConfig().endTag;
@@ -478,6 +484,8 @@ std::optional<Delta> OutputParser::parseChunk(const std::string& chunkResponse, 
     } else if (processingPhase == TOOL_CALLS_PROCESSING_TOOL) {
         // Active tool call: accumulate until the end tag, then transition to WAITING_FOR_TOOL
         // to determine whether another tool call or a content turn follows.
+        if (toolParser->getParsingConfig().ownsToolCallBoundaries)
+            return parseToolCallChunk(tokens, finishReason);
         TagLookupStatus toolEndTagStatus = streamOutputCache.lookupTag(toolParser->getParsingConfig().endTag);
         if (toolEndTagStatus == TagLookupStatus::FOUND_INCOMPLETE && finishReason == ov::genai::GenerationFinishReason::NONE) {
             return std::nullopt;  // Wait for more chunks to determine if end tag is complete

--- a/src/llm/io_processing/output_parsing_config.hpp
+++ b/src/llm/io_processing/output_parsing_config.hpp
@@ -67,6 +67,9 @@ struct OutputParsingConfig {
     std::vector<std::string> stringsToErase;
 
     bool needsSpecialTokens = false;
+    // The tool parser owns quoted end markers and subsequent call framing.
+    // The generic router must not split or replay its input at a raw endTag.
+    bool ownsToolCallBoundaries = false;
     // See comment block above.
     bool defaultDecodingWithSpecialTokens = false;
 };

--- a/src/test/llm/chat_template_adapter_test.cpp
+++ b/src/test/llm/chat_template_adapter_test.cpp
@@ -130,6 +130,63 @@ TEST_F(ChatTemplateAdapterTest, funcArgsToObjectNoopWithoutToolCalls) {
     EXPECT_EQ(history[0]["content"].get_string(), "hello");
 }
 
+// --- toolResponseJsonContentToObjectHistory ---
+
+TEST_F(ChatTemplateAdapterTest, toolResponseJsonContentConvertsObjectAndPreservesOpaqueValue) {
+    static const std::string expectedSha = "798e99e04d53fba2b1c87bd6b88260f0d6c3ca83";
+    auto history = buildHistory(R"([
+        {"role": "assistant", "content": null, "tool_calls": [
+            {"id": "call_repo", "type": "function", "function": {"name": "inspect_repository_state", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "call_repo", "name": "inspect_repository_state",
+         "content": "{\"head_sha\":\"798e99e04d53fba2b1c87bd6b88260f0d6c3ca83\",\"nested\":{\"dirty\":true}}"}
+    ])");
+
+    chat_template_adapter::toolResponseJsonContentToObjectHistory(history);
+
+    ASSERT_GE(history.size(), 2u);
+    auto content = history[1]["content"];
+    ASSERT_TRUE(content.is_object());
+    EXPECT_EQ(content["head_sha"].get_string(), expectedSha);
+    EXPECT_EQ(content["nested"].to_json_string(), R"({"dirty":true})");
+}
+
+TEST_F(ChatTemplateAdapterTest, toolResponseJsonContentLeavesNonJsonStringUntouched) {
+    auto history = buildHistory(R"([
+        {"role": "tool", "tool_call_id": "call_1", "content": "not json at all"}
+    ])");
+
+    chat_template_adapter::toolResponseJsonContentToObjectHistory(history);
+
+    ASSERT_TRUE(history[0]["content"].is_string());
+    EXPECT_EQ(history[0]["content"].get_string(), "not json at all");
+}
+
+TEST_F(ChatTemplateAdapterTest, toolResponseJsonContentLeavesJsonArrayStringUntouched) {
+    auto history = buildHistory(R"([
+        {"role": "tool", "tool_call_id": "call_1", "content": "[1,2,3]"}
+    ])");
+
+    chat_template_adapter::toolResponseJsonContentToObjectHistory(history);
+
+    ASSERT_TRUE(history[0]["content"].is_string());
+    EXPECT_EQ(history[0]["content"].get_string(), "[1,2,3]");
+}
+
+TEST_F(ChatTemplateAdapterTest, toolResponseJsonContentSkipsNonToolMessages) {
+    auto history = buildHistory(R"([
+        {"role": "user", "content": "{\"head_sha\":\"do-not-touch\"}"},
+        {"role": "assistant", "content": "{\"head_sha\":\"also-do-not-touch\"}"}
+    ])");
+
+    chat_template_adapter::toolResponseJsonContentToObjectHistory(history);
+
+    ASSERT_TRUE(history[0]["content"].is_string());
+    EXPECT_EQ(history[0]["content"].get_string(), R"({"head_sha":"do-not-touch"})");
+    ASSERT_TRUE(history[1]["content"].is_string());
+    EXPECT_EQ(history[1]["content"].get_string(), R"({"head_sha":"also-do-not-touch"})");
+}
+
 // --- applyToHistory ---
 
 TEST_F(ChatTemplateAdapterTest, applyToHistoryAppliesObjectArgsWhenRequired) {
@@ -148,6 +205,22 @@ TEST_F(ChatTemplateAdapterTest, applyToHistoryAppliesObjectArgsWhenRequired) {
     auto args = history[0]["tool_calls"][0]["function"]["arguments"];
     ASSERT_TRUE(args.is_object());
     EXPECT_EQ(args.to_json_string(), R"({"x":42})");
+}
+
+TEST_F(ChatTemplateAdapterTest, applyToHistoryStructuresToolResponseWhenCapabilitySet) {
+    ChatTemplateCaps caps;
+    caps.parseToolResponseJsonContent = true;
+
+    auto history = buildHistory(R"([
+        {"role": "tool", "tool_call_id": "call_repo",
+         "content": "{\"commit_sha\":\"798e99e04d53fba2b1c87bd6b88260f0d6c3ca83\",\"verdict\":\"PASS\"}"}
+    ])");
+
+    chat_template_adapter::applyToHistory(caps, history);
+
+    ASSERT_TRUE(history[0]["content"].is_object());
+    EXPECT_EQ(history[0]["content"]["commit_sha"].get_string(), "798e99e04d53fba2b1c87bd6b88260f0d6c3ca83");
+    EXPECT_EQ(history[0]["content"]["verdict"].get_string(), "PASS");
 }
 
 TEST_F(ChatTemplateAdapterTest, applyToHistoryDoesNothingWhenNoCapsSet) {

--- a/src/test/llm/chat_template_analyzer_test.cpp
+++ b/src/test/llm/chat_template_analyzer_test.cpp
@@ -86,6 +86,27 @@ TEST_F(ChatTemplateAnalyzerTest, detectsGemma4) {
     EXPECT_EQ(result.detectedReasoningParser.value(), "gemma4");
     EXPECT_TRUE(result.caps.supportsToolCalls);
     EXPECT_TRUE(result.caps.supportsResponseFieldInToolDefinition);
+    EXPECT_FALSE(result.caps.parseToolResponseJsonContent);
+}
+
+TEST_F(ChatTemplateAnalyzerTest, gemma4DoesNotParseToolJsonWhenPartsScanWouldCallGetOnDictKeys) {
+    const std::string tmpl =
+        "<|tool_call>call:{% if response is mapping %}x{% endif %}"
+        "{% for part in tool_body %}{{ part.get('type') }}{% endfor %}";
+    auto result = ChatTemplateAnalyzer::analyze(tmpl);
+    ASSERT_TRUE(result.detectedToolParser.has_value());
+    EXPECT_EQ(result.detectedToolParser.value(), "gemma4");
+    EXPECT_TRUE(result.caps.supportsResponseFieldInToolDefinition);
+    EXPECT_FALSE(result.caps.parseToolResponseJsonContent);
+}
+
+TEST_F(ChatTemplateAnalyzerTest, gemma4ParsesToolJsonWhenMappingBranchHasNoPartsGetScan) {
+    const std::string tmpl = "<|tool_call>call:{% if response is mapping %}{{ response }}{% endif %}";
+    auto result = ChatTemplateAnalyzer::analyze(tmpl);
+    ASSERT_TRUE(result.detectedToolParser.has_value());
+    EXPECT_EQ(result.detectedToolParser.value(), "gemma4");
+    EXPECT_TRUE(result.caps.supportsResponseFieldInToolDefinition);
+    EXPECT_TRUE(result.caps.parseToolResponseJsonContent);
 }
 
 // --- Qwen3-Coder ---
@@ -247,5 +268,7 @@ TEST_F(ChatTemplateAnalyzerTest, defaultCapsValues) {
     ChatTemplateCaps caps;
     EXPECT_FALSE(caps.supportsToolCalls);
     EXPECT_FALSE(caps.requiresObjectArguments);
+    EXPECT_FALSE(caps.parseToolResponseJsonContent);
     EXPECT_TRUE(caps.missnamedReasoningField.empty());
+    EXPECT_FALSE(caps.supportsResponseFieldInToolDefinition);
 }

--- a/src/test/llm/generation_config/BUILD
+++ b/src/test/llm/generation_config/BUILD
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 load("//:common_settings.bzl", "COMMON_LOCAL_DEFINES", "COMMON_STATIC_LIBS_LINKOPTS", "COPTS_TESTS")
 
 cc_test(

--- a/src/test/llm/generation_config/BUILD
+++ b/src/test/llm/generation_config/BUILD
@@ -1,0 +1,15 @@
+load("//:common_settings.bzl", "COMMON_LOCAL_DEFINES", "COMMON_STATIC_LIBS_LINKOPTS", "COPTS_TESTS")
+
+cc_test(
+    name = "gemma4_generation_contract_test",
+    srcs = ["gemma4_generation_contract_test.cpp"],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+        "//src/llm:generation_config_builders",
+        "//third_party:genai",
+    ],
+    copts = COPTS_TESTS,
+    local_defines = COMMON_LOCAL_DEFINES,
+    linkopts = COMMON_STATIC_LIBS_LINKOPTS,
+    linkstatic = 1,
+)

--- a/src/test/llm/generation_config/BUILD
+++ b/src/test/llm/generation_config/BUILD
@@ -18,11 +18,14 @@ load("//:common_settings.bzl", "COMMON_LOCAL_DEFINES", "COMMON_STATIC_LIBS_LINKO
 
 cc_test(
     name = "gemma4_generation_contract_test",
+    env_inherit = ["PATH"],
     srcs = ["gemma4_generation_contract_test.cpp"],
     deps = [
         "@com_google_googletest//:gtest_main",
+        "//src:test_platform_utils",
         "//src/llm:generation_config_builders",
         "//third_party:genai",
+        "//third_party:openvino",
     ],
     copts = COPTS_TESTS,
     local_defines = COMMON_LOCAL_DEFINES,

--- a/src/test/llm/generation_config/gemma4_generation_contract_test.cpp
+++ b/src/test/llm/generation_config/gemma4_generation_contract_test.cpp
@@ -1,0 +1,142 @@
+// Copyright 2026 Intel Corporation
+// Licensed under the Apache License, Version 2.0.
+
+#include <gtest/gtest.h>
+#include <openvino/genai/llm_pipeline.hpp>
+
+#include <string>
+#include <variant>
+
+#include "src/llm/io_processing/generation_config_builder.hpp"
+
+using namespace ovms;
+using Structured = ov::genai::StructuredOutputConfig;
+
+namespace {
+const std::string emptySchema = R"({"type":"object","properties":{},"additionalProperties":false})";
+const std::string responseSchema = R"({"type":"structural_tag","format":{"type":"json_schema","json_schema":{"type":"object","properties":{"answer":{"type":"string"}}}}})";
+const std::string openCodeQuestionSchema = R"({"type":"object","properties":{"questions":{"type":"array","items":{"type":"object","properties":{"question":{"type":"string"},"header":{"type":"string"},"options":{"type":"array","items":{"type":"object","properties":{"label":{"type":"string"},"description":{"type":"string"}},"required":["label","description"]}},"multiple":{"type":"boolean"},"custom":{"type":"boolean"}},"required":["question","header","options"]}}},"required":["questions"]})";
+
+OpenAIRequest requestWithTools(const std::string& choice) {
+    OpenAIRequest request;
+    request.toolChoice = choice;
+    request.toolNameSchemaMap.emplace("first", ToolSchemaWrapper{nullptr, emptySchema});
+    request.toolNameSchemaMap.emplace("second", ToolSchemaWrapper{nullptr, emptySchema});
+    return request;
+}
+
+template <typename T>
+const T& grammar(const ov::genai::GenerationConfig& config) {
+    return *std::get<std::shared_ptr<T>>(std::get<Structured::StructuralTag>(
+        config.structured_output_config.value().structural_tags_config.value()));
+}
+}  // namespace
+
+TEST(Gemma4GenerationContractTest, AbsentToolsAndNonePreserveResponseFormat) {
+    for (bool guided : {false, true}) {
+        for (bool response : {false, true}) {
+            for (bool tools : {false, true}) {
+                auto request = tools ? requestWithTools("none") : OpenAIRequest{};
+                if (response)
+                    request.responseFormat = responseSchema;
+                GenerationConfigBuilder builder({}, "gemma4", guided, STANDARD);
+                builder.parseConfigFromRequest(request);
+                EXPECT_EQ(builder.getConfig().structured_output_config.has_value(), response);
+            }
+        }
+    }
+}
+
+TEST(Gemma4GenerationContractTest, ValidationFallbackPolicyIsGemmaSpecific) {
+    auto request = requestWithTools("required");
+
+    GenerationConfigBuilder gemma({}, "gemma4", false, STANDARD);
+    gemma.parseConfigFromRequest(request);
+    ASSERT_TRUE(gemma.getConfig().structured_output_config.has_value());
+    EXPECT_NO_THROW(gemma.unsetStructuredOutputConfig());
+    EXPECT_TRUE(gemma.getConfig().structured_output_config.has_value());
+
+    GenerationConfigBuilder hermes({}, "hermes3", false, STANDARD);
+    hermes.parseConfigFromRequest(request);
+    ASSERT_TRUE(hermes.getConfig().structured_output_config.has_value());
+    EXPECT_NO_THROW(hermes.unsetStructuredOutputConfig());
+    EXPECT_FALSE(hermes.getConfig().structured_output_config.has_value());
+}
+
+TEST(Gemma4GenerationContractTest, AutoUsesNativeGemmaGenerationAndHardChoicesStayImmediateAndRepeatable) {
+    for (bool guided : {false, true}) {
+        for (const std::string choice : {"auto", "required", "second"}) {
+            auto request = requestWithTools(choice);
+            GenerationConfigBuilder builder({}, "gemma4", guided, STANDARD);
+            builder.parseConfigFromRequest(request);
+            if (choice == "auto") {
+                EXPECT_FALSE(builder.getConfig().structured_output_config)
+                    << "Gemma4 auto tool choice must remain native/unconstrained";
+            } else {
+                const auto& tags = grammar<Structured::TagsWithSeparator>(builder.getConfig());
+                EXPECT_TRUE(tags.at_least_one);
+                EXPECT_FALSE(tags.stop_after_first);
+                EXPECT_TRUE(tags.separator.empty());
+                ASSERT_EQ(tags.tags.size(), choice == "second" ? 1u : 2u);
+                if (choice == "second")
+                    EXPECT_EQ(tags.tags[0].begin, "<|tool_call>call:second");
+            }
+        }
+    }
+}
+
+TEST(Gemma4GenerationContractTest, OpenCodeQuestionSchemaDoesNotConstrainAutoButRemainsEnforcedForRequired) {
+    for (const std::string choice : {"auto", "required"}) {
+        OpenAIRequest request;
+        request.toolChoice = choice;
+        request.toolNameSchemaMap.emplace("question", ToolSchemaWrapper{nullptr, openCodeQuestionSchema});
+        GenerationConfigBuilder builder({}, "gemma4", true, STANDARD);
+        builder.parseConfigFromRequest(request);
+
+        if (choice == "auto") {
+            EXPECT_FALSE(builder.getConfig().structured_output_config);
+        } else {
+            const auto& tags = grammar<Structured::TagsWithSeparator>(builder.getConfig());
+            ASSERT_EQ(tags.tags.size(), 1u);
+            EXPECT_EQ(tags.tags[0].begin, "<|tool_call>call:question");
+            EXPECT_EQ(std::get<Structured::JSONSchema>(tags.tags[0].content).value, openCodeQuestionSchema);
+        }
+    }
+}
+
+TEST(Gemma4GenerationContractTest, ImpossibleHardChoiceIsRejected) {
+    for (bool guided : {false, true}) {
+        for (const std::string choice : {"required", "missing"}) {
+            OpenAIRequest request;
+            request.toolChoice = choice;
+            GenerationConfigBuilder builder({}, "gemma4", guided, STANDARD);
+            EXPECT_THROW(builder.parseConfigFromRequest(request), std::invalid_argument);
+        }
+        auto request = requestWithTools("missing");
+        GenerationConfigBuilder builder({}, "gemma4", guided, STANDARD);
+        EXPECT_THROW(builder.parseConfigFromRequest(request), std::invalid_argument);
+    }
+}
+
+TEST(Gemma4GenerationContractTest, ResponseFormatAndActiveToolsCannotSilentlyReplaceConstraints) {
+    for (bool guided : {false, true}) {
+        for (const std::string choice : {"auto", "required", "second"}) {
+            auto request = requestWithTools(choice);
+            request.responseFormat = responseSchema;
+            GenerationConfigBuilder builder({}, "gemma4", guided, STANDARD);
+            EXPECT_THROW(builder.parseConfigFromRequest(request), std::invalid_argument);
+        }
+    }
+}
+
+TEST(Gemma4GenerationContractTest, ObjectSchemaIsPassedWithoutLosingNestedConstraints) {
+    const std::string schema = R"({"type":"object","properties":{"nested":{"type":"object","properties":{"x":{"enum":[1,2]}}},"array":{"type":"array","items":{"type":["number","boolean","null"]}},"optional":{"type":"string"}},"required":["nested"],"additionalProperties":false})";
+    auto request = requestWithTools("first");
+    request.toolNameSchemaMap.erase("second");
+    request.toolNameSchemaMap["first"].stringRepr = schema;
+    GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+    builder.parseConfigFromRequest(request);
+    const auto& tags = grammar<Structured::TagsWithSeparator>(builder.getConfig());
+    ASSERT_EQ(tags.tags.size(), 1u);
+    EXPECT_EQ(std::get<Structured::JSONSchema>(tags.tags[0].content).value, schema);
+}

--- a/src/test/llm/generation_config/gemma4_generation_contract_test.cpp
+++ b/src/test/llm/generation_config/gemma4_generation_contract_test.cpp
@@ -3,11 +3,14 @@
 
 #include <gtest/gtest.h>
 #include <openvino/genai/llm_pipeline.hpp>
-
+#include <memory>
+#include <set>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "src/llm/io_processing/generation_config_builder.hpp"
+#include "src/test/platform_utils.hpp"
 
 using namespace ovms;
 using Structured = ov::genai::StructuredOutputConfig;
@@ -25,10 +28,35 @@ OpenAIRequest requestWithTools(const std::string& choice) {
     return request;
 }
 
+const Structured::StructuralTag& rootGrammar(const ov::genai::GenerationConfig& config) {
+    return std::get<Structured::StructuralTag>(
+        config.structured_output_config.value().structural_tags_config.value());
+}
+
 template <typename T>
 const T& grammar(const ov::genai::GenerationConfig& config) {
-    return *std::get<std::shared_ptr<T>>(std::get<Structured::StructuralTag>(
-        config.structured_output_config.value().structural_tags_config.value()));
+    const auto& root = rootGrammar(config);
+    if (const auto* sequence = std::get_if<std::shared_ptr<Structured::Concat>>(&root))
+        return *std::get<std::shared_ptr<T>>((*sequence)->elements.back());
+    if (const auto* alternatives = std::get_if<std::shared_ptr<Structured::Union>>(&root)) {
+        for (const auto& element : (*alternatives)->elements) {
+            if (const auto* tags = std::get_if<std::shared_ptr<T>>(&element))
+                return **tags;
+            if (const auto* sequence = std::get_if<std::shared_ptr<Structured::Concat>>(&element))
+                return *std::get<std::shared_ptr<T>>((*sequence)->elements.back());
+        }
+    }
+    return *std::get<std::shared_ptr<T>>(root);
+}
+
+const Structured::TriggeredTags& autoGrammar(const ov::genai::GenerationConfig& config) {
+    return *std::get<std::shared_ptr<Structured::TriggeredTags>>(rootGrammar(config));
+}
+
+std::string grammarString(const ov::genai::GenerationConfig& config) {
+    return std::visit([](const auto& value) {
+        return Structured::structural_tag_to_string(value);
+    }, rootGrammar(config));
 }
 }  // namespace
 
@@ -53,25 +81,91 @@ TEST(Gemma4GenerationContractTest, ValidationFallbackPolicyIsGemmaSpecific) {
     GenerationConfigBuilder gemma({}, "gemma4", false, STANDARD);
     gemma.parseConfigFromRequest(request);
     ASSERT_TRUE(gemma.getConfig().structured_output_config.has_value());
-    EXPECT_NO_THROW(gemma.unsetStructuredOutputConfig());
+    gemma.unsetStructuredOutputConfig();
     EXPECT_TRUE(gemma.getConfig().structured_output_config.has_value());
 
     GenerationConfigBuilder hermes({}, "hermes3", false, STANDARD);
     hermes.parseConfigFromRequest(request);
     ASSERT_TRUE(hermes.getConfig().structured_output_config.has_value());
-    EXPECT_NO_THROW(hermes.unsetStructuredOutputConfig());
+    hermes.unsetStructuredOutputConfig();
     EXPECT_FALSE(hermes.getConfig().structured_output_config.has_value());
 }
 
-TEST(Gemma4GenerationContractTest, AutoUsesNativeGemmaGenerationAndHardChoicesStayImmediateAndRepeatable) {
+TEST(Gemma4GenerationContractTest, HardChoicesAllowReasoningBeforeMandatoryToolSelection) {
+    for (const std::string choice : {"required", "second"}) {
+        SCOPED_TRACE(choice);
+        auto request = requestWithTools(choice);
+        GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+        builder.parseConfigFromRequest(request);
+        const auto& root = rootGrammar(builder.getConfig());
+        ASSERT_TRUE(std::holds_alternative<std::shared_ptr<Structured::Union>>(root));
+        const auto& alternatives = *std::get<std::shared_ptr<Structured::Union>>(root);
+        ASSERT_EQ(alternatives.elements.size(), 2u);
+        const auto& toolsOnly = *std::get<std::shared_ptr<Structured::TagsWithSeparator>>(alternatives.elements[0]);
+        EXPECT_TRUE(toolsOnly.at_least_one);
+        EXPECT_EQ(toolsOnly.tags.size(), choice == "second" ? 1u : 2u);
+        if (choice == "second")
+            EXPECT_EQ(toolsOnly.tags[0].begin, "<|tool_call>call:second");
+        const auto& thoughtThenTools = *std::get<std::shared_ptr<Structured::Concat>>(alternatives.elements[1]);
+        ASSERT_EQ(thoughtThenTools.elements.size(), 2u);
+        const auto& thought = *std::get<std::shared_ptr<Structured::Tag>>(thoughtThenTools.elements[0]);
+        EXPECT_EQ(thought.begin, "<|channel>thought\n");
+        EXPECT_EQ(thought.end, "<channel|>");
+        const auto& toolsAfterThought = *std::get<std::shared_ptr<Structured::TagsWithSeparator>>(thoughtThenTools.elements[1]);
+        EXPECT_TRUE(toolsAfterThought.at_least_one);
+        EXPECT_EQ(toolsAfterThought.tags.size(), choice == "second" ? 1u : 2u);
+        if (choice == "second")
+            EXPECT_EQ(toolsAfterThought.tags[0].begin, "<|tool_call>call:second");
+
+        ov::genai::Tokenizer tokenizer(getGenericFullPathForSrcTest(
+            "/ovms/src/test/llm_testing/OpenVINO/gemma-4-E4B-it-int4-ov"));
+        EXPECT_NO_THROW(builder.validateStructuredOutputConfig(tokenizer));
+    }
+}
+
+TEST(Gemma4GenerationContractTest, HardChoiceCannotBeClearedButAutoMayFallbackAfterValidationFailure) {
+    for (const std::string choice : {"required", "second"}) {
+        auto request = requestWithTools(choice);
+        GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+        builder.parseConfigFromRequest(request);
+        ASSERT_TRUE(builder.getConfig().structured_output_config.has_value());
+        EXPECT_NO_THROW(builder.unsetStructuredOutputConfig()) << choice;
+        EXPECT_TRUE(builder.getConfig().structured_output_config.has_value()) << choice;
+    }
+
+    auto autoRequest = requestWithTools("auto");
+    GenerationConfigBuilder autoBuilder({}, "gemma4", false, STANDARD);
+    autoBuilder.parseConfigFromRequest(autoRequest);
+    ASSERT_TRUE(autoBuilder.getConfig().structured_output_config.has_value());
+    EXPECT_NO_THROW(autoBuilder.unsetStructuredOutputConfig());
+    EXPECT_FALSE(autoBuilder.getConfig().structured_output_config.has_value());
+}
+
+TEST(Gemma4GenerationContractTest, AutoUsesTriggeredToolGrammarAndHardChoicesStayImmediateAndRepeatable) {
     for (bool guided : {false, true}) {
         for (const std::string choice : {"auto", "required", "second"}) {
+            SCOPED_TRACE(choice);
             auto request = requestWithTools(choice);
             GenerationConfigBuilder builder({}, "gemma4", guided, STANDARD);
             builder.parseConfigFromRequest(request);
+            ASSERT_TRUE(builder.getConfig().structured_output_config.has_value());
             if (choice == "auto") {
-                EXPECT_FALSE(builder.getConfig().structured_output_config)
-                    << "Gemma4 auto tool choice must remain native/unconstrained";
+                const auto& triggered = autoGrammar(builder.getConfig());
+                ASSERT_EQ(triggered.triggers.size(), 1u);
+                EXPECT_EQ(triggered.triggers[0], "<|tool_call>");
+                EXPECT_FALSE(triggered.at_least_one)
+                    << "Gemma4 auto must permit ordinary prose without a tool call";
+                EXPECT_FALSE(triggered.stop_after_first);
+                ASSERT_EQ(triggered.tags.size(), 2u);
+
+                std::set<std::string> begins;
+                for (const auto& tag : triggered.tags) {
+                    begins.insert(tag.begin);
+                    EXPECT_EQ(tag.end, "<tool_call|>");
+                    ASSERT_TRUE(std::holds_alternative<Structured::JSONSchema>(tag.content));
+                    EXPECT_EQ(std::get<Structured::JSONSchema>(tag.content).value, emptySchema);
+                }
+                EXPECT_EQ(begins, (std::set<std::string>{"<|tool_call>call:first", "<|tool_call>call:second"}));
             } else {
                 const auto& tags = grammar<Structured::TagsWithSeparator>(builder.getConfig());
                 EXPECT_TRUE(tags.at_least_one);
@@ -85,7 +179,45 @@ TEST(Gemma4GenerationContractTest, AutoUsesNativeGemmaGenerationAndHardChoicesSt
     }
 }
 
-TEST(Gemma4GenerationContractTest, OpenCodeQuestionSchemaDoesNotConstrainAutoButRemainsEnforcedForRequired) {
+TEST(Gemma4GenerationContractTest, ParallelToolCallsControlsGrammarRepeatability) {
+    for (const std::string choice : {"auto", "required", "second"}) {
+        for (bool parallel : {false, true}) {
+            SCOPED_TRACE(choice + std::string(parallel ? ":parallel" : ":single"));
+            auto request = requestWithTools(choice);
+            request.parallelToolCalls = parallel;
+            GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+            builder.parseConfigFromRequest(request);
+
+            if (choice == "auto") {
+                const auto& triggered = autoGrammar(builder.getConfig());
+                EXPECT_EQ(triggered.stop_after_first, !parallel);
+            } else {
+                const auto& root = rootGrammar(builder.getConfig());
+                ASSERT_TRUE(std::holds_alternative<std::shared_ptr<Structured::Union>>(root));
+                const auto& alternatives = *std::get<std::shared_ptr<Structured::Union>>(root);
+                ASSERT_EQ(alternatives.elements.size(), 2u);
+                const auto& toolsOnly = *std::get<std::shared_ptr<Structured::TagsWithSeparator>>(alternatives.elements[0]);
+                EXPECT_EQ(toolsOnly.stop_after_first, !parallel);
+                const auto& thoughtThenTools = *std::get<std::shared_ptr<Structured::Concat>>(alternatives.elements[1]);
+                const auto& toolsAfterThought = *std::get<std::shared_ptr<Structured::TagsWithSeparator>>(thoughtThenTools.elements[1]);
+                EXPECT_EQ(toolsAfterThought.stop_after_first, !parallel);
+            }
+        }
+    }
+}
+
+TEST(Gemma4GenerationContractTest, AutoTriggeredGrammarValidatesWithGemmaTokenizer) {
+    auto request = requestWithTools("auto");
+    GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+    builder.parseConfigFromRequest(request);
+    ASSERT_TRUE(builder.getConfig().structured_output_config.has_value());
+
+    ov::genai::Tokenizer tokenizer(getGenericFullPathForSrcTest(
+        "/ovms/src/test/llm_testing/OpenVINO/gemma-4-E4B-it-int4-ov"));
+    EXPECT_NO_THROW(builder.validateStructuredOutputConfig(tokenizer));
+}
+
+TEST(Gemma4GenerationContractTest, OpenCodeQuestionSchemaIsEnforcedForAutoAndRequired) {
     for (const std::string choice : {"auto", "required"}) {
         OpenAIRequest request;
         request.toolChoice = choice;
@@ -94,7 +226,11 @@ TEST(Gemma4GenerationContractTest, OpenCodeQuestionSchemaDoesNotConstrainAutoBut
         builder.parseConfigFromRequest(request);
 
         if (choice == "auto") {
-            EXPECT_FALSE(builder.getConfig().structured_output_config);
+            const auto& triggered = autoGrammar(builder.getConfig());
+            ASSERT_EQ(triggered.tags.size(), 1u);
+            EXPECT_EQ(triggered.tags[0].begin, "<|tool_call>call:question");
+            EXPECT_EQ(std::get<Structured::JSONSchema>(triggered.tags[0].content).value, openCodeQuestionSchema);
+            EXPECT_FALSE(triggered.at_least_one);
         } else {
             const auto& tags = grammar<Structured::TagsWithSeparator>(builder.getConfig());
             ASSERT_EQ(tags.tags.size(), 1u);
@@ -131,12 +267,53 @@ TEST(Gemma4GenerationContractTest, ResponseFormatAndActiveToolsCannotSilentlyRep
 
 TEST(Gemma4GenerationContractTest, ObjectSchemaIsPassedWithoutLosingNestedConstraints) {
     const std::string schema = R"({"type":"object","properties":{"nested":{"type":"object","properties":{"x":{"enum":[1,2]}}},"array":{"type":"array","items":{"type":["number","boolean","null"]}},"optional":{"type":"string"}},"required":["nested"],"additionalProperties":false})";
-    auto request = requestWithTools("first");
-    request.toolNameSchemaMap.erase("second");
-    request.toolNameSchemaMap["first"].stringRepr = schema;
-    GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
-    builder.parseConfigFromRequest(request);
-    const auto& tags = grammar<Structured::TagsWithSeparator>(builder.getConfig());
-    ASSERT_EQ(tags.tags.size(), 1u);
-    EXPECT_EQ(std::get<Structured::JSONSchema>(tags.tags[0].content).value, schema);
+    for (const std::string choice : {"auto", "first"}) {
+        auto request = requestWithTools(choice);
+        request.toolNameSchemaMap.erase("second");
+        request.toolNameSchemaMap["first"].stringRepr = schema;
+        GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+        builder.parseConfigFromRequest(request);
+        if (choice == "auto") {
+            const auto& triggered = autoGrammar(builder.getConfig());
+            ASSERT_EQ(triggered.tags.size(), 1u);
+            EXPECT_EQ(std::get<Structured::JSONSchema>(triggered.tags[0].content).value, schema);
+        } else {
+            const auto& tags = grammar<Structured::TagsWithSeparator>(builder.getConfig());
+            ASSERT_EQ(tags.tags.size(), 1u);
+            EXPECT_EQ(std::get<Structured::JSONSchema>(tags.tags[0].content).value, schema);
+        }
+    }
+}
+
+TEST(Gemma4GenerationContractTest, RejectsToolNamesThatItsParserCannotExecute) {
+    for (const std::string choice : {"auto", "required"}) {
+        for (const std::string name : {"bad name", "", "bad:name"}) {
+            OpenAIRequest request;
+            request.toolChoice = choice;
+            request.toolNameSchemaMap.emplace(name, ToolSchemaWrapper{nullptr, emptySchema});
+            GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+            EXPECT_THROW(builder.parseConfigFromRequest(request), std::invalid_argument) << choice << ":" << name;
+        }
+    }
+}
+
+TEST(Gemma4GenerationContractTest, RejectsEmptyToolSchemasForAutoAndHardChoices) {
+    for (const std::string choice : {"auto", "required", "first"}) {
+        auto request = requestWithTools(choice);
+        request.toolNameSchemaMap["first"].stringRepr.clear();
+        if (choice == "first")
+            request.toolNameSchemaMap.erase("second");
+        GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+        EXPECT_THROW(builder.parseConfigFromRequest(request), std::invalid_argument) << choice;
+    }
+}
+
+TEST(Gemma4GenerationContractTest, GeneratedToolGrammarsNeverUseEmptyConstString) {
+    for (const std::string choice : {"auto", "required", "second"}) {
+        auto request = requestWithTools(choice);
+        GenerationConfigBuilder builder({}, "gemma4", false, STANDARD);
+        builder.parseConfigFromRequest(request);
+        ASSERT_TRUE(builder.getConfig().structured_output_config.has_value());
+        EXPECT_EQ(grammarString(builder.getConfig()).find("ConstString(\"\")"), std::string::npos) << choice;
+    }
 }

--- a/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
@@ -722,8 +722,8 @@ TEST_F(Gemma4OutputParserTest, ParseToolCallWithArgumentMissingEquals) {
     auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
     std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
     ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
-    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
-    EXPECT_EQ(parsedOutput.toolCalls[0].name, "broken");
+    // Fail-closed: a native body without `key:value` pairs is not an executable call.
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 0);
 }
 
 TEST_F(Gemma4OutputParserTest, ParseToolCallWithStringArgumentsContainingComparison) {
@@ -768,7 +768,7 @@ TEST_F(Gemma4OutputParserTest, ParseToolCallWithStringArgumentsContainingEscaped
     EXPECT_EQ(parsedOutput.content, "");
     ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
     EXPECT_EQ(parsedOutput.toolCalls[0].name, "execute");
-    EXPECT_EQ(parsedOutput.toolCalls[0].arguments, R"x({"code":"print(\"hello world\")","verbose":true})x");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments, R"x({"code":"print(\\\"hello world\\\")","verbose":true})x");
 }
 
 TEST_F(Gemma4OutputParserTest, ParseToolCallWithStringArgumentsContainingApostrophes) {

--- a/src/test/llm/output_parsers/gemma4_v2_contract_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_v2_contract_test.cpp
@@ -104,6 +104,47 @@ TEST_F(Gemma4V2ContractTest, AcceptsDirectCallImmediatelyAfterReasoningEnd) {
     EXPECT_EQ(parsed.toolCalls[0].arguments, expectedQuestionJson);
 }
 
+TEST_F(Gemma4V2ContractTest, RecoversObservedBareCallAfterOrdinaryTextBoundary) {
+    const std::string input = "I need the user to choose.\ncall:question{" + nativeQuestionArgs + "}<tool_call|>";
+    auto parsed = parse(input);
+    EXPECT_EQ(parsed.content, "I need the user to choose.\n");
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].name, "question");
+    EXPECT_EQ(parsed.toolCalls[0].arguments, expectedQuestionJson);
+}
+
+TEST_F(Gemma4V2ContractTest, RecoversWhitespacePrefixedBareKnownCallWithoutEndMarker) {
+    const std::string input = "prefix\n  call:question{" + nativeQuestionArgs + "}";
+    auto parsed = parse(input);
+    EXPECT_EQ(parsed.content, "prefix\n  ");
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].name, "question");
+    EXPECT_EQ(parsed.toolCalls[0].arguments, expectedQuestionJson);
+}
+
+TEST_F(Gemma4V2ContractTest, DoesNotPromoteBareUnknownTool) {
+    auto parsed = parse("prefix\ncall:not_in_request{x:1}");
+    EXPECT_TRUE(parsed.toolCalls.empty());
+    EXPECT_NE(parsed.content.find("call:not_in_request"), std::string::npos);
+}
+
+TEST_F(Gemma4V2ContractTest, DoesNotPromoteQuotedBareCallExample) {
+    auto parsed = parse("Example: \"call:question{questions:[]}\"");
+    EXPECT_TRUE(parsed.toolCalls.empty());
+    EXPECT_NE(parsed.content.find("call:question"), std::string::npos);
+}
+
+TEST_F(Gemma4V2ContractTest, DoesNotPromoteBareCallEmbeddedInWord) {
+    auto parsed = parse("recall:question{questions:[]}");
+    EXPECT_TRUE(parsed.toolCalls.empty());
+    EXPECT_EQ(parsed.content, "recall:question{questions:[]}");
+}
+
+TEST_F(Gemma4V2ContractTest, DoesNotPromoteMalformedBareCall) {
+    auto parsed = parse("prefix\ncall:question{questions:[1,2}");
+    EXPECT_TRUE(parsed.toolCalls.empty());
+}
+
 TEST_F(Gemma4V2ContractTest, DoesNotEmitUnknownToolAsExecutableCall) {
     auto parsed = parse(R"(<|tool_call>call:not_in_request{x:1}<tool_call|>)");
     EXPECT_TRUE(parsed.toolCalls.empty());

--- a/src/test/llm/output_parsers/gemma4_v2_contract_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_v2_contract_test.cpp
@@ -1,0 +1,119 @@
+//*****************************************************************************
+// Copyright 2026 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//*****************************************************************************
+
+#include <gtest/gtest.h>
+#include <openvino/genai/tokenizer.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "../../../llm/io_processing/output_parser.hpp"
+#include "output_parser_test_utils.hpp"
+#include "../../platform_utils.hpp"
+
+using namespace ovms;
+
+namespace {
+#ifdef _WIN32
+const std::string tokenizerPath = getWindowsRepoRootPath() + "\\src\\test\\llm_testing\\OpenVINO\\gemma-4-E4B-it-int4-ov";
+#else
+const std::string tokenizerPath = "/ovms/src/test/llm_testing/OpenVINO/gemma-4-E4B-it-int4-ov";
+#endif
+
+const std::string questionSchema = R"({"type":"object","properties":{"questions":{"type":"array","items":{"type":"object","properties":{"question":{"type":"string"},"header":{"type":"string"},"options":{"type":"array","items":{"type":"object","properties":{"label":{"type":"string"},"description":{"type":"string"}}}},"multiple":{"type":"boolean"},"custom":{"type":"boolean"}}}}}})";
+
+class Gemma4V2ContractTest : public ::testing::Test {
+protected:
+    static std::unique_ptr<ov::genai::Tokenizer> tokenizer;
+
+    static void SetUpTestSuite() {
+        tokenizer = std::make_unique<ov::genai::Tokenizer>(tokenizerPath);
+    }
+
+    static void TearDownTestSuite() {
+        tokenizer.reset();
+    }
+
+    static ToolsSchemas_t questionTools() {
+        ToolsSchemas_t tools;
+        tools.emplace("question", ToolSchemaWrapper{nullptr, questionSchema});
+        return tools;
+    }
+
+    ParsedOutput parse(const std::string& input, const ToolsSchemas_t& tools = questionTools()) {
+        OutputParser parser(*tokenizer, "gemma4", "gemma4", tools);
+        auto tensor = tokenizer->encode(input).input_ids;
+        std::vector<int64_t> tokens(tensor.data<int64_t>(), tensor.data<int64_t>() + tensor.get_size());
+        return ovms::test::parseWithStreamer(*tokenizer, parser, tokens, true, true);
+    }
+};
+
+std::unique_ptr<ov::genai::Tokenizer> Gemma4V2ContractTest::tokenizer;
+
+const std::string nativeQuestionArgs =
+    R"(questions:[{question:<|"|>Pick one?<|"|>,header:<|"|>Test<|"|>,options:[{label:<|"|>A<|"|>,description:<|"|>Alpha<|"|>},{label:<|"|>B<|"|>,description:<|"|>Beta<|"|>}],multiple:false,custom:true}])";
+
+const std::string expectedQuestionJson =
+    R"({"questions":[{"question":"Pick one?","header":"Test","options":[{"label":"A","description":"Alpha"},{"label":"B","description":"Beta"}],"multiple":false,"custom":true}]})";
+}  // namespace
+
+TEST_F(Gemma4V2ContractTest, ParsesOpenCodeQuestionArrayOfObjectsRecursively) {
+    auto parsed = parse("<|tool_call>call:question{" + nativeQuestionArgs + "}<tool_call|>");
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].name, "question");
+    EXPECT_EQ(parsed.toolCalls[0].arguments, expectedQuestionJson);
+}
+
+TEST_F(Gemma4V2ContractTest, PreservesNestedScalarTypes) {
+    const std::string input =
+        R"(<|tool_call>call:question{questions:[{question:<|"|>q<|"|>,header:<|"|>h<|"|>,options:[],multiple:false,custom:true}],meta:{count:2,score:22.8,missing:null,flags:[true,false,null,3]}}<tool_call|>)";
+    auto parsed = parse(input);
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].arguments,
+        R"({"questions":[{"question":"q","header":"h","options":[],"multiple":false,"custom":true}],"meta":{"count":2,"score":22.8,"missing":null,"flags":[true,false,null,3]}})");
+}
+
+TEST_F(Gemma4V2ContractTest, AcceptsParenthesizedArgumentsWhenAnchoredByToolMarker) {
+    auto parsed = parse("<|tool_call>call:question(" + nativeQuestionArgs + ")<tool_call|>");
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].name, "question");
+    EXPECT_EQ(parsed.toolCalls[0].arguments, expectedQuestionJson);
+}
+
+TEST_F(Gemma4V2ContractTest, AcceptsColonNameVariantWhenAnchoredByToolMarker) {
+    auto parsed = parse("<|tool_call>:question{" + nativeQuestionArgs + "}<tool_call|>");
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].name, "question");
+    EXPECT_EQ(parsed.toolCalls[0].arguments, expectedQuestionJson);
+}
+
+TEST_F(Gemma4V2ContractTest, AcceptsDirectCallImmediatelyAfterReasoningEnd) {
+    const std::string input = "<|channel>thought\nNeed user input<channel|>call:question{" + nativeQuestionArgs + "}<tool_call|>";
+    auto parsed = parse(input);
+    EXPECT_EQ(parsed.reasoning, "Need user input");
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].name, "question");
+    EXPECT_EQ(parsed.toolCalls[0].arguments, expectedQuestionJson);
+}
+
+TEST_F(Gemma4V2ContractTest, DoesNotEmitUnknownToolAsExecutableCall) {
+    auto parsed = parse(R"(<|tool_call>call:not_in_request{x:1}<tool_call|>)");
+    EXPECT_TRUE(parsed.toolCalls.empty());
+}
+
+TEST_F(Gemma4V2ContractTest, MalformedCallIsBoundedAndLaterValidCallSurvives) {
+    const std::string input =
+        R"(<|tool_call>call:question{questions:[{question:<|"|>broken<|"|>}<tool_call|><|tool_call>call:question{questions:[]}<tool_call|>)";
+    auto parsed = parse(input);
+    ASSERT_EQ(parsed.toolCalls.size(), 1u);
+    EXPECT_EQ(parsed.toolCalls[0].name, "question");
+    EXPECT_EQ(parsed.toolCalls[0].arguments, R"({"questions":[]})");
+}


### PR DESCRIPTION
### 🛠 Summary

JIRA/Issue if applicable.
Describe the changes.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``## Summary

This PR hardens native Gemma4 tool calling in OVMS across three layers that must work together:

1. **tool output parsing**
2. **tool generation constraints**
3. **chat-template compatibility for multi-turn tool conversations**

The work was driven by live Gemma4 failures observed with OpenAI-compatible agent clients and then cross-checked against the native Gemma4 protocol, existing OVMS/OpenVINO structured-generation primitives, vLLM parsing behavior, and llama.cpp lazy tool activation semantics.

The implementation remains native to OVMS/OpenVINO.

No vLLM or llama.cpp parser/generator implementation code is transplanted into OVMS.

---

## Motivation

The existing Gemma4 path could fail in several distinct ways that looked similar from an agent client's perspective:

* the model emitted a valid native Gemma4 tool call that the parser failed to reconstruct;
* streaming boundaries split native syntax in ways the parser did not preserve correctly;
* nested Gemma4 arguments were flattened or incompletely normalized;
* large numeric tool arguments could lose lexical precision;
* `tool_choice=required` or a named tool could silently lose its generation constraint after structured-output validation failure;
* `tool_choice=auto` was either effectively unguided or risked becoming equivalent to `required`;
* multi-turn tool history could become incompatible with the canonical Gemma4 Jinja template;
* malformed or stray `call:` text could be over-promoted into executable tool calls.

These are separate Parser, Generator, and input-template problems. Fixing only the parser is insufficient if generation never emits the tool structure in the first place, and fixing only generation is insufficient if the emitted structure cannot be recovered safely.

A parser cannot recover a tool call that the Generator never caused the model to emit.

---

## 1. Gemma4 parser hardening

The Gemma4 tool parser now understands the native protocol recursively rather than treating tool arguments as a mostly flat serialization problem.

The parser handles:

* native `<|tool_call>call:name...<tool_call|>` boundaries;
* Gemma4's native string delimiter `<|"|>`;
* nested objects;
* nested arrays;
* JSON strings;
* booleans;
* `null`;
* numeric values;
* parenthesized and braced argument containers;
* streaming prefixes and incomplete chunks.

### Lossless numeric handling

Tool arguments are API payload text, not values that OVMS needs to perform arithmetic on.

Large integers and precise decimals therefore should not be unnecessarily routed through `uint64_t` or `double` during normalization.

The parser preserves numeric lexical representation while converting native Gemma4 argument syntax into JSON.

This avoids avoidable precision loss in values such as identifiers, counters, hashes represented numerically, or high-precision decimal fields.

### Bounded malformed-call handling

Malformed tool syntax is kept bounded to the current candidate instead of poisoning the remainder of the stream.

A later valid tool call can still be recovered after a malformed one.

### Request tool registry validation

When request tool schemas are available, executable tool calls are checked against the request's actual tool registry.

Unknown tools are not promoted into executable calls.

This is particularly important for recovery paths.

### Guarded bare `call:` recovery

Live Gemma4 traces showed a narrow variant where the model may close a reasoning channel and continue directly with:

```text
call:tool_name{...}
```

without repeating `<|tool_call>`.

The parser can recover this observed shape, but only under bounded conditions:

* `call:` must begin at a logical line/phase boundary;
* optional indentation is allowed;
* the tool name must be syntactically sane;
* when a request registry is available, the tool must exist in that registry;
* the arguments still pass the normal structural parser.

Arbitrary prose such as:

```text
Documentation example: call:foo{...}
```

is deliberately not treated as an executable call.

This recovery is intentionally narrow rather than a general search for `call:` substrings.

---

## 2. Parser provenance: vLLM as an independent behavioral reference

While hardening the parser, the Gemma4 implementation in vLLM was used as an independent protocol reference.

The useful comparison points were:

* native Gemma4 tool-call framing;
* the `<|"|>` string delimiter;
* recursive object/array argument structure;
* distinction between structural delimiters and delimiters occurring inside strings;
* interaction between reasoning and tool-call channels.

This is **not a source-code port of the vLLM parser**.

The useful part carried into OVMS is the protocol-aware parsing model and its edge cases, implemented inside OVMS's existing parser interfaces and streaming response machinery.

---

## 3. Explicit Gemma4 Generator policy

This PR also adds an explicit Gemma4 tool-constraint policy to generation.

The implementation separates tool behavior into:

```text
Disabled
Auto
Hard
```

### Disabled

Used when:

* there are no tools; or
* `tool_choice=none`.

No tool grammar is imposed.

### Hard

Used for:

* `tool_choice=required`;
* named tool choices.

Hard choices are represented using native OpenVINO GenAI structural tags.

They:

* require at least one tool call;
* restrict named choices to the requested tool;
* respect `parallel_tool_calls`;
* remain fail-closed if grammar validation fails.

A hard OpenAI API contract must not silently turn into unconstrained generation because structured-output validation failed.

### Optional reasoning before a hard tool call

Gemma4 may emit a reasoning channel before selecting a required or named tool.

The hard grammar therefore accepts either:

```text
tool call(s)
```

or:

```text
thought channel
followed by
tool call(s)
```

The optional path is represented as a `Union`, rather than using an empty `ConstString`.

This matters because xgrammar rejects empty `ConstString` nodes.

---

## 4. Lazy `tool_choice=auto`

`auto` must not mean `required`.

The model must remain able to answer with normal text when no tool is necessary, while any tool call it does initiate must conform to the available tool registry and JSON schema.

Gemma4 `auto` therefore uses OpenVINO GenAI `TriggeredTags`:

```text
normal generation
        |
        | model emits <|tool_call>
        v
structured tool grammar activates
```

The trigger is the native Gemma4 tool marker:

```text
<|tool_call>
```

Once triggered, the generated call is constrained to the request's available tool names and schemas.

Before the trigger, normal assistant text remains legal.

### llama.cpp provenance

llama.cpp was used as an independent behavioral reference for this lazy/optional activation model.

Only the **semantics** were ported.

OVMS does not use llama.cpp's PEG grammar, sampler, or parser implementation.

The implementation here uses the existing native OpenVINO GenAI structured-output abstraction.

A concise description is:

> behavioral port, native OVMS implementation.

---

## 5. Why `TriggeredTags` fits OVMS architecture

This PR does not introduce an external generation architecture into OVMS.

The layering is:

```text
Gemma4-specific tool policy
        |
        v
OVMS GenerationConfigBuilder
        |
        v
OpenVINO GenAI StructuredOutputConfig / TriggeredTags
        |
        v
xgrammar structural-tag enforcement
```

`TriggeredTags` already exists in OpenVINO GenAI and is already used by OVMS for other model-specific generation behavior.

This patch applies that existing abstraction to Gemma4's native protocol.

---

## 6. `parallel_tool_calls`

Both lazy and hard modes respect the OpenAI `parallel_tool_calls` request field.

When parallel tool calls are disabled:

```text
stop_after_first = true
```

When they are enabled, subsequent compatible tool calls remain legal.

This behavior is covered for:

* `auto`;
* `required`;
* named tool choices.

---

## 7. Tool schema and name validation

The Generator rejects active Gemma4 tool configurations that cannot be represented safely.

Examples include:

* hard choices with no tool schemas;
* named choices referring to unavailable tools;
* empty tool schemas;
* unsupported tool-name characters;
* conflicting `response_format` and active tool generation constraints.

The same tool-name shape accepted by the Generator is compatible with what the parser can safely recognize and execute.

---

## 8. Google Gemma4 chat-template compatibility

The work was also tested against the canonical Google Gemma4 tool protocol and chat-template behavior.

A multi-turn incompatibility was found in OVMS input adaptation.

OVMS may parse JSON text from a `role: "tool"` message into an object before rendering the chat template.

That is not universally safe.

The canonical Gemma4 template includes a path that iterates message content parts and calls:

```jinja
part.get('type')
```

If a JSON object has already replaced the original content string, Jinja iterates the object's keys, producing strings rather than part objects.

The resulting failure is equivalent to:

```text
'str object' has no attribute 'get'
```

### Capability-driven fix

The chat-template analyzer now distinguishes between templates where converting tool-response JSON into an object is safe and templates where a parts scan makes that transformation unsafe.

A capability controls the history adaptation.

JSON tool-response content is converted to an object only where the detected template semantics support it.

This preserves the existing upstream tool-definition adaptation behavior as well.

---

## 9. Template adaptation is conservative

The tool-response conversion itself is intentionally narrow.

Only:

* messages with `role == "tool"`;
* whose `content` is a string;
* whose string parses as a JSON **object**

are eligible.

Arrays, scalars, invalid JSON, user messages, and assistant messages retain their original string semantics.

This avoids changing general OpenAI message behavior merely because content happens to look like JSON.

---

## 10. Regression coverage

The PR adds contract tests covering the failure modes that motivated the work.

### Generation contracts

Coverage includes:

* no-tools and `tool_choice=none`;
* `response_format` preservation when tools are inactive;
* Gemma4-specific validation fallback policy;
* mandatory tool selection after optional reasoning;
* hard choices remaining fail-closed;
* lazy `auto` using `TriggeredTags`;
* `auto` remaining optional;
* named tool restriction;
* `parallel_tool_calls`;
* validation of lazy grammar using a Gemma4 tokenizer;
* nested schema preservation;
* invalid tool names;
* empty schemas;
* invalid hard choices;
* avoidance of empty `ConstString`.

### Parser contracts

Coverage includes:

* recursive arrays of objects;
* nested scalar types;
* native strings;
* parenthesized arguments;
* colon/name variants;
* direct calls after reasoning;
* guarded bare-call recovery;
* rejection of unknown tools;
* rejection of embedded or quoted `call:` examples;
* malformed-call bounding;
* recovery of a later valid tool call.

### Chat-template contracts

Coverage includes:

* Gemma4 template detection;
* disabling tool-response JSON conversion when the template performs a `part.get(...)` scan;
* retaining conversion for mapping-safe templates;
* preserving opaque values such as commit SHAs during JSON conversion;
* leaving arrays and non-JSON strings unchanged;
* leaving non-tool messages untouched;
* preserving the existing upstream tool-definition `response` adaptation.

---

## 11. Real-world validation background

This patch grew out of live Gemma4 deployment work using OVMS on Windows with Intel Arc hardware and OpenAI-compatible agent clients.

The local integration environment also includes:

* explicit `tool_parser: gemma4`;
* explicit `reasoning_parser: gemma4`;
* guided generation enabled;
* long-context profiles;
* correctness-gated performance tuning;
* Google-template provenance tracking;
* multi-turn agent/tool-loop tests.

An earlier exact-source runtime baseline in that environment produced:

```text
100 / 100 tool-call executions
```

through the OVMS REST path.

That result is useful supporting evidence for the architecture, but it is **not claimed as exact-head validation of this PR**, because additional parser, lazy-generator, and template-compatibility changes were made afterward.

The authoritative validation for this PR head should be the upstream CI results and any exact-head runtime testing performed during review.

---

## 12. External implementation references and code provenance

The implementation was informed by several independent sources, each for a different purpose:

### Google Gemma4

Authority for:

* native tool-call syntax;
* tool-response syntax;
* reasoning/tool channel behavior;
* chat serialization semantics.

### vLLM

Independent behavioral reference for:

* protocol-aware Gemma4 parsing;
* recursive native argument handling;
* reasoning/tool parsing boundaries.

No vLLM parser code is copied into this patch.

### llama.cpp

Independent behavioral reference for:

* optional/lazy tool activation under `auto`.

No llama.cpp grammar, sampler, or parser code is copied into this patch.

### OpenVINO GenAI / OVMS

Native implementation mechanism:

* `StructuredOutputConfig`;
* `TriggeredTags`;
* structural tag grammar;
* xgrammar-backed validation and enforcement.

---

## 13. What this PR intentionally does not include

The development fork contains additional deployment and diagnostics work used to validate Gemma4 on Windows and Intel Arc hardware.

That includes launch profiles, acceptance harnesses, long-context experiments, and local chat-template deployment helpers.

Those are intentionally not included in this upstream core PR.

This PR is limited to the reusable OVMS runtime changes:

* Gemma4 parser correctness;
* Gemma4 generation policy;
* lazy `auto` constraints;
* hard tool-choice enforcement;
* multi-turn chat-template compatibility;
* focused regression tests.

---

## Current PR coordinates

Upstream base:

```text
openvinotoolkit/model_server
main
b935fe8b96a0445f3746297f872b55ed202fa6e5
```

Proposed head:

```text
DassaultFalconKing/model_server
fix/gemma4-native-tool-calling-upstream-v2
b45d2aa41046089d98861266eb07f276df752035
```

The branch is based directly on the upstream commit above and contains only the Gemma4 runtime and contract-test scope described in this PR.


