### PR TITLE
Array parsing fix for gemma4 output parser 

### DIFF
--- a/src/llm/BUILD
+++ b/src/llm/BUILD
@@ -263,6 +263,7 @@ ovms_cc_library(
     srcs = ["io_processing/utils.cpp"],
     deps = [
         "@com_github_tencent_rapidjson//:rapidjson",
+        "//src:libovmsstring_utils",
         "//src/port:rapidjson_stringbuffer",
         "//src/port:rapidjson_writer",
         "//src/port:rapidjson_document",

--- a/src/llm/io_processing/gemma4/gemma4_reasoning_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_reasoning_parser.cpp
@@ -35,7 +35,7 @@ std::optional<Delta> Gemma4ReasoningParser::parseChunk(const std::string& chunk,
     }
 
     if (chunk.find(parsingConfig.startTags[0]) != std::string::npos || chunk.find(parsingConfig.endTag) != std::string::npos ||
-     chunk.find(parsingConfig.preambleStartTags[0]) != std::string::npos) {
+        chunk.find(parsingConfig.preambleStartTags[0]) != std::string::npos) {
         return std::nullopt;
     } else {
         return ReasoningDelta{chunk};

--- a/src/llm/io_processing/gemma4/gemma4_reasoning_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_reasoning_parser.cpp
@@ -34,7 +34,8 @@ std::optional<Delta> Gemma4ReasoningParser::parseChunk(const std::string& chunk,
         return std::nullopt;
     }
 
-    if (chunk.find(parsingConfig.startTags[0]) != std::string::npos || chunk.find(parsingConfig.endTag) != std::string::npos) {
+    if (chunk.find(parsingConfig.startTags[0]) != std::string::npos || chunk.find(parsingConfig.endTag) != std::string::npos ||
+     chunk.find(parsingConfig.preambleStartTags[0]) != std::string::npos) {
         return std::nullopt;
     } else {
         return ReasoningDelta{chunk};

--- a/src/llm/io_processing/gemma4/gemma4_reasoning_parser.hpp
+++ b/src/llm/io_processing/gemma4/gemma4_reasoning_parser.hpp
@@ -42,6 +42,7 @@ public:
                 return configOverride;
             OutputParsingConfig cfg;
             cfg.startTags = {"<|channel>thought\n"};
+            cfg.preambleStartTags = {"thought\n"};
             cfg.tokenIdStartTags = {"<|channel>"};
             cfg.endTag = "<channel|>";
             cfg.needsSpecialTokens = true;

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
@@ -51,7 +51,7 @@ std::string Gemma4ToolParser::parseArrayParameter(const std::string& argumentStr
 
     std::string parsedArray = "[";
     bool firstElement = true;
-    for (const std::string& element : splitTopLevel(body, maskStringValues(body), TOOL_ARGS_SEPARATOR_STR)) {
+    for (const std::string& element : splitRespectingSpecialChars(body, TOOL_ARGS_SEPARATOR_STR, maskDelimitedStringValues(body, TOOL_ARGS_STRING_INDICATOR))) {
         if (!firstElement) {
             parsedArray += ",";
         }
@@ -71,8 +71,8 @@ std::string Gemma4ToolParser::parseObjectParameter(const std::string& argumentSt
 
     std::string parsedObject = "{";
     bool firstMember = true;
-    for (const std::string& member : splitTopLevel(body, maskStringValues(body), TOOL_ARGS_SEPARATOR_STR)) {
-        const std::string maskedMember = maskStringValues(member);
+    for (const std::string& member : splitRespectingSpecialChars(body, TOOL_ARGS_SEPARATOR_STR, maskDelimitedStringValues(body, TOOL_ARGS_STRING_INDICATOR))) {
+        const std::string maskedMember = maskDelimitedStringValues(member, TOOL_ARGS_STRING_INDICATOR);
         size_t keyEndPos = findInStringRespectingSpecialChars(maskedMember, ":", 0);
         if (keyEndPos == std::string::npos) {
             SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Object member does not contain a key separator, leaving argument unchanged. Member: {}", member);
@@ -129,12 +129,7 @@ std::string Gemma4ToolParser::normalizeArgStr(const std::string& arg) {
     size_t errorOffset = tempDoc.GetErrorOffset();
     SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Failed to parse argument string as JSON, falling back to string value. Argument string: {}, Error: {} Offset: {}", normalized, errorMessage, errorOffset);
 
-    std::string fallback = arg;
-    trim(fallback);
-    if (fallback.size() >= 2 && fallback.front() == '\"' && fallback.back() == '\"') {
-        fallback = fallback.substr(1, fallback.size() - 2);
-    }
-    return escapeAsJsonString(fallback);
+    return escapeAsJsonString(arg);
 }
 
 void Gemma4ToolParser::writeArgumentToWriter(const std::string& arg, rapidjson::Writer<rapidjson::StringBuffer>& writer) {
@@ -161,48 +156,16 @@ std::pair<std::string, std::string> Gemma4ToolParser::parseSingleArgument(const 
         argument.second = "";
         SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument string: {} does not contain ':', setting name as entire string and value as empty", argumentStr);
     }
+    trim(argument.first);
+    
     return argument;
-}
-
-std::string Gemma4ToolParser::maskStringValues(const std::string& text) {
-    std::string masked = text;
-    size_t pos = 0;
-    while (true) {
-        const size_t openPos = text.find(TOOL_ARGS_STRING_INDICATOR, pos);
-        if (openPos == std::string::npos)
-            break;
-        const size_t valueStart = openPos + TOOL_ARGS_STRING_INDICATOR.size();
-        const size_t closePos = text.find(TOOL_ARGS_STRING_INDICATOR, valueStart);
-        // Value not closed yet (still streaming): mask through the current buffer end too,
-        // otherwise its already-received tail would desync quote/brace tracking; a later
-        // call re-masks from scratch once the closing delimiter has arrived.
-        const size_t maskEnd = (closePos == std::string::npos) ? text.size() : closePos;
-        for (size_t i = valueStart; i < maskEnd; i++) {
-            switch (masked[i]) {
-            case '"':
-            case '\'':
-            case '{':
-            case '}':
-            case '[':
-            case ']':
-                masked[i] = '\x01';
-                break;
-            default:
-                break;
-            }
-        }
-        if (closePos == std::string::npos)
-            break;
-        pos = closePos + TOOL_ARGS_STRING_INDICATOR.size();
-    }
-    return masked;
 }
 
 std::vector<std::pair<std::string, std::string>> Gemma4ToolParser::parseArguments(const std::string& argumentsStr) {
     std::vector<std::string> args;
     std::vector<std::pair<std::string, std::string>> parsedArgs;
 
-    const std::string maskedArgumentsStr = maskStringValues(argumentsStr);
+    const std::string maskedArgumentsStr = maskDelimitedStringValues(argumentsStr, TOOL_ARGS_STRING_INDICATOR);
     size_t argPos = 0;
     while (argPos < argumentsStr.length()) {
         size_t commaPos = findInStringRespectingSpecialChars(maskedArgumentsStr, TOOL_ARGS_SEPARATOR_STR, argPos);
@@ -267,7 +230,7 @@ bool Gemma4ToolParser::parseToolCallParametersState() {
     if (this->streamingContent.back() == TOOL_ARGS_END_INDICATOR.back()) {
         SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool arguments end indicator found at the end of streaming content, attempting to parse arguments: {}", this->streamingContent.substr(this->streamingPosition));
     }
-    const std::string maskedStreamingContent = maskStringValues(this->streamingContent);
+    const std::string maskedStreamingContent = maskDelimitedStringValues(this->streamingContent, TOOL_ARGS_STRING_INDICATOR);
     size_t pos = findInStringRespectingSpecialChars(maskedStreamingContent, TOOL_ARGS_END_INDICATOR, this->streamingPosition);
     if (pos == std::string::npos) {
         SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Tool arguments end indicator not found in streaming content starting from position: {}", this->streamingPosition);

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
@@ -157,7 +157,7 @@ std::pair<std::string, std::string> Gemma4ToolParser::parseSingleArgument(const 
         SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument string: {} does not contain ':', setting name as entire string and value as empty", argumentStr);
     }
     trim(argument.first);
-    
+
     return argument;
 }
 

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.cpp
@@ -43,144 +43,98 @@ const int64_t Gemma4ToolParser::reasoningTokenId = 100;     // <|channel>
 const int64_t Gemma4ToolParser::reasoningEndTokenId = 101;  // <channel|>
 
 std::string Gemma4ToolParser::parseArrayParameter(const std::string& argumentStr) {
-    size_t pos = 1;
-    std::string parsedArguments = "[";
-
-    while (pos != std::string::npos) {
-        size_t stringStartPos = argumentStr.find(TOOL_ARGS_STRING_INDICATOR, pos);
-        if (stringStartPos == std::string::npos) {
-            break;
-        }
-        stringStartPos += TOOL_ARGS_STRING_INDICATOR.size();
-        size_t stringEndPos = argumentStr.find(TOOL_ARGS_STRING_INDICATOR, stringStartPos);
-        if (stringEndPos == std::string::npos) {
-            break;
-        }
-
-        std::string originalStr = argumentStr.substr(stringStartPos, stringEndPos - stringStartPos);
-        size_t quotePos = 0;
-        while ((quotePos = originalStr.find('\"', quotePos)) != std::string::npos) {
-            originalStr.insert(quotePos, "\\");
-            quotePos += 2;
-        }
-        parsedArguments += "\"" + originalStr + "\",";
-
-        pos = stringEndPos + TOOL_ARGS_STRING_INDICATOR.size() + 1;
+    std::string body = argumentStr.substr(1, argumentStr.size() - 2);
+    trim(body);
+    if (body.empty()) {
+        return "[]";
     }
 
-    parsedArguments.back() = ']';
-
-    return parsedArguments;
+    std::string parsedArray = "[";
+    bool firstElement = true;
+    for (const std::string& element : splitTopLevel(body, maskStringValues(body), TOOL_ARGS_SEPARATOR_STR)) {
+        if (!firstElement) {
+            parsedArray += ",";
+        }
+        parsedArray += normalizeArgStr(element);
+        firstElement = false;
+    }
+    parsedArray += "]";
+    return parsedArray;
 }
 
 std::string Gemma4ToolParser::parseObjectParameter(const std::string& argumentStr) {
-    size_t pos = 1;
-    std::vector<std::pair<std::string, std::string>> keyValuePairs;
-
-    while (pos != std::string::npos) {
-        std::string key, value;
-        bool isStringValue = false;
-        size_t keyEndPos = argumentStr.find(':', pos);
-        if (keyEndPos == std::string::npos) {
-            break;
-        }
-        key = argumentStr.substr(pos, keyEndPos - pos);
-        size_t valueStartPos = keyEndPos + 1;
-        size_t valueEndPos = std::string::npos;
-        if (argumentStr.substr(valueStartPos, TOOL_ARGS_STRING_INDICATOR.size()) == TOOL_ARGS_STRING_INDICATOR) {
-            valueStartPos = valueStartPos + TOOL_ARGS_STRING_INDICATOR.size();
-            valueEndPos = argumentStr.find(TOOL_ARGS_STRING_INDICATOR, valueStartPos);
-            isStringValue = true;
-        } else {
-            valueEndPos = argumentStr.find(',', valueStartPos);
-        }
-
-        if (valueEndPos == std::string::npos) {
-            valueEndPos = argumentStr.size() - 1;
-        }
-        value = argumentStr.substr(valueStartPos, valueEndPos - valueStartPos);
-        if (isStringValue) {
-            value = "\"" + value + "\"";
-        }
-        keyValuePairs.emplace_back(key, value);
-        if (valueEndPos == argumentStr.size() - 1) {
-            break;
-        } else if (isStringValue) {
-            pos = valueEndPos + TOOL_ARGS_STRING_INDICATOR.size() + 1;
-        } else {
-            pos = valueEndPos + 1;
-        }
-    }
-
-    if (keyValuePairs.empty()) {
-        return argumentStr;
+    std::string body = argumentStr.substr(1, argumentStr.size() - 2);
+    trim(body);
+    if (body.empty()) {
+        return "{}";
     }
 
     std::string parsedObject = "{";
-    for (const auto& [key, value] : keyValuePairs) {
-        parsedObject += "\"" + key + "\":" + value + ",";
+    bool firstMember = true;
+    for (const std::string& member : splitTopLevel(body, maskStringValues(body), TOOL_ARGS_SEPARATOR_STR)) {
+        const std::string maskedMember = maskStringValues(member);
+        size_t keyEndPos = findInStringRespectingSpecialChars(maskedMember, ":", 0);
+        if (keyEndPos == std::string::npos) {
+            SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Object member does not contain a key separator, leaving argument unchanged. Member: {}", member);
+            return argumentStr;
+        }
+        std::string key = member.substr(0, keyEndPos);
+        trim(key);
+        if (isWrappedByDelimiter(key, TOOL_ARGS_STRING_INDICATOR)) {
+            key = key.substr(TOOL_ARGS_STRING_INDICATOR.size(), key.size() - 2 * TOOL_ARGS_STRING_INDICATOR.size());
+        }
+        if (!firstMember) {
+            parsedObject += ",";
+        }
+        parsedObject += escapeAsJsonString(key) + ":" + normalizeArgStr(member.substr(keyEndPos + 1));
+        firstMember = false;
     }
-    parsedObject.back() = '}';
+    parsedObject += "}";
     return parsedObject;
 }
 
 std::string Gemma4ToolParser::normalizeArgStr(const std::string& arg) {
-    if (arg.empty()) {
-        return arg;
-    }
-
     std::string normalized = arg;
     trim(normalized);
+    if (normalized.empty()) {
+        return "\"\"";
+    }
+
     std::string lower = normalized;
     std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-
     if (lower == "true" || lower == "false" || lower == "null") {
         return lower;
     }
 
-    const char first = normalized.front();
-    const char last = normalized.back();
-    if (first == '{' && last == '}') {
+    // Build valid JSON out of the Gemma4 specific syntax before handing it over to rapidjson.
+    if (isWrappedByDelimiter(normalized, TOOL_ARGS_STRING_INDICATOR)) {
+        normalized = escapeAsJsonString(normalized.substr(TOOL_ARGS_STRING_INDICATOR.size(), normalized.size() - 2 * TOOL_ARGS_STRING_INDICATOR.size()));
+        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument is a string, converted it to correct JSON format. Modified string: {}", normalized);
+    } else if (normalized.front() == '{' && normalized.back() == '}') {
         normalized = parseObjectParameter(normalized);
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument contains is an object, changed it to correct JSON format. Modified string: {}", normalized);
-    }
-
-    if (first == '[' && last == ']' && normalized.find(TOOL_ARGS_STRING_INDICATOR) != std::string::npos) {
+        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument is an object, converted it to correct JSON format. Modified string: {}", normalized);
+    } else if (normalized.front() == '[' && normalized.back() == ']') {
         normalized = parseArrayParameter(normalized);
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument is an array, normalized quotes for JSON parsing. Modified string: {}", normalized);
-    }
-
-    if (normalized.substr(0, TOOL_ARGS_STRING_INDICATOR.size()) == TOOL_ARGS_STRING_INDICATOR &&
-        normalized.substr(normalized.size() - TOOL_ARGS_STRING_INDICATOR.size(), TOOL_ARGS_STRING_INDICATOR.size()) == TOOL_ARGS_STRING_INDICATOR) {
-        normalized = "\"" + normalized.substr(TOOL_ARGS_STRING_INDICATOR.size(), normalized.size() - 2 * TOOL_ARGS_STRING_INDICATOR.size()) + "\"";
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument is enclosed in string indicators, removed them for JSON parsing. Modified string: {}", normalized);
+        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Argument is an array, converted it to correct JSON format. Modified string: {}", normalized);
     }
 
     rapidjson::Document tempDoc;
-    rapidjson::Value finalValue;
     tempDoc.Parse(normalized.c_str());
-    if (tempDoc.HasParseError()) {
-        auto errorCode = tempDoc.GetParseError();
-        auto errorMessage = rapidjson::GetParseError_En(errorCode);
-        size_t errorOffset = tempDoc.GetErrorOffset();
-        SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Failed to parse argument string as JSON. Argument string: {}, Error: {} Offset: {}", normalized, errorMessage, errorOffset);
-
-        if (normalized.front() == '\"' && normalized.back() == '\"') {
-            normalized = normalized.substr(1, normalized.size() - 2);
-        }
-        finalValue.SetString(normalized.c_str(), static_cast<rapidjson::SizeType>(normalized.size()), tempDoc.GetAllocator());
-    } else {
-        finalValue.CopyFrom(tempDoc, tempDoc.GetAllocator());
+    if (!tempDoc.HasParseError()) {
+        return normalized;
     }
 
-    {
-        rapidjson::StringBuffer buffer;
-        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-        finalValue.Accept(writer);
-        normalized = buffer.GetString();
-    }
+    auto errorCode = tempDoc.GetParseError();
+    auto errorMessage = rapidjson::GetParseError_En(errorCode);
+    size_t errorOffset = tempDoc.GetErrorOffset();
+    SPDLOG_LOGGER_TRACE(llm_calculator_logger, "Failed to parse argument string as JSON, falling back to string value. Argument string: {}, Error: {} Offset: {}", normalized, errorMessage, errorOffset);
 
-    return normalized;
+    std::string fallback = arg;
+    trim(fallback);
+    if (fallback.size() >= 2 && fallback.front() == '\"' && fallback.back() == '\"') {
+        fallback = fallback.substr(1, fallback.size() - 2);
+    }
+    return escapeAsJsonString(fallback);
 }
 
 void Gemma4ToolParser::writeArgumentToWriter(const std::string& arg, rapidjson::Writer<rapidjson::StringBuffer>& writer) {

--- a/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
+++ b/src/llm/io_processing/gemma4/gemma4_tool_parser.hpp
@@ -83,14 +83,6 @@ public:
 private:
     void writeArgumentToWriter(const std::string& arg, rapidjson::Writer<rapidjson::StringBuffer>& writer);
 
-    // Masks '"', '\'', '{', '}', '[', ']' found inside <|"|>...<|"|> pairs (same length,
-    // delimiter's own quotes left intact) so a Gemma4 string value's own payload (e.g. code
-    // containing commas/braces/quotes) can't be mistaken for structural tokens by
-    // findInStringRespectingSpecialChars. An unclosed trailing value (still streaming) is
-    // masked through the current buffer end too; a later call re-masks from scratch once
-    // its closing delimiter has arrived.
-    static std::string maskStringValues(const std::string& text);
-
     std::pair<std::string, std::string> parseSingleArgument(const std::string& argumentStr);
     std::vector<std::pair<std::string, std::string>> parseArguments(const std::string& argumentsStr);
 

--- a/src/llm/io_processing/utils.cpp
+++ b/src/llm/io_processing/utils.cpp
@@ -224,7 +224,7 @@ std::string escapeAsJsonString(const std::string& rawValue) {
     std::string value = rawValue;
     rapidjson::Document doc;
 
-    if(rawValue.size() >= 2 && rawValue.front() == '"' && rawValue.back() == '"') {
+    if (rawValue.size() >= 2 && rawValue.front() == '"' && rawValue.back() == '"') {
         doc.Parse(rawValue.c_str());
     } else {
         doc.Parse(("\"" + rawValue + "\"").c_str());

--- a/src/llm/io_processing/utils.cpp
+++ b/src/llm/io_processing/utils.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 
 #include "utils.hpp"
+#include "src/stringutils.hpp"
 
 namespace ovms {
 std::string generateRandomId() {
@@ -222,7 +223,13 @@ std::string replaceSingleWithDoubleQuotes(const std::string& input) {
 std::string escapeAsJsonString(const std::string& rawValue) {
     std::string value = rawValue;
     rapidjson::Document doc;
-    doc.Parse(("\"" + rawValue + "\"").c_str());
+
+    if(rawValue.size() >= 2 && rawValue.front() == '"' && rawValue.back() == '"') {
+        doc.Parse(rawValue.c_str());
+    } else {
+        doc.Parse(("\"" + rawValue + "\"").c_str());
+    }
+
     if (!doc.HasParseError() && doc.IsString()) {
         value.assign(doc.GetString(), doc.GetStringLength());
     }
@@ -239,11 +246,46 @@ bool isWrappedByDelimiter(const std::string& value, const std::string& delimiter
            value.compare(value.size() - delimiter.size(), delimiter.size(), delimiter) == 0;
 }
 
-std::vector<std::string> splitTopLevel(const std::string& content, const std::string& maskedContent, const std::string& separator) {
+std::string maskDelimitedStringValues(const std::string& text, const std::string& delimiter) {
+    std::string masked = text;
+    size_t pos = 0;
+    while (true) {
+        const size_t openPos = text.find(delimiter, pos);
+        if (openPos == std::string::npos)
+            break;
+        const size_t valueStart = openPos + delimiter.size();
+        const size_t closePos = text.find(delimiter, valueStart);
+        // Value not closed yet (still streaming): mask through the current buffer end too,
+        // otherwise its already-received tail would desync quote/brace tracking; a later
+        // call re-masks from scratch once the closing delimiter has arrived.
+        const size_t maskEnd = (closePos == std::string::npos) ? text.size() : closePos;
+        for (size_t i = valueStart; i < maskEnd; i++) {
+            switch (masked[i]) {
+            case '"':
+            case '\'':
+            case '{':
+            case '}':
+            case '[':
+            case ']':
+                masked[i] = '\x01';
+                break;
+            default:
+                break;
+            }
+        }
+        if (closePos == std::string::npos)
+            break;
+        pos = closePos + delimiter.size();
+    }
+    return masked;
+}
+
+std::vector<std::string> splitRespectingSpecialChars(const std::string& content, const std::string& separator, const std::optional<std::string>& maskedContent) {
+    const std::string& lookup = maskedContent.has_value() ? *maskedContent : content;
     std::vector<std::string> parts;
     size_t pos = 0;
     while (true) {
-        size_t separatorPos = findInStringRespectingSpecialChars(maskedContent, separator, pos);
+        size_t separatorPos = findInStringRespectingSpecialChars(lookup, separator, pos);
         if (separatorPos == std::string::npos) {
             parts.push_back(content.substr(pos));
             return parts;

--- a/src/llm/io_processing/utils.cpp
+++ b/src/llm/io_processing/utils.cpp
@@ -219,4 +219,38 @@ std::string replaceSingleWithDoubleQuotes(const std::string& input) {
     return result;
 }
 
+std::string escapeAsJsonString(const std::string& rawValue) {
+    std::string value = rawValue;
+    rapidjson::Document doc;
+    doc.Parse(("\"" + rawValue + "\"").c_str());
+    if (!doc.HasParseError() && doc.IsString()) {
+        value.assign(doc.GetString(), doc.GetStringLength());
+    }
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    writer.String(value.c_str(), static_cast<rapidjson::SizeType>(value.size()));
+    return buffer.GetString();
+}
+
+bool isWrappedByDelimiter(const std::string& value, const std::string& delimiter) {
+    return value.size() >= 2 * delimiter.size() &&
+           value.compare(0, delimiter.size(), delimiter) == 0 &&
+           value.compare(value.size() - delimiter.size(), delimiter.size(), delimiter) == 0;
+}
+
+std::vector<std::string> splitTopLevel(const std::string& content, const std::string& maskedContent, const std::string& separator) {
+    std::vector<std::string> parts;
+    size_t pos = 0;
+    while (true) {
+        size_t separatorPos = findInStringRespectingSpecialChars(maskedContent, separator, pos);
+        if (separatorPos == std::string::npos) {
+            parts.push_back(content.substr(pos));
+            return parts;
+        }
+        parts.push_back(content.substr(pos, separatorPos - pos));
+        pos = separatorPos + separator.size();
+    }
+}
+
 }  // namespace ovms

--- a/src/llm/io_processing/utils.hpp
+++ b/src/llm/io_processing/utils.hpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //*****************************************************************************
 #pragma once
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -63,8 +64,16 @@ std::string escapeAsJsonString(const std::string& rawValue);
 // Returns true if value is wrapped on both ends by delimiter (and long enough to hold two).
 bool isWrappedByDelimiter(const std::string& value, const std::string& delimiter);
 
-// Splits content into top-level parts on separator, using maskedContent (a same-length
-// version of content with in-string special characters masked out, see callers) to find
-// separators that are not nested inside a string value, an object or an array.
-std::vector<std::string> splitTopLevel(const std::string& content, const std::string& maskedContent, const std::string& separator);
+// Masks '"', '\'', '{', '}', '[', ']' found inside delimiter...delimiter pairs (same length,
+// the delimiters themselves left intact) so a string value's own payload (e.g. code containing
+// commas/braces/quotes) can't be mistaken for structural tokens by findInStringRespectingSpecialChars.
+// An unclosed trailing value (still streaming) is masked through the current buffer end too; a later
+// call re-masks from scratch once its closing delimiter has arrived.
+std::string maskDelimitedStringValues(const std::string& text, const std::string& delimiter);
+
+// Splits content into top-level parts on separator, ignoring separators that are nested inside
+// a string value, an object or an array. maskedContent, if provided, must be a same-length version
+// of content with in-string special characters masked out (see maskDelimitedStringValues);
+// when omitted, content itself is used to look up separators.
+std::vector<std::string> splitRespectingSpecialChars(const std::string& content, const std::string& separator, const std::optional<std::string>& maskedContent = std::nullopt);
 }  // namespace ovms

--- a/src/llm/io_processing/utils.hpp
+++ b/src/llm/io_processing/utils.hpp
@@ -15,6 +15,7 @@
 //*****************************************************************************
 #pragma once
 #include <string>
+#include <vector>
 
 #pragma warning(push)
 #pragma warning(disable : 6313)
@@ -53,4 +54,17 @@ void normalizeBooleanString(std::string& value);
 // Replaces single-quote string delimiters with double quotes for JSON compatibility.
 // Handles nested quoting: apostrophes inside double-quoted strings are preserved.
 std::string replaceSingleWithDoubleQuotes(const std::string& input);
+
+// Converts a raw string payload into a quoted, properly escaped JSON string value.
+// Interprets rawValue as JSON string content when that is valid (respecting existing
+// escapes), otherwise takes it literally (e.g. Windows paths are not validly escaped JSON).
+std::string escapeAsJsonString(const std::string& rawValue);
+
+// Returns true if value is wrapped on both ends by delimiter (and long enough to hold two).
+bool isWrappedByDelimiter(const std::string& value, const std::string& delimiter);
+
+// Splits content into top-level parts on separator, using maskedContent (a same-length
+// version of content with in-string special characters masked out, see callers) to find
+// separators that are not nested inside a string value, an object or an array.
+std::vector<std::string> splitTopLevel(const std::string& content, const std::string& maskedContent, const std::string& separator);
 }  // namespace ovms

--- a/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
@@ -359,7 +359,8 @@ TEST_F(Gemma4OutputParserTest, ParseToolCallWithStringWithMaskedValues) {
 }
 
 TEST_F(Gemma4OutputParserTest, ParseToolCallWithThoughtPreamble) {
-    std::string input = "thought\n<channel|>" R"(<|tool_call>call:rename{old_name:<|"|>a,b<|"|>, new_name:<|"|>c,d<|"|>}<tool_call|>)";
+    std::string input = "thought\n<channel|>"
+                        R"(<|tool_call>call:rename{old_name:<|"|>a,b<|"|>, new_name:<|"|>c,d<|"|>}<tool_call|>)";
     auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
     std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
     ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);

--- a/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
@@ -336,6 +336,39 @@ TEST_F(Gemma4OutputParserTest, ParseToolCallWithNestedArrayOfArrays) {
     EXPECT_EQ(parsedOutput.toolCalls[0].arguments, R"({"rows":[[1,2],[3,4]],"labels":[["a"],["b"]]})");
 }
 
+TEST_F(Gemma4OutputParserTest, ParseToolCallWithNestedArrayOfStringWithMaskedValues) {
+    std::string input = R"(<|tool_call>call:sort{strings:[[<|"|>a,b<|"|>, <|"|>c<|"|>], [<|"|>d,e<|"|>, <|"|>e,f<|"|>]]}<tool_call|>)";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "sort");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments, R"({"strings":[["a,b","c"],["d,e","e,f"]]})");
+}
+
+TEST_F(Gemma4OutputParserTest, ParseToolCallWithStringWithMaskedValues) {
+    std::string input = R"(<|tool_call>call:rename{old_name:<|"|>a,b<|"|>, new_name:<|"|>c,d<|"|>}<tool_call|>)";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "rename");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments, R"({"old_name":"a,b","new_name":"c,d"})");
+}
+
+TEST_F(Gemma4OutputParserTest, ParseToolCallWithThoughtPreamble) {
+    std::string input = "thought\n<channel|>" R"(<|tool_call>call:rename{old_name:<|"|>a,b<|"|>, new_name:<|"|>c,d<|"|>}<tool_call|>)";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "rename");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments, R"({"old_name":"a,b","new_name":"c,d"})");
+}
+
 TEST_F(Gemma4OutputParserTest, ParseToolCallWithArrayOfObjectsArgumentsStreaming) {
     std::vector<std::tuple<std::string, ov::genai::GenerationFinishReason, std::optional<std::string>>> chunkToDeltaVec{
         {"<|tool_call>", ov::genai::GenerationFinishReason::NONE, std::nullopt},

--- a/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
+++ b/src/test/llm/output_parsers/gemma4_output_parser_test.cpp
@@ -300,6 +300,65 @@ TEST_F(Gemma4OutputParserTest, ParseToolCallWithArrayArguments) {
     }
 }
 
+TEST_F(Gemma4OutputParserTest, ParseToolCallWithArrayOfObjectsArguments) {
+    std::string input = R"(<|tool_call>call:read_files{files:[{path:<|"|>c:\opt\demo\hello_world_project\hello.py<|"|>},{path:<|"|>c:\opt\demo\hello_world_project\README.md<|"|>}]}<tool_call|>)";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "read_files");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments,
+        R"({"files":[{"path":"c:\\opt\\demo\\hello_world_project\\hello.py"},{"path":"c:\\opt\\demo\\hello_world_project\\README.md"}]})");
+    EXPECT_EQ(parsedOutput.toolCalls[0].id.empty(), false);
+}
+
+TEST_F(Gemma4OutputParserTest, ParseToolCallWithArrayOfObjectsWithMixedValueTypes) {
+    std::string input = R"(<|tool_call>call:batch{items:[{name:<|"|>a<|"|>,count:2,tags:[<|"|>x<|"|>,<|"|>y<|"|>]},{name:<|"|>b<|"|>,count:3,tags:[]}],dry_run:false}<tool_call|>)";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "batch");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments,
+        R"({"items":[{"name":"a","count":2,"tags":["x","y"]},{"name":"b","count":3,"tags":[]}],"dry_run":false})");
+}
+
+TEST_F(Gemma4OutputParserTest, ParseToolCallWithNestedArrayOfArrays) {
+    std::string input = R"(<|tool_call>call:matrix{rows:[[1,2],[3,4]],labels:[[<|"|>a<|"|>],[<|"|>b<|"|>]]}<tool_call|>)";
+    auto generatedTensor = gemma4Tokenizer->encode(input).input_ids;
+    std::vector<int64_t> generatedTokens(generatedTensor.data<int64_t>(), generatedTensor.data<int64_t>() + generatedTensor.get_size());
+    ParsedOutput parsedOutput = ovms::test::parseWithStreamer(*gemma4Tokenizer, *outputParserWithRegularToolParsing, generatedTokens, true, true);
+    EXPECT_EQ(parsedOutput.content, "");
+    ASSERT_EQ(parsedOutput.toolCalls.size(), 1);
+    EXPECT_EQ(parsedOutput.toolCalls[0].name, "matrix");
+    EXPECT_EQ(parsedOutput.toolCalls[0].arguments, R"({"rows":[[1,2],[3,4]],"labels":[["a"],["b"]]})");
+}
+
+TEST_F(Gemma4OutputParserTest, ParseToolCallWithArrayOfObjectsArgumentsStreaming) {
+    std::vector<std::tuple<std::string, ov::genai::GenerationFinishReason, std::optional<std::string>>> chunkToDeltaVec{
+        {"<|tool_call>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"call:", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"read_files", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"{files", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"tool_calls":[{"id":"XXXXXXXXX","type":"function","index":0,"function":{"name":"read_files"}}]}})"},
+        {":[", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"{path", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {":<|\"|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {R"(c:\opt\demo\hello_world_project)", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {R"(\hello.py)", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"<|\"|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"},", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"{path:<|\"|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {R"(c:\opt\demo\hello_world_project\README.md)", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"<|\"|>", ov::genai::GenerationFinishReason::NONE, std::nullopt},
+        {"}]}", ov::genai::GenerationFinishReason::NONE, R"({"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"files\":[{\"path\":\"c:\\\\opt\\\\demo\\\\hello_world_project\\\\hello.py\"},{\"path\":\"c:\\\\opt\\\\demo\\\\hello_world_project\\\\README.md\"}]}"}}]}})"},
+        {"<tool_call|>", ov::genai::GenerationFinishReason::STOP, std::nullopt},
+    };
+
+    assertStreamingVec(chunkToDeltaVec);
+}
+
 TEST_F(Gemma4OutputParserTest, ParseToolCallOutputWithThreeToolCalls) {
     std::string inputWithProperClosure = "<|tool_call>call:example_tool{arg1:<|\"|>value1<|\"|>,arg2:42}call:another_tool{param1:<|\"|>data<|\"|>,param2:true}call:third_tool{key:<|\"|>value<|\"|>}<tool_call|>";
 


### PR DESCRIPTION
### 🛠 Summary

[CVS-194540](https://jira.devtools.intel.com/browse/CVS-194540)
Changing the way of handling gemma4 arrays, RapidJson::Parse was called too early so arrays were converted to the json strings: `"[\"first_string\", \"second\", ... ]"`, helper functions were added to `utils.cpp` . 

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
``

