### PR TITLE
Do not mistake a URL port for a LoRA alpha suffix

### DIFF
--- a/src/graph_export/image_generation_graph_cli_parser.cpp
+++ b/src/graph_export/image_generation_graph_cli_parser.cpp
@@ -230,19 +230,22 @@ void ImageGenerationGraphCLIParser::prepare(ServerSettingsImpl& serverSettings, 
 
             LoraAdapterSettings adapter;
             adapter.alias = alias;
-            // Parse optional :alpha suffix
+            // Parse optional :alpha suffix. Only a colon in the final path segment can be an
+            // alpha delimiter, which keeps the scheme colon of "https://...", the port colon of
+            // "https://host:8080/file.safetensors" and a Windows drive letter ("C:\\...") from
+            // being misread as one. A "//" check is no longer needed: everything after the last
+            // separator is free of path separators, so alphaStr can never start with one.
+            const size_t lastSeparator = source.find_last_of("/\\");
+            const size_t segmentStart = (lastSeparator == std::string::npos) ? 0 : lastSeparator + 1;
             auto lastColon = source.rfind(':');
-            if (lastColon != std::string::npos && lastColon > 1) {
+            if (lastColon != std::string::npos && lastColon > 1 && lastColon >= segmentStart) {
                 std::string alphaStr = source.substr(lastColon + 1);
-                // Skip protocol colons (https:// or http://)
-                if (alphaStr.substr(0, 2) != "//") {
-                    auto alpha = ovms::stof(alphaStr);
-                    if (!alpha.has_value()) {
-                        throw std::invalid_argument("Invalid alpha value '" + alphaStr + "' in --source_loras entry: '" + entry + "'");
-                    }
-                    adapter.alpha = alpha.value();
-                    source = source.substr(0, lastColon);
+                auto alpha = ovms::stof(alphaStr);
+                if (!alpha.has_value()) {
+                    throw std::invalid_argument("Invalid alpha value '" + alphaStr + "' in --source_loras entry: '" + entry + "'");
                 }
+                adapter.alpha = alpha.value();
+                source = source.substr(0, lastColon);
             }
             // Detect source type
             if (source.substr(0, 8) == "https://" || source.substr(0, 7) == "http://") {

--- a/src/test/lora_graph_export_test.cpp
+++ b/src/test/lora_graph_export_test.cpp
@@ -585,6 +585,37 @@ TEST(ImageGenCLILoraParsingTest, UrlLoraWithoutAlphaPreservesDefault) {
     EXPECT_FALSE(graphSettings.loraAdapters[0].alpha.has_value());
 }
 
+// A URL may carry an explicit port. Without an alpha suffix the port colon is the last
+// colon in the entry, so it must not be taken for an alpha delimiter.
+TEST(ImageGenCLILoraParsingTest, UrlLoraWithPortWithoutAlpha) {
+    ovms::ServerSettingsImpl serverSettings;
+    serverSettings.serverMode = ovms::HF_PULL_MODE;
+    ovms::HFSettingsImpl hfSettings;
+    hfSettings.sourceLoras = "pokemon=https://registry.internal:8080/loras/weights.safetensors";
+    ovms::ImageGenerationGraphCLIParser parser;
+    parser.prepare(serverSettings, hfSettings, "test_model");
+    auto& graphSettings = std::get<ovms::ImageGenerationGraphSettingsImpl>(hfSettings.graphSettings);
+    ASSERT_EQ(graphSettings.loraAdapters.size(), 1);
+    EXPECT_EQ(graphSettings.loraAdapters[0].sourceType, ovms::LoraSourceType::DIRECT_URL);
+    EXPECT_EQ(graphSettings.loraAdapters[0].sourceLora, "https://registry.internal:8080/loras/weights.safetensors");
+    EXPECT_EQ(graphSettings.loraAdapters[0].safetensorsFile.value(), "weights.safetensors");
+    EXPECT_FALSE(graphSettings.loraAdapters[0].alpha.has_value());
+}
+
+TEST(ImageGenCLILoraParsingTest, UrlLoraWithPortAndAlpha) {
+    ovms::ServerSettingsImpl serverSettings;
+    serverSettings.serverMode = ovms::HF_PULL_MODE;
+    ovms::HFSettingsImpl hfSettings;
+    hfSettings.sourceLoras = "pokemon=https://registry.internal:8080/loras/weights.safetensors:0.45";
+    ovms::ImageGenerationGraphCLIParser parser;
+    parser.prepare(serverSettings, hfSettings, "test_model");
+    auto& graphSettings = std::get<ovms::ImageGenerationGraphSettingsImpl>(hfSettings.graphSettings);
+    ASSERT_EQ(graphSettings.loraAdapters.size(), 1);
+    EXPECT_EQ(graphSettings.loraAdapters[0].sourceLora, "https://registry.internal:8080/loras/weights.safetensors");
+    ASSERT_TRUE(graphSettings.loraAdapters[0].alpha.has_value());
+    EXPECT_FLOAT_EQ(graphSettings.loraAdapters[0].alpha.value(), 0.45f);
+}
+
 TEST(ImageGenCLILoraParsingTest, NPURejectsMultiLoraWithoutComposites) {
     ovms::ServerSettingsImpl serverSettings;
     serverSettings.serverMode = ovms::HF_PULL_MODE;


### PR DESCRIPTION
### 🛠 Summary

Fixes #4545.

The optional `:alpha` suffix of a `--source_loras` entry was found with `rfind(':')` over the whole source string, guarded only by a check that the text after the colon does not start with `//`. That guard covers the scheme colon of a URL with no port, but not the port colon itself, so

```
xray=https://registry.internal:8080/loras/f.safetensors
```

aborts startup with `Invalid alpha value '8080/loras/f.safetensors'`.

Restricts the alpha colon to the final path segment, via `source.find_last_of("/\\")`. The scheme colon, the port colon and a Windows drive letter all sit before the last separator, so all three are excluded structurally instead of by special-casing. The `//` check is dropped because it is now unreachable — nothing after the last separator can contain a path separator. `lastColon > 1` is kept so a source with no separator behaves as before.

This only affected entries without an explicit alpha; with `:0.45` appended, `rfind()` happened to land on the alpha colon and parsing worked. Adds `UrlLoraWithPortWithoutAlpha` for the broken case and `UrlLoraWithPortAndAlpha` to pin the one that already worked.

I have no OVMS build container available, so this is not compiled against the full tree and CI will need to confirm the build. I did check the rewritten block in isolation against the HF repo, URL, posix path and Windows drive-letter forms, with and without an alpha suffix; only the two port cases change behaviour. Draft for that reason.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
