### PR TITLE
Use ObjectEmpty() instead of array-only Empty() on a JSON object

### DIFF
--- a/src/llm/io_processing/partial_json_builder.cpp
+++ b/src/llm/io_processing/partial_json_builder.cpp
@@ -38,7 +38,7 @@ Document computeDeltaImpl(const Value::ConstObject& previous, const Value::Const
             delta.AddMember(key, copiedValue, delta.GetAllocator());
         } else if (m.value.IsObject() && previous[m.name].IsObject()) {
             Document nestedDelta = computeDeltaImpl(previous[m.name].GetObject(), m.value.GetObject());
-            if (!nestedDelta.Empty()) {
+            if (!nestedDelta.ObjectEmpty()) {
                 Value nestedDeltaValue;
                 nestedDeltaValue.CopyFrom(nestedDelta, delta.GetAllocator());
                 Value key;

--- a/src/test/llm/output_parsers/partial_json_builder_test.cpp
+++ b/src/test/llm/output_parsers/partial_json_builder_test.cpp
@@ -494,7 +494,7 @@ TEST_F(PartialJsonBuilderTest, computeDeltaWithEmptyJson) {
     current.SetObject();
     auto delta = PartialJsonBuilder::computeDelta(previous, current);
     ASSERT_TRUE(delta.IsObject());
-    ASSERT_TRUE(delta.Empty());
+    ASSERT_TRUE(delta.ObjectEmpty());
 }
 
 TEST_F(PartialJsonBuilderTest, computeDeltaWithAddedMember) {
@@ -514,7 +514,7 @@ TEST_F(PartialJsonBuilderTest, computeDeltaWithAddedMember) {
     auto delta = PartialJsonBuilder::computeDelta(previous, current);
     // Expecting delta {"arguments": "\""}
     ASSERT_TRUE(delta.IsObject());
-    ASSERT_FALSE(delta.Empty());
+    ASSERT_FALSE(delta.ObjectEmpty());
     ASSERT_FALSE(delta.HasMember("name"));
     ASSERT_TRUE(delta.HasMember("arguments"));
     ASSERT_TRUE(delta["arguments"].IsString());
@@ -544,12 +544,34 @@ TEST_F(PartialJsonBuilderTest, computeDeltaWithAddedNestedMember) {
     auto delta = PartialJsonBuilder::computeDelta(previous, current);
     // Expecting delta {"object": {"new_key": null}}
     ASSERT_TRUE(delta.IsObject());
-    ASSERT_FALSE(delta.Empty());
+    ASSERT_FALSE(delta.ObjectEmpty());
     ASSERT_TRUE(delta.HasMember("object"));
     ASSERT_TRUE(delta["object"].IsObject());
     ASSERT_EQ(delta["object"].MemberCount(), 1);
     ASSERT_TRUE(delta["object"].HasMember("new_key"));
     ASSERT_TRUE(delta["object"]["new_key"].IsNull());
+}
+
+// A nested object present and unchanged in both snapshots must contribute nothing to the
+// delta. This is the branch whose emptiness check actually decides the output, so it pins
+// that the object accessor is used - Value::Empty() is array-only and asserts on an object.
+TEST_F(PartialJsonBuilderTest, computeDeltaWithUnchangedNestedMember) {
+    const char* json = R"({
+        "name": "get_weather",
+        "object": {
+            "key": "value"
+        }
+    })";
+    rapidjson::Document previous;
+    previous.Parse(json);
+    rapidjson::Document current;
+    current.Parse(json);
+
+    auto delta = PartialJsonBuilder::computeDelta(previous, current);
+    // Expecting an empty delta {} - nothing changed.
+    ASSERT_TRUE(delta.IsObject());
+    ASSERT_TRUE(delta.ObjectEmpty());
+    ASSERT_FALSE(delta.HasMember("object"));
 }
 
 TEST_F(PartialJsonBuilderTest, computeDeltaWithAddedNestedArrayElement) {
@@ -581,7 +603,7 @@ TEST_F(PartialJsonBuilderTest, computeDeltaWithAddedNestedArrayElement) {
     auto delta = PartialJsonBuilder::computeDelta(previous, current);
     // Expecting delta {"objects": [{"key": "value2"}]}
     ASSERT_TRUE(delta.IsObject());
-    ASSERT_FALSE(delta.Empty());
+    ASSERT_FALSE(delta.ObjectEmpty());
     ASSERT_TRUE(delta.HasMember("objects"));
     ASSERT_TRUE(delta["objects"].IsArray());
     ASSERT_EQ(delta["objects"].Size(), 1);
@@ -608,7 +630,7 @@ TEST_F(PartialJsonBuilderTest, computeDeltaWithModifiedStringMember) {
     auto delta = PartialJsonBuilder::computeDelta(previous, current);
     // Expecting delta {"arguments": ", \"date\": "}
     ASSERT_TRUE(delta.IsObject());
-    ASSERT_FALSE(delta.Empty());
+    ASSERT_FALSE(delta.ObjectEmpty());
     ASSERT_TRUE(delta.HasMember("arguments"));
     ASSERT_TRUE(delta["arguments"].IsString());
     // Only the new part should be present in arguments


### PR DESCRIPTION
### 🛠 Summary

Fixes #4547.

`computeDeltaImpl()` builds its result with `delta.SetObject()`, so `nestedDelta` is always an object, but it was tested with `Value::Empty()`. In the pinned RapidJSON that accessor is array-only:

```cpp
// rapidjson/document.h:1649
bool Empty() const { RAPIDJSON_ASSERT(IsArray()); return data_.a.size == 0; }
// rapidjson/document.h:1197
bool ObjectEmpty() const { RAPIDJSON_ASSERT(IsObject()); return data_.o.size == 0; }
```

`RAPIDJSON_ASSERT` is `assert()` and is not overridden anywhere in the tree, so a build with assertions live (`-c dbg`, `Makefile:118`) aborts with ``Assertion `IsArray()' failed`` as soon as a streamed delta contains a nested object present in both snapshots — ordinary streaming of a tool call with nested arguments. Under `NDEBUG` the assert disappears and `data_.a.size` aliases `data_.o.size`, so the wrong accessor returns the right number. Release behaviour is unchanged by this PR.

The four tool parsers computing the same kind of delta already use `ObjectEmpty()` (hermes3, llama3, mistral, phi4), so this brings the builder in line. The other two `Value::Empty()` call sites in `src/` are genuinely arrays and are left alone.

The five delta assertions in `partial_json_builder_test.cpp` made the same misuse, so the suite aborted under `-c dbg` before reaching the production call; they now use `ObjectEmpty()`. Adds `computeDeltaWithUnchangedNestedMember` for the branch whose emptiness result decides the output. Note that test passes both before and after in a release build, for the aliasing reason above — its value is running correctly under assertions.

I have no OVMS build container available, so this is not compiled against the full tree and CI will need to confirm the build. I did reproduce the abort and the fix against the exact pinned RapidJSON revision from `WORKSPACE:102`. Draft for that reason.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
