### PR TITLE
Reject malformed transcription temperature instead of reinterpreting it

### DIFF
--- a/src/audio/speech_to_text/s2t_servable.cpp
+++ b/src/audio/speech_to_text/s2t_servable.cpp
@@ -76,12 +76,14 @@ absl::Status SttServable::parseTemperature(const HttpPayload& payload, ov::genai
     std::string temperatureStr = payload.multipartParser->getFieldByName("temperature");
     if (temperatureStr.size() > 0) {
         SPDLOG_LOGGER_TRACE(s2t_calculator_logger, "Received temperature: {}", temperatureStr);
+        // No integer fallback: ovms::stof already parses integer spellings ("1" -> 1.0f) and
+        // is the stricter of the two, requiring the whole field to be consumed. ovms::stou32
+        // does not, so it used to rescue exactly the values stof had just rejected - "0.5x"
+        // became 0.0 and "1e400" became 1.0 - turning malformed input into a plausible
+        // temperature instead of the intended "Invalid temperature type." error.
         auto temp = ovms::stof(temperatureStr);
-        if (!temp.has_value()) {
-            temp = ovms::stou32(temperatureStr);
-            if (!temp.has_value())
-                return absl::InvalidArgumentError("Invalid temperature type.");
-        }
+        if (!temp.has_value())
+            return absl::InvalidArgumentError("Invalid temperature type.");
         config.temperature = temp.value();
         if (config.temperature != 0) {
             config.do_sample = true;

--- a/src/test/audio/speech2text_test.cpp
+++ b/src/test/audio/speech2text_test.cpp
@@ -19,6 +19,8 @@
 #include <gtest/gtest.h>
 
 #include <drogon/drogon.h>
+
+#include "absl/status/status.h"
 #include "../../http_frontend/multi_part_parser_drogon_impl.hpp"
 #include "../../audio/audio_utils.hpp"
 #include "../../audio/speech_to_text/s2t_servable.hpp"
@@ -125,6 +127,73 @@ TEST(SttServableParseTemperatureTest, positiveTemperatureEnablesSampling) {
     EXPECT_TRUE(status.ok());
     EXPECT_FLOAT_EQ(config.temperature, 1.0f);
     EXPECT_TRUE(config.do_sample);
+}
+
+// A temperature field that is not entirely a number must be rejected rather than silently
+// reinterpreted. These all used to be accepted: the ovms::stou32 fallback parsed the leading
+// digits of a value ovms::stof had already rejected.
+TEST(SttServableParseTemperatureTest, trailingGarbageTemperatureRejected) {
+    HttpPayload payload;
+    std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
+    payload.multipartParser = multipartParser;
+    EXPECT_CALL(*multipartParser, getFieldByName("temperature"))
+        .WillOnce(::testing::Return("0.5x"));
+
+    ov::genai::ASRGenerationConfig config;
+    config.do_sample = false;
+
+    auto status = SttServable::parseTemperature(payload, config);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_FALSE(config.do_sample);
+}
+
+TEST(SttServableParseTemperatureTest, digitsFollowedByLettersTemperatureRejected) {
+    HttpPayload payload;
+    std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
+    payload.multipartParser = multipartParser;
+    EXPECT_CALL(*multipartParser, getFieldByName("temperature"))
+        .WillOnce(::testing::Return("0abc"));
+
+    ov::genai::ASRGenerationConfig config;
+    config.do_sample = false;
+
+    auto status = SttServable::parseTemperature(payload, config);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_FALSE(config.do_sample);
+}
+
+TEST(SttServableParseTemperatureTest, outOfRangeFloatTemperatureRejected) {
+    HttpPayload payload;
+    std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
+    payload.multipartParser = multipartParser;
+    EXPECT_CALL(*multipartParser, getFieldByName("temperature"))
+        .WillOnce(::testing::Return("1e400"));
+
+    ov::genai::ASRGenerationConfig config;
+    config.do_sample = false;
+
+    auto status = SttServable::parseTemperature(payload, config);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_FALSE(config.do_sample);
+}
+
+TEST(SttServableParseTemperatureTest, embeddedSpaceTemperatureRejected) {
+    HttpPayload payload;
+    std::shared_ptr<MockedMultiPartParser> multipartParser = std::make_shared<MockedMultiPartParser>();
+    payload.multipartParser = multipartParser;
+    EXPECT_CALL(*multipartParser, getFieldByName("temperature"))
+        .WillOnce(::testing::Return("5 5"));
+
+    ov::genai::ASRGenerationConfig config;
+    config.do_sample = false;
+
+    auto status = SttServable::parseTemperature(payload, config);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_FALSE(config.do_sample);
 }
 
 // ====================== Speech2Text Streaming Tests ======================


### PR DESCRIPTION
### 🛠 Summary

Fixes #4552.

`parseTemperature()` parsed the multipart `temperature` field with `ovms::stof` and, on failure, retried with `ovms::stou32`. `ovms::stof` requires the whole field to be consumed; `ovms::stou32` does not, and it erases spaces first. The fallback therefore rescued exactly the values `stof` had just rejected, turning malformed input into a plausible temperature instead of the intended `Invalid temperature type.` error:

```
temperature=0.5x   -> accepted as 0.0, not 0.5, so sampling is silently off
temperature=0abc   -> accepted as 0.0
temperature=1e400  -> accepted as 1.0
temperature=5 5    -> accepted as 55.0
```

The fallback had no purpose — `ovms::stof` already parses integer spellings, so `"1"` never reached it. Every input it could rescue is malformed by definition. Removing it lets the existing error path fire.

This deliberately adds no range check. Passing a negative temperature through for GenAI to reject is the behaviour established by #4201 and pinned by `negativeTemperatureEnableSampling`, so I left it alone rather than quietly reverse it. Happy to revisit separately if the endpoint should enforce the OpenAI audio range at the parse layer.

Adds four cases for the spellings above. The three existing `SttServableParseTemperatureTest` cases are unaffected — `-1.0`, `0` and `1.0` all parse cleanly through `ovms::stof` and never reached the fallback.

The root cause is that `ovms::stou32` alone among the `stringutils` converters does not check for a partial parse; that is #4554, and the two fixes are independent.

I have no OVMS build container available, so this is not compiled against the full tree and CI will need to confirm the build. I did check the change in isolation and verified the three existing test inputs behave identically. Draft for that reason.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
