### PR TITLE
Reject partial parses in stou32

### DIFF
--- a/src/stringutils.cpp
+++ b/src/stringutils.cpp
@@ -117,8 +117,15 @@ std::optional<uint32_t> stou32(const std::string& input) {
         return std::nullopt;
     }
 
+    size_t idx = 0;
     try {
-        uint64_t val = std::stoul(str);
+        uint64_t val = std::stoul(str, &idx);
+        // Check if the whole string was consumed, as stou64/stoi32/stof do. Without this
+        // std::stoul stops at the first non-digit and reports success, so "12abc" parsed
+        // as 12 and "3.9" as 3.
+        if (idx != str.size()) {
+            return std::nullopt;
+        }
         if (val > std::numeric_limits<uint32_t>::max()) {
             return std::nullopt;
         }

--- a/src/test/stringutils_test.cpp
+++ b/src/test/stringutils_test.cpp
@@ -211,6 +211,27 @@ TEST(StringUtils, stou32) {
     EXPECT_EQ(result.value(), 4294967295);
 }
 
+// A string that is not entirely a number must be rejected, matching stou64/stoi32/stof.
+// std::stoul stops at the first character it cannot use and still reports success, so
+// without an explicit length check these all parsed as their leading digits.
+TEST(StringUtils, stou32RejectsPartialParse) {
+    EXPECT_FALSE(ovms::stou32("12abc"));
+    EXPECT_FALSE(ovms::stou32("3.9"));
+    EXPECT_FALSE(ovms::stou32("0x10"));
+    EXPECT_FALSE(ovms::stou32("100%"));
+    EXPECT_FALSE(ovms::stou32("abc"));
+    EXPECT_FALSE(ovms::stou32(""));
+
+    // Plain numbers are still accepted.
+    auto result = ovms::stou32("12");
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result.value(), 12u);
+
+    result = ovms::stou32("0");
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result.value(), 0u);
+}
+
 TEST(StringUtils, stou64) {
     auto result = ovms::stou64("-100");
     EXPECT_FALSE(result);


### PR DESCRIPTION
### 🛠 Summary

Fixes #4554.

`stou32()` is the only converter in `stringutils` that does not verify the whole string was consumed. `std::stoul` stops at the first character it cannot use and still reports success, so `stou32("12abc")` returned 12, `stou32("3.9")` returned 3 and `stou32("0x10")` returned 0. Its siblings all guard against this by passing `&idx` and comparing against the length — `stou64` at `:143-147`, `stoi32` at `:161-165`, `stof` at `:203-206`. This adds the same check.

Two call sites are affected. `grpcservermodule.cpp:79` reads the `GRPC_SERVERS` environment variable, so `GRPC_SERVERS=4x` silently started 4 servers instead of being rejected and falling back to `config.grpcWorkers()`. `s2t_servable.cpp:81` uses it as a fallback for the transcription temperature field; that endpoint is also addressed in #4553, and either change alone fixes it — they do not conflict.

The surrounding `erase_spaces()` call is deliberately left alone, so `stou32("12 34")` still yields 1234. That is a separate question from partial parsing — note `stou64` rejects `"   100 "` outright — and I did not want two behaviour changes in one commit.

The existing `StringUtils.stou32` case covers a negative value, overflow and the maximum, none of which change. Adds `StringUtils.stou32RejectsPartialParse` for the trailing-garbage spellings plus plain numbers.

I have no OVMS build container available, so this is not compiled against the full tree and CI will need to confirm the build. I did check the change in isolation and confirmed the existing test inputs are unaffected. Draft for that reason.

### 🧪 Checklist

- [ ] Unit tests added.
- [ ] The documentation updated.
- [ ] Change follows security best practices.
